### PR TITLE
Mie v2: overlap-gated pairing, catalog-derived N_MODES, Miller fusion

### DIFF
--- a/benchmarks/mie_sphere/results.toml
+++ b/benchmarks/mie_sphere/results.toml
@@ -5,14 +5,14 @@
 
 [meta]
 description = "Mie sphere benchmark (issue #4 v1, issue #40, issue #54): FEM eigenmodes vs. extended analytic PEC-cavity catalog (l ∈ [1,4], TE+TM, n ∈ [1,5]) with multiplicity-claim mode classification."
-generated_at_commit = "fa7b91c4a9bc093f27cd6e779548729094fa355c"
+generated_at_commit = "bef2d7d5f2ba04379eb7ed0f1c1d270fa2c4fa10"
 pml_kernel = "anisotropic"
 n_inside = 1.5
 sigma_0 = 5
 k0_ref = 2
 r_sphere = 1
 r_buffer = 2
-n_modes = 8
+n_modes = 11
 l_max = 4
 n_max_radial = 5
 notes = [
@@ -30,11 +30,12 @@ l = 1
 n = 1
 m_idx = 0
 incomplete = false
+ambiguous = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 1.226785141236030e0
-fem_im_k = 2.258077907930088e-2
-rel_err_re_k = 5.880541813247695e-2
-q = 2.716436702488680e1
+fem_re_k = 1.226785139722476e0
+fem_im_k = 2.258077766737991e-2
+rel_err_re_k = 5.880541929368106e-2
+q = 2.716436868989425e1
 
 [mode_1]
 polarisation = "TM"
@@ -42,11 +43,12 @@ l = 1
 n = 1
 m_idx = 1
 incomplete = false
+ambiguous = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 1.229383729068619e0
-fem_im_k = 2.259649608680165e-2
-rel_err_re_k = 5.681177091070167e-2
-q = 2.720297262783782e1
+fem_re_k = 1.229375402700578e0
+fem_im_k = 2.259795958911164e-2
+rel_err_re_k = 5.681815893434500e-2
+q = 2.720102666465796e1
 
 [mode_2]
 polarisation = "TM"
@@ -54,11 +56,12 @@ l = 1
 n = 1
 m_idx = 2
 incomplete = false
+ambiguous = false
 analytic_k = 1.303434130274992e0
-fem_re_k = 1.231355324958534e0
-fem_im_k = 2.233209982705323e-2
-rel_err_re_k = 5.529915447376770e-2
-q = 2.756917921947634e1
+fem_re_k = 1.229630674077200e0
+fem_im_k = 2.253157970589054e-2
+rel_err_re_k = 5.662231368931669e-2
+q = 2.728682786843684e1
 
 [mode_3]
 polarisation = "TE"
@@ -66,11 +69,12 @@ l = 1
 n = 1
 m_idx = 0
 incomplete = false
+ambiguous = true
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.872257355903034e0
-fem_im_k = 1.033791125890927e-1
-rel_err_re_k = 9.090558052921673e-3
-q = 9.055298062698657e0
+fem_re_k = 1.866633915480937e0
+fem_im_k = 1.122412276429923e-1
+rel_err_re_k = 1.206681566671309e-2
+q = 8.315277526267677e0
 
 [mode_4]
 polarisation = "TE"
@@ -78,11 +82,12 @@ l = 1
 n = 1
 m_idx = 1
 incomplete = false
+ambiguous = true
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.902421585245929e0
-fem_im_k = 1.918428241288060e-2
-rel_err_re_k = 6.874138024084716e-3
-q = 4.958281848396415e1
+fem_re_k = 1.872227727996784e0
+fem_im_k = 1.033684912056443e-1
+rel_err_re_k = 9.106238895064364e-3
+q = 9.056085206236201e0
 
 [mode_5]
 polarisation = "TE"
@@ -90,33 +95,75 @@ l = 1
 n = 1
 m_idx = 2
 incomplete = false
+ambiguous = true
 analytic_k = 1.889433359545106e0
-fem_re_k = 1.933559029519444e0
-fem_im_k = -3.207804426911283e-2
-rel_err_re_k = 2.335391706271214e-2
-q = 3.013835590003879e1
+fem_re_k = 1.901958223282575e0
+fem_im_k = 1.992974935005222e-2
+rel_err_re_k = 6.628899439186640e-3
+q = 4.771656155519065e1
 
 [mode_6]
 polarisation = "TM"
 l = 2
 n = 1
 m_idx = 0
-incomplete = true
+incomplete = false
+ambiguous = false
 analytic_k = 1.890736585383276e0
-fem_re_k = 2.470478814612743e0
-fem_im_k = 2.300960690775667e-1
-rel_err_re_k = 3.066224209714255e-1
-q = 5.368363798035876e0
+fem_re_k = 1.933617316891034e0
+fem_im_k = -3.204457474580294e-2
+rel_err_re_k = 2.267937894641518e-2
+q = 3.017074391265391e1
 
 [mode_7]
 polarisation = "TM"
 l = 2
 n = 1
 m_idx = 1
-incomplete = true
+incomplete = false
+ambiguous = false
 analytic_k = 1.890736585383276e0
-fem_re_k = 2.599586181127099e0
-fem_im_k = 2.455262253676720e-3
-rel_err_re_k = 3.749065846737875e-1
-q = 5.293907355994774e2
+fem_re_k = 2.449559713441481e0
+fem_im_k = 2.252040550971520e-1
+rel_err_re_k = 2.955584254191201e-1
+q = 5.438533760825825e0
+
+[mode_8]
+polarisation = "TM"
+l = 2
+n = 1
+m_idx = 2
+incomplete = false
+ambiguous = false
+analytic_k = 1.890736585383276e0
+fem_re_k = 2.487083522364764e0
+fem_im_k = 1.295507354382351e-1
+rel_err_re_k = 3.154045579863789e-1
+q = 9.598878439213923e0
+
+[mode_9]
+polarisation = "TM"
+l = 2
+n = 1
+m_idx = 3
+incomplete = false
+ambiguous = false
+analytic_k = 1.890736585383276e0
+fem_re_k = 2.580046765858372e0
+fem_im_k = -2.542006843832825e-2
+rel_err_re_k = 3.645722972750137e-1
+q = 5.074822619218818e1
+
+[mode_10]
+polarisation = "TM"
+l = 2
+n = 1
+m_idx = 4
+incomplete = false
+ambiguous = false
+analytic_k = 1.890736585383276e0
+fem_re_k = 3.155842425695794e0
+fem_im_k = 1.032229884733910e-1
+rel_err_re_k = 6.691073997788355e-1
+q = 1.528652905892815e1
 

--- a/crates/geode-core/examples/mie_sphere.rs
+++ b/crates/geode-core/examples/mie_sphere.rs
@@ -100,17 +100,46 @@ const SIGMA_0: f64 = 5.0;
 /// the documented ~6% TM_1,1 rel err on the bundled fixture.
 const K0_REF: f64 = 2.0;
 
-/// Number of physical FEM modes to compare (above the gradient nullspace).
+/// Number of analytic multiplets to walk when sizing the FEM eigen
+/// request (issue #43).
 ///
-/// Bumped to 8 (v0 was 5) so the consecutive-multiplicity claim walks
-/// at least two full analytic groups: the 3-fold TM_1,1 triplet
-/// plus another (l, n, pol) cluster above it.
-const N_MODES: usize = 8;
+/// `N_MODES` (the actual count of FEM modes requested above the
+/// gradient nullspace) is no longer a hand-tuned magic number — it is
+/// derived from the cumulative multiplicities of the first
+/// `N_ANALYTIC_GROUPS` rows in `mie_roots_catalog`. With the n = 1.5,
+/// `L_MAX = 4`, `N_MAX = 5` catalog the first three groups are
+/// `TM_1,1` (multiplicity 3), `TE_1,1` (multiplicity 3), and
+/// `TM_2,1` (multiplicity 5), summing to 11 — comfortably above the
+/// v1 hand-set count of 8 and including the canonical
+/// `TE_1,1` / `TM_2,1` close-pair (0.07 % spacing on this catalog)
+/// that exercises the overlap-gated pairing path. Mesh refinement or
+/// catalog widening (`L_MAX`, `N_MAX`) automatically tracks through
+/// this derivation.
+const N_ANALYTIC_GROUPS: usize = 3;
 
 /// Maximum angular order in the analytic catalog (issue #40).
 const L_MAX: usize = 4;
 /// Maximum radial order per `(l, pol)` in the analytic catalog.
 const N_MAX: usize = 5;
+
+/// Relative-gap threshold (~10 %) for flagging a close-pair in the
+/// analytic catalog (issue #43). When two consecutive roots are
+/// within this fraction of each other AND the FEM spread inside the
+/// first root's multiplet is large enough to bridge that gap, the
+/// pairing is considered ambiguous.
+const CLOSE_PAIR_GAP_FRAC: f64 = 0.10;
+
+/// Compute the requested FEM-mode count from the first
+/// `N_ANALYTIC_GROUPS` rows of the catalog. Sums their multiplicities
+/// so refinement-driven changes (more rows, different multiplicities)
+/// track automatically.
+fn n_modes_from_catalog(analytic: &[MieRoot]) -> usize {
+    analytic
+        .iter()
+        .take(N_ANALYTIC_GROUPS)
+        .map(|r| r.multiplicity)
+        .sum()
+}
 
 /// Result for a single benchmark row.
 ///
@@ -127,6 +156,14 @@ struct Row {
     /// True if the FEM spectrum ran out before the full multiplicity
     /// was filled.
     incomplete: bool,
+    /// True if the analytic catalog has another root within
+    /// `CLOSE_PAIR_GAP_FRAC` of this one AND the FEM modes claimed
+    /// inside this multiplet span more than half that inter-root gap
+    /// (issue #43). Indicates the consecutive-`Re(k)` claim may have
+    /// silently interleaved FEM modes between two close analytic
+    /// roots; the row's `(pol, l, n)` label should be treated as
+    /// best-guess rather than physically certain.
+    ambiguous: bool,
     analytic_k: f64,
     fem_re_k: f64,
     fem_im_k: f64,
@@ -178,7 +215,7 @@ fn results_path() -> PathBuf {
 /// scalar-isotropic complex ε (16% rel err ceiling, issue #52),
 /// `false` (default) uses the anisotropic-UPML diagonal complex
 /// tensor (~6% rel err on TM_1,1, issue #54).
-fn fem_complex_k(use_dense: bool, scalar_pml: bool) -> Vec<faer::c64> {
+fn fem_complex_k(use_dense: bool, scalar_pml: bool, n_modes: usize) -> Vec<faer::c64> {
     let device = <B as BackendTypes>::Device::default();
 
     let f = read_sphere_fixture().expect("fixture load");
@@ -261,7 +298,7 @@ fn fem_complex_k(use_dense: bool, scalar_pml: bool) -> Vec<faer::c64> {
     );
 
     let spurious_dim = sphere_n_interior_nodes(&f.mesh, R_BUFFER);
-    let n_request = spurious_dim + N_MODES + 5;
+    let n_request = spurious_dim + n_modes + 5;
 
     eprintln!("predicted spurious-mode count: {spurious_dim}, requesting {n_request} eigenvalues",);
 
@@ -342,7 +379,7 @@ fn fem_complex_k(use_dense: bool, scalar_pml: bool) -> Vec<faer::c64> {
     lambdas
         .iter()
         .skip(first_physical)
-        .take(N_MODES)
+        .take(n_modes)
         .map(|lam| {
             // Principal branch of sqrt: Re(k) ≥ 0.
             let r = (lam.re * lam.re + lam.im * lam.im).sqrt();
@@ -363,7 +400,8 @@ fn q_factor(k: faer::c64) -> f64 {
     }
 }
 
-/// Multiplicity-aware mode-claim pairing (issue #40).
+/// Multiplicity-aware mode-claim pairing with overlap gating
+/// (issues #40, #43).
 ///
 /// Walks the analytic catalog in ascending-`k` order. For each root,
 /// claims the next `multiplicity = 2 l + 1` FEM modes (in sorted `Re(k)`
@@ -373,8 +411,18 @@ fn q_factor(k: faer::c64) -> f64 {
 /// reached, the row is still emitted with `incomplete = true`. This
 /// is informational, never panicking.
 ///
-/// Im(k) banding tiebreaker is currently a soft sanity check: within
-/// each claimed group we record the median `Im(k)` and warn if the
+/// **Overlap gating (issue #43)**: if the next analytic root is within
+/// `CLOSE_PAIR_GAP_FRAC` (~10 %) of the current one — e.g. the
+/// canonical `TE_1,1` / `TM_2,1` pair at `k ≈ 1.889 / 1.891` (0.07 %
+/// spacing) on the n = 1.5 catalog — the FEM modes inside the current
+/// multiplet's `Re(k)` span may not be cleanly separable from the next
+/// multiplet's. We flag rows as `ambiguous = true` when the
+/// within-multiplet FEM spread exceeds half the inter-root gap, and
+/// print a warning so a downstream reader doesn't take the
+/// physically-uncertain `(pol, l, n)` label at face value.
+///
+/// Im(k) banding tiebreaker is a soft sanity check: within each
+/// claimed group we record the median `Im(k)` and warn if the
 /// per-slot spread exceeds ~10 % of that median. The FEM coarse
 /// fixture often violates this band (mesh asymmetry), so the message
 /// is logged but not enforced.
@@ -386,7 +434,7 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
     let mut rows = Vec::new();
     let mut cursor = 0_usize;
 
-    for root in analytic {
+    for (g_idx, root) in analytic.iter().enumerate() {
         if cursor >= fem_sorted.len() {
             break;
         }
@@ -417,6 +465,45 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
             }
         }
 
+        // Overlap gating against the next analytic root.
+        // ambiguity test: only when there is a "next" root, that root
+        // is within CLOSE_PAIR_GAP_FRAC of the current one, AND the
+        // FEM spread inside this multiplet is more than half that gap.
+        let mut ambiguous = false;
+        if let Some(next) = analytic.get(g_idx + 1) {
+            let gap = (next.k - root.k).abs();
+            let rel_gap = gap / root.k;
+            if rel_gap < CLOSE_PAIR_GAP_FRAC && group.len() >= 2 {
+                let res: Vec<f64> = group.iter().map(|k| k.re).collect();
+                let re_min = res.iter().cloned().fold(f64::INFINITY, f64::min);
+                let re_max = res.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                let spread = re_max - re_min;
+                // Trigger when within-multiplet FEM spread is more
+                // than half the gap to the next analytic root: the
+                // FEM modes inside this multiplet could plausibly
+                // belong to either group.
+                if spread > 0.5 * gap {
+                    ambiguous = true;
+                    eprintln!(
+                        "  warn: close-pair gating — {}_{},{} (k = {:.5}) next root \
+                         {}_{},{} (k = {:.5}, rel gap = {:.3}%) and within-multiplet \
+                         FEM spread = {:.3e} > 0.5 * gap ({:.3e}); claim is ambiguous",
+                        pol_str(root.pol),
+                        root.l,
+                        root.n,
+                        root.k,
+                        pol_str(next.pol),
+                        next.l,
+                        next.n,
+                        next.k,
+                        rel_gap * 100.0,
+                        spread,
+                        0.5 * gap,
+                    );
+                }
+            }
+        }
+
         for (slot, fem_k) in group.iter().enumerate() {
             let rel_err = (fem_k.re - root.k).abs() / root.k;
             rows.push(Row {
@@ -425,6 +512,7 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
                 n: root.n,
                 m_idx: slot,
                 incomplete,
+                ambiguous,
                 analytic_k: root.k,
                 fem_re_k: fem_k.re,
                 fem_im_k: fem_k.im,
@@ -451,9 +539,14 @@ fn print_table(rows: &[Row]) {
     );
     for (i, r) in rows.iter().enumerate() {
         let label = format!("{}_{},{}", r.pol, r.l, r.n);
-        let suffix = if r.incomplete { "*" } else { " " };
+        let suffix = match (r.incomplete, r.ambiguous) {
+            (true, true) => "*?",
+            (true, false) => "* ",
+            (false, true) => "? ",
+            (false, false) => "  ",
+        };
         eprintln!(
-            "{:>3}  {:>11}{}  {:>4}  {:>11.5}  {:>11.5}  {:>11.5e}  {:>12.3}%  {:>10.3e}",
+            "{:>3}  {:>10}{}  {:>4}  {:>11.5}  {:>11.5}  {:>11.5e}  {:>12.3}%  {:>10.3e}",
             i,
             label,
             suffix,
@@ -468,10 +561,13 @@ fn print_table(rows: &[Row]) {
     if rows.iter().any(|r| r.incomplete) {
         eprintln!("  (* = analytic multiplicity not fully filled by FEM modes)");
     }
+    if rows.iter().any(|r| r.ambiguous) {
+        eprintln!("  (? = close-pair overlap; pairing label is best-guess, issue #43)");
+    }
     eprintln!();
 }
 
-fn write_toml(rows: &[Row], path: &PathBuf, scalar_pml: bool) {
+fn write_toml(rows: &[Row], path: &PathBuf, scalar_pml: bool, n_modes: usize) {
     let commit = current_commit();
     let pml_kind = if scalar_pml { "scalar" } else { "anisotropic" };
 
@@ -493,7 +589,7 @@ fn write_toml(rows: &[Row], path: &PathBuf, scalar_pml: bool) {
     }
     s.push_str(&format!("r_sphere = {}\n", R_SPHERE));
     s.push_str(&format!("r_buffer = {}\n", R_BUFFER));
-    s.push_str(&format!("n_modes = {}\n", N_MODES));
+    s.push_str(&format!("n_modes = {}\n", n_modes));
     s.push_str(&format!("l_max = {}\n", L_MAX));
     s.push_str(&format!("n_max_radial = {}\n", N_MAX));
     s.push_str("notes = [\n");
@@ -525,6 +621,7 @@ fn write_toml(rows: &[Row], path: &PathBuf, scalar_pml: bool) {
         s.push_str(&format!("n = {}\n", r.n));
         s.push_str(&format!("m_idx = {}\n", r.m_idx));
         s.push_str(&format!("incomplete = {}\n", r.incomplete));
+        s.push_str(&format!("ambiguous = {}\n", r.ambiguous));
         s.push_str(&format!("analytic_k = {:.15e}\n", r.analytic_k));
         s.push_str(&format!("fem_re_k = {:.15e}\n", r.fem_re_k));
         s.push_str(&format!("fem_im_k = {:.15e}\n", r.fem_im_k));
@@ -571,11 +668,16 @@ fn main() {
     // both TE and TM polarisations, lowest N_MAX radial overtones each.
     // Each MieRoot carries its (l, n, pol, multiplicity = 2l+1) label.
     let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
+    let n_modes = n_modes_from_catalog(&analytic);
     eprintln!(
         "Analytic catalog: {} roots over l ∈ [1, {}], TE+TM, n ∈ [1, {}]",
         analytic.len(),
         L_MAX,
         N_MAX
+    );
+    eprintln!(
+        "Catalog-derived N_MODES = {} (sum of multiplicities of first {} groups, issue #43)",
+        n_modes, N_ANALYTIC_GROUPS,
     );
     eprintln!("Lowest 12 analytic roots (PEC-cavity dielectric resonator):");
     for r in analytic.iter().take(12) {
@@ -593,7 +695,7 @@ fn main() {
     // FEM eigensolve.
     eprintln!();
     eprintln!("=== FEM eigensolve ===");
-    let fem_k = fem_complex_k(use_dense, scalar_pml);
+    let fem_k = fem_complex_k(use_dense, scalar_pml, n_modes);
     eprintln!("Lowest {} physical FEM modes (k = sqrt(λ)):", fem_k.len());
     for (i, k) in fem_k.iter().enumerate() {
         eprintln!("  mode[{i}]  k = {:.5} + {:.5e}i", k.re, k.im);
@@ -604,7 +706,7 @@ fn main() {
     print_table(&rows);
 
     // Persist.
-    write_toml(&rows, &results_path(), scalar_pml);
+    write_toml(&rows, &results_path(), scalar_pml, n_modes);
 
     // Issue #33 — open-space Mie WGM cross-check.
     //
@@ -672,4 +774,136 @@ fn main() {
     eprintln!();
 
     eprintln!("=== Done ===");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic FEM-mode vector that mimics a coarse-mesh
+    /// split of an analytic root: three modes (multiplicity 2l+1 = 3)
+    /// clustered around `k` with the given `spread` in Re(k) and a
+    /// uniform damping `im`.
+    fn synth_triplet(k: f64, spread: f64, im: f64) -> Vec<faer::c64> {
+        vec![
+            faer::c64::new(k - 0.5 * spread, im),
+            faer::c64::new(k, im),
+            faer::c64::new(k + 0.5 * spread, im),
+        ]
+    }
+
+    #[test]
+    fn close_pair_te11_tm21_flags_ambiguous_on_overlap() {
+        // Use the bundled n = 1.5 catalog: TE_1,1 (k ≈ 1.88943) and
+        // TM_2,1 (k ≈ 1.89074) are 0.07 % apart, the canonical
+        // close-pair (issue #43). Concoct a synthetic FEM spectrum
+        // where the TE_1,1 multiplet spreads enough in Re(k) to bridge
+        // half the gap to TM_2,1; the pairing must flag the affected
+        // rows as `ambiguous = true`.
+        let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
+        // Find the TE_1,1 / TM_2,1 pair indices in the catalog.
+        let i_te11 = analytic
+            .iter()
+            .position(|r| r.pol == MiePolarisation::TE && r.l == 1 && r.n == 1)
+            .expect("TE_1,1 in catalog");
+        let te11 = analytic[i_te11];
+        let tm21 = analytic
+            .get(i_te11 + 1)
+            .copied()
+            .expect("TM_2,1 follows TE_1,1");
+        assert_eq!(tm21.pol, MiePolarisation::TM);
+        assert_eq!(tm21.l, 2);
+        assert_eq!(tm21.n, 1);
+        let gap = tm21.k - te11.k;
+        let rel_gap = gap / te11.k;
+        assert!(
+            rel_gap < CLOSE_PAIR_GAP_FRAC,
+            "TE_1,1 / TM_2,1 must be within {}% (got {:.5}%)",
+            CLOSE_PAIR_GAP_FRAC * 100.0,
+            rel_gap * 100.0
+        );
+
+        // Build a synthetic FEM spectrum: a low-k multiplet for the
+        // ground TM_1,1 (just to anchor the cursor at the start), then
+        // a TE_1,1 triplet whose spread spans MORE than half the gap
+        // to TM_2,1, then a TM_2,1 quintet.
+        let ground = analytic[0];
+        let mut fem: Vec<faer::c64> = Vec::new();
+        fem.extend(synth_triplet(ground.k, 1e-3, 1e-2));
+        // TE_1,1 triplet: spread = gap so it definitely bridges > 0.5*gap.
+        fem.extend(synth_triplet(te11.k, gap, 1e-2));
+        // TM_2,1 quintet (multiplicity 5).
+        for slot in 0..5 {
+            fem.push(faer::c64::new(tm21.k + (slot as f64 - 2.0) * 1e-4, 1e-2));
+        }
+
+        let rows = pair_modes(&analytic, &fem);
+        // Rows for TE_1,1 should be flagged ambiguous.
+        let te11_rows: Vec<&Row> = rows
+            .iter()
+            .filter(|r| r.pol == "TE" && r.l == 1 && r.n == 1)
+            .collect();
+        assert_eq!(te11_rows.len(), 3, "TE_1,1 multiplet should be 3 rows");
+        assert!(
+            te11_rows.iter().all(|r| r.ambiguous),
+            "all TE_1,1 rows must be flagged ambiguous when FEM spread > 0.5 * gap to TM_2,1"
+        );
+    }
+
+    #[test]
+    fn close_pair_not_flagged_when_fem_spread_is_tight() {
+        // Same catalog but with a TIGHT TE_1,1 multiplet: spread much
+        // less than half the gap to TM_2,1. Must NOT be flagged
+        // ambiguous — the close-pair gate should only fire when the
+        // FEM modes actually bridge the analytic gap.
+        let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
+        let i_te11 = analytic
+            .iter()
+            .position(|r| r.pol == MiePolarisation::TE && r.l == 1 && r.n == 1)
+            .expect("TE_1,1 in catalog");
+        let te11 = analytic[i_te11];
+        let tm21 = analytic[i_te11 + 1];
+        let gap = tm21.k - te11.k;
+
+        let ground = analytic[0];
+        let mut fem: Vec<faer::c64> = Vec::new();
+        fem.extend(synth_triplet(ground.k, 1e-3, 1e-2));
+        // Spread is 0.1 * gap → well under the 0.5 * gap threshold.
+        fem.extend(synth_triplet(te11.k, 0.1 * gap, 1e-2));
+        for slot in 0..5 {
+            fem.push(faer::c64::new(tm21.k + (slot as f64 - 2.0) * 1e-4, 1e-2));
+        }
+
+        let rows = pair_modes(&analytic, &fem);
+        let te11_rows: Vec<&Row> = rows
+            .iter()
+            .filter(|r| r.pol == "TE" && r.l == 1 && r.n == 1)
+            .collect();
+        assert_eq!(te11_rows.len(), 3);
+        assert!(
+            te11_rows.iter().all(|r| !r.ambiguous),
+            "TE_1,1 rows must NOT be ambiguous when FEM spread is << gap"
+        );
+    }
+
+    #[test]
+    fn n_modes_from_catalog_matches_sum_of_multiplicities() {
+        // Catalog-derived N_MODES must equal the cumulative
+        // multiplicity sum of the first N_ANALYTIC_GROUPS catalog
+        // entries (issue #43, replaces hard-coded N_MODES = 8).
+        let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
+        let expected: usize = analytic
+            .iter()
+            .take(N_ANALYTIC_GROUPS)
+            .map(|r| r.multiplicity)
+            .sum();
+        assert_eq!(n_modes_from_catalog(&analytic), expected);
+        // For N_ANALYTIC_GROUPS = 2 on the bundled catalog, that's
+        // TM_1,1 (mult 3) + TE_1,1 (mult 3) = 6 — the catalog tracks
+        // automatically, no hand-tuned magic 8.
+        assert!(
+            n_modes_from_catalog(&analytic) >= 3,
+            "must cover at least the TM_1,1 ground triplet"
+        );
+    }
 }

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -42,8 +42,8 @@ pub use mesh::{
 };
 pub use mie::{
     characteristic_te, characteristic_tm, chi, chi_prime, merged_roots, mie_roots_catalog, psi,
-    psi_prime, resonance_roots, spherical_j, spherical_j_prime, spherical_y, spherical_y_prime,
-    MiePolarisation, MieRoot,
+    psi_prime, resonance_roots, spherical_j, spherical_j_pair, spherical_j_prime, spherical_y,
+    spherical_y_prime, MiePolarisation, MieRoot,
 };
 pub use mie_open::{
     characteristic_te_open, characteristic_tm_open, open_space_wgm_roots_n15, spherical_h1_c,

--- a/crates/geode-core/src/mie.rs
+++ b/crates/geode-core/src/mie.rs
@@ -74,9 +74,21 @@ pub struct MieRoot {
     pub multiplicity: usize,
 }
 
-/// Spherical Bessel function `j_l(x)` of the first kind, real arg.
+/// Spherical Bessel functions `j_{l-1}(x)` and `j_l(x)` of the first
+/// kind, real arg, computed in a single pass.
 ///
-/// Uses two strategies based on the relative size of `l` and `x`:
+/// Returns `(j_{l-1}, j_l)`. For `l == 0` the first slot is `j_{-1}(x) =
+/// cos(x)/x` (the analytic continuation per the standard recurrence;
+/// not normally used but kept consistent so the recurrence stays
+/// closed).
+///
+/// Sharing one Miller downward pass between `j_{l-1}` and `j_l` is the
+/// whole point of this helper: [`spherical_j`] and [`spherical_j_prime`]
+/// both call into it so we recompute the Bessel ladder once instead of
+/// twice (issue #43).
+///
+/// Uses the same two-regime strategy as the previous standalone
+/// `spherical_j`:
 ///
 /// - **Upward recurrence** `j_l = (2l-1)/x · j_{l-1} - j_{l-2}` when
 ///   `l ≤ x + 1`. Stable in this regime, and matches the original v0
@@ -89,19 +101,31 @@ pub struct MieRoot {
 ///   normalise against the known closed form `j_0(x) = sin(x)/x`.
 ///   `l_start = l + 20` and the canonical 1 / scale renormalisation
 ///   give 12-digit accuracy across the catalog range (NR §6.5).
-pub fn spherical_j(l: usize, x: f64) -> f64 {
+pub fn spherical_j_pair(l: usize, x: f64) -> (f64, f64) {
     if x.abs() < 1e-14 {
-        return if l == 0 { 1.0 } else { 0.0 };
+        // j_0(0) = 1, j_n(0) = 0 for n ≥ 1. The l = 0 case returns
+        // j_{-1}(0) which is formally singular; we never call into
+        // it from the wrapper code, but return 0 here as a safe
+        // sentinel so the function stays total.
+        return match l {
+            0 => (0.0, 1.0),
+            1 => (1.0, 0.0),
+            _ => (0.0, 0.0),
+        };
     }
     let s = x.sin();
     let c = x.cos();
     let j0 = s / x;
-    if l == 0 {
-        return j0;
-    }
     let j1 = s / (x * x) - c / x;
+    if l == 0 {
+        // j_{-1}(x) = cos(x)/x by the standard recurrence (this
+        // matches the convention used in the derivative formula
+        // j_0'(x) = -j_1(x); the j_{-1} value itself is not currently
+        // consumed by callers).
+        return (c / x, j0);
+    }
     if l == 1 {
-        return j1;
+        return (j0, j1);
     }
 
     // Upward recurrence regime: stable when `l ≤ x`.
@@ -113,19 +137,26 @@ pub fn spherical_j(l: usize, x: f64) -> f64 {
             prev = curr;
             curr = next;
         }
-        return curr;
+        // After the loop: prev = j_{l-1}, curr = j_l.
+        return (prev, curr);
     }
 
     // Downward (Miller's) recurrence: seed with `j_{l_start+1} = 0`,
     // `j_{l_start} = 1` (unnormalised), recurse downward using
     // `j_{k-1} = (2k+1)/x · j_k - j_{k+1}` and normalise against the
     // closed form `j_0(x) = sin(x)/x`.
+    //
+    // Single pass: we capture `j_l` *and* `j_{l-1}` simultaneously, so
+    // callers needing both (notably [`spherical_j_prime`]) pay only one
+    // Miller traversal.
     let l_start = l + 20;
     // `j_high = j_{k}`, `j_higher = j_{k+1}` at the top of each loop.
     let mut j_higher = 0.0_f64;
     let mut j_high = 1.0_f64;
-    // Snapshots at the rungs we care about.
+    // Snapshots at the rungs we care about. `at_target_minus_1`
+    // captures `j_{l-1}` so we can return it alongside `j_l`.
     let mut at_target = if l == l_start { Some(j_high) } else { None };
+    let mut at_target_minus_1: Option<f64> = None;
     let mut at_zero: Option<f64> = None;
     // Walk k = l_start, l_start - 1, …, 1; the body computes
     // `j_{k-1}` and slides the window down.
@@ -139,6 +170,10 @@ pub fn spherical_j(l: usize, x: f64) -> f64 {
         if k - 1 == l {
             at_target = Some(j_high);
         }
+        if k - 1 + 1 == l {
+            // k - 1 == l - 1 — capture j_{l-1}.
+            at_target_minus_1 = Some(j_high);
+        }
         if k - 1 == 0 {
             at_zero = Some(j_high);
         }
@@ -150,15 +185,28 @@ pub fn spherical_j(l: usize, x: f64) -> f64 {
             if let Some(t) = at_target.as_mut() {
                 *t /= scale;
             }
+            if let Some(t) = at_target_minus_1.as_mut() {
+                *t /= scale;
+            }
             if let Some(z) = at_zero.as_mut() {
                 *z /= scale;
             }
         }
     }
     let target = at_target.expect("target rung visited");
+    let target_minus_1 = at_target_minus_1.expect("target-1 rung visited");
     let zero = at_zero.expect("k=0 rung visited");
     // Normalise: true j_0(x) = sin(x)/x = j0.
-    target * (j0 / zero)
+    let norm = j0 / zero;
+    (target_minus_1 * norm, target * norm)
+}
+
+/// Spherical Bessel function `j_l(x)` of the first kind, real arg.
+///
+/// Thin wrapper over [`spherical_j_pair`] returning only the `j_l`
+/// component. See that function for the recurrence strategy.
+pub fn spherical_j(l: usize, x: f64) -> f64 {
+    spherical_j_pair(l, x).1
 }
 
 /// Spherical Bessel function `y_l(x)` of the second kind, real arg.
@@ -189,14 +237,20 @@ pub fn spherical_y(l: usize, x: f64) -> f64 {
 }
 
 /// Derivative `j_l'(x) = j_{l-1}(x) - (l+1)/x · j_l(x)`.
+///
+/// Fused Miller pass (issue #43): both `j_{l-1}` and `j_l` come from a
+/// single call to [`spherical_j_pair`], so the downward recurrence runs
+/// once instead of twice. Identical numerical result, half the work.
 pub fn spherical_j_prime(l: usize, x: f64) -> f64 {
     if x.abs() < 1e-14 {
         return if l == 1 { 1.0 / 3.0 } else { 0.0 };
     }
     if l == 0 {
+        // j_0'(x) = -j_1(x); cheap closed form, no pair needed.
         return -spherical_j(1, x);
     }
-    spherical_j(l - 1, x) - ((l + 1) as f64) / x * spherical_j(l, x)
+    let (j_lm1, j_l) = spherical_j_pair(l, x);
+    j_lm1 - ((l + 1) as f64) / x * j_l
 }
 
 /// Derivative `y_l'(x) = y_{l-1}(x) - (l+1)/x · y_l(x)`.
@@ -536,6 +590,46 @@ mod tests {
         // Sorted globally by k.
         for w in cat.windows(2) {
             assert!(w[0].k <= w[1].k);
+        }
+    }
+
+    #[test]
+    fn spherical_j_pair_returns_consistent_ladder() {
+        // The fused pair (issue #43) must produce the same values as
+        // two separate calls to `spherical_j`. Cover both the upward
+        // and the Miller-downward regimes by sweeping `l` against `x`.
+        for &x in &[0.5_f64, 1.0, 1.5, 2.0, 3.0, 5.0, 8.0] {
+            for l in 1..=8_usize {
+                let (j_lm1_pair, j_l_pair) = spherical_j_pair(l, x);
+                let j_l_solo = spherical_j(l, x);
+                let j_lm1_solo = spherical_j(l - 1, x);
+                assert!(
+                    (j_l_pair - j_l_solo).abs() <= 1e-12 * j_l_solo.abs().max(1.0),
+                    "j_{l}({x}): pair = {j_l_pair}, solo = {j_l_solo}"
+                );
+                assert!(
+                    (j_lm1_pair - j_lm1_solo).abs() <= 1e-12 * j_lm1_solo.abs().max(1.0),
+                    "j_{}({x}): pair = {j_lm1_pair}, solo = {j_lm1_solo}",
+                    l - 1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn spherical_j_prime_after_miller_fusion_matches_unfused_formula() {
+        // Cross-check the fused `j_l'` against the textbook two-call
+        // version `j_{l-1}(x) - (l+1)/x · j_l(x)` to confirm the fusion
+        // is a pure perf change, not a semantics change (issue #43).
+        for &x in &[0.7_f64, 1.3, 1.88943, 1.89074, 2.0, 4.0, 6.0] {
+            for l in 1..=6_usize {
+                let fused = spherical_j_prime(l, x);
+                let two_call = spherical_j(l - 1, x) - ((l + 1) as f64) / x * spherical_j(l, x);
+                assert!(
+                    (fused - two_call).abs() <= 1e-12 * two_call.abs().max(1.0),
+                    "j'_{l}({x}): fused = {fused}, two-call = {two_call}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #43.

Three independent hardenings to the Mie benchmark, addressing the spot-check finding from PR #41 / issue #43.

## Summary

- **Overlap-gated pairing** (`examples/mie_sphere.rs::pair_modes`): when two consecutive analytic roots are within ~10% of each other AND the FEM modes inside the current multiplet span more than half the inter-root gap, the affected rows are flagged `ambiguous = true` and a warning is printed. The canonical TE_1,1 (k=1.88943) / TM_2,1 (k=1.89074) close-pair (0.07% spacing) on the n=1.5 catalog exercises this path on the bundled fixture; the example output now warns and the TOML row carries `ambiguous = true`.
- **Catalog-derived `N_MODES`**: the hard-coded `N_MODES = 8` is gone. `n_modes_from_catalog(analytic)` sums multiplicities of the first `N_ANALYTIC_GROUPS = 3` rows of `mie_roots_catalog`. On the bundled n=1.5 catalog this yields 11 modes (TM_1,1 + TE_1,1 + TM_2,1 = 3+3+5), and any future change in `L_MAX` / `N_MAX` / catalog ordering tracks automatically.
- **Miller fusion in `spherical_j_prime`**: previously called `spherical_j` twice. Now a single `spherical_j_pair(l, x) -> (j_{l-1}, j_l)` helper does one Miller downward pass; both `spherical_j` and `spherical_j_prime` call into it. Same numerical result, half the work for the high-`l` regime.

## Test plan

- [x] `cargo test -p geode-core --release --lib mie` — 17/17 pass, including new `spherical_j_pair_returns_consistent_ladder` and `spherical_j_prime_after_miller_fusion_matches_unfused_formula`.
- [x] `cargo test -p geode-core --release --example mie_sphere` — 3/3 pass: `close_pair_te11_tm21_flags_ambiguous_on_overlap`, `close_pair_not_flagged_when_fem_spread_is_tight`, `n_modes_from_catalog_matches_sum_of_multiplicities`.
- [x] `cargo test -p geode-core --release --test mie_sphere -- --ignored` — 3/3 pass (no regression on `mie_sphere_ground_mode_within_8_percent_of_analytic`, `mie_sphere_tm11_triplet_q_above_band`, `mie_sphere_ground_mode_matches_open_space_wgm`).
- [x] `cargo test -p geode-core --release` — full geode-core suite green.
- [x] `cargo fmt --check`, `cargo clippy --tests --release -- -D warnings` — clean.
- [x] Re-ran the example end-to-end — close-pair warning fires on TE_1,1, TOML regenerated with `n_modes = 11` and `ambiguous = true` on the affected rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)