### PR TITLE
PML doc/test polish: tighten σ₀=0 tolerance + plane-wave/σ₀ upper-limit caveats

### DIFF
--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -344,12 +344,27 @@ pub fn tet_centroid_radii(mesh: &TetMesh) -> Vec<f64> {
 ///   `L = 0.5`, `k₀ ≈ 2`, so `σ₀ ≈ 5` gives `R(0) ≈ e⁻¹·⁷ ≈ 0.18`
 ///   at normal incidence — modest, deliberately so (heavy absorption
 ///   on a coarse mesh introduces its own discrete-PML reflections).
+///   This is the **normal-incidence plane-wave** reflection
+///   coefficient on a flat slab; the curved wavefronts emitted by a
+///   sphere have a different effective absorption (and the angle θ
+///   here is the local incidence angle on the PML inner interface,
+///   not the polar coordinate), so the formula is an order-of-
+///   magnitude guide rather than a precise reflection budget.
 /// - As a working rule, scale `σ₀ ∝ √ω` when changing the operating
 ///   frequency: low-k modes need stronger absorption per unit length
 ///   to attenuate the longer wavelength, while very-high-k modes are
 ///   already well-trapped and tolerate weaker σ₀.
 /// - If you refine the mesh inside the PML, you can usually push σ₀
 ///   higher without exciting numerical reflections.
+/// - **Practical upper limit on the bundled fixture.** The layered
+///   sphere fixture (post #42) sits near `Q ≈ 5.7` at `σ₀ = 5`, with
+///   headroom to push higher. The empirical sweet spot for this mesh
+///   density is roughly `σ₀ ∈ [5, 50]`: below 5 the absorption is too
+///   weak and outgoing energy reflects off the outer PEC wall; above
+///   ~50 the discrete jump in `Im(ε)` at the PML inner interface
+///   starts to dominate, and the reflection from the **discrete**
+///   interface (not the analytic profile) sets the floor. Mesh
+///   refinement inside the shell pushes this ceiling up.
 /// - `σ₀ = 0` reduces this routine to a real `ε = 1` everywhere
 ///   outside the dielectric (vacuum on both shells), recovering the
 ///   PEC-sphere eigenproblem. The `sphere_pml_eigenmode_sigma_zero`

--- a/crates/geode-core/tests/sphere_pml_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pml_eigenmode.rs
@@ -540,13 +540,21 @@ fn sphere_pml_eigenmode_sigma_zero_is_real() {
         lambdas.len()
     );
 
-    // Real-spectrum tolerance: f32 readback noise from the Burn
-    // backend dominates here, so use ~1e-5 rather than f64-precision.
-    // The point of the test is to catch *systematic* imag content, not
-    // to bound floating-point arithmetic to bit-for-bit zero.
+    // Real-spectrum tolerance: in practice the observed
+    // `max |Im(λ)| / max(|Re(λ)|, 1)` runs at ~2e-13 — small
+    // eigenvalues sit at f64 machine epsilon (~1e-16) while the
+    // largest eigenvalues (|λ| ~ 3) carry imaginary noise around
+    // ~1e-13 from f64 accumulation in the eigensolve. The complex
+    // pencil collapses to a real one when σ₀ = 0, so the lack of
+    // systematic imaginary content is the property we want to
+    // guard. We bound at 1e-10 — three orders of magnitude above
+    // the observed floor — to catch any regression that introduces
+    // *systematic* imaginary content (much tighter than the old
+    // 1e-5 bound, which would not have flagged a non-trivial
+    // Im(M) leak).
     assert!(
-        max_relative_im < 1e-5,
-        "σ₀ = 0 spectrum should be real to f32 readback noise; \
+        max_relative_im < 1e-10,
+        "σ₀ = 0 spectrum should be real to f64 precision; \
          observed max |Im(λ)|/|Re(λ)| = {max_relative_im:.3e}"
     );
 }


### PR DESCRIPTION
## Summary

Three non-blocking PR #42 follow-ups (per issue #44):

- **Tighten `sphere_pml_eigenmode_sigma_zero_is_real` tolerance** from `1e-5` → `1e-10`. Observed `max |Im(λ)|/|Re(λ)|` runs at ~`2e-13` on the bundled fixture (small eigenvalues sit at f64 machine epsilon ~`1e-16`; the largest `|λ| ~ 3` carry ~`1e-13` imaginary noise from f64 accumulation in the eigensolve). New bound still passes with three orders of magnitude of headroom and catches any systematic `Im(M)` leak well below f32-readback noise.
- **Plane-wave caveat** on `build_complex_epsilon_r_pml`: the `R(θ) ≈ exp(−2σ₀L cos θ · k₀ / 3)` formula is the **normal-incidence plane-wave** reflection coefficient on a flat slab. Sphere wavefronts have different effective absorption, so the formula is an order-of-magnitude guide rather than a precise reflection budget.
- **σ₀ upper-limit guidance**: documented the practical sweet spot `σ₀ ∈ [5, 50]` on the bundled fixture. Below 5 the absorption is too weak (outgoing energy reflects off the outer PEC wall); above ~50 the discrete jump in `Im(ε)` at the PML inner interface starts to dominate. Mesh refinement inside the shell pushes the ceiling up.

Pure doc/test polish — no behaviour change in `build_complex_epsilon_r_pml`.

## Test plan

- [x] `cargo build -p geode-core --release` succeeds
- [x] `cargo test -p geode-core --release --lib` — 43 passed
- [x] `cargo test -p geode-core --release sphere_pml_eigenmode_sigma_zero_is_real -- --ignored` passes with the tightened `1e-10` bound (observed `max |Im(λ)|/|Re(λ)| = 1.692e-13`)
- [x] `cargo doc -p geode-core --no-deps` builds (no new warnings from the edited block)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)