### PR TITLE
Regenerate Mie benchmark results.toml on layered fixture

### DIFF
--- a/benchmarks/mie_sphere/results.toml
+++ b/benchmarks/mie_sphere/results.toml
@@ -5,7 +5,7 @@
 
 [meta]
 description = "Mie sphere benchmark (issue #4 v1, issue #40): FEM eigenmodes vs. extended analytic PEC-cavity catalog (l ∈ [1,4], TE+TM, n ∈ [1,5]) with multiplicity-claim mode classification."
-generated_at_commit = "5396fb4ba762a456889fd0d1c4bb9ffac533ff8a"
+generated_at_commit = "a2fc43bc5e8339ff7d2d61d5b5fc6736ebe993c7"
 n_inside = 1.5
 sigma_0 = 5
 r_sphere = 1
@@ -28,10 +28,10 @@ n = 1
 m_idx = 0
 incomplete = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 9.767692068720364e-1
-fem_im_k = 2.376316520534408e-1
-rel_err_re_k = 2.506186663487455e-1
-q = 2.055216968008057e0
+fem_re_k = 1.106133193583890e0
+fem_im_k = 9.803138205773222e-2
+rel_err_re_k = 1.513700862271238e-1
+q = 5.641730078499103e0
 
 [mode_1]
 polarisation = "TM"
@@ -40,10 +40,10 @@ n = 1
 m_idx = 1
 incomplete = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 9.976574242831773e-1
-fem_im_k = 2.330815682112031e-1
-rel_err_re_k = 2.345931404506827e-1
-q = 2.140146541701586e0
+fem_re_k = 1.106599400780261e0
+fem_im_k = 9.700480406836774e-2
+rel_err_re_k = 1.510124101577756e-1
+q = 5.703838131564826e0
 
 [mode_2]
 polarisation = "TM"
@@ -52,10 +52,10 @@ n = 1
 m_idx = 2
 incomplete = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 1.007808045363144e0
-fem_im_k = 2.338648142096668e-1
-rel_err_re_k = 2.268055424093259e-1
-q = 2.154680790201331e0
+fem_re_k = 1.106901675821355e0
+fem_im_k = 9.566502062457638e-2
+rel_err_re_k = 1.507805035089680e-1
+q = 5.785299938235687e0
 
 [mode_3]
 polarisation = "TE"
@@ -64,10 +64,10 @@ n = 1
 m_idx = 0
 incomplete = false
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.353507841096154e0
-fem_im_k = 5.195302183921454e-1
-rel_err_re_k = 2.836435144650882e-1
-q = 1.302626674233716e0
+fem_re_k = 1.610802916978593e0
+fem_im_k = 2.547777610976749e-1
+rel_err_re_k = 1.474677268499142e-1
+q = 3.161192150442547e0
 
 [mode_4]
 polarisation = "TE"
@@ -76,10 +76,10 @@ n = 1
 m_idx = 1
 incomplete = false
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.359688666011950e0
-fem_im_k = 5.200636895559044e-1
-rel_err_re_k = 2.803722559766254e-1
-q = 1.307232838321228e0
+fem_re_k = 1.611054914404906e0
+fem_im_k = 2.595362820594396e-1
+rel_err_re_k = 1.473343548921043e-1
+q = 3.103718103729210e0
 
 [mode_5]
 polarisation = "TE"
@@ -88,10 +88,10 @@ n = 1
 m_idx = 2
 incomplete = false
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.365479790243979e0
-fem_im_k = 5.310823549792577e-1
-rel_err_re_k = 2.773072501627006e-1
-q = 1.285563131067789e0
+fem_re_k = 1.613911001880237e0
+fem_im_k = 2.611047077857281e-1
+rel_err_re_k = 1.458227443021343e-1
+q = 3.090543666498481e0
 
 [mode_6]
 polarisation = "TM"
@@ -100,10 +100,10 @@ n = 1
 m_idx = 0
 incomplete = true
 analytic_k = 1.890736585383276e0
-fem_re_k = 1.382084717902614e0
-fem_im_k = 5.237164430865181e-1
-rel_err_re_k = 2.690231264433653e-1
-q = 1.319497159338086e0
+fem_re_k = 1.614815995111759e0
+fem_im_k = 2.555629707531792e-1
+rel_err_re_k = 1.459328562236417e-1
+q = 3.159330928014874e0
 
 [mode_7]
 polarisation = "TM"
@@ -112,8 +112,8 @@ n = 1
 m_idx = 1
 incomplete = true
 analytic_k = 1.890736585383276e0
-fem_re_k = 1.387628643656011e0
-fem_im_k = 5.350636869619039e-1
-rel_err_re_k = 2.660909751345816e-1
-q = 1.296694839762887e0
+fem_re_k = 1.615084876780074e0
+fem_im_k = 2.591015691942202e-1
+rel_err_re_k = 1.457906462138534e-1
+q = 3.116702229559677e0
 


### PR DESCRIPTION
## Summary

Single-file mechanical update: `benchmarks/mie_sphere/results.toml` regenerated on current main after PRs #41 (Mie v1) and #42 (PML hardening: layered fixture) both landed.

## Numbers

| Metric | Pre-#42 fixture | Post-#42 layered |
|---|---|---|
| TM_1,1 rel err Re(k) | 22–25% | **15.1%** |
| TE_1,1 rel err Re(k) | ~28% | **14.7%** |
| TM_1,1 Q | 2.14 | **5.78** |
| TE_1,1 Q | 1.30 | **3.16** |

## Why

The PR #42 layered-fixture geometry inserts a real-vacuum gap (`R_SPHERE < r ≤ 1.5`) between the dielectric and the absorbing `pml_shell` (`1.5 < r ≤ R_BUFFER`). This decouples the wave from the lossy region before it enters, raising Q and tightening Re(k) agreement with the analytic PEC-cavity Mie roots. The improvement is the expected physics consequence of PR #42 — this PR just records it in the committed artifact.

## Verification

`cargo test -p geode-core` (default debug): green. The Mie regression test passes by a much wider margin (15% vs 30% bound). Q-band test now reads ~5.78 vs the 1.5 band — also passes.

## Not in scope

- Tightening the test bounds — separate follow-up (#42 judge suggestions, see #44).
- Open-space WGM root comparison — separate follow-up (re-scoped #33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
