### PR TITLE
PML doc: fix R(0) worked numeric (0.18 → 0.036) and cite Bérenger/Taflove

### DIFF
--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -340,10 +340,12 @@ pub fn tet_centroid_radii(mesh: &TetMesh) -> Vec<f64> {
 ///
 /// - Theoretical reflection of the scalar-ε approximation is roughly
 ///   `R(θ) ≈ exp(−2 σ₀ L cos θ · k₀ / 3)` (the factor of 3 comes from
-///   integrating the quadratic profile). For our fixture
-///   `L = 0.5`, `k₀ ≈ 2`, so `σ₀ ≈ 5` gives `R(0) ≈ e⁻¹·⁷ ≈ 0.18`
-///   at normal incidence — modest, deliberately so (heavy absorption
-///   on a coarse mesh introduces its own discrete-PML reflections).
+///   integrating the quadratic profile, after Bérenger 1994 / Taflove
+///   §7.7). For our fixture `L = 0.5`, `k₀ ≈ 2`, so `σ₀ ≈ 5` gives
+///   `R(0) ≈ e⁻³·³³ ≈ 0.036` at normal incidence — small enough to
+///   keep PML-induced reflections below the dominant discretization
+///   error on our coarse mesh, but not so large that the discrete PML
+///   itself starts to reflect.
 ///   This is the **normal-incidence plane-wave** reflection
 ///   coefficient on a flat slab; the curved wavefronts emitted by a
 ///   sphere have a different effective absorption (and the angle θ


### PR DESCRIPTION
## Summary

Doc-only fix for the worked example in `build_complex_epsilon_r_pml`'s rustdoc (`crates/geode-core/src/nedelec_assembly.rs:341-352`). Surfaced by Judge on PR #65 as a non-blocking nit, pre-existing from PR #42.

The doc stated the formula `R(θ) ≈ exp(−2 σ₀ L cos θ · k₀ / 3)` and then claimed the worked example gave `R(0) ≈ e⁻¹·⁷ ≈ 0.18`. The formula is correct (it matches the standard quadratic-profile result from Bérenger 1994 / Taflove §7.7), but at the fixture parameters the exponent is `−2 · 5 · 0.5 · 1 · 2 / 3 = −10/3 ≈ −3.33`, so `R(0) ≈ e⁻³·³³ ≈ 0.036` — not 0.18.

This PR corrects the worked numeric and the editorial framing around it (3.6% is not "modest", colloquially), and adds an inline citation so the formula is traceable.

- Fix worked numeric: `R(0) ≈ e⁻¹·⁷ ≈ 0.18` → `R(0) ≈ e⁻³·³³ ≈ 0.036`.
- Replace "modest, deliberately so" framing with prose that fits 3.6% (below dominant discretization error without provoking discrete-PML reflections).
- Add inline citation to Bérenger 1994 / Taflove §7.7 so a future reader can verify the quadratic-profile derivation.

Net diff: +6/−4 inside a single `///` block. No code or behaviour change.

## Test plan

- [x] `cargo build -p geode-core` — clean build.
- [x] `cargo test -p geode-core --doc` — 0 doc-tests defined for this module, runs clean.
- [x] `cargo doc -p geode-core --no-deps` — generates docs; only pre-existing warnings in unrelated modules (`lib.rs`, `sparse.rs`), no new warnings for `nedelec_assembly.rs`.
- [x] Sanity recompute: `exp(-10/3) ≈ 0.0357` (matches the new `≈ 0.036`).
- [x] Adjacent regression test `sphere_pml_eigenmode_sigma_zero` (referenced in the same doc block) is not touched and continues to compile.
- [x] Editorial: the σ₀ upper-limit guidance added in PR #65 in the subsequent bullets reads cleanly alongside the corrected example.

Closes #68