### PR TITLE
Scalar PML for outward-radiating dielectric-sphere modes (#28)

### DIFF
--- a/crates/geode-core/src/complex_eigen.rs
+++ b/crates/geode-core/src/complex_eigen.rs
@@ -53,6 +53,31 @@ pub trait ComplexEigenSolver {
         k0: f64,
         n: usize,
     ) -> Result<Vec<c64>, EigenError>;
+
+    /// Solve the **fully-complex** generalized pencil `K E = λ M E`
+    /// where both `K` and `M` are complex (the PML / lossy-ε path,
+    /// issue #28) and return the lowest-`n` eigenvalues by `|Re(λ)|`.
+    ///
+    /// This is the natural surface for any path that produces a
+    /// complex mass matrix — PMLs, dispersive dielectrics, dispersive
+    /// boundary conditions. The Silver-Müller pencil is **not** a
+    /// special case of this entry point (its pencil is `(K + j k₀ S, M)`
+    /// with `M` real), so the two methods coexist.
+    ///
+    /// # Arguments
+    ///
+    /// * `k_complex` — complex curl-curl stiffness (typically real, but
+    ///   declared complex for forward compatibility with anisotropic
+    ///   PML where K can also pick up a tensor stretching).
+    /// * `m_complex` — complex mass matrix (typically scalar PML or
+    ///   dispersive ε).
+    /// * `n` — number of lowest-real-part eigenvalues to return.
+    fn smallest_complex_pencil_eigenvalues(
+        &self,
+        k_complex: MatRef<c64>,
+        m_complex: MatRef<c64>,
+        n: usize,
+    ) -> Result<Vec<c64>, EigenError>;
 }
 
 /// Dense `faer`-backed complex generalized eigensolver.
@@ -117,6 +142,65 @@ impl ComplexEigenSolver for FaerComplexEigensolver {
         // Whitney gradient nullspace cluster near zero, so by-Re sort
         // groups them at the front (the test layer is responsible for
         // detecting the spectral gap).
+        lambdas.sort_by(|a, b| {
+            a.re.abs()
+                .partial_cmp(&b.re.abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let take = n.min(lambdas.len());
+        Ok(lambdas.into_iter().take(take).collect())
+    }
+
+    fn smallest_complex_pencil_eigenvalues(
+        &self,
+        k_complex: MatRef<c64>,
+        m_complex: MatRef<c64>,
+        n: usize,
+    ) -> Result<Vec<c64>, EigenError> {
+        assert_eq!(
+            k_complex.nrows(),
+            k_complex.ncols(),
+            "K_complex must be square"
+        );
+        assert_eq!(
+            m_complex.nrows(),
+            m_complex.ncols(),
+            "M_complex must be square"
+        );
+        assert_eq!(
+            k_complex.nrows(),
+            m_complex.nrows(),
+            "K_complex and M_complex must agree in size"
+        );
+
+        let dim = k_complex.nrows();
+
+        // Materialize owned copies (faer's generalized_eigen takes
+        // owned-or-ref of the second argument; safest to clone).
+        let a = Mat::<c64>::from_fn(dim, dim, |i, j| k_complex[(i, j)]);
+        let b = Mat::<c64>::from_fn(dim, dim, |i, j| m_complex[(i, j)]);
+
+        let evd = a
+            .generalized_eigen(&b)
+            .map_err(|e| EigenError::FaerGevd(format!("{e:?}")))?;
+
+        let s_a = evd.S_a().column_vector();
+        let s_b = evd.S_b().column_vector();
+
+        let mut lambdas: Vec<c64> = Vec::with_capacity(dim);
+        for i in 0..dim {
+            let a_i = s_a[i];
+            let b_i = s_b[i];
+            let denom = b_i.re * b_i.re + b_i.im * b_i.im;
+            if denom < 1e-30 {
+                continue;
+            }
+            let re = (a_i.re * b_i.re + a_i.im * b_i.im) / denom;
+            let im = (a_i.im * b_i.re - a_i.re * b_i.im) / denom;
+            lambdas.push(c64::new(re, im));
+        }
+
         lambdas.sort_by(|a, b| {
             a.re.abs()
                 .partial_cmp(&b.re.abs())

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -35,9 +35,11 @@ pub use mesh::{
 };
 pub use nedelec::{batched_nedelec_local_matrices, tet_edges, NedelecLocalMatrices};
 pub use nedelec_assembly::{
-    assemble_global_nedelec, assemble_global_nedelec_with_epsilon, build_epsilon_r,
-    cube_pec_interior_edges, pec_interior_edge_mask, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, NedelecGlobalSystem,
+    assemble_global_nedelec, assemble_global_nedelec_with_complex_epsilon,
+    assemble_global_nedelec_with_epsilon, build_complex_epsilon_r_pml, build_epsilon_r,
+    burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
+    sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii,
+    NedelecComplexGlobalSystem, NedelecGlobalSystem,
 };
 pub use p1::{batched_p1_local_matrices, P1LocalMatrices};
 pub use silvermuller::assemble_silver_muller_surface;

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -39,6 +39,25 @@ pub struct NedelecGlobalSystem<B: Backend> {
     pub sparsity: SparsityPattern,
 }
 
+/// Assembled global Nédélec system with complex-valued (PML / lossy
+/// dielectric) mass matrix.
+///
+/// Same shape as [`NedelecGlobalSystem`], but the mass is split into its
+/// real and imaginary parts as two separate Burn tensors. Callers that
+/// want a `faer::Mat<faer::c64>` can combine them with
+/// [`burn_complex_mass_to_faer`].
+#[derive(Debug, Clone)]
+pub struct NedelecComplexGlobalSystem<B: Backend> {
+    /// Global curl-curl stiffness matrix `[n_edges, n_edges]` (real).
+    pub k: Tensor<B, 2>,
+    /// Real part of the complex mass matrix, `[n_edges, n_edges]`.
+    pub m_re: Tensor<B, 2>,
+    /// Imaginary part of the complex mass matrix, `[n_edges, n_edges]`.
+    pub m_im: Tensor<B, 2>,
+    /// `(row, col)` index pairs touched during assembly.
+    pub sparsity: SparsityPattern,
+}
+
 /// Assemble dense global Nédélec stiffness and mass matrices from
 /// per-element local matrices, preserving autodiff through 1-D
 /// `scatter(0, …, Add)`.
@@ -252,6 +271,102 @@ pub fn build_epsilon_r(physical_tags: &[i32], n_inside: f64) -> Vec<f64> {
         .collect()
 }
 
+/// Compute the per-tet centroid radius `|c_e| = |(p₀ + p₁ + p₂ + p₃) / 4|`
+/// for every tet in `mesh`. Returned in `mesh.tets` order.
+///
+/// Used by the PML profile in
+/// [`build_complex_epsilon_r_pml`] to decide which tets sit in the
+/// absorbing layer and how strongly to absorb in each.
+pub fn tet_centroid_radii(mesh: &TetMesh) -> Vec<f64> {
+    mesh.tets
+        .iter()
+        .map(|tet| {
+            let mut c = [0.0_f64; 3];
+            for &v in tet {
+                let p = mesh.nodes[v as usize];
+                c[0] += p[0];
+                c[1] += p[1];
+                c[2] += p[2];
+            }
+            c[0] *= 0.25;
+            c[1] *= 0.25;
+            c[2] *= 0.25;
+            (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt()
+        })
+        .collect()
+}
+
+/// Build a per-tet **complex** relative permittivity vector that
+/// realizes a scalar-isotropic PML in the vacuum buffer region of the
+/// bundled sphere fixture.
+///
+/// This is a UPML-reduced-to-isotropic approximation (sometimes called a
+/// "lossy buffer" or scalar PML): instead of stretching the spatial
+/// coordinate via a tensor `Λ = diag(s_r, s_θ, s_φ)`, we collapse the
+/// stretching to a scalar `s_r → 1 + (i/ω) σ(r)` and absorb it into a
+/// scalar complex ε. It is **less effective** than a properly
+/// anisotropic split-field PML — the tangential field components do not
+/// see the absorption — but it requires no changes to the constitutive
+/// tensor data path and is a defensible v0 starting point.
+///
+/// # Profile
+///
+/// - Tet centroid `r_c ≤ R_SPHERE`: `ε = n_inside² + 0j` (real dielectric).
+/// - Tet centroid `r_c > R_SPHERE`: smooth quadratic absorption ramp
+///   anchored at the dielectric interface,
+///
+///   ```text
+///   ε(r) = 1 − j σ₀ ((r_c − R_SPHERE) / (R_BUFFER − R_SPHERE))²
+///   ```
+///
+///   The `r → R_SPHERE` limit returns `ε = 1` (matches the vacuum) and
+///   the `r → R_BUFFER` limit gives the full absorption `ε = 1 − jσ₀`.
+///   The quadratic profile is the standard low-reflection start point
+///   for discrete PMLs.
+///
+/// # Sign convention
+///
+/// We use the `exp(+jωt)` time convention (same as the rest of the
+/// codebase — see `silvermuller.rs`). Outgoing-wave attenuation
+/// therefore requires `Im(ε) < 0`, which is what the ramp produces.
+///
+/// `physical_tags.len()` and `centroid_radii.len()` must both equal the
+/// number of tets in the mesh.
+pub fn build_complex_epsilon_r_pml(
+    physical_tags: &[i32],
+    centroid_radii: &[f64],
+    n_inside: f64,
+    sigma_0: f64,
+) -> Vec<faer::c64> {
+    use crate::mesh::{R_BUFFER, R_SPHERE};
+    assert_eq!(
+        physical_tags.len(),
+        centroid_radii.len(),
+        "physical_tags and centroid_radii length mismatch"
+    );
+    let eps_inside = n_inside * n_inside;
+    let width = R_BUFFER - R_SPHERE;
+
+    physical_tags
+        .iter()
+        .zip(centroid_radii.iter())
+        .map(|(&tag, &r_c)| {
+            if tag == crate::mesh::PHYS_SPHERE_INTERIOR {
+                faer::c64::new(eps_inside, 0.0)
+            } else {
+                // Buffer region — apply quadratic PML ramp anchored at
+                // r = R_SPHERE. Clamp to the [0, 1] normalized range so
+                // any tet whose centroid drifts slightly outside R_BUFFER
+                // (mesh nodes on the outer wall + interior tet) does not
+                // overshoot.
+                let u = ((r_c - R_SPHERE) / width).clamp(0.0, 1.0);
+                let im = -sigma_0 * u * u;
+                faer::c64::new(1.0, im)
+            }
+        })
+        .collect()
+}
+
 /// Variant of [`assemble_global_nedelec`] that takes a per-element
 /// relative permittivity `epsilon_r: [n_elem]` and scales the mass
 /// matrix accordingly: `M_e ← epsilon_r[e] * M_e`. Stiffness (curl-
@@ -333,4 +448,90 @@ pub fn assemble_global_nedelec_with_epsilon<B: Backend>(
     let sparsity = sparsity_pattern_from_tet_edges(tet_edge_idx);
 
     NedelecGlobalSystem { k, m, sparsity }
+}
+
+/// Variant of [`assemble_global_nedelec_with_epsilon`] that accepts a
+/// **complex** per-tet permittivity and returns the real K plus the
+/// real/imaginary parts of the complex-scaled mass matrix.
+///
+/// The implementation reuses the real-ε path twice: once with
+/// `Re(ε)` and once with `Im(ε)`. This avoids threading
+/// `Complex<f32>` through the Burn tensor pipeline (which currently
+/// has no complex dtype) and keeps the GPU/autodiff-friendly scatter
+/// path intact. The caller combines `m_re + j m_im` on the host side
+/// (e.g. via [`burn_complex_mass_to_faer`]) before handing the system
+/// to a complex eigensolver.
+///
+/// # Cost
+///
+/// Two extra scatter passes on the mass; stiffness is assembled once
+/// and shared (caller-side: see `K = sys.k`). For the bundled sphere
+/// fixture (~7k edges, ~1226 tets) this is dominated by the dense
+/// global matrix shape, so the cost difference vs the real path is
+/// in the noise.
+pub fn assemble_global_nedelec_with_complex_epsilon<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    n_edges: usize,
+    epsilon_r_complex: &[faer::c64],
+) -> NedelecComplexGlobalSystem<B> {
+    assert_eq!(
+        epsilon_r_complex.len(),
+        tet_edge_idx.len(),
+        "complex epsilon_r length mismatch"
+    );
+
+    let eps_re: Vec<f64> = epsilon_r_complex.iter().map(|c| c.re).collect();
+    let eps_im: Vec<f64> = epsilon_r_complex.iter().map(|c| c.im).collect();
+
+    // Real-part assembly produces K and Re(M); we reuse its K and
+    // sparsity, then run a second assembly with eps = Im(ε) and keep
+    // only the mass output.
+    let sys_re = assemble_global_nedelec_with_epsilon(
+        nodes.clone(),
+        tets.clone(),
+        tet_edge_idx,
+        tet_edge_sign,
+        n_edges,
+        &eps_re,
+    );
+    let sys_im = assemble_global_nedelec_with_epsilon(
+        nodes,
+        tets,
+        tet_edge_idx,
+        tet_edge_sign,
+        n_edges,
+        &eps_im,
+    );
+
+    NedelecComplexGlobalSystem {
+        k: sys_re.k,
+        m_re: sys_re.m,
+        m_im: sys_im.m,
+        sparsity: sys_re.sparsity,
+    }
+}
+
+/// Combine the real and imaginary parts of a Burn-resident complex
+/// mass matrix into an owned `faer::Mat<faer::c64>`.
+///
+/// Mirrors [`crate::eigen::burn_matrix_to_faer`] for complex inputs.
+/// Pulls both halves off the device once and zips them into the
+/// complex output.
+pub fn burn_complex_mass_to_faer<B: Backend>(
+    m_re: Tensor<B, 2>,
+    m_im: Tensor<B, 2>,
+) -> faer::Mat<faer::c64> {
+    let dims_re = m_re.dims();
+    let dims_im = m_im.dims();
+    assert_eq!(dims_re, dims_im, "M_re and M_im must have matching dims");
+    let data_re: Vec<f32> = m_re.into_data().to_vec().expect("readback Re");
+    let data_im: Vec<f32> = m_im.into_data().to_vec().expect("readback Im");
+    let n = dims_re[0];
+    faer::Mat::<faer::c64>::from_fn(n, dims_re[1], |i, j| {
+        let idx = i * dims_re[1] + j;
+        faer::c64::new(data_re[idx] as f64, data_im[idx] as f64)
+    })
 }

--- a/crates/geode-core/tests/sphere_pml_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pml_eigenmode.rs
@@ -1,0 +1,365 @@
+//! Scalar-PML dielectric-sphere eigenmode integration test (issue #28).
+//!
+//! Replaces the Silver-Müller absorbing boundary (#27) with a scalar
+//! perfectly-matched-layer (PML) realized as a complex permittivity in
+//! the existing `vacuum_buffer` region of the bundled sphere fixture.
+//!
+//! # Approach (scope-reduction Option 2)
+//!
+//! For this v0 cut we reuse the existing fixture topology — no new mesh
+//! is generated — and treat the entire vacuum buffer (`R_SPHERE < r ≤
+//! R_BUFFER`) as the PML. The outer wall stays PEC; the PML absorbs
+//! outgoing radiation **before** it reaches the wall, so the PEC
+//! boundary condition is essentially unreachable for well-trapped
+//! modes.
+//!
+//! The PML is a UPML reduced to a scalar isotropic complex ε via the
+//! standard quadratic absorption ramp,
+//!
+//! ```text
+//! ε_r(r) = 1 − j σ₀ ((r − R_SPHERE) / (R_BUFFER − R_SPHERE))²
+//! ```
+//!
+//! This is **less effective** than a fully anisotropic split-field PML
+//! (the tangential field components do not see the absorption) but it
+//! requires no constitutive-tensor refactor and is a defensible
+//! starting point. See [`geode_core::build_complex_epsilon_r_pml`] for
+//! the profile and sign-convention discussion.
+//!
+//! # Acceptance (soft)
+//!
+//! 1. The complex generalized eigensolver runs without panic in release
+//!    mode on the full (PEC-reduced) edge system with complex M.
+//! 2. Spurious gradient modes still cluster near zero — the gradient
+//!    kernel survives the lossy-ε scaling because gradients of H¹_0
+//!    are not amplified or suppressed by `ε(x)` scalar scaling on the
+//!    mass.
+//! 3. At least one of the lowest physical modes has non-trivial Im(λ)
+//!    (the PML absorbs radiation — that's the whole point).
+//! 4. Q-factor of the lowest physical mode is computed and printed; the
+//!    Silver-Müller baseline from #27 reported Q ≈ 0.5 for the same
+//!    fixture. We do **not** hard-assert "Q > Silver-Müller" — see the
+//!    PR body for the negative-result discussion if the absorption is
+//!    weaker than hoped.
+//!
+//! # Running
+//!
+//! ```sh
+//! cargo test -p geode-core --release --test sphere_pml_eigenmode -- --ignored
+//! ```
+//!
+//! Marked `#[ignore]` because faer 0.24's `gevd` path panics under
+//! `debug-assertions` (same root cause as the PEC and Silver-Müller
+//! tests).
+
+use burn::tensor::backend::BackendTypes;
+
+use geode_core::{
+    apply_dirichlet_bc, assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
+    burn_complex_mass_to_faer, burn_matrix_to_faer, read_sphere_fixture, sphere_n_interior_nodes,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh, ComplexEigenSolver, DefaultBackend,
+    FaerComplexEigensolver, R_BUFFER, R_SPHERE,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+#[test]
+fn pml_profile_is_real_inside_imag_in_buffer() {
+    // Smoke: the PML profile produces real ε in the dielectric region
+    // and a strictly negative imaginary part in the vacuum buffer
+    // (using the exp(+jωt) convention).
+    let f = read_sphere_fixture().expect("fixture load");
+    let radii = tet_centroid_radii(&f.mesh);
+    let eps = build_complex_epsilon_r_pml(&f.tet_physical_tags, &radii, 1.5, 5.0);
+
+    assert_eq!(eps.len(), f.mesh.n_tets());
+
+    let n_interior_real_only = eps
+        .iter()
+        .zip(f.tet_physical_tags.iter())
+        .filter(|(c, &t)| {
+            t == geode_core::PHYS_SPHERE_INTERIOR
+                && c.im.abs() < 1e-12
+                && (c.re - 2.25).abs() < 1e-9
+        })
+        .count();
+    let n_buffer = f
+        .tet_physical_tags
+        .iter()
+        .filter(|&&t| t == geode_core::PHYS_VACUUM_BUFFER)
+        .count();
+    assert_eq!(
+        n_interior_real_only,
+        f.n_interior_tets(),
+        "all interior tets must have real ε = 2.25"
+    );
+
+    let n_lossy = eps
+        .iter()
+        .zip(f.tet_physical_tags.iter())
+        .filter(|(c, &t)| t == geode_core::PHYS_VACUUM_BUFFER && c.im < 0.0)
+        .count();
+    assert_eq!(
+        n_lossy, n_buffer,
+        "every buffer tet must carry strictly-negative Im(ε)"
+    );
+
+    // Re(ε) in the buffer is exactly 1 by construction.
+    for (c, &t) in eps.iter().zip(f.tet_physical_tags.iter()) {
+        if t == geode_core::PHYS_VACUUM_BUFFER {
+            assert!(
+                (c.re - 1.0).abs() < 1e-12,
+                "buffer tet has Re(ε) = {} (expected 1)",
+                c.re
+            );
+        }
+    }
+    eprintln!(
+        "PML profile: {} interior tets at ε = 2.25 + 0j, {} buffer tets with Im(ε) < 0",
+        n_interior_real_only, n_lossy
+    );
+}
+
+#[test]
+#[ignore = "faer 0.24 gevd panics under debug-assertions; run with --release"]
+fn sphere_pml_eigenmode_spectrum() {
+    // 1. Load the sphere fixture.
+    let f = read_sphere_fixture().expect("fixture load");
+    eprintln!(
+        "sphere fixture: {} nodes, {} tets, {} boundary triangles",
+        f.mesh.n_nodes(),
+        f.mesh.n_tets(),
+        f.boundary_triangles.len(),
+    );
+
+    // 2. PML profile: real ε = n² in the dielectric, quadratic absorption
+    //    ramp in the buffer. σ₀ = 5.0 is a starting absorption strength;
+    //    tuning belongs to a follow-up.
+    let n_index = 1.5_f64;
+    let sigma_0 = 5.0_f64;
+    let radii = tet_centroid_radii(&f.mesh);
+    let eps_complex = build_complex_epsilon_r_pml(&f.tet_physical_tags, &radii, n_index, sigma_0);
+    eprintln!(
+        "PML profile: dielectric ε = {} + 0j, max |Im(ε)| in buffer = {}",
+        n_index * n_index,
+        sigma_0,
+    );
+
+    // 3. Edge tables and sign convention.
+    let edges = f.mesh.edges();
+    let n_edges = edges.len();
+    let tet_edges = f.mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+    eprintln!("global edges: {n_edges}");
+
+    // 4. Upload + assemble K (real) and complex M.
+    let (nodes_t, tets_t) = upload_mesh::<B>(&f.mesh, &device());
+    let sys = assemble_global_nedelec_with_complex_epsilon(
+        nodes_t,
+        tets_t,
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_complex,
+    );
+
+    // 5. PEC outer-wall reduction. The PML does the absorbing; the
+    //    outer wall is PEC. Reuse the existing real-only mask helper
+    //    and apply it to K, Re(M), Im(M) independently before
+    //    recombining.
+    let (mask_edges, interior_mask) = sphere_pec_interior_edges(&f.mesh, R_BUFFER);
+    assert_eq!(mask_edges.len(), n_edges, "edge ordering mismatch");
+    let n_interior_edges = interior_mask.iter().filter(|&&b| b).count();
+    eprintln!(
+        "PEC reduction: {} edges → {} interior DOFs",
+        n_edges, n_interior_edges
+    );
+
+    let k_full = burn_matrix_to_faer(sys.k);
+    let m_complex_full = burn_complex_mass_to_faer(sys.m_re, sys.m_im);
+
+    // Reduce K (real) and the two halves of M individually so we can
+    // re-zip them after; faer 0.24's gevd needs the full pencil at
+    // call time anyway.
+    // Use the existing real-only Dirichlet reduction on K; do the
+    // analogous slice on M_complex by hand using the same mask.
+    let dummy_zero = faer::Mat::<f64>::zeros(k_full.nrows(), k_full.ncols());
+    let (k_int, _) = apply_dirichlet_bc(k_full.as_ref(), dummy_zero.as_ref(), &interior_mask)
+        .expect("BC reduction K");
+
+    let interior_idx: Vec<usize> = interior_mask
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &b)| if b { Some(i) } else { None })
+        .collect();
+    let dim = interior_idx.len();
+    let m_int_complex = faer::Mat::<faer::c64>::from_fn(dim, dim, |i, j| {
+        m_complex_full[(interior_idx[i], interior_idx[j])]
+    });
+    let k_int_complex =
+        faer::Mat::<faer::c64>::from_fn(dim, dim, |i, j| faer::c64::new(k_int[(i, j)], 0.0));
+
+    // 6. Solve the complex generalized eigenproblem.
+    //    Request enough eigenvalues to skip past the gradient nullspace
+    //    plus the lowest few physical modes.
+    let spurious_dim = sphere_n_interior_nodes(&f.mesh, R_BUFFER);
+    let n_request = spurious_dim + 10;
+    eprintln!("predicted spurious-mode count: {spurious_dim}, requesting {n_request} eigenvalues",);
+
+    let solver = FaerComplexEigensolver;
+    let lambdas = solver
+        .smallest_complex_pencil_eigenvalues(
+            k_int_complex.as_ref(),
+            m_int_complex.as_ref(),
+            n_request,
+        )
+        .expect("complex eigensolve");
+
+    eprintln!(
+        "lowest {} complex eigenvalues λ = k² (sorted by |Re(λ)|):",
+        lambdas.len()
+    );
+    for (i, lam) in lambdas.iter().enumerate() {
+        eprintln!("  λ[{i:>3}] = {:.4e} + {:.4e}i", lam.re, lam.im);
+    }
+
+    // 7. Spurious-mode filter. The gradient kernel of the Whitney
+    //    1-form basis is independent of the mass scaling, so we expect
+    //    the same `spurious_dim`-sized cluster as the PEC test (modulo
+    //    tiny imaginary perturbations from the lossy ε scaling on the
+    //    mass-matrix gradient block).
+    //
+    //    Detect by relative-magnitude jump: anything below 1e-3 of the
+    //    largest |λ| in the requested slice is treated as spurious.
+    let max_abs = lambdas
+        .iter()
+        .map(|l| l.re.hypot(l.im))
+        .fold(0.0_f64, f64::max);
+    let spurious_threshold = 1e-3 * max_abs;
+    let first_physical = lambdas
+        .iter()
+        .position(|l| l.re.hypot(l.im) > spurious_threshold)
+        .expect("at least one mode above the spurious threshold");
+    let n_spurious = first_physical;
+    eprintln!(
+        "max |λ| = {max_abs:.3e}, spurious threshold {spurious_threshold:.3e}, \
+         {n_spurious} spurious modes (predicted ≥ {spurious_dim})"
+    );
+
+    // Acceptance 1: spurious cluster still present.
+    assert!(
+        n_spurious >= spurious_dim,
+        "observed spurious count {n_spurious} below predicted floor \
+         {spurious_dim} — the gradient kernel was unexpectedly lifted by the PML"
+    );
+
+    // 8. Physical modes — first few above the spurious cluster.
+    let physical: Vec<(usize, faer::c64)> = lambdas
+        .iter()
+        .enumerate()
+        .skip(first_physical)
+        .take(5)
+        .map(|(i, l)| (i, *l))
+        .collect();
+    eprintln!("first physical-mode candidates:");
+    for (i, lam) in physical.iter() {
+        eprintln!("  λ[{i:>3}] = {:.4e} + {:.4e}i", lam.re, lam.im);
+    }
+
+    // Acceptance 2: at least one oscillatory mode (Re(λ) > 0).
+    let n_oscillatory = physical.iter().filter(|(_, l)| l.re > 0.0).count();
+    assert!(
+        n_oscillatory > 0,
+        "no oscillatory mode (Re > 0) in first 5 physical candidates — \
+         the PML profile may be over-absorbing"
+    );
+
+    // Acceptance 3: PML is absorbing — at least one mode has Im(λ) ≠ 0.
+    let n_radiating = physical
+        .iter()
+        .filter(|(_, l)| l.im.abs() > 1e-3 * l.re.hypot(l.im).max(1.0))
+        .count();
+    eprintln!(
+        "radiating modes among first 5 physical: {} / {}",
+        n_radiating,
+        physical.len()
+    );
+    assert!(
+        n_radiating > 0,
+        "no radiating mode (all Im(λ) ≈ 0) — PML is not coupling in"
+    );
+
+    // 9. Q-factor diagnostic for the first 5 physical modes.
+    //    k = sqrt(λ) with Re(k) > 0 branch.
+    eprintln!(
+        "\nQ-factor diagnostic (PML, σ₀ = {sigma_0}). \
+         Silver-Müller baseline from #27 had Q ≈ 0.5 for the ground mode."
+    );
+    let mut best_q: Option<f64> = None;
+    for (i, lam) in physical.iter() {
+        let r = (lam.re * lam.re + lam.im * lam.im).sqrt();
+        let re_k = ((r + lam.re) / 2.0).sqrt();
+        let im_k_mag = ((r - lam.re) / 2.0).sqrt();
+        let im_k = if lam.im >= 0.0 { im_k_mag } else { -im_k_mag };
+        let q = if im_k.abs() > 1e-12 {
+            re_k / (2.0 * im_k.abs())
+        } else {
+            f64::INFINITY
+        };
+        eprintln!(
+            "  λ[{i:>3}] = {:.4e} + {:.4e}i → k = {:.4} + {:.4e}i → Q = {:.3e}",
+            lam.re, lam.im, re_k, im_k, q
+        );
+        if q.is_finite() {
+            best_q = match best_q {
+                Some(prev) if prev > q => Some(prev),
+                _ => Some(q),
+            };
+        }
+    }
+
+    eprintln!(
+        "\nsoft acceptance: {} spurious modes near zero, {} physical inspected, {} radiating",
+        n_spurious,
+        physical.len(),
+        n_radiating
+    );
+    if let Some(q) = best_q {
+        eprintln!(
+            "best Q among first 5 physical modes: {:.3e}. \
+             Silver-Müller #27 reference: ≈ 0.5.",
+            q
+        );
+    }
+
+    // Sanity: the inner sphere has roughly R_SPHERE = 1 and refractive
+    // index n = 1.5, so a naive dielectric Mie mode lies near
+    // k ≈ π / (n·R) ≈ 2.1. With the PEC outer wall on a coarse mesh
+    // the ground mode wanders, but values outside [0.1, 20] would
+    // indicate a gross scaling failure.
+    let k_ground_re_sq = physical[0].1.re;
+    assert!(
+        (0.01..=400.0).contains(&k_ground_re_sq),
+        "ground Re(k²) = {k_ground_re_sq:.4} outside the plausibility band [0.01, 400]"
+    );
+
+    // Sanity: R_SPHERE matches the fixture convention used by the
+    // PML profile. Both constants come from the same module so this is
+    // really a self-consistency reminder for anyone editing either.
+    eprintln!(
+        "fixture invariants: R_SPHERE = {R_SPHERE}, R_BUFFER = {R_BUFFER} \
+         (PML thickness = {})",
+        R_BUFFER - R_SPHERE,
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **scalar-isotropic perfectly matched layer** absorbing boundary
for the dielectric-sphere eigenproblem, following on from the Silver-
Müller path in #27. The PML is realized as a complex-valued, per-tet
relative permittivity in the existing `vacuum_buffer` region — no new
mesh, no constitutive-tensor refactor.

Closes #28.

## Scope ladder picked

The issue spec laid out four scope options (full anisotropic PML → API
passthrough). This PR ships **Option 2 (scalar complex PML)**: the
existing `vacuum_buffer` is repurposed as the PML region with a smooth
quadratic absorption ramp. This is a UPML reduced to scalar isotropic;
the tangential field components do not see the absorption (so it is
strictly less effective than a full anisotropic PML) but it requires
no constitutive-tensor refactor and the implementation surface is
small.

## PML profile

Quadratic ramp anchored at the dielectric interface:

```text
ε_r(r) = 1 − j σ₀ ((r − R_SPHERE) / (R_BUFFER − R_SPHERE))²
```

with `σ₀ = 5.0` for v0 (tuning vs reflection at the inner PML interface
deferred to a follow-up). Sign convention is `exp(+jωt)` (matching the
Silver-Müller path), so attenuating ε has `Im(ε) < 0`.

## API additions

- `tet_centroid_radii(&mesh) → Vec<f64>` — per-tet centroid `|c_e|`.
- `build_complex_epsilon_r_pml(tags, radii, n_inside, σ₀) → Vec<c64>` —
  applies the ramp.
- `assemble_global_nedelec_with_complex_epsilon(...)` returning a new
  `NedelecComplexGlobalSystem { k, m_re, m_im, sparsity }`. Burn has
  no complex dtype, so the impl runs the existing real-ε assembly
  twice (once for `Re(ε)`, once for `Im(ε)`) and the host-side caller
  zips the halves into `Mat<c64>`. The GPU scatter / autodiff path
  stays intact.
- `burn_complex_mass_to_faer(m_re, m_im) → Mat<c64>`.
- `ComplexEigenSolver::smallest_complex_pencil_eigenvalues(K, M)` for
  fully-complex pencils. The existing Silver-Müller method
  `smallest_complex_eigenvalues` is unchanged — the two coexist.

## Observed Q vs Silver-Müller baseline

Release-mode run on the bundled sphere fixture (~313 nodes, 1226 tets):

| metric | PEC (#26) | Silver-Müller (#27) | **PML (this PR)** |
|---|---|---|---|
| ground mode λ = k² | ~real | complex, small Im | **0.898 + 0.464j** |
| ground k | ~real | small Q | **0.977 + 0.238j** |
| ground Q | ∞ (closed cavity) | ~0.5 | **~2.06** |
| spurious mode count | 118 | ≥ 118 | **exactly 118** |
| radiating modes / 5 inspected | 0 | ≥ 1 | **5 / 5** |

The PML gives roughly **4× the Q of Silver-Müller** on the same
fixture. Intuition: Silver-Müller absorbs *at* the boundary (and
imperfectly, with reflection that grows away from the matched `k₀`);
the PML absorbs the outgoing wave *throughout the buffer*, so modes
that decay smoothly into the buffer effectively never reach the wall.

The 118 spurious-mode count matches the predicted gradient-kernel
dimension exactly — the lossy ε does not lift the kernel, which is the
expected behaviour for scalar-isotropic scaling on the mass matrix.

## What's deferred

- Layered fixture with explicit `pml_shell` physical group, leaving a
  real vacuum gap between sphere and absorber (Option 3 in the spec).
- Fully anisotropic split-field PML with per-tet 3×3 complex
  constitutive tensors (Option 1 — the "real" PML).
- σ₀ tuning vs reflection at the inner PML interface.
- Quantitative Mie-root match (still gated on Mie root tables).

## Test plan

- [x] `cargo build -p geode-core` — clean.
- [x] `cargo fmt --all` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p geode-core` (debug, non-ignored) — all pass,
  including new `pml_profile_is_real_inside_imag_in_buffer`.
- [x] `cargo test -p geode-core --release --test sphere_pml_eigenmode -- --ignored`
  — pass with Q ≈ 2.06 for ground mode (vs Silver-Müller ≈ 0.5),
  5/5 radiating, 118 spurious modes matching prediction.

The integration test is `#[ignore]`d for the same faer 0.24 debug-
assertions reason as the PEC and Silver-Müller tests; the docstring
documents the `--release` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)