### PR TITLE
Anisotropic-diagonal UPML for sphere PML (closes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,17 @@ error, higher-l modes would be worse — they aren't. This is the
 signature of an h-independent **scalar-isotropic PML reflection
 floor** at the inner PML interface. Refining further does not help.
 
-The canonical fix is **anisotropic UPML** with tensor permittivity
-(tracked as [#54](https://github.com/rjwalters/geode-fem/issues/54)).
-This is the next critical-path accuracy work and pairs naturally with
-the just-landed sparse complex Lanczos (PR #55) since UPML requires
-iterating at refined mesh where the dense eigensolve was previously
-intractable.
+**Anisotropic UPML breaks the ceiling** (issue #54). A diagonal
+anisotropic permittivity tensor in the global Cartesian basis,
+`ε_α = (1/s_r) r̂_α² + s_t (1 - r̂_α²)` per centroid radial unit
+vector `r̂`, is now available via
+[`assemble_global_nedelec_with_anisotropic_epsilon`] and
+[`build_anisotropic_pml_tensor_diag`]. On the bundled 774-node
+fixture the lowest TM_1,1 mode improves from **16% → ~6% rel err**
+(σ₀ = 5.0, k₀_ref = 2.0). The full off-diagonal rotation
+`R · diag(1/s_r, s_t, s_t) · R^T` is a follow-up; the diagonal-only
+approximation drops mixed-axis coupling for off-axis tets, so
+further accuracy gains are still on the table.
 
 The same physical problem is computed in the time domain by the sister
 project [`rjwalters/strata-fdtd`](https://github.com/rjwalters/strata-fdtd)

--- a/benchmarks/mie_sphere/results.toml
+++ b/benchmarks/mie_sphere/results.toml
@@ -17,7 +17,8 @@ notes = [
   "Analytic side is PEC-cavity dielectric resonator, not open-space Mie WGM.",
   "Real analytic roots only; complex open-space Mie roots are a separate axis (#33).",
   "Mode classification: walk catalog by ascending k, claim 2l+1 FEM modes per analytic root.",
-  "FEM side: scalar isotropic PML, bundled 774-node refined fixture (issue #49).",
+  "FEM side (this file): scalar isotropic PML, bundled 774-node refined fixture (issue #49).",
+  "Anisotropic UPML (issue #54) is now available via `assemble_global_nedelec_with_anisotropic_epsilon`; spot-check on the same fixture yields TM_1,1 rel err ≈ 5.7% (vs. 16.2% scalar). Full benchmark sweep with the new path is a follow-up — re-running the example with anisotropic ε is not yet wired into the example CLI.",
   "Driven scattering benchmark (Q_ext vs. ka) is v2 (separate scope).",
 ]
 

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -44,12 +44,16 @@ pub use mie::{
     psi_prime, resonance_roots, spherical_j, spherical_j_prime, spherical_y, spherical_y_prime,
     MiePolarisation, MieRoot,
 };
-pub use nedelec::{batched_nedelec_local_matrices, tet_edges, NedelecLocalMatrices};
+pub use nedelec::{
+    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices, tet_edges,
+    NedelecLocalMatrices,
+};
 pub use nedelec_assembly::{
-    assemble_global_nedelec, assemble_global_nedelec_with_complex_epsilon,
-    assemble_global_nedelec_with_epsilon, build_complex_epsilon_r_pml, build_epsilon_r,
+    assemble_global_nedelec, assemble_global_nedelec_with_anisotropic_epsilon,
+    assemble_global_nedelec_with_complex_epsilon, assemble_global_nedelec_with_epsilon,
+    build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, build_epsilon_r,
     burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
-    sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii,
+    sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii, tet_centroids,
     NedelecComplexGlobalSystem, NedelecGlobalSystem,
 };
 pub use p1::{batched_p1_local_matrices, P1LocalMatrices};

--- a/crates/geode-core/src/nedelec.rs
+++ b/crates/geode-core/src/nedelec.rs
@@ -267,3 +267,157 @@ pub fn batched_nedelec_local_matrices<B: Backend>(coords: Tensor<B, 3>) -> Nedel
         signed_volumes,
     }
 }
+
+/// Per-element Nédélec local mass matrix for a **diagonal anisotropic**
+/// permittivity tensor expressed in the global Cartesian basis.
+///
+/// The integrand becomes
+///
+/// ```text
+/// (N_i)^T · diag(ε_x, ε_y, ε_z) · N_j
+///    = ε_x N_{i,x} N_{j,x} + ε_y N_{i,y} N_{j,y} + ε_z N_{i,z} N_{j,z},
+/// ```
+///
+/// which is exactly the existing scalar mass formula with the gradient
+/// gram `G_pq = ∇λ_p · ∇λ_q` replaced by the per-component product
+/// `G^(α)_pq = (∇λ_p)_α (∇λ_q)_α`. The three per-axis local matrices
+/// are linearly combined per element with the supplied diagonal entries.
+///
+/// This is the **diagonal-only** UPML simplification (Option B in
+/// issue #54): the off-diagonal terms of the full rotation
+/// `R · diag(1/s_r, s_t, s_t) · R^T` are dropped. For axis-aligned
+/// directions (the dominant absorption channels on a Cartesian-ish
+/// mesh) the diagonal already carries the correct anisotropy; for
+/// off-axis tets it is an approximation, but still strictly more
+/// accurate than scalar-isotropic.
+///
+/// # Arguments
+///
+/// * `coords` — `[n_elem, 4, 3]` per-tet vertex coordinates.
+/// * `eps_diag` — `[n_elem, 3]` per-tet, per-axis weights to apply
+///   to the three component-product mass matrices before summing.
+///
+/// # Returns
+///
+/// `[n_elem, 6, 6]` local mass matrix (sign-unaware, same orientation
+/// caveat as [`batched_nedelec_local_matrices`]).
+pub fn batched_nedelec_local_mass_anisotropic_diag<B: Backend>(
+    coords: Tensor<B, 3>,
+    eps_diag: Tensor<B, 2>,
+) -> Tensor<B, 3> {
+    let dims = coords.dims();
+    let n_elem = dims[0];
+    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
+    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+    let eps_dims = eps_diag.dims();
+    assert_eq!(
+        eps_dims,
+        [n_elem, 3],
+        "expected eps_diag shape [n_elem, 3], got {:?}",
+        eps_dims
+    );
+
+    // Reuse the same per-vertex / edge / cofactor / det machinery as
+    // the scalar kernel.
+    let v0 = coords
+        .clone()
+        .slice([0..n_elem, 0..1, 0..3])
+        .squeeze_dim::<2>(1);
+    let v1 = coords
+        .clone()
+        .slice([0..n_elem, 1..2, 0..3])
+        .squeeze_dim::<2>(1);
+    let v2 = coords
+        .clone()
+        .slice([0..n_elem, 2..3, 0..3])
+        .squeeze_dim::<2>(1);
+    let v3 = coords.slice([0..n_elem, 3..4, 0..3]).squeeze_dim::<2>(1);
+
+    let e1 = v1 - v0.clone();
+    let e2 = v2 - v0.clone();
+    let e3 = v3 - v0;
+
+    let g1 = e2.clone().cross(e3.clone(), 1);
+    let g2 = e3.clone().cross(e1.clone(), 1);
+    let g3 = e1.clone().cross(e2.clone(), 1);
+
+    let det = e1.mul(g1.clone()).sum_dim(1).squeeze_dim::<1>(1);
+    let g0 = (g1.clone() + g2.clone() + g3.clone()).neg();
+
+    // Stack into G: [n_elem, 4, 3] with row p = g_p (cofactor column,
+    // shape [3]).
+    let g_mat = Tensor::<B, 2>::stack::<3>(vec![g0, g1, g2, g3], 1); // [n_elem, 4, 3]
+
+    // Per-axis component product G^(α)_pq = g_p[α] g_q[α] / det²,
+    // captured here as gg^(α)_pq = g_p[α] g_q[α].
+    //
+    // Compute by slicing the α-column out of g_mat, getting a
+    // [n_elem, 4] tensor per axis, then forming the outer product
+    // [n_elem, 4, 4].
+    let abs_det = det.abs();
+    let inv_abs_det = abs_det.clone().recip();
+
+    // Per-axis epsilon weights: [n_elem] tensors for α ∈ {x, y, z}.
+    let eps_x = eps_diag
+        .clone()
+        .slice([0..n_elem, 0..1])
+        .squeeze_dim::<1>(1);
+    let eps_y = eps_diag
+        .clone()
+        .slice([0..n_elem, 1..2])
+        .squeeze_dim::<1>(1);
+    let eps_z = eps_diag.slice([0..n_elem, 2..3]).squeeze_dim::<1>(1);
+
+    let per_axis_gg = |alpha: usize| -> Tensor<B, 3> {
+        // g_mat[:, :, alpha] → [n_elem, 4]
+        let g_col = g_mat
+            .clone()
+            .slice([0..n_elem, 0..4, alpha..alpha + 1])
+            .squeeze_dim::<2>(2);
+        // outer product per element: [n_elem, 4, 1] × [n_elem, 1, 4]
+        let col_row = g_col.clone().unsqueeze_dim::<3>(2); // [n_elem, 4, 1]
+        let col_col = g_col.unsqueeze_dim::<3>(1); // [n_elem, 1, 4]
+        col_row.mul(col_col) // [n_elem, 4, 4]
+    };
+
+    let gg_x = per_axis_gg(0);
+    let gg_y = per_axis_gg(1);
+    let gg_z = per_axis_gg(2);
+
+    let gg_entry = |gg: &Tensor<B, 3>, p: usize, q: usize| -> Tensor<B, 1> {
+        gg.clone()
+            .slice([0..n_elem, p..p + 1, q..q + 1])
+            .squeeze_dim::<2>(1)
+            .squeeze_dim::<1>(1)
+    };
+
+    let mut m_entries: Vec<Tensor<B, 1>> = Vec::with_capacity(36);
+
+    for &(a, b) in TET_LOCAL_EDGES.iter() {
+        for &(c, d) in TET_LOCAL_EDGES.iter() {
+            let f_ac = if a == c { 2.0_f32 } else { 1.0_f32 };
+            let f_ad = if a == d { 2.0_f32 } else { 1.0_f32 };
+            let f_bc = if b == c { 2.0_f32 } else { 1.0_f32 };
+            let f_bd = if b == d { 2.0_f32 } else { 1.0_f32 };
+
+            // Per-axis closed-form integrand. Same shape as the scalar
+            // kernel but with G replaced by gg^(α) / det²; the /det²
+            // and (V/20) = (|det|/120) collapse into 1/(120 |det|).
+            let m_axis = |gg: &Tensor<B, 3>, eps: &Tensor<B, 1>| -> Tensor<B, 1> {
+                let term = gg_entry(gg, b, d).mul_scalar(f_ac)
+                    - gg_entry(gg, b, c).mul_scalar(f_ad)
+                    - gg_entry(gg, a, d).mul_scalar(f_bc)
+                    + gg_entry(gg, a, c).mul_scalar(f_bd);
+                term.mul(inv_abs_det.clone())
+                    .div_scalar(120.0)
+                    .mul(eps.clone())
+            };
+
+            let m_val = m_axis(&gg_x, &eps_x) + m_axis(&gg_y, &eps_y) + m_axis(&gg_z, &eps_z);
+            m_entries.push(m_val);
+        }
+    }
+
+    let m_stacked = Tensor::<B, 1>::stack::<2>(m_entries, 1); // [n_elem, 36]
+    m_stacked.reshape([n_elem, 6, 6])
+}

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -24,7 +24,7 @@ use burn::tensor::Tensor;
 use burn::tensor::{IndexingUpdateOp, Int, TensorData};
 
 use crate::assembly::{gather_tet_coords, SparsityPattern};
-use crate::nedelec::batched_nedelec_local_matrices;
+use crate::nedelec::{batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices};
 use crate::TetMesh;
 
 /// Assembled global Nédélec linear system in dense Burn-tensor form.
@@ -544,6 +544,248 @@ pub fn assemble_global_nedelec_with_complex_epsilon<B: Backend>(
         m_re: sys_re.m,
         m_im: sys_im.m,
         sparsity: sys_re.sparsity,
+    }
+}
+
+/// Build a per-tet **diagonal anisotropic** complex permittivity tensor
+/// in the global Cartesian basis for the bundled sphere fixture's PML
+/// shell (issue #54).
+///
+/// This implements the diagonal-only UPML simplification:
+/// `ε(x) = R · diag(1/s_r, s_t, s_t) · R^T`, restricted to its main
+/// diagonal entries (`ε_x, ε_y, ε_z`). For the simplified UPML
+/// `s_r = s_t = 1 - jσ(r)/ω` (Sacks et al. 1995, §III), the
+/// per-tet diagonal evaluates to
+///
+/// ```text
+/// ε_α(x) = (1/s_r) r̂_α² + s_t (1 - r̂_α²),     α ∈ {x, y, z},
+/// ```
+///
+/// where `r̂ = c / |c|` is the outward radial unit vector at the tet
+/// centroid `c`. Outside the PML shell (interior + vacuum gap) the
+/// tensor reduces to the real scalar `(ε_r, ε_r, ε_r)`.
+///
+/// # σ(r) profile
+///
+/// Same quadratic ramp as [`build_complex_epsilon_r_pml`]:
+/// `σ(r_c) = σ₀ · ((r_c − R_PML_INNER) / (R_BUFFER − R_PML_INNER))²`.
+/// `σ₀ = 0` collapses the tensor to the real scalar everywhere, which
+/// is the regression test point: with `n_inside = 1.0` it must
+/// reproduce the PEC-cavity numbers bit-identically.
+///
+/// # ω heuristic
+///
+/// The constitutive frequency `ω` is approximated by `k0_ref` (the
+/// reference wavenumber convention shared with Silver-Müller). For a
+/// driven eigenproblem the iteration over k₀ is left to follow-up
+/// #48.
+///
+/// # Sign convention
+///
+/// `exp(+jωt)` time convention. Outgoing absorption requires
+/// `Im(ε) < 0`, which is what the ramp produces.
+///
+/// `physical_tags.len()`, `centroid_radii.len()`, and `centroids.len()`
+/// must all equal the number of tets in the mesh.
+pub fn build_anisotropic_pml_tensor_diag(
+    physical_tags: &[i32],
+    centroids: &[[f64; 3]],
+    n_inside: f64,
+    sigma_0: f64,
+    k0_ref: f64,
+) -> Vec<[faer::c64; 3]> {
+    use crate::mesh::{R_BUFFER, R_PML_INNER};
+    assert_eq!(
+        physical_tags.len(),
+        centroids.len(),
+        "physical_tags and centroids length mismatch"
+    );
+    let eps_inside = n_inside * n_inside;
+    let width = R_BUFFER - R_PML_INNER;
+    let omega = k0_ref.max(1e-12);
+
+    physical_tags
+        .iter()
+        .zip(centroids.iter())
+        .map(|(&tag, c)| {
+            let r_c = (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt();
+            let eps_scalar = if tag == crate::mesh::PHYS_SPHERE_INTERIOR {
+                eps_inside
+            } else {
+                1.0
+            };
+
+            if tag != crate::mesh::PHYS_PML_SHELL || r_c <= R_PML_INNER {
+                // Interior dielectric or vacuum gap: real, isotropic.
+                let v = faer::c64::new(eps_scalar, 0.0);
+                return [v, v, v];
+            }
+
+            // PML shell: build s_r = s_t = 1 - jσ/ω and combine with
+            // r̂ to form the diagonal in Cartesian.
+            let u = ((r_c - R_PML_INNER) / width).clamp(0.0, 1.0);
+            let sigma = sigma_0 * u * u;
+            let s = faer::c64::new(1.0, -sigma / omega); // s_r = s_t = 1 - jσ/ω
+            let s_inv = faer::c64::new(1.0, 0.0) / s;
+
+            // Radial unit vector at the centroid. Guard against |c| ≈ 0
+            // (PML shell tets are always well away from the origin, but
+            // defensive guard is cheap).
+            let inv_r = if r_c > 1e-12 { 1.0 / r_c } else { 0.0 };
+            let rx = c[0] * inv_r;
+            let ry = c[1] * inv_r;
+            let rz = c[2] * inv_r;
+
+            // ε_α = s_inv · r̂_α² + s · (1 - r̂_α²)
+            let bg = faer::c64::new(eps_scalar, 0.0);
+            let mk = |r_alpha: f64| -> faer::c64 {
+                let w = r_alpha * r_alpha;
+                bg * (s_inv * w + s * (1.0 - w))
+            };
+            [mk(rx), mk(ry), mk(rz)]
+        })
+        .collect()
+}
+
+/// Compute per-tet centroids `(x, y, z)` for every tet in `mesh`.
+///
+/// Returned in `mesh.tets` order; companion to [`tet_centroid_radii`]
+/// for callers that need the full vector centroid (e.g. the
+/// anisotropic PML tensor builder, which needs the radial direction
+/// not just its magnitude).
+pub fn tet_centroids(mesh: &TetMesh) -> Vec<[f64; 3]> {
+    mesh.tets
+        .iter()
+        .map(|tet| {
+            let mut c = [0.0_f64; 3];
+            for &v in tet {
+                let p = mesh.nodes[v as usize];
+                c[0] += p[0];
+                c[1] += p[1];
+                c[2] += p[2];
+            }
+            c[0] *= 0.25;
+            c[1] *= 0.25;
+            c[2] *= 0.25;
+            c
+        })
+        .collect()
+}
+
+/// Anisotropic-ε variant of [`assemble_global_nedelec_with_complex_epsilon`].
+///
+/// Accepts a **diagonal** per-tet complex permittivity tensor in the
+/// global Cartesian basis (3 complex entries per tet) and assembles
+/// the resulting complex mass matrix using
+/// [`batched_nedelec_local_mass_anisotropic_diag`]. The stiffness
+/// (curl-curl) and sparsity pattern are computed exactly as in the
+/// scalar path.
+///
+/// Returns the same [`NedelecComplexGlobalSystem`] struct as the
+/// scalar-ε complex assembler so downstream eigensolvers and PEC
+/// reductions don't have to branch on the PML variant.
+///
+/// # Implementation
+///
+/// Real and imaginary parts of the per-tet tensor are pushed through
+/// the new kernel as two separate Burn tensors (Re-pass, Im-pass),
+/// matching the two-pass split established for the scalar complex
+/// path. Stiffness is computed once via
+/// [`batched_nedelec_local_matrices`] and reused — the curl-curl
+/// integrand is permittivity-independent.
+pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    n_edges: usize,
+    epsilon_tensor_diag: &[[faer::c64; 3]],
+) -> NedelecComplexGlobalSystem<B> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        epsilon_tensor_diag.len(),
+        n_elem,
+        "epsilon_tensor_diag length mismatch"
+    );
+
+    // 1. Compute element-local Nédélec stiffness (real, permittivity-
+    //    independent) and the anisotropic mass twice (Re-pass + Im-pass).
+    let coords = gather_tet_coords(nodes, tets);
+    let local = batched_nedelec_local_matrices(coords.clone());
+
+    let eps_re_flat: Vec<f32> = epsilon_tensor_diag
+        .iter()
+        .flat_map(|row| row.iter().map(|c| c.re as f32))
+        .collect();
+    let eps_im_flat: Vec<f32> = epsilon_tensor_diag
+        .iter()
+        .flat_map(|row| row.iter().map(|c| c.im as f32))
+        .collect();
+    let eps_re_tensor =
+        Tensor::<B, 2>::from_data(TensorData::new(eps_re_flat, [n_elem, 3]), &device);
+    let eps_im_tensor =
+        Tensor::<B, 2>::from_data(TensorData::new(eps_im_flat, [n_elem, 3]), &device);
+
+    let m_local_re = batched_nedelec_local_mass_anisotropic_diag(coords.clone(), eps_re_tensor);
+    let m_local_im = batched_nedelec_local_mass_anisotropic_diag(coords, eps_im_tensor);
+
+    // 2. Sign outer product.
+    let sign_flat: Vec<f32> = tet_edge_sign
+        .iter()
+        .flat_map(|row| row.iter().map(|&s| s as f32))
+        .collect();
+    let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), &device);
+    let sign_row = sign_2d.clone().unsqueeze_dim::<3>(2);
+    let sign_col = sign_2d.unsqueeze_dim::<3>(1);
+    let sign_outer = sign_row.mul(sign_col);
+
+    let k_signed = local.k_local.mul(sign_outer.clone());
+    let m_re_signed = m_local_re.mul(sign_outer.clone());
+    let m_im_signed = m_local_im.mul(sign_outer);
+
+    // 3. Flat scatter indices.
+    let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
+    let n_edges_i32 = n_edges as i32;
+    for row in tet_edge_idx {
+        for i in 0..6 {
+            for j in 0..6 {
+                linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
+            }
+        }
+    }
+    let flat_indices =
+        Tensor::<B, 1, Int>::from_data(TensorData::new(linear_idx, [n_elem * 36]), &device);
+
+    // 4. Scatter-add into flat zero tensors.
+    let k_flat = k_signed.reshape([n_elem * 36]);
+    let m_re_flat = m_re_signed.reshape([n_elem * 36]);
+    let m_im_flat = m_im_signed.reshape([n_elem * 36]);
+
+    let zeros_flat = Tensor::<B, 1>::zeros([n_edges * n_edges], &device);
+    let k_assembled =
+        zeros_flat
+            .clone()
+            .scatter(0, flat_indices.clone(), k_flat, IndexingUpdateOp::Add);
+    let m_re_assembled =
+        zeros_flat
+            .clone()
+            .scatter(0, flat_indices.clone(), m_re_flat, IndexingUpdateOp::Add);
+    let m_im_assembled = zeros_flat.scatter(0, flat_indices, m_im_flat, IndexingUpdateOp::Add);
+
+    let k = k_assembled.reshape([n_edges, n_edges]);
+    let m_re = m_re_assembled.reshape([n_edges, n_edges]);
+    let m_im = m_im_assembled.reshape([n_edges, n_edges]);
+
+    let sparsity = sparsity_pattern_from_tet_edges(tet_edge_idx);
+
+    NedelecComplexGlobalSystem {
+        k,
+        m_re,
+        m_im,
+        sparsity,
     }
 }
 

--- a/crates/geode-core/tests/sphere_pml_anisotropic_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pml_anisotropic_eigenmode.rs
@@ -1,0 +1,341 @@
+//! Anisotropic-UPML dielectric-sphere eigenmode integration test
+//! (issue #54).
+//!
+//! Replaces the **scalar-isotropic** PML's per-tet complex ε scalar
+//! with a **diagonal anisotropic** complex permittivity tensor in
+//! the global Cartesian basis. PR #52 showed that the scalar PML
+//! introduces a ~15-16% reflection-driven error ceiling on the
+//! lowest TM_1,1 Mie mode and that this ceiling is **independent of
+//! mesh refinement**. The UPML formulation absorbs along the
+//! propagation direction in a direction-aware way, which is the
+//! textbook fix.
+//!
+//! # What this test asserts
+//!
+//! 1. **σ₀ = 0 regression** — with absorption strength turned off,
+//!    the anisotropic tensor reduces to the scalar real-vacuum case
+//!    everywhere outside the dielectric, so the assembled mass
+//!    should match the scalar-ε path to within tight numerical
+//!    tolerance.
+//! 2. **Non-trivial radiation** — at nominal `σ₀ = 5.0` at least one
+//!    of the lowest physical modes carries non-zero Im(λ).
+//! 3. **Improvement vs scalar baseline** — the lowest TM_1,1 mode
+//!    has relative error strictly less than the documented 16%
+//!    scalar-PML ceiling. Soft assertion (eprintln + acceptance
+//!    band ≤ 15%) so the test is robust to release-rebuild drift.
+//!
+//! # Running
+//!
+//! ```sh
+//! cargo test -p geode-core --release \
+//!     --test sphere_pml_anisotropic_eigenmode -- --ignored
+//! ```
+
+use burn::tensor::backend::BackendTypes;
+
+use geode_core::{
+    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    assemble_global_nedelec_with_complex_epsilon, build_anisotropic_pml_tensor_diag,
+    build_complex_epsilon_r_pml, burn_complex_mass_to_faer, burn_matrix_to_faer, merged_roots,
+    read_sphere_fixture, sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii,
+    tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver,
+    MiePolarisation, R_BUFFER, R_SPHERE,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+#[test]
+fn anisotropic_pml_tensor_sigma_zero_is_isotropic() {
+    // σ₀ = 0 ⇒ the tensor must collapse to the real scalar in every
+    // tet (ε = n² inside, ε = 1 outside) on all three diagonal slots.
+    let f = read_sphere_fixture().expect("fixture load");
+    let centroids = tet_centroids(&f.mesh);
+    let eps = build_anisotropic_pml_tensor_diag(&f.tet_physical_tags, &centroids, 1.5, 0.0, 1.0);
+    assert_eq!(eps.len(), f.mesh.n_tets());
+
+    for (i, diag) in eps.iter().enumerate() {
+        let expected = if f.tet_physical_tags[i] == geode_core::PHYS_SPHERE_INTERIOR {
+            2.25
+        } else {
+            1.0
+        };
+        for (alpha, val) in diag.iter().enumerate() {
+            assert!(
+                val.im.abs() < 1e-12,
+                "σ₀ = 0 anisotropic ε_{alpha} on tet {i} has Im = {} (expected 0)",
+                val.im
+            );
+            assert!(
+                (val.re - expected).abs() < 1e-12,
+                "σ₀ = 0 anisotropic ε_{alpha} on tet {i} has Re = {} (expected {expected})",
+                val.re
+            );
+        }
+    }
+}
+
+#[test]
+fn anisotropic_pml_pml_shell_is_lossy() {
+    // At nominal σ₀, every PML-shell tet must carry non-zero
+    // imaginary content somewhere on its diagonal; tets outside the
+    // PML stay strictly real.
+    let f = read_sphere_fixture().expect("fixture load");
+    let centroids = tet_centroids(&f.mesh);
+    let eps = build_anisotropic_pml_tensor_diag(&f.tet_physical_tags, &centroids, 1.5, 5.0, 2.0);
+
+    let mut lossy_pml = 0usize;
+    for (diag, &tag) in eps.iter().zip(f.tet_physical_tags.iter()) {
+        let max_im = diag.iter().map(|c| c.im.abs()).fold(0.0_f64, f64::max);
+        if tag == geode_core::PHYS_PML_SHELL {
+            if max_im > 1e-12 {
+                lossy_pml += 1;
+            }
+        } else {
+            // Interior + gap: every slot must be strictly real.
+            for c in diag.iter() {
+                assert!(
+                    c.im.abs() < 1e-12,
+                    "non-PML tet (tag {tag}) leaked Im(ε) = {}",
+                    c.im
+                );
+            }
+        }
+    }
+    assert_eq!(
+        lossy_pml,
+        f.n_pml_shell_tets(),
+        "expected every PML-shell tet to carry imaginary ε"
+    );
+}
+
+#[test]
+#[ignore = "faer 0.24 gevd panics under debug-assertions; run with --release"]
+fn anisotropic_pml_sigma_zero_matches_scalar() {
+    // Bit-identical (to readback precision) reduction-to-scalar
+    // check: with σ₀ = 0 and identical ε_r, both pipelines must
+    // produce the same K and M matrices. This is the load-bearing
+    // sanity test for the new kernel — any disagreement points to a
+    // bug in `batched_nedelec_local_mass_anisotropic_diag`.
+    let f = read_sphere_fixture().expect("fixture load");
+
+    let edges = f.mesh.edges();
+    let n_edges = edges.len();
+    let tet_edges = f.mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+
+    let (nodes_t, tets_t) = upload_mesh::<B>(&f.mesh, &device());
+
+    // Scalar path: ε complex with σ₀ = 0.
+    let radii = tet_centroid_radii(&f.mesh);
+    let eps_scalar = build_complex_epsilon_r_pml(&f.tet_physical_tags, &radii, 1.5, 0.0);
+    let sys_scalar = assemble_global_nedelec_with_complex_epsilon(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_scalar,
+    );
+
+    // Anisotropic path: σ₀ = 0 ⇒ collapses to same scalar ε per tet.
+    let centroids = tet_centroids(&f.mesh);
+    let eps_aniso =
+        build_anisotropic_pml_tensor_diag(&f.tet_physical_tags, &centroids, 1.5, 0.0, 1.0);
+    let sys_aniso = assemble_global_nedelec_with_anisotropic_epsilon(
+        nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &eps_aniso,
+    );
+
+    let k_s = burn_matrix_to_faer(sys_scalar.k);
+    let m_s = burn_complex_mass_to_faer(sys_scalar.m_re, sys_scalar.m_im);
+    let k_a = burn_matrix_to_faer(sys_aniso.k);
+    let m_a = burn_complex_mass_to_faer(sys_aniso.m_re, sys_aniso.m_im);
+
+    assert_eq!(k_s.nrows(), k_a.nrows());
+    assert_eq!(k_s.ncols(), k_a.ncols());
+
+    let max_diff_k = (0..k_s.nrows())
+        .flat_map(|i| (0..k_s.ncols()).map(move |j| (i, j)))
+        .map(|(i, j)| (k_s[(i, j)] - k_a[(i, j)]).abs())
+        .fold(0.0_f64, f64::max);
+    let max_diff_m_re = (0..m_s.nrows())
+        .flat_map(|i| (0..m_s.ncols()).map(move |j| (i, j)))
+        .map(|(i, j)| (m_s[(i, j)].re - m_a[(i, j)].re).abs())
+        .fold(0.0_f64, f64::max);
+    let max_diff_m_im = (0..m_s.nrows())
+        .flat_map(|i| (0..m_s.ncols()).map(move |j| (i, j)))
+        .map(|(i, j)| (m_s[(i, j)].im - m_a[(i, j)].im).abs())
+        .fold(0.0_f64, f64::max);
+
+    eprintln!(
+        "scalar vs anisotropic-diag (σ₀=0): \
+         max |ΔK| = {max_diff_k:.3e}, max |ΔRe(M)| = {max_diff_m_re:.3e}, \
+         max |ΔIm(M)| = {max_diff_m_im:.3e}"
+    );
+
+    // Tolerance allows for f32 readback noise on the GPU path while
+    // catching anything bigger than a 6th-significant-figure drift.
+    assert!(
+        max_diff_k < 1e-3,
+        "K mismatch between scalar and anisotropic paths: {max_diff_k}"
+    );
+    assert!(
+        max_diff_m_re < 1e-3,
+        "Re(M) mismatch between scalar and anisotropic paths: {max_diff_m_re}"
+    );
+    assert!(
+        max_diff_m_im < 1e-9,
+        "Im(M) leaked at σ₀=0: {max_diff_m_im}"
+    );
+}
+
+#[test]
+#[ignore = "faer 0.24 gevd panics under debug-assertions; run with --release"]
+fn anisotropic_pml_beats_scalar_on_tm11() {
+    // The load-bearing acceptance test: anisotropic UPML must
+    // produce a lower relative error on the lowest TM_1,1 mode than
+    // the scalar-PML 16% ceiling documented in PR #52.
+
+    let f = read_sphere_fixture().expect("fixture load");
+
+    let edges = f.mesh.edges();
+    let n_edges = edges.len();
+    let tet_edges = f.mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+    eprintln!(
+        "anisotropic PML test: {} nodes, {} tets, {n_edges} edges",
+        f.mesh.n_nodes(),
+        f.mesh.n_tets()
+    );
+
+    let n_inside = 1.5_f64;
+    let sigma_0 = 5.0_f64;
+    let k0_ref = 2.0_f64;
+    let centroids = tet_centroids(&f.mesh);
+    let eps_aniso = build_anisotropic_pml_tensor_diag(
+        &f.tet_physical_tags,
+        &centroids,
+        n_inside,
+        sigma_0,
+        k0_ref,
+    );
+
+    let (nodes_t, tets_t) = upload_mesh::<B>(&f.mesh, &device());
+    let sys = assemble_global_nedelec_with_anisotropic_epsilon(
+        nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &eps_aniso,
+    );
+
+    // PEC outer reduction.
+    let (mask_edges, interior_mask) = sphere_pec_interior_edges(&f.mesh, R_BUFFER);
+    assert_eq!(mask_edges.len(), n_edges);
+    let dummy_zero = faer::Mat::<f64>::zeros(n_edges, n_edges);
+    let k_full = burn_matrix_to_faer(sys.k);
+    let m_full = burn_complex_mass_to_faer(sys.m_re, sys.m_im);
+    let (k_int, _) =
+        apply_dirichlet_bc(k_full.as_ref(), dummy_zero.as_ref(), &interior_mask).expect("BC K");
+    let interior_idx: Vec<usize> = interior_mask
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &b)| if b { Some(i) } else { None })
+        .collect();
+    let dim = interior_idx.len();
+    let m_int = faer::Mat::<faer::c64>::from_fn(dim, dim, |i, j| {
+        m_full[(interior_idx[i], interior_idx[j])]
+    });
+    let k_int_c =
+        faer::Mat::<faer::c64>::from_fn(dim, dim, |i, j| faer::c64::new(k_int[(i, j)], 0.0));
+    eprintln!("PEC reduction: {n_edges} → {dim} interior DOFs");
+
+    // Solve.
+    let spurious_dim = sphere_n_interior_nodes(&f.mesh, R_BUFFER);
+    let n_request = spurious_dim + 10;
+    let solver = FaerComplexEigensolver;
+    let lambdas = solver
+        .smallest_complex_pencil_eigenvalues(k_int_c.as_ref(), m_int.as_ref(), n_request)
+        .expect("complex eigensolve");
+
+    // Spurious skip via magnitude jump.
+    let max_abs = lambdas
+        .iter()
+        .map(|l| l.re.hypot(l.im))
+        .fold(0.0_f64, f64::max);
+    let thresh = 1e-3 * max_abs;
+    let first_physical = lambdas
+        .iter()
+        .position(|l| l.re.hypot(l.im) > thresh)
+        .expect("at least one physical mode");
+    eprintln!(
+        "{first_physical} spurious modes skipped (predicted ≥ {spurious_dim}); \
+         {} physical candidates returned",
+        lambdas.len() - first_physical
+    );
+
+    // Analytic TM_1,1 ground.
+    let analytic = merged_roots(n_inside, &[1, 2, 3], R_SPHERE, R_BUFFER, 3);
+    let ground = analytic
+        .iter()
+        .filter(|r| r.pol == MiePolarisation::TM && r.l == 1 && r.n == 1)
+        .min_by(|a, b| a.k.partial_cmp(&b.k).unwrap())
+        .expect("TM_1,1 analytic root");
+    eprintln!(
+        "analytic TM_1,1 ground k = {:.5} (k² = {:.5})",
+        ground.k,
+        ground.k * ground.k
+    );
+
+    // Pull first few physical modes; the ground TM_1,1 triplet is
+    // typically the lowest oscillatory cluster.
+    let mut physical: Vec<faer::c64> = lambdas
+        .iter()
+        .skip(first_physical)
+        .filter(|l| l.re > 0.0)
+        .copied()
+        .collect();
+    physical.sort_by(|a, b| a.re.partial_cmp(&b.re).unwrap());
+    eprintln!("first 6 oscillatory physical modes (sorted by Re(λ)):");
+    for (i, l) in physical.iter().take(6).enumerate() {
+        let r = (l.re * l.re + l.im * l.im).sqrt();
+        let re_k = ((r + l.re) / 2.0).sqrt();
+        eprintln!(
+            "  λ[{i}] = {:.4e} + {:.4e}i → Re(k) = {:.4}",
+            l.re, l.im, re_k
+        );
+    }
+
+    let best = physical.first().expect("at least one oscillatory mode");
+    let r = (best.re * best.re + best.im * best.im).sqrt();
+    let re_k = ((r + best.re) / 2.0).sqrt();
+    let rel_err = (re_k - ground.k).abs() / ground.k;
+    eprintln!(
+        "anisotropic-UPML TM_1,1 ground: Re(k) = {re_k:.4} \
+         vs analytic {:.4} → rel err = {:.2}%",
+        ground.k,
+        rel_err * 100.0
+    );
+    eprintln!("scalar-PML baseline from PR #52: rel err ≈ 16%.");
+
+    // Soft acceptance: must be strictly under 15% (margin for noise
+    // below the documented 16% scalar ceiling). Target ≤ 8%.
+    assert!(
+        rel_err < 0.15,
+        "anisotropic UPML did not beat the scalar 16% ceiling: rel err = {:.2}%",
+        rel_err * 100.0
+    );
+}


### PR DESCRIPTION
## Summary

Implements **diagonal anisotropic UPML** for the sphere eigenmode pipeline,
breaking the **16% scalar-PML reflection ceiling** documented in PR #52.

**Headline result** (bundled 774-node fixture, σ₀ = 5.0):

| mode    | analytic `k` | scalar PML `Re(k)` | aniso `Re(k)` | scalar rel err | **aniso rel err** |
|---------|--------------|--------------------|---------------|----------------|-------------------|
| TM_1,1  | 1.30343      | 1.0915 (mode 0)    | **1.2293**    | 16.26%         | **5.69%**         |
| TM_1,1  | 1.30343      | 1.0924 (mode 1)    | 1.2296        | 16.19%         | 5.67%             |
| TM_1,1  | 1.30343      | 1.0948 (mode 2)    | 1.2298        | 16.01%         | 5.65%             |

The TM_1,1 ground triplet rel err drops from ~16% to ~5.7% — a 3× gain
that breaks the mesh-independent scalar-PML ceiling (PR #52's smoking
gun). The next physical cluster (TE_1,1 / TM_2,1 at Re(k) ≈ 1.87) also
appears at much tighter error than the scalar baseline; full per-mode
re-tabulation across the catalog is a follow-up since the example CLI
doesn't yet have an --anisotropic switch.

## Implementation (Option B — diagonal-in-Cartesian UPML)

Per-tet ε is a diagonal complex tensor in {x̂, ŷ, ẑ}:

\`\`\`
ε_α(x) = (1/s_r) r̂_α² + s_t (1 - r̂_α²),   α ∈ {x, y, z}
\`\`\`

with s_r = s_t = 1 - jσ(r)/ω (simplified UPML, Sacks-Kingsland-Lee-Lee
1995 §III) and σ(r) the existing quadratic ramp. ω is approximated by
k0_ref (frequency-independent eigenproblem heuristic, same convention
as Silver-Müller).

This is the diagonal of the full UPML rotation
R · diag(1/s_r, s_t, s_t) · R^T. Off-diagonal coupling for non-axis-
aligned tets is dropped — that is an explicit simplification noted in
the rustdoc; further accuracy gain is on the table for a follow-up that
keeps the full 3×3 ε.

### New public API

- geode_core::batched_nedelec_local_mass_anisotropic_diag(coords, eps_diag)
- geode_core::build_anisotropic_pml_tensor_diag(physical_tags, centroids, n_inside, sigma_0, k0_ref)
- geode_core::assemble_global_nedelec_with_anisotropic_epsilon(...) returning the same NedelecComplexGlobalSystem as the scalar complex path
- geode_core::tet_centroids(mesh) companion to tet_centroid_radii

The new kernel reuses the existing closed-form mass identity:
∫ N_{i,α} N_{j,α} dV has the same form as the scalar kernel with
G_pq = ∇λ_p · ∇λ_q replaced by the component product
G^(α)_pq = (∇λ_p)_α (∇λ_q)_α. Three per-axis 6×6 closed-form
matrices, weighted by per-tet ε_α, summed elementwise — no quadrature.

## Test plan

- [x] anisotropic_pml_tensor_sigma_zero_is_isotropic (unit) — σ₀=0 collapses to scalar real ε.
- [x] anisotropic_pml_pml_shell_is_lossy (unit) — PML shell carries Im(ε); gap stays real.
- [x] anisotropic_pml_sigma_zero_matches_scalar (release-only) — load-bearing: σ₀=0 K, M_Re, M_Im match the scalar path to f32 readback precision (max|ΔK| = 0, max|ΔRe(M)| = 1.2e-7, max|ΔIm(M)| = 0).
- [x] anisotropic_pml_beats_scalar_on_tm11 (release-only) — TM_1,1 rel err < 15% (asserted); observed 5.69%.
- [x] cargo fmt -p geode-core --check clean.
- [x] cargo clippy -p geode-core --tests -- -D warnings clean (debug + release).
- [x] Existing sphere_pml_eigenmode and mie_sphere tests untouched (new functions only).

## Deferred (follow-ups)

- Full off-diagonal R · diag(1/s_r, s_t, s_t) · R^T rotation — keeps mixed-axis coupling for non-axis-aligned tets. The diagonal-only approximation drops these; on coarse meshes it is still strictly better than scalar, but the remaining gap to the FEM h-error floor is partly here.
- Wire --anisotropic into examples/mie_sphere.rs and re-generate benchmarks/mie_sphere/results.toml with the new path. The TOML notes section has been updated to point at the new function and the spot-check result; full re-tabulation is the follow-up.
- σ₀ / k0_ref tuning sweep is still open as #38; with the anisotropic path absorbing better per unit σ, the optimum probably shifts.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)