### PR TITLE
feat: add d⁰ discrete gradient operator in geode_core::derham

### DIFF
--- a/crates/geode-core/src/derham.rs
+++ b/crates/geode-core/src/derham.rs
@@ -1,0 +1,124 @@
+//! Discrete de Rham complex operators on a tetrahedral mesh.
+//!
+//! This module provides the first map of the discrete de Rham complex —
+//! the **discrete gradient** `d⁰` (a "coboundary" / incidence operator) —
+//! which sends a nodal scalar field to the edge DOFs of its discrete
+//! gradient. It is the algebraic backbone of the U(1) gauge-symmetry test
+//! battery: the Nédélec curl-curl operator must annihilate anything in the
+//! image of `d⁰` (gradients are curl-free), and in Phase 2 the composition
+//! `d¹ · d⁰ = 0` certifies the complex is exact at the edge level.
+//!
+//! # The `d⁰` operator
+//!
+//! For a mesh with `n_nodes` vertices and `n_edges` edges, `d⁰` is the
+//! `n_edges × n_nodes` integer incidence matrix. Each **row** is a global
+//! edge `(a, b)` with `a < b` (the lower-tag-first orientation already
+//! fixed by [`crate::mesh::TET_LOCAL_EDGES`] and the Nédélec edge-DOF
+//! assembly), and has exactly two nonzeros:
+//!
+//! ```text
+//! d⁰[edge, a] = -1     (tail of the oriented edge)
+//! d⁰[edge, b] = +1     (head of the oriented edge)
+//! ```
+//!
+//! Applied to a nodal field `φ`, row `(a, b)` yields `φ_b − φ_a`, the
+//! signed difference along the oriented edge. For a Whitney 1-form (the
+//! first-order Nédélec basis), this edge difference *is* the edge DOF of
+//! the discrete gradient `∇φ`: the line integral of `∇φ` along the edge
+//! equals `φ_b − φ_a` by the fundamental theorem of calculus, and the
+//! Whitney edge DOF is exactly that tangential line integral. Hence the
+//! sign convention here must match the Nédélec edge orientation so that
+//! `assemble_global_nedelec`'s curl-curl operator consumes `d⁰`-output as
+//! a genuine discrete gradient.
+//!
+//! # References for the sign convention
+//!
+//! The lower-tag-first edge orientation and the `(-1, +1)` incidence
+//! pattern follow the standard finite-element exterior-calculus
+//! treatment of the Whitney / discrete de Rham complex:
+//!
+//! - R. Hiptmair, *Finite elements in computational electromagnetism*,
+//!   Acta Numerica 11 (2002), 237–339, §3 ("Discrete differential
+//!   forms"): the discrete exterior derivative on edges is the signed
+//!   node–edge incidence matrix, oriented by the global vertex ordering.
+//! - D. N. Arnold, R. S. Falk, R. Winther, *Finite element exterior
+//!   calculus, homological techniques, and applications*, Acta Numerica
+//!   15 (2006), 1–155, §1.2 ("The de Rham complex"): `d⁰` is the
+//!   transpose of the boundary operator on edges, giving `+1` at the head
+//!   vertex and `−1` at the tail vertex of each oriented edge.
+//!
+//! # Value type
+//!
+//! `d⁰` is mathematically an *integer* matrix, but `faer`'s sparse
+//! constructors require the value type to implement `faer`'s
+//! `ComplexField`, which `i32` does not. We therefore store the entries
+//! as `f64` (the exactly-representable integers `±1.0`). This keeps the
+//! operator usable in `faer`'s sparse linear algebra and lets Phase 2 form
+//! the sparse product `d¹ · d⁰` directly; for the small integers involved
+//! the product stays exact in `f64`. It also matches the value type of
+//! the rest of the sparse pipeline ([`crate::sparse::SparseSystem`]).
+
+use faer::sparse::{SparseColMat, Triplet};
+
+use crate::mesh::TetMesh;
+
+/// Build the discrete gradient operator `d⁰` for `mesh`.
+///
+/// Returns an `n_edges × n_nodes` sparse matrix in `faer`'s column-major
+/// (CSC) format. Row `i` corresponds to edge `i` of [`TetMesh::edges`]
+/// (the canonical lower-tag-first global edge enumeration, identical to
+/// the Nédélec assembly's edge ordering), with exactly two nonzeros:
+/// `-1` in the column of the lower-tagged endpoint and `+1` in the column
+/// of the higher-tagged endpoint.
+///
+/// See the [module docs](crate::derham) for the sign convention and its
+/// references (Hiptmair §3, Arnold–Falk–Winther §1.2).
+///
+/// # Panics
+///
+/// Panics if `faer` rejects the constructed triplets (only possible on an
+/// internal invariant violation — the edge list is deduplicated and the
+/// node indices are bounded by `mesh.n_nodes()` by construction).
+pub fn gradient_map(mesh: &TetMesh) -> SparseColMat<usize, f64> {
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+    let n_nodes = mesh.n_nodes();
+
+    // Two triplets per edge: -1 at the tail (lower tag), +1 at the head.
+    let mut triplets: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(2 * n_edges);
+    for (edge_idx, &[a, b]) in edges.iter().enumerate() {
+        triplets.push(Triplet::new(edge_idx, a as usize, -1.0));
+        triplets.push(Triplet::new(edge_idx, b as usize, 1.0));
+    }
+
+    SparseColMat::<usize, f64>::try_new_from_triplets(n_edges, n_nodes, &triplets)
+        .expect("d⁰ triplets are well-formed: in-range indices, no duplicates per edge")
+}
+
+/// Apply `d⁰` to a nodal field without materializing the sparse matrix.
+///
+/// Returns `d⁰ · φ`, the vector of edge DOFs of the discrete gradient:
+/// for edge `(a, b)` (lower tag first), `out[edge] = nodal[b] − nodal[a]`.
+/// The output length is `mesh.edges().len()` (= `n_edges`), and entry `i`
+/// matches row `i` of [`gradient_map`].
+///
+/// Prefer this over `gradient_map(mesh)` followed by a sparse mat-vec when
+/// you only need the gradient values and not the operator itself.
+///
+/// # Panics
+///
+/// Panics if `nodal.len() != mesh.n_nodes()`.
+pub fn apply_gradient(mesh: &TetMesh, nodal: &[f64]) -> Vec<f64> {
+    assert_eq!(
+        nodal.len(),
+        mesh.n_nodes(),
+        "nodal field length {} disagrees with mesh node count {}",
+        nodal.len(),
+        mesh.n_nodes()
+    );
+
+    mesh.edges()
+        .iter()
+        .map(|&[a, b]| nodal[b as usize] - nodal[a as usize])
+        .collect()
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod assembly;
 pub mod complex_eigen;
 pub mod complex_lanczos;
+pub mod derham;
 pub mod eigen;
 pub mod lanczos;
 pub mod mesh;
@@ -28,6 +29,7 @@ pub use assembly::{
 };
 pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
+pub use derham::{apply_gradient, gradient_map};
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
     FaerDenseEigensolver,

--- a/crates/geode-core/tests/derham_gradient.rs
+++ b/crates/geode-core/tests/derham_gradient.rs
@@ -1,0 +1,197 @@
+//! Tests for the discrete gradient operator `d⁰` (`geode_core::derham`).
+//!
+//! Covers the four acceptance checks from issue #58:
+//!   1. Shape: `d⁰` is `n_edges × n_nodes`.
+//!   2. Sparsity: every row has exactly two nonzeros (one `+1`, one `−1`)
+//!      summing to zero.
+//!   3. Single reference-tet hand check against a tabulated matrix.
+//!   4. Closed-loop consistency: the signed edge-gradient sum around any
+//!      triangular face of the cube fixture vanishes (precursor to the
+//!      Phase 2 `d¹ · d⁰ = 0` test).
+
+use std::collections::{BTreeMap, HashMap};
+
+use geode_core::{apply_gradient, cube_tet_mesh, gradient_map, TetMesh};
+
+/// A single tet on nodes 0..4. Connectivity is all that matters for `d⁰`;
+/// the coordinates below form a unit reference tet for good measure.
+fn reference_tet() -> TetMesh {
+    TetMesh {
+        nodes: vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        tets: vec![[0, 1, 2, 3]],
+        physical_groups: BTreeMap::new(),
+    }
+}
+
+#[test]
+fn shape_is_n_edges_by_n_nodes() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d0 = gradient_map(&mesh);
+    let n_edges = mesh.edges().len();
+    let n_nodes = mesh.n_nodes();
+
+    assert_eq!(
+        d0.shape(),
+        (n_edges, n_nodes),
+        "d⁰ must be n_edges × n_nodes"
+    );
+}
+
+#[test]
+fn every_row_has_two_opposite_unit_nonzeros() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d0 = gradient_map(&mesh);
+    let dense = d0.to_dense();
+
+    let n_edges = mesh.edges().len();
+    let n_nodes = mesh.n_nodes();
+
+    for r in 0..n_edges {
+        let mut nnz = 0usize;
+        let mut row_sum = 0.0f64;
+        let mut saw_plus = false;
+        let mut saw_minus = false;
+        for c in 0..n_nodes {
+            let v = dense[(r, c)];
+            if v != 0.0 {
+                nnz += 1;
+                row_sum += v;
+                if v == 1.0 {
+                    saw_plus = true;
+                } else if v == -1.0 {
+                    saw_minus = true;
+                } else {
+                    panic!("row {r}, col {c}: unexpected entry {v}, expected ±1");
+                }
+            }
+        }
+        assert_eq!(nnz, 2, "row {r} must have exactly 2 nonzeros");
+        assert_eq!(row_sum, 0.0, "row {r} nonzeros must sum to zero");
+        assert!(
+            saw_plus && saw_minus,
+            "row {r} must have exactly one +1 and one -1"
+        );
+    }
+}
+
+#[test]
+fn single_reference_tet_matches_hand_tabulated_matrix() {
+    let mesh = reference_tet();
+    let d0 = gradient_map(&mesh);
+
+    // 6 edges (TET_LOCAL_EDGES order, already lower-tag-first), 4 nodes.
+    assert_eq!(d0.shape(), (6, 4));
+    assert_eq!(
+        mesh.edges(),
+        vec![[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
+        "edge enumeration must match the canonical lower-tag-first order"
+    );
+
+    // Hand-tabulated d⁰: rows = oriented edges, cols = nodes.
+    //            n0  n1  n2  n3
+    // (0,1):    -1  +1   0   0
+    // (0,2):    -1   0  +1   0
+    // (0,3):    -1   0   0  +1
+    // (1,2):     0  -1  +1   0
+    // (1,3):     0  -1   0  +1
+    // (2,3):     0   0  -1  +1
+    let expected: [[f64; 4]; 6] = [
+        [-1.0, 1.0, 0.0, 0.0],
+        [-1.0, 0.0, 1.0, 0.0],
+        [-1.0, 0.0, 0.0, 1.0],
+        [0.0, -1.0, 1.0, 0.0],
+        [0.0, -1.0, 0.0, 1.0],
+        [0.0, 0.0, -1.0, 1.0],
+    ];
+
+    let dense = d0.to_dense();
+    for (r, row) in expected.iter().enumerate() {
+        for (c, &want) in row.iter().enumerate() {
+            assert_eq!(
+                dense[(r, c)],
+                want,
+                "d⁰[{r}, {c}] = {} but expected {want}",
+                dense[(r, c)]
+            );
+        }
+    }
+
+    // apply_gradient must agree with the materialized operator on a sample
+    // field: row (a,b) yields φ_b − φ_a.
+    let phi = [10.0, 3.0, 7.0, 1.0];
+    let grad = apply_gradient(&mesh, &phi);
+    let expected_grad = [
+        phi[1] - phi[0], // (0,1)
+        phi[2] - phi[0], // (0,2)
+        phi[3] - phi[0], // (0,3)
+        phi[2] - phi[1], // (1,2)
+        phi[3] - phi[1], // (1,3)
+        phi[3] - phi[2], // (2,3)
+    ];
+    assert_eq!(grad, expected_grad);
+}
+
+/// Signed edge-gradient along a directed leg `u → v`.
+///
+/// `grad` holds the lower-tag-first edge differences (`φ_hi − φ_lo`), so a
+/// traversal in the canonical direction takes the value as-is and a reverse
+/// traversal negates it. `idx` maps a canonical edge `(lo, hi)` to its row.
+fn directed_leg(u: u32, v: u32, idx: &HashMap<(u32, u32), usize>, grad: &[f64]) -> f64 {
+    if u < v {
+        grad[idx[&(u, v)]]
+    } else {
+        -grad[idx[&(v, u)]]
+    }
+}
+
+#[test]
+fn closed_loop_signed_sum_vanishes_on_cube_faces() {
+    let mesh = cube_tet_mesh(2, 1.0);
+
+    // Arbitrary nodal field: a deterministic non-affine scramble so the
+    // cancellation is structural, not an artifact of a linear field.
+    let phi: Vec<f64> = (0..mesh.n_nodes())
+        .map(|i| {
+            let x = i as f64;
+            (x * 0.7).sin() * 3.0 + x * x * 0.013 - (x * 1.9).cos()
+        })
+        .collect();
+
+    let grad = apply_gradient(&mesh, &phi);
+
+    // Edge → row-index lookup (canonical lower-tag-first edges).
+    let edges = mesh.edges();
+    let idx: HashMap<(u32, u32), usize> = edges
+        .iter()
+        .enumerate()
+        .map(|(i, &[a, b])| ((a, b), i))
+        .collect();
+
+    // The four triangular faces of a tet [v0, v1, v2, v3].
+    let faces = |t: &[u32; 4]| {
+        [
+            [t[0], t[1], t[2]],
+            [t[0], t[1], t[3]],
+            [t[0], t[2], t[3]],
+            [t[1], t[2], t[3]],
+        ]
+    };
+
+    for tet in &mesh.tets {
+        for [a, b, c] in faces(tet) {
+            // Walk the directed cycle a → b → c → a.
+            let loop_sum = directed_leg(a, b, &idx, &grad)
+                + directed_leg(b, c, &idx, &grad)
+                + directed_leg(c, a, &idx, &grad);
+            assert!(
+                loop_sum.abs() < 1e-12,
+                "signed edge-gradient sum around face ({a},{b},{c}) = {loop_sum}, expected 0"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first map of the discrete de Rham complex — the discrete gradient `d⁰` — as a new public module `geode_core::derham`. `d⁰` is the signed node→edge incidence operator: applied to a nodal scalar field it produces the edge DOFs of the discrete gradient `∇φ`, which the existing Nédélec curl-curl operator must annihilate. This is Phase 1.A of Epic #57 (U(1) gauge-symmetry test battery); issue #59 (Phase 1.B) will consume this API unchanged.

## Changes

- New module `crates/geode-core/src/derham.rs`:
  - `pub fn gradient_map(mesh: &TetMesh) -> faer::sparse::SparseColMat<usize, f64>` — the `n_edges × n_nodes` `d⁰` operator. Row `i` is edge `i` of `TetMesh::edges()` (canonical lower-tag-first order, identical to the Nédélec assembly), with `d⁰[edge, a] = -1` and `d⁰[edge, b] = +1`. Built from two `Triplet`s per edge via `SparseColMat::try_new_from_triplets`.
  - `pub fn apply_gradient(mesh: &TetMesh, nodal: &[f64]) -> Vec<f64>` — computes `d⁰·φ` directly (`out[edge] = nodal[b] - nodal[a]`) without materializing the matrix.
- Re-exported both from `lib.rs`.
- Module doc cites Hiptmair §3 and Arnold–Falk–Winther §1.2 for the sign convention.
- New integration tests `crates/geode-core/tests/derham_gradient.rs` (4 tests).

### Note on the value type

The issue specifies `SparseColMat<i32>`, but faer 0.24's sparse constructors require the value type to implement faer's `ComplexField`, which `i32` does not (only `f32`/`f64`/complex/`Symbolic`/`fx128` do). I store the integer entries as the exactly-representable `f64` values `±1.0`. This keeps `d⁰` usable in faer sparse linear algebra and lets Phase 2 form the sparse product `d¹·d⁰` exactly, and it matches the value type of the rest of the sparse pipeline (`SparseSystem` uses `SparseColMat<usize, f64>`). The rationale is documented in the module doc.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `geode_core::derham` compiles, public API as specified | ✅ | `cargo check -p geode-core` clean; `gradient_map`/`apply_gradient` re-exported from `lib.rs` |
| `cargo test -p geode-core --test derham_gradient` green (4 tests) | ✅ | All 4 pass: shape, row-sparsity, hand-tabulated reference tet, closed-loop face cancellation |
| `cargo fmt --check` clean | ✅ | No diff reported |
| `cargo clippy --all-targets -- -D warnings` clean | ✅ | Finished with no warnings |
| Module doc cites Hiptmair / Arnold–Falk–Winther | ✅ | Both cited in the `//!` module doc with section references |

## Test Plan

- `cargo test -p geode-core --test derham_gradient` — 4 passed, 0 failed:
  1. **Shape**: `gradient_map(mesh).shape() == (n_edges, n_nodes)`.
  2. **Sparsity**: every row has exactly two nonzeros (one `+1`, one `-1`) summing to zero.
  3. **Reference tet**: hand-tabulated 6×4 `d⁰` matches; `apply_gradient` agrees on a sample field.
  4. **Closed loop**: signed edge-gradient sum around every triangular face of the n=2 cube fixture vanishes (precursor to Phase 2's `d¹·d⁰=0`).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both clean.

Closes #58