### PR TITLE
Tighten sphere_pec_eigenmode_spectrum to quantitative match vs mie::merged_roots (n=1.5)

### DIFF
--- a/crates/geode-core/tests/sphere_pec_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pec_eigenmode.rs
@@ -46,8 +46,8 @@ use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
     apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_n_interior_nodes, sphere_pec_interior_edges, upload_mesh,
-    DefaultBackend, EigenSolver, FaerDenseEigensolver, R_BUFFER,
+    merged_roots, read_sphere_fixture, sphere_n_interior_nodes, sphere_pec_interior_edges,
+    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver, R_BUFFER, R_SPHERE,
 };
 
 type B = DefaultBackend;
@@ -279,4 +279,71 @@ fn sphere_pec_eigenmode_spectrum() {
          positive/real, ground k = {k0:.4}",
         n_spurious
     );
+
+    // 10. Quantitative acceptance (issue #69): each of the lowest 5
+    //     physical FEM eigenvalues `k_fem = √λ` pairs to the closest
+    //     analytic PEC-cavity root from `mie::merged_roots` within ≤ 15 %
+    //     relative on `k`.
+    //
+    //     The analytic catalog covers `l ∈ [1, 4]` with `n_max = 3`
+    //     radial orders per `(l, polarisation)` — well past the lowest
+    //     5 FEM roots, which on the bundled 313-node fixture sit in the
+    //     `k ∈ [1, 4]` band where the catalog is dense.
+    //
+    //     **Pairing rule**: closest-root by absolute `k` distance, not
+    //     index-ordered. Two FEM eigenvalues are allowed to pair to the
+    //     same analytic root (e.g. mesh-asymmetry splitting of a `2l+1`
+    //     degenerate multiplet) — we do not enforce distinct pairings.
+    //
+    //     **Tolerance**: the 15 % bound is calibrated to the bundled
+    //     coarse fixture (313 nodes / ~1226 tets); convergence-under-
+    //     refinement is the deferred sub-issue. Do not tighten this
+    //     bound in this ticket.
+    let analytic = merged_roots(n_index, &[1, 2, 3, 4], R_SPHERE, R_BUFFER, 3);
+    assert!(
+        !analytic.is_empty(),
+        "analytic PEC catalog produced no roots — merged_roots wiring broken"
+    );
+    eprintln!(
+        "analytic PEC catalog: {} roots for n = {}, R_s = {}, R_b = {}",
+        analytic.len(),
+        n_index,
+        R_SPHERE,
+        R_BUFFER,
+    );
+
+    let rel_tol = 0.15_f64;
+    for (i, &lam) in physical.iter().enumerate() {
+        let k_fem = lam.sqrt();
+        let closest = analytic
+            .iter()
+            .min_by(|a, b| {
+                (a.k - k_fem)
+                    .abs()
+                    .partial_cmp(&(b.k - k_fem).abs())
+                    .unwrap()
+            })
+            .expect("non-empty analytic catalog");
+        let rel_err = (k_fem - closest.k).abs() / closest.k;
+        eprintln!(
+            "  physical[{i}]: k_fem = {k_fem:.4} → closest analytic {pol:?}_{l},{n} k = {ka:.4} \
+             (rel err {err:.2}%)",
+            pol = closest.pol,
+            l = closest.l,
+            n = closest.n,
+            ka = closest.k,
+            err = 100.0 * rel_err,
+        );
+        assert!(
+            rel_err <= rel_tol,
+            "physical[{i}] k_fem = {k_fem:.4} does not pair to any analytic PEC root within \
+             {tol:.0}%: closest is {pol:?}_{l},{n} at k = {ka:.4} (rel err {err:.2}%)",
+            tol = 100.0 * rel_tol,
+            pol = closest.pol,
+            l = closest.l,
+            n = closest.n,
+            ka = closest.k,
+            err = 100.0 * rel_err,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Wires `crates/geode-core/tests/sphere_pec_eigenmode.rs::sphere_pec_eigenmode_spectrum` (the `#[ignore]`-by-debug-assertions heavy path) up to the existing analytic PEC catalog in `geode_core::mie::merged_roots`.
- For each of the lowest 5 physical FEM eigenvalues (after the existing soft acceptance: positivity, real, spurious-count, spectral-gap, wavenumber-band), asserts `(k_fem - k_analytic).abs() / k_analytic ≤ 0.15` against the closest root in `merged_roots(1.5, &[1,2,3,4], R_SPHERE, R_BUFFER, 3)`.
- Pairing is closest-root (not index-ordered), so two FEM eigenvalues are allowed to claim the same analytic root — this is intentional, since the 313-node fixture splits the `2l+1 = 3`-fold degenerate multiplets across consecutive FEM modes.
- All existing soft assertions are preserved (purely additive change). No production code touched.

## Observed pairings on the bundled fixture

```
physical[0]: k_fem = 1.1914 → TM_1,1 k = 1.3034 (rel err 8.59%)
physical[1]: k_fem = 1.1918 → TM_1,1 k = 1.3034 (rel err 8.56%)
physical[2]: k_fem = 1.1919 → TM_1,1 k = 1.3034 (rel err 8.56%)
physical[3]: k_fem = 1.8088 → TE_1,1 k = 1.8894 (rel err 4.27%)
physical[4]: k_fem = 1.8104 → TE_1,1 k = 1.8894 (rel err 4.18%)
```

physical[0..2] is the mesh-asymmetry-split TM_1,1 triplet; physical[3..4] are two of the TE_1,1 triplet — both well inside the 15% bound calibrated for the coarse 313-node fixture. Convergence-under-refinement is the deferred sub-issue noted in #69.

## Notes

- Used the real `merged_roots(n, l_set, r_s, r_b, n_max)` signature per the curator's correction in the issue body — there is no `k_grid` parameter; the function builds its own grid internally.
- Mirrors the import + call pattern already in `tests/mie_sphere.rs:44-50` / `:92`.
- 15% tolerance held per the issue's "do not tighten in this ticket" guidance — tightening lives in the deferred mesh-refinement sub-issue.

## Test plan

- [x] `cargo test -p geode-core --release --test sphere_pec_eigenmode -- --ignored` is green (51.89 s, 1 passed)
- [x] `cargo test -p geode-core --release --test sphere_pec_eigenmode` (non-ignored: epsilon-assignment + PEC-mask) is green (2 passed, 1 ignored)
- [x] `cargo clippy -p geode-core --tests --release -- -D warnings` clean
- [x] `cargo fmt --check -p geode-core` clean
- [x] Manually inspected eprintln output to confirm the new pairing block actually runs and prints per-mode rel-err (8.59% / 8.56% / 8.56% / 4.27% / 4.18%) — assertion is exercised, not bypassed

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)