### PR TITLE
fix(geode-core): precedence-based backend cfg robust to feature unification

### DIFF
--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -77,20 +77,21 @@ pub use arpack::ArpackEigensolver;
 use burn::tensor::backend::{Backend, BackendTypes};
 use burn::tensor::Tensor;
 
-// Backend selection is feature-driven and the three backends are mutually
-// exclusive. `wgpu` is the default (local/GPU). `cuda` is the NVIDIA path.
-// `ndarray` is the headless CPU path used by CI, where no Vulkan/CUDA
-// adapter exists. Exactly one must be enabled.
-#[cfg(any(
-    all(feature = "wgpu", feature = "cuda"),
-    all(feature = "wgpu", feature = "ndarray"),
-    all(feature = "cuda", feature = "ndarray"),
-))]
+// Backend selection is feature-driven, with a precedence policy:
+// `ndarray` > `cuda` > `wgpu`. The native GPU backends `wgpu` and
+// `cuda` remain mutually exclusive (both pull native GPU stacks that
+// cannot coexist), but `ndarray` is allowed to coexist with either
+// because Cargo feature unification across workspace targets can
+// re-activate the default `wgpu` feature even when the user passes
+// `--no-default-features --features ndarray`. The headless CPU
+// backend takes precedence in that case so that CI / local clippy
+// runs against `--features ndarray` compile cleanly.
+#[cfg(all(feature = "wgpu", feature = "cuda"))]
 compile_error!(
-    "geode-core: backend features `wgpu`, `cuda`, and `ndarray` are mutually \
-     exclusive — enable exactly one. To use a non-default backend, build with \
-     e.g. --no-default-features --features ndarray (CPU) or \
-     --no-default-features --features cuda (NVIDIA)."
+    "geode-core: backends `wgpu` and `cuda` are mutually exclusive — \
+     both pull native GPU stacks. To switch backends, build with \
+     `--no-default-features --features cuda` (NVIDIA) or \
+     `--no-default-features --features ndarray` (CPU)."
 );
 
 #[cfg(not(any(feature = "wgpu", feature = "cuda", feature = "ndarray")))]
@@ -99,19 +100,23 @@ compile_error!(
      `cuda`, or `ndarray` (CPU)."
 );
 
-#[cfg(feature = "wgpu")]
-pub type DefaultBackend = burn::backend::Wgpu;
-
-#[cfg(feature = "cuda")]
-pub type DefaultBackend = burn::backend::Cuda;
-
-// CPU backend with f64 floats so the double-precision ARPACK driver
-// (`dsaupd_c`/`dseupd_c`) keeps full precision parity with the dense oracle.
-// The Int element is pinned to `i32` (NdArray's default is `i64`) to match
-// the GPU backends: `assembly::tets_to_cpu` reads connectivity back as
-// `i32`, and Burn's typed readback rejects a width mismatch.
+// Precedence: ndarray > cuda > wgpu. `ndarray` wins so CI / headless
+// `--features ndarray` builds compile even when Cargo feature
+// unification across workspace dev-targets silently re-activates the
+// default `wgpu` feature. The CPU backend with f64 floats keeps the
+// double-precision ARPACK driver (`dsaupd_c`/`dseupd_c`) in full
+// precision parity with the dense oracle. The Int element is pinned
+// to `i32` (NdArray's default is `i64`) to match the GPU backends:
+// `assembly::tets_to_cpu` reads connectivity back as `i32`, and Burn's
+// typed readback rejects a width mismatch.
 #[cfg(feature = "ndarray")]
 pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
+
+#[cfg(all(feature = "cuda", not(feature = "ndarray")))]
+pub type DefaultBackend = burn::backend::Cuda;
+
+#[cfg(all(feature = "wgpu", not(feature = "ndarray"), not(feature = "cuda")))]
+pub type DefaultBackend = burn::backend::Wgpu;
 
 /// A geometric mesh: element connectivity and node coordinates.
 ///
@@ -156,14 +161,15 @@ pub fn device_info() -> DeviceInfo {
     }
 }
 
-#[cfg(feature = "wgpu")]
-const BACKEND_NAME: &str = "wgpu";
-
-#[cfg(feature = "cuda")]
-const BACKEND_NAME: &str = "cuda";
-
+// Same precedence as `DefaultBackend`: ndarray > cuda > wgpu.
 #[cfg(feature = "ndarray")]
 const BACKEND_NAME: &str = "ndarray";
+
+#[cfg(all(feature = "cuda", not(feature = "ndarray")))]
+const BACKEND_NAME: &str = "cuda";
+
+#[cfg(all(feature = "wgpu", not(feature = "ndarray"), not(feature = "cuda")))]
+const BACKEND_NAME: &str = "wgpu";
 
 fn default_device_label() -> String {
     let device = <DefaultBackend as BackendTypes>::Device::default();
@@ -230,5 +236,15 @@ mod tests {
             "device label must be non-empty"
         );
         assert!(!info.backend.is_empty(), "backend name must be non-empty");
+
+        // Lock in the backend-selection precedence policy (issue #76):
+        // when `ndarray` is enabled it wins regardless of whether
+        // `wgpu` was re-activated via Cargo feature unification across
+        // workspace targets.
+        #[cfg(feature = "ndarray")]
+        assert_eq!(
+            info.backend, "ndarray",
+            "ndarray must take precedence over wgpu/cuda when enabled"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the strict mutually-exclusive `compile_error!` guard in `crates/geode-core/src/lib.rs` with a precedence policy `ndarray > cuda > wgpu`, so Cargo feature unification across workspace targets cannot trigger E0428 duplicate-definition errors.
- Only the `(wgpu, cuda)` pair remains a hard `compile_error!` (both pull native GPU stacks); the `(*, ndarray)` pairs are tolerated and resolve to the headless CPU backend.
- Extends `tests::device_info_is_populated` with a precedence assertion that locks `info.backend == "ndarray"` whenever the `ndarray` feature is on, so future regressions surface under the existing CI `arpack,ndarray` invocation.

## Root cause recap

`geode-cli`'s workspace edge `geode-core = { workspace = true }` pulls `geode-core` with its default `wgpu` feature. When the workspace root is clippy'd with `--no-default-features --features ndarray`, `--all-targets` triggers unification: both `wgpu` and `ndarray` end up active. The old cfg blocks both compiled, producing E0428 before the `compile_error!` could fire — and even the intended message was misleading.

## Truth table (post-fix)

| wgpu | cuda | ndarray | active `DefaultBackend` | compile_error? |
|------|------|---------|-------------------------|----------------|
| on   | off  | off     | `Wgpu`                  | no             |
| off  | on   | off     | `Cuda`                  | no             |
| off  | off  | on      | `NdArray<f64,i32>`      | no             |
| on   | on   | off     | (error)                 | yes (wgpu+cuda) |
| on   | off  | on      | `NdArray<f64,i32>`      | no             |
| off  | on   | on      | `NdArray<f64,i32>`      | no             |
| on   | on   | on      | (error)                 | yes (wgpu+cuda) |
| off  | off  | off     | (error)                 | yes (none enabled) |

## Test plan

- [x] `cargo clippy --all-targets --no-default-features --features ndarray -- -D warnings` passes from workspace root (primary acceptance, was the failing command at HEAD)
- [x] `cargo clippy --tests -p geode-core --no-default-features --features arpack,ndarray -- -D warnings` passes (CI path, `.github/workflows/arpack.yml:62-63`)
- [x] `cargo build -p geode-core` (default `wgpu`) builds clean
- [x] `cargo test --no-default-features --features ndarray -p geode-core --lib tests::device_info_is_populated` passes and asserts `backend == "ndarray"`
- [ ] CI confirms `cargo clippy --all-targets -- -D warnings` (default wgpu) still passes (deferred to CI runners — full default-feature clippy of the entire workspace is slow locally)
- [ ] CI confirms the existing ARPACK acceptance test (`sparse_eigensolver` `--ignored`) still passes (deferred to CI; no behavioral change to test code)

## Out of scope (per curator)

- Re-architecting backend selection (runtime dispatch, trait-object device).
- Removing `geode-cli`'s default-features activation of `geode-core` (the cfg-precedence fix subsumes it and is more durable for downstream consumers).
- Adding a dedicated CI step that runs the bare reproducer command (optional, recommended follow-up).

Closes #76