### PR TITLE
Mesh I/O: mshio integration and MeshReader trait (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,8 +104,14 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -170,9 +176,9 @@ dependencies = [
  "aligned",
  "anyhow",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.6",
  "log",
- "num-rational",
+ "num-rational 0.4.2",
  "num-traits",
  "pastey",
  "rayon",
@@ -188,10 +194,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
 dependencies = [
  "anyhow",
- "arrayvec",
+ "arrayvec 0.7.6",
  "log",
  "nom 8.0.0",
- "num-rational",
+ "num-rational 0.4.2",
  "v_frame",
 ]
 
@@ -201,7 +207,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -253,7 +259,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -264,7 +270,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.2",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -287,6 +293,12 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -346,7 +358,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -534,7 +546,7 @@ dependencies = [
  "derive-new",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -787,7 +799,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1218,7 +1230,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
@@ -1364,7 +1376,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1376,7 +1388,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1390,7 +1402,7 @@ dependencies = [
  "cubecl-ir",
  "float-ord",
  "log",
- "num",
+ "num 0.4.3",
  "petgraph",
  "smallvec",
  "stable-vec",
@@ -1654,7 +1666,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1667,7 +1679,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1680,7 +1692,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1691,7 +1703,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1702,7 +1714,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1713,7 +1725,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1748,7 +1760,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1769,7 +1781,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1779,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1801,7 +1813,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1849,7 +1861,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -1861,7 +1873,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1975,7 +1987,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1997,7 +2009,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2017,7 +2029,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2257,7 +2269,7 @@ dependencies = [
  "gemm-f16",
  "gemm-f32",
  "gemm-f64",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2272,7 +2284,7 @@ checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2287,7 +2299,7 @@ checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2304,7 +2316,7 @@ dependencies = [
  "dyn-stack",
  "half",
  "libm",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "once_cell",
  "paste",
@@ -2325,7 +2337,7 @@ dependencies = [
  "gemm-common",
  "gemm-f32",
  "half",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2341,7 +2353,7 @@ checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2356,7 +2368,7 @@ checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
 dependencies = [
  "dyn-stack",
  "gemm-common",
- "num-complex",
+ "num-complex 0.4.6",
  "num-traits",
  "paste",
  "raw-cpuid",
@@ -2385,6 +2397,8 @@ name = "geode-core"
 version = "0.1.0"
 dependencies = [
  "burn",
+ "mshio",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2502,7 +2516,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2513,7 +2527,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2904,7 +2918,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2962,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3021,6 +3035,19 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -3167,7 +3194,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3280,7 +3307,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3294,14 +3321,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mshio"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f3aa844a89eb69a2f58cea74055711d77356e20490cdd0a3670117a96a8e2e"
+dependencies = [
+ "nom 5.1.3",
+ "num 0.3.1",
+ "num-derive 0.3.3",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "naga"
 version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "bit-set",
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -3341,7 +3381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.4.6",
  "num-integer",
  "num-traits",
  "portable-atomic",
@@ -3356,7 +3396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.4.6",
  "num-integer",
  "num-traits",
  "portable-atomic",
@@ -3386,6 +3426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -3424,15 +3475,40 @@ dependencies = [
 
 [[package]]
 name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-complex 0.3.1",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
- "num-complex",
+ "num-bigint 0.4.6",
+ "num-complex 0.4.6",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.4.2",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3443,6 +3519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
  "num-traits",
 ]
 
@@ -3464,13 +3549,24 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3495,11 +3591,23 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -3539,7 +3647,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -3556,7 +3664,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3577,7 +3685,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3589,7 +3697,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3623,7 +3731,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -3754,7 +3862,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3816,7 +3924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3844,7 +3952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3856,7 +3964,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "libm",
- "num-complex",
+ "num-complex 0.4.6",
  "paste",
  "pulp-wasm-simd-flag",
  "raw-cpuid",
@@ -4078,7 +4186,7 @@ dependencies = [
  "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.6",
  "av-scenechange",
  "av1-grain",
  "bitstream-io",
@@ -4092,7 +4200,7 @@ dependencies = [
  "maybe-rayon",
  "new_debug_unreachable",
  "noop_proc_macro",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "paste",
  "profiling",
@@ -4125,7 +4233,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4195,7 +4303,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4357,7 +4465,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4506,7 +4614,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4646,7 +4754,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4693,6 +4801,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4719,7 +4838,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4728,7 +4847,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -4830,7 +4949,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4841,7 +4960,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5056,7 +5175,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5131,7 +5250,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tracel-llvm-bundler",
  "tracel-tblgen-rs",
  "unindent",
@@ -5178,7 +5297,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5359,7 +5478,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5459,7 +5578,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5500,7 +5619,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5568,8 +5687,8 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
- "arrayvec",
- "bitflags",
+ "arrayvec 0.7.6",
+ "bitflags 2.11.1",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -5598,10 +5717,10 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -5659,10 +5778,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
- "arrayvec",
+ "arrayvec 0.7.6",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "bytemuck",
  "cfg-if",
@@ -5722,7 +5841,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "js-sys",
  "log",
@@ -5814,7 +5933,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5825,7 +5944,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6069,7 +6188,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6085,7 +6204,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6097,7 +6216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -6180,7 +6299,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6201,7 +6320,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6221,7 +6340,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6261,7 +6380,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -9,6 +9,8 @@ description = "GEODE-FEM solver primitives: tensor ops over Burn."
 
 [dependencies]
 burn = { workspace = true }
+mshio = "0.4"
+thiserror = "2"
 
 [features]
 default = ["wgpu"]

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -28,7 +28,11 @@ pub type DefaultBackend = burn::backend::Cuda;
 
 /// A geometric mesh: element connectivity and node coordinates.
 ///
-/// Concrete implementations (tetrahedral first) arrive with #3.
+/// This trait describes an *in-pipeline* mesh — backend-parameterized so a
+/// concrete impl can hold device-side tensors. The raw CPU output of mesh
+/// I/O lives in [`mesh::TetMesh`], which is what `MeshReader` returns; a
+/// future `Mesh`-implementing struct will typically wrap one of those plus
+/// the Burn tensors it owns.
 pub trait Mesh {
     type Backend: Backend;
 

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -5,6 +5,9 @@
 //! shape of the API; concrete implementations arrive with scalar
 //! Helmholtz (#3) and the eigenmode solver work that follows.
 
+pub mod mesh;
+pub use mesh::{GmshReader, MeshError, MeshReader, TetMesh};
+
 use burn::tensor::backend::{Backend, BackendTypes};
 use burn::tensor::Tensor;
 

--- a/crates/geode-core/src/mesh.rs
+++ b/crates/geode-core/src/mesh.rs
@@ -15,6 +15,12 @@ use mshio::mshfile::ElementType;
 ///
 /// Node indices in `tets` are 0-based linear indices into `nodes`,
 /// independent of the (possibly sparse, 1-based) tags in the source file.
+///
+/// Not to be confused with the [`Mesh`](crate::Mesh) trait in the crate
+/// root — that one is a placeholder for in-pipeline (potentially GPU-resident)
+/// mesh objects parameterized by a Burn backend. `TetMesh` is the raw CPU
+/// output of mesh I/O; a `Mesh`-implementing struct would typically wrap
+/// (or be constructed from) a `TetMesh` plus device-side tensors.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TetMesh {
     /// Node coordinates, `nodes[i] = [x, y, z]`.
@@ -139,6 +145,20 @@ impl MeshReader for GmshReader {
 }
 
 /// First tag we haven't yet observed; assumes contiguous append-order.
+///
+/// **Writer-convention dependency.** When `mshio` reports a node block as
+/// non-sparse (no `node_tags` map), it leaves us no way to recover the
+/// block's starting tag from `mshio`'s API — that information is normalized
+/// away in `mshio-0.4.2/src/parsers/nodes_section.rs`. We therefore rely
+/// on the convention that Gmsh emits node blocks in ascending tag order
+/// and that tags are contiguous across blocks. Both hold for files written
+/// by Gmsh ≥ 4.0 and for any hand-rolled fixture that meets the MSH 4.1
+/// node-tag uniqueness requirement.
+///
+/// If we ever encounter a file that violates this (e.g. node blocks with
+/// gaps between them but no per-block sparse map), the symptom will be
+/// tet connectivity referencing tags we never inserted, which surfaces
+/// cleanly as [`MeshError::InvalidNodeRef`].
 fn next_contiguous_start(map: &BTreeMap<u64, u32>) -> u64 {
     map.keys().next_back().map(|t| t + 1).unwrap_or(1)
 }
@@ -212,4 +232,66 @@ fn split_quoted_name(row: &str) -> Result<(&str, String), MeshError> {
         .find('"')
         .ok_or_else(|| MeshError::PhysicalNames(format!("missing closing quote in {row:?}")))?;
     Ok((&row[..open], rest[..close].to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_physical_names_err(input: &str, needle: &str) {
+        match parse_physical_names(input.as_bytes()) {
+            Err(MeshError::PhysicalNames(msg)) => assert!(
+                msg.contains(needle),
+                "expected error containing {needle:?}, got {msg:?}"
+            ),
+            Err(other) => panic!("expected PhysicalNames error, got {other:?}"),
+            Ok(map) => panic!("expected error, got Ok({map:?})"),
+        }
+    }
+
+    #[test]
+    fn happy_path_minimal() {
+        let input = "$PhysicalNames\n1\n3 1 \"domain\"\n$EndPhysicalNames\n";
+        let map = parse_physical_names(input.as_bytes()).unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&(3, 1)).unwrap(), "domain");
+    }
+
+    #[test]
+    fn missing_section_is_ok_empty() {
+        let map = parse_physical_names(b"$MeshFormat\n4.1 0 8\n$EndMeshFormat\n").unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn missing_end_terminator_errs() {
+        let input = "$PhysicalNames\n1\n3 1 \"domain\"\n";
+        assert_physical_names_err(input, "$EndPhysicalNames");
+    }
+
+    #[test]
+    fn count_mismatch_errs() {
+        // Declares 2 entries, provides only 1.
+        let input = "$PhysicalNames\n2\n3 1 \"domain\"\n$EndPhysicalNames\n";
+        assert_physical_names_err(input, "disagrees");
+    }
+
+    #[test]
+    fn missing_closing_quote_errs() {
+        let input = "$PhysicalNames\n1\n3 1 \"domain\n$EndPhysicalNames\n";
+        assert_physical_names_err(input, "closing quote");
+    }
+
+    #[test]
+    fn missing_opening_quote_errs() {
+        // Entry without quotes around the name.
+        let input = "$PhysicalNames\n1\n3 1 domain\n$EndPhysicalNames\n";
+        assert_physical_names_err(input, "opening quote");
+    }
+
+    #[test]
+    fn bad_count_line_errs() {
+        let input = "$PhysicalNames\nNOT_A_NUMBER\n3 1 \"domain\"\n$EndPhysicalNames\n";
+        assert_physical_names_err(input, "bad count line");
+    }
 }

--- a/crates/geode-core/src/mesh.rs
+++ b/crates/geode-core/src/mesh.rs
@@ -1,0 +1,215 @@
+//! Mesh I/O — Gmsh MSH 4.1 ASCII reader.
+//!
+//! Provides a `MeshReader` trait so the parser is swappable, and a
+//! concrete `GmshReader` backed by the `mshio` crate.
+//!
+//! `mshio` does not parse the `$PhysicalNames` section (it silently
+//! ignores unknown sections); we hand-scan that one section ourselves
+//! so callers get physical-group tags. Everything else is delegated.
+
+use std::collections::BTreeMap;
+
+use mshio::mshfile::ElementType;
+
+/// CPU-side tetrahedral mesh produced by a `MeshReader`.
+///
+/// Node indices in `tets` are 0-based linear indices into `nodes`,
+/// independent of the (possibly sparse, 1-based) tags in the source file.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TetMesh {
+    /// Node coordinates, `nodes[i] = [x, y, z]`.
+    pub nodes: Vec<[f64; 3]>,
+    /// Tet connectivity: each tet's four 0-based node indices.
+    pub tets: Vec<[u32; 4]>,
+    /// Physical groups keyed by `(dim, tag)`.
+    pub physical_groups: BTreeMap<(i32, i32), String>,
+}
+
+impl TetMesh {
+    pub fn n_nodes(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn n_tets(&self) -> usize {
+        self.tets.len()
+    }
+}
+
+/// Errors produced by mesh I/O.
+#[derive(Debug, thiserror::Error)]
+pub enum MeshError {
+    #[error("MSH parse error: {0}")]
+    Parse(String),
+    #[error("unsupported element type {0:?}; only Tet4 is supported")]
+    UnsupportedElement(ElementType),
+    #[error("element references node tag {0} not present in node section")]
+    InvalidNodeRef(u64),
+    #[error("node tag {0} does not fit in u32")]
+    NodeTagOverflow(u64),
+    #[error("malformed $PhysicalNames section: {0}")]
+    PhysicalNames(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// A parser that produces a [`TetMesh`] from a byte slice.
+pub trait MeshReader {
+    fn read_tet_mesh(&self, source: &[u8]) -> Result<TetMesh, MeshError>;
+}
+
+/// MSH 4.1 ASCII reader backed by the `mshio` crate, with a side-channel
+/// parser for `$PhysicalNames` (which `mshio` does not handle).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GmshReader;
+
+impl MeshReader for GmshReader {
+    fn read_tet_mesh(&self, source: &[u8]) -> Result<TetMesh, MeshError> {
+        let msh = mshio::parse_msh_bytes(source).map_err(|e| MeshError::Parse(format!("{e}")))?;
+
+        let physical_groups = parse_physical_names(source)?;
+
+        // Build a node-tag → linear-index map and a flat coordinate Vec.
+        let mut tag_to_index: BTreeMap<u64, u32> = BTreeMap::new();
+        let mut nodes: Vec<[f64; 3]> = Vec::new();
+
+        if let Some(node_data) = &msh.data.nodes {
+            nodes.reserve(node_data.num_nodes as usize);
+            for block in &node_data.node_blocks {
+                // Tags within a block may be sparse (carried in `node_tags`)
+                // or contiguous (then implicitly `min_tag..min_tag + len`).
+                if let Some(map) = &block.node_tags {
+                    // Sparse case: rebuild tag list ordered by block index.
+                    let mut ordered: Vec<(usize, u64)> =
+                        map.iter().map(|(t, i)| (*i, *t)).collect();
+                    ordered.sort_unstable_by_key(|(i, _)| *i);
+                    for (block_idx, tag) in ordered {
+                        let node = &block.nodes[block_idx];
+                        let linear_idx = u32::try_from(nodes.len())
+                            .map_err(|_| MeshError::NodeTagOverflow(tag))?;
+                        tag_to_index.insert(tag, linear_idx);
+                        nodes.push([node.x, node.y, node.z]);
+                    }
+                } else {
+                    // Contiguous tags starting at the smallest tag in this block.
+                    // mshio doesn't expose a min-tag-per-block field, but the
+                    // ordering matches the order of `block.nodes` exactly.
+                    let mut next_tag = next_contiguous_start(&tag_to_index);
+                    for node in &block.nodes {
+                        let linear_idx = u32::try_from(nodes.len())
+                            .map_err(|_| MeshError::NodeTagOverflow(next_tag))?;
+                        tag_to_index.insert(next_tag, linear_idx);
+                        nodes.push([node.x, node.y, node.z]);
+                        next_tag += 1;
+                    }
+                }
+            }
+        }
+
+        // Collect tet connectivity, remapping tags to linear indices.
+        let mut tets: Vec<[u32; 4]> = Vec::new();
+        if let Some(elem_data) = &msh.data.elements {
+            for block in &elem_data.element_blocks {
+                if block.element_type != ElementType::Tet4 {
+                    // Non-tet blocks (lines, triangles on boundary, etc.) are
+                    // silently skipped — they are valid inputs but not the
+                    // volume elements we want here.
+                    continue;
+                }
+                for elem in &block.elements {
+                    if elem.nodes.len() != 4 {
+                        return Err(MeshError::UnsupportedElement(block.element_type));
+                    }
+                    let mut idx = [0u32; 4];
+                    for (slot, &tag) in idx.iter_mut().zip(elem.nodes.iter()) {
+                        *slot = *tag_to_index
+                            .get(&tag)
+                            .ok_or(MeshError::InvalidNodeRef(tag))?;
+                    }
+                    tets.push(idx);
+                }
+            }
+        }
+
+        Ok(TetMesh {
+            nodes,
+            tets,
+            physical_groups,
+        })
+    }
+}
+
+/// First tag we haven't yet observed; assumes contiguous append-order.
+fn next_contiguous_start(map: &BTreeMap<u64, u32>) -> u64 {
+    map.keys().next_back().map(|t| t + 1).unwrap_or(1)
+}
+
+/// Hand-parse `$PhysicalNames` from the raw MSH bytes.
+///
+/// Format (always ASCII, per MSH 4.1 spec, even when surrounding sections
+/// are binary):
+///
+/// ```text
+/// $PhysicalNames
+/// numPhysicalNames
+/// dim tag "name"
+/// ...
+/// $EndPhysicalNames
+/// ```
+fn parse_physical_names(source: &[u8]) -> Result<BTreeMap<(i32, i32), String>, MeshError> {
+    let text = std::str::from_utf8(source).map_err(|e| MeshError::PhysicalNames(e.to_string()))?;
+    let Some(start) = text.find("$PhysicalNames") else {
+        return Ok(BTreeMap::new());
+    };
+    let after_header = &text[start + "$PhysicalNames".len()..];
+    let Some(end_offset) = after_header.find("$EndPhysicalNames") else {
+        return Err(MeshError::PhysicalNames(
+            "missing $EndPhysicalNames terminator".into(),
+        ));
+    };
+    let body = &after_header[..end_offset];
+
+    let mut lines = body.lines().map(str::trim).filter(|l| !l.is_empty());
+    let count_line = lines
+        .next()
+        .ok_or_else(|| MeshError::PhysicalNames("missing count line".into()))?;
+    let expected: usize = count_line
+        .parse()
+        .map_err(|_| MeshError::PhysicalNames(format!("bad count line: {count_line:?}")))?;
+
+    let mut groups = BTreeMap::new();
+    for raw in lines {
+        let (head, name) = split_quoted_name(raw)?;
+        let mut parts = head.split_ascii_whitespace();
+        let dim: i32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| MeshError::PhysicalNames(format!("bad dim in {raw:?}")))?;
+        let tag: i32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| MeshError::PhysicalNames(format!("bad tag in {raw:?}")))?;
+        groups.insert((dim, tag), name);
+    }
+
+    if groups.len() != expected {
+        return Err(MeshError::PhysicalNames(format!(
+            "$PhysicalNames count {} disagrees with {} parsed entries",
+            expected,
+            groups.len()
+        )));
+    }
+
+    Ok(groups)
+}
+
+/// Splits a `$PhysicalNames` row into `(prefix_before_first_quote, name_inside_quotes)`.
+fn split_quoted_name(row: &str) -> Result<(&str, String), MeshError> {
+    let open = row
+        .find('"')
+        .ok_or_else(|| MeshError::PhysicalNames(format!("missing opening quote in {row:?}")))?;
+    let rest = &row[open + 1..];
+    let close = rest
+        .find('"')
+        .ok_or_else(|| MeshError::PhysicalNames(format!("missing closing quote in {row:?}")))?;
+    Ok((&row[..open], rest[..close].to_string()))
+}

--- a/crates/geode-core/tests/fixtures/unit_cube.msh
+++ b/crates/geode-core/tests/fixtures/unit_cube.msh
@@ -1,0 +1,40 @@
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+3 1 "domain"
+$EndPhysicalNames
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0
+$EndEntities
+$Nodes
+1 8 1 8
+3 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+1 1 0
+0 1 0
+0 0 1
+1 0 1
+1 1 1
+0 1 1
+$EndNodes
+$Elements
+1 5 1 5
+3 1 4 5
+1 1 2 3 6
+2 1 3 4 8
+3 1 6 8 5
+4 1 3 6 8
+5 3 6 7 8
+$EndElements

--- a/crates/geode-core/tests/mesh_roundtrip.rs
+++ b/crates/geode-core/tests/mesh_roundtrip.rs
@@ -1,0 +1,102 @@
+//! Round-trip integration test for the Gmsh MSH 4.1 ASCII reader.
+//!
+//! Reads `tests/fixtures/unit_cube.msh` (8 nodes, 5 tets, one physical
+//! group "domain") and asserts that every value parsed back matches
+//! what was written into the fixture.
+
+use geode_core::{GmshReader, MeshReader};
+
+const UNIT_CUBE_MSH: &[u8] = include_bytes!("fixtures/unit_cube.msh");
+
+/// Hand-mirror of the fixture, used as ground truth for the round-trip.
+fn expected_nodes() -> [[f64; 3]; 8] {
+    [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 1.0],
+        [1.0, 1.0, 1.0],
+        [0.0, 1.0, 1.0],
+    ]
+}
+
+/// Tet connectivity in 0-based indices (subtract 1 from each Gmsh tag).
+fn expected_tets() -> [[u32; 4]; 5] {
+    [
+        [0, 1, 2, 5],
+        [0, 2, 3, 7],
+        [0, 5, 7, 4],
+        [0, 2, 5, 7],
+        [2, 5, 6, 7],
+    ]
+}
+
+#[test]
+fn unit_cube_node_count() {
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    assert_eq!(mesh.n_nodes(), 8);
+}
+
+#[test]
+fn unit_cube_tet_count() {
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    assert_eq!(mesh.n_tets(), 5);
+}
+
+#[test]
+fn unit_cube_node_coordinates_round_trip() {
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    for (got, want) in mesh.nodes.iter().zip(expected_nodes().iter()) {
+        for (a, b) in got.iter().zip(want.iter()) {
+            assert!((a - b).abs() < 1e-12, "{a} != {b}");
+        }
+    }
+}
+
+#[test]
+fn unit_cube_tet_connectivity_round_trip() {
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    assert_eq!(mesh.tets, expected_tets());
+}
+
+#[test]
+fn unit_cube_physical_groups_round_trip() {
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    assert_eq!(mesh.physical_groups.len(), 1);
+    let name = mesh
+        .physical_groups
+        .get(&(3, 1))
+        .expect("physical group (3, 1) missing");
+    assert_eq!(name, "domain");
+}
+
+#[test]
+fn unit_cube_tet_volumes_are_positive() {
+    // Sanity check: the 5-tet split of the unit cube should partition it
+    // exactly. Sum of |det| / 6 across the five tets should equal 1.0.
+    let mesh = GmshReader.read_tet_mesh(UNIT_CUBE_MSH).expect("parse");
+    let mut total_volume = 0.0;
+    for tet in &mesh.tets {
+        let [a, b, c, d] = *tet;
+        let p0 = mesh.nodes[a as usize];
+        let p1 = mesh.nodes[b as usize];
+        let p2 = mesh.nodes[c as usize];
+        let p3 = mesh.nodes[d as usize];
+        let e1 = sub(p1, p0);
+        let e2 = sub(p2, p0);
+        let e3 = sub(p3, p0);
+        let det = e1[0] * (e2[1] * e3[2] - e2[2] * e3[1]) - e1[1] * (e2[0] * e3[2] - e2[2] * e3[0])
+            + e1[2] * (e2[0] * e3[1] - e2[1] * e3[0]);
+        total_volume += det.abs() / 6.0;
+    }
+    assert!(
+        (total_volume - 1.0).abs() < 1e-12,
+        "sum of tet volumes = {total_volume}, expected 1.0"
+    );
+}
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}


### PR DESCRIPTION
Closes #9. First child PR for the #3 (scalar Helmholtz) decomposition.

## Summary

Adds a Gmsh MSH 4.1 ASCII reader behind a `MeshReader` trait so the downstream P1 reference element + assembly work (#10, #11) has a well-typed mesh data structure to consume. Ships a hand-crafted unit-cube tet fixture and a round-trip test suite that verifies coordinates, connectivity, physical groups, and volume conservation.

## What's in the PR

- **`geode_core::mesh` module** (`crates/geode-core/src/mesh.rs`):
  - `TetMesh` — CPU-side mesh: flat node coords, 0-based tet connectivity, physical groups keyed by `(dim, tag)`
  - `MeshReader` — trait returning a `TetMesh` from a byte slice (the curator's "isolate behind a trait so we can swap later" recommendation)
  - `GmshReader` — concrete impl backed by `mshio` plus a hand-rolled `$PhysicalNames` scanner
  - `MeshError` — `thiserror` enum covering parse / connectivity / group errors
- **`$PhysicalNames` side-channel parser** — `mshio` silently ignores `$PhysicalNames` (it's on their TODO list, see lib.rs line 92 of `mshio-0.4.2`). Issue #9 acceptance requires physical groups, so we scan that one section ourselves (~30 LOC). All other sections go through `mshio` unchanged.
- **Node-tag remapping** — Gmsh tags are 1-based and may be sparse. We build a tag→linear-index map so downstream consumers see contiguous 0-based indices.
- **Non-tet blocks are skipped, not rejected** — real Gmsh exports often emit surface triangles for boundary physical groups; we ignore them rather than error.
- **Fixture**: `crates/geode-core/tests/fixtures/unit_cube.msh` — 8 nodes, standard 5-tet decomposition of the unit cube, one `"domain"` physical group.
- **Tests** (`crates/geode-core/tests/mesh_roundtrip.rs`):
  1. `unit_cube_node_count` — 8 nodes
  2. `unit_cube_tet_count` — 5 tets
  3. `unit_cube_node_coordinates_round_trip` — coords match fixture to 1e-12
  4. `unit_cube_tet_connectivity_round_trip` — connectivity exactly matches expected 0-based table
  5. `unit_cube_physical_groups_round_trip` — `(3, 1)` → `"domain"`
  6. `unit_cube_tet_volumes_are_positive` — Σ |det|/6 across all 5 tets = 1.0 ± 1e-12 (catches bad coords + bad connectivity in one assertion)

## Dependencies added

- `mshio = "0.4"` — pure-Rust Gmsh MSH 4.1 parser, low-dep
- `thiserror = "2"` — derive macro for `MeshError`

## Local verification

```
$ cargo test -p geode-core
running 2 tests
test tests::device_info_is_populated ... ok
test tests::smoke_add_runs_on_default_backend ... ok
test result: ok. 2 passed; ...

running 6 tests
test unit_cube_tet_volumes_are_positive ... ok
test unit_cube_physical_groups_round_trip ... ok
test unit_cube_tet_count ... ok
test unit_cube_tet_connectivity_round_trip ... ok
test unit_cube_node_count ... ok
test unit_cube_node_coordinates_round_trip ... ok
test result: ok. 6 passed; ...
```

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both pass.

## Test plan

- [ ] CI builds + tests on ubuntu-latest (when CI lands)
- [ ] CI builds + tests on macos-14 (when CI lands)
- [ ] Verify on a Gmsh-generated real-world cube mesh (deferred; can be added to fixtures in a follow-up if useful)

## Not in scope (per #9 non-goals)

- Writing MSH files
- MSH binary format
- Non-tet elements (hex, prism, pyramid, curvilinear)
- Boundary/face extraction beyond physical groups
- Pushing mesh data onto a Burn `Tensor` — that lives with #10 (batched local matrices), where the natural layout is `[n_elem, 4, 3]` element-local

## Notes for the Builder claiming #10

`TetMesh` exposes `nodes: Vec<[f64; 3]>` and `tets: Vec<[u32; 4]>` — feed these into a batched gather to build the `[n_elem, 4, 3]` element-coordinate tensor for closed-form Jacobian/stiffness computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
