### PR TITLE
fix: backend-agnostic complex mass readback (#84)

### DIFF
--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -811,7 +811,11 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
 ///
 /// Mirrors [`crate::eigen::burn_matrix_to_faer`] for complex inputs.
 /// Pulls both halves off the device once and zips them into the
-/// complex output.
+/// complex output. `TensorData::iter::<f64>` reads the values as f64
+/// regardless of the backend's stored float dtype (f32 on the wgpu/cuda
+/// GPU backends, f64 on the ndarray CPU backend), so this is genuinely
+/// backend-agnostic — the f32 GPU path upcasts and the f64 CPU path is
+/// read losslessly.
 pub fn burn_complex_mass_to_faer<B: Backend>(
     m_re: Tensor<B, 2>,
     m_im: Tensor<B, 2>,
@@ -819,11 +823,11 @@ pub fn burn_complex_mass_to_faer<B: Backend>(
     let dims_re = m_re.dims();
     let dims_im = m_im.dims();
     assert_eq!(dims_re, dims_im, "M_re and M_im must have matching dims");
-    let data_re: Vec<f32> = m_re.into_data().to_vec().expect("readback Re");
-    let data_im: Vec<f32> = m_im.into_data().to_vec().expect("readback Im");
+    let data_re: Vec<f64> = m_re.into_data().iter::<f64>().collect();
+    let data_im: Vec<f64> = m_im.into_data().iter::<f64>().collect();
     let n = dims_re[0];
     faer::Mat::<faer::c64>::from_fn(n, dims_re[1], |i, j| {
         let idx = i * dims_re[1] + j;
-        faer::c64::new(data_re[idx] as f64, data_im[idx] as f64)
+        faer::c64::new(data_re[idx], data_im[idx])
     })
 }


### PR DESCRIPTION
Closes #84.

## Summary

`burn_complex_mass_to_faer` was reading both real and imaginary halves of the complex Nédélec mass matrix via `TensorData::to_vec::<f32>()`, which panics with `TensorData::TypeMismatch` on the `ndarray` CPU backend (which stores values as f64). Same root cause and same fix as PR #73 applied to `burn_matrix_to_faer` in `eigen.rs`.

Switch the readback to `iter::<f64>().collect()` so it works on every backend: the wgpu/cuda f32 GPU paths upcast losslessly, and the f64 ndarray CPU path is read with full precision. The two `as f64` casts in the `faer::c64::new(...)` call become no-ops and are dropped. The doc comment picks up the same backend-agnostic explanation as `burn_matrix_to_faer` got in PR #73.

## Acceptance check

The fix matches the curator-prescribed shape exactly (~3 lines + doc).

| Check | Result |
|---|---|
| `cargo check -p geode-core` (default wgpu) | green |
| `cargo test --no-default-features --features ndarray --test sphere_pml_eigenmode --release -- --ignored` | `sphere_pml_eigenmode_sigma_zero_is_real ... ok` (no `TypeMismatch` panic — readback fix proved). The second test `sphere_pml_eigenmode_spectrum` was still running in `faer::linalg::gevd::qz_cplx` after ~2h on the local M-series CPU (genuinely O(n^3) dense complex QZ) and was interrupted; both tests successfully exercised the patched readback before reaching the eigensolver. |
| `cargo test --no-default-features --features ndarray --test derham_kernel_dim --release -- --ignored` | `cube_pec_kernel_dim_matches_d0_rank ... ok` (no `TypeMismatch` panic). The second `sphere_pml_kernel_dim_matches_d0_rank` test was still in the same QZ phase after ~50 min and was interrupted. |

Both sphere-PML-sized tests on this hardware are dominated by the dense complex generalized eigensolver (`faer::linalg::gevd::qz_cplx`) — the readback fix itself is verified to work on the ndarray backend by the fact that the smaller fixtures (`sphere_pml_eigenmode_sigma_zero_is_real`, `cube_pec_kernel_dim_matches_d0_rank`) both passed end-to-end, and the larger ones both entered the QZ phase (which is downstream of `burn_complex_mass_to_faer`).

## Test plan

- [x] `cargo check -p geode-core` (default features / wgpu backend) — green
- [x] Smaller sphere PML eigenmode fixture passes on ndarray (`sphere_pml_eigenmode_sigma_zero_is_real`)
- [x] Smaller derham kernel-dim fixture passes on ndarray (`cube_pec_kernel_dim_matches_d0_rank`)
- [x] Larger sphere PML fixtures successfully pass through `burn_complex_mass_to_faer` (no `TypeMismatch`) — verified via stack sampling showing process in QZ algorithm downstream of the patched call site
- [ ] CI to confirm both `--ignored --release` test files run to completion in the Linux runner's CPU/time budget (smaller fixtures are the regression gate; larger ones are the wall-clock-bound spectrum checks)