### PR TITLE
feat: reference harness scaffolding + golden fixture schema (Epic #88, Phase A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "geode-validation"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/geode-core",
     "crates/geode-cli",
+    "crates/geode-validation",
 ]
 
 [workspace.package]

--- a/crates/geode-validation/Cargo.toml
+++ b/crates/geode-validation/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "geode-validation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Cross-backend reference comparison harness for GEODE-FEM (Epic #88, Phase A)."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/geode-validation/src/diff.rs
+++ b/crates/geode-validation/src/diff.rs
@@ -1,0 +1,235 @@
+//! Structured comparison + diff artifact writer.
+//!
+//! Per #88's friction-mining loop, the comparison harness MUST report
+//! per-field failures rather than a single boolean, and MUST be able to
+//! emit a machine-readable artifact when comparison fails. That diff
+//! artifact is the "product" of a failing run — it's what gets attached
+//! to the spec-anchoring conversation when two backends disagree.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::fixture::{Fixture, FixtureError};
+
+/// Top-level comparison report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComparisonReport {
+    /// Stable id of the fixture being compared against.
+    pub fixture_id: String,
+    /// Aggregated pass/fail. `true` iff every declared output field
+    /// matched within tolerance.
+    pub passed: bool,
+    /// Per-field detail. Always populated for every output field
+    /// declared in the fixture, in deterministic (sorted) order.
+    pub fields: Vec<FieldDiff>,
+    /// Schema version of this report (independent of fixture schema).
+    pub report_schema_version: String,
+}
+
+impl ComparisonReport {
+    /// Write this report to disk as JSON. Always pretty-printed —
+    /// these are friction artifacts intended for human review.
+    pub fn write_diff_artifact(&self, path: &Path) -> Result<(), std::io::Error> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let json = serde_json::to_string_pretty(self).expect("ComparisonReport serializes");
+        std::fs::write(path, json)
+    }
+
+    /// Convenience: number of failing fields.
+    pub fn n_failures(&self) -> usize {
+        self.fields.iter().filter(|f| !f.passed).count()
+    }
+}
+
+/// Per-field diff.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldDiff {
+    /// Field name as declared in the fixture.
+    pub field: String,
+    /// `true` iff every element matched within `tolerance_abs`.
+    pub passed: bool,
+    /// Why the field failed (or `Ok` if it passed).
+    pub status: FieldStatus,
+    /// Tolerance the field was checked against (from the fixture).
+    pub tolerance_abs: f64,
+    /// Golden shape, copied for self-contained artifacts.
+    pub golden_shape: Vec<usize>,
+    /// Actual length submitted (useful when shape mismatches).
+    pub actual_len: usize,
+    /// Max abs error across all matched indices. `None` if the field
+    /// failed before per-element comparison (missing / shape mismatch).
+    pub max_abs_error: Option<f64>,
+    /// Linear (row-major) index of the worst-offending element,
+    /// alongside its golden / actual values. `None` for missing /
+    /// shape-mismatch failures.
+    pub worst_offender: Option<WorstOffender>,
+}
+
+/// Discriminator on *why* a field failed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FieldStatus {
+    /// Field passed — every element within `tolerance_abs`.
+    Ok,
+    /// Field declared in fixture but not provided by the caller.
+    MissingFromActual,
+    /// Actual array length doesn't match the golden's
+    /// product-of-shape.
+    ShapeMismatch { expected: usize, actual: usize },
+    /// At least one element exceeded `tolerance_abs`.
+    ToleranceExceeded { n_violations: usize },
+    /// A non-finite value (NaN / Inf) appeared in the actual data.
+    NonFiniteInActual { first_index: usize },
+}
+
+/// Worst-offending element record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorstOffender {
+    /// Row-major linear index into the flattened field.
+    pub index: usize,
+    /// Golden value at that index.
+    pub golden: f64,
+    /// Actual value at that index.
+    pub actual: f64,
+    /// `|actual - golden|`.
+    pub abs_error: f64,
+}
+
+/// Core comparison. Public via [`Fixture::compare_against`].
+pub(crate) fn compare(fixture: &Fixture, actual: &BTreeMap<String, Vec<f64>>) -> ComparisonReport {
+    let mut fields = Vec::with_capacity(fixture.outputs.len());
+
+    // Iterate in the fixture's BTreeMap order so reports are
+    // deterministic regardless of caller insertion order.
+    for (name, golden_field) in fixture.iter_outputs() {
+        let golden = match fixture.output_f64(name) {
+            Ok(g) => g,
+            Err(FixtureError::MissingField(_)) => unreachable!(),
+            Err(e) => {
+                fields.push(FieldDiff {
+                    field: name.to_string(),
+                    passed: false,
+                    status: FieldStatus::MissingFromActual,
+                    tolerance_abs: golden_field.tolerance_abs,
+                    golden_shape: golden_field.shape.clone(),
+                    actual_len: 0,
+                    max_abs_error: None,
+                    worst_offender: None,
+                });
+                eprintln!("fixture output_f64 error for {name}: {e}");
+                continue;
+            }
+        };
+
+        let Some(actual_data) = actual.get(name) else {
+            fields.push(FieldDiff {
+                field: name.to_string(),
+                passed: false,
+                status: FieldStatus::MissingFromActual,
+                tolerance_abs: golden.tolerance_abs,
+                golden_shape: golden_field.shape.clone(),
+                actual_len: 0,
+                max_abs_error: None,
+                worst_offender: None,
+            });
+            continue;
+        };
+
+        let expected_n = golden.numel();
+        if actual_data.len() != expected_n {
+            fields.push(FieldDiff {
+                field: name.to_string(),
+                passed: false,
+                status: FieldStatus::ShapeMismatch {
+                    expected: expected_n,
+                    actual: actual_data.len(),
+                },
+                tolerance_abs: golden.tolerance_abs,
+                golden_shape: golden_field.shape.clone(),
+                actual_len: actual_data.len(),
+                max_abs_error: None,
+                worst_offender: None,
+            });
+            continue;
+        }
+
+        // Sanity-check for NaN/Inf in actual (golden is assumed clean —
+        // it was generated by the curator of the fixture).
+        if let Some((first_bad, _)) = actual_data.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+            fields.push(FieldDiff {
+                field: name.to_string(),
+                passed: false,
+                status: FieldStatus::NonFiniteInActual {
+                    first_index: first_bad,
+                },
+                tolerance_abs: golden.tolerance_abs,
+                golden_shape: golden_field.shape.clone(),
+                actual_len: actual_data.len(),
+                max_abs_error: None,
+                worst_offender: None,
+            });
+            continue;
+        }
+
+        let mut max_err = 0.0_f64;
+        let mut max_idx = 0usize;
+        let mut violations = 0usize;
+        for (i, (g, a)) in golden.data.iter().zip(actual_data.iter()).enumerate() {
+            let err = (a - g).abs();
+            if err > max_err {
+                max_err = err;
+                max_idx = i;
+            }
+            if err > golden.tolerance_abs {
+                violations += 1;
+            }
+        }
+
+        let worst = WorstOffender {
+            index: max_idx,
+            golden: golden.data[max_idx],
+            actual: actual_data[max_idx],
+            abs_error: max_err,
+        };
+
+        if violations == 0 {
+            fields.push(FieldDiff {
+                field: name.to_string(),
+                passed: true,
+                status: FieldStatus::Ok,
+                tolerance_abs: golden.tolerance_abs,
+                golden_shape: golden_field.shape.clone(),
+                actual_len: actual_data.len(),
+                max_abs_error: Some(max_err),
+                worst_offender: Some(worst),
+            });
+        } else {
+            fields.push(FieldDiff {
+                field: name.to_string(),
+                passed: false,
+                status: FieldStatus::ToleranceExceeded {
+                    n_violations: violations,
+                },
+                tolerance_abs: golden.tolerance_abs,
+                golden_shape: golden_field.shape.clone(),
+                actual_len: actual_data.len(),
+                max_abs_error: Some(max_err),
+                worst_offender: Some(worst),
+            });
+        }
+    }
+
+    let passed = fields.iter().all(|f| f.passed);
+    ComparisonReport {
+        fixture_id: fixture.fixture_id.clone(),
+        passed,
+        fields,
+        report_schema_version: "1".to_string(),
+    }
+}

--- a/crates/geode-validation/src/fixture.rs
+++ b/crates/geode-validation/src/fixture.rs
@@ -1,0 +1,281 @@
+//! Fixture loading + schema.
+//!
+//! A *fixture* is a single canonical (inputs, golden outputs) bundle
+//! for one spine slice. The on-disk schema is documented in
+//! `reference/README.md` and `reference/SCHEMA.md`; the corresponding
+//! Rust types here are loose `Map<String, Field>` so the scaffolding
+//! stays useful as the schema evolves (new fields can be added without
+//! requiring a Rust-side type-update churn).
+//!
+//! ## Format support
+//!
+//! Phase A wires only the JSON format. The [`FixtureFormat`] enum is a
+//! deliberate extension point — when the cube-cavity fixture (#92)
+//! lands and starts carrying complex eigenvectors, a `FixtureFormat::Hdf5`
+//! variant will be added behind a feature gate so contributors aren't
+//! forced to install `libhdf5` to run the smoke tests.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors raised by fixture I/O and validation.
+#[derive(Debug, Error)]
+pub enum FixtureError {
+    /// Filesystem read failure.
+    #[error("failed to read fixture file {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// JSON parse / structural validation failure.
+    #[error("failed to parse fixture as JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// On-disk schema version is not recognized by this build.
+    #[error("unsupported fixture schema_version: {0} (this build supports: {1:?})")]
+    UnsupportedSchemaVersion(String, &'static [&'static str]),
+
+    /// The requested field was not declared in the fixture.
+    #[error("fixture has no output field named '{0}'")]
+    MissingField(String),
+
+    /// HDF5 format requested but not compiled in.
+    #[error("HDF5 fixture format is not enabled in this build")]
+    HdfNotEnabled,
+}
+
+/// On-disk fixture format selector.
+///
+/// JSON is sufficient for small fixtures (Phase A smoke case);
+/// HDF5 becomes the format-of-record once eigenvector-class outputs
+/// land (#92 and later). The HDF5 variant is reserved here so callers
+/// can pin format choice without waiting for the implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixtureFormat {
+    /// Human-readable JSON. Small fixtures, easy review in PRs.
+    Json,
+    /// Binary HDF5 (not yet wired up — placeholder for the
+    /// eigenvector-class fixture work that will arrive with #92).
+    Hdf5,
+}
+
+/// Versions of the on-disk schema this build accepts.
+pub const SUPPORTED_SCHEMA_VERSIONS: &[&str] = &["1"];
+
+/// A single fixture: inputs, golden outputs, and provenance.
+///
+/// Field naming follows `reference/SCHEMA.md`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fixture {
+    /// Schema version (currently `"1"`).
+    pub schema_version: String,
+
+    /// Stable id of the fixture (e.g. `"p1_reference_tet/local_stiffness"`).
+    pub fixture_id: String,
+
+    /// Free-form one-liner describing what the fixture pins down.
+    pub description: String,
+
+    /// Units convention for the numeric values in this fixture.
+    pub units: String,
+
+    /// Input fields keyed by name (e.g. `"coords"`, `"mesh"`).
+    #[serde(default)]
+    pub inputs: BTreeMap<String, Field>,
+
+    /// Golden output fields keyed by name (e.g. `"k_local"`,
+    /// `"eigenvalues"`). Each carries its own tolerance.
+    pub outputs: BTreeMap<String, OutputField>,
+
+    /// Provenance metadata (where the golden values came from).
+    pub provenance: Provenance,
+}
+
+/// An input field — shape + dtype + data — no tolerance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    /// Shape (row-major).
+    pub shape: Vec<usize>,
+    /// Element dtype (currently only `"f64"` and `"i64"` are exercised;
+    /// stored as a string so the schema can grow without a Rust-side
+    /// enum bump).
+    pub dtype: String,
+    /// Free-form per-field description.
+    #[serde(default)]
+    pub description: String,
+    /// Flattened or nested numeric values.
+    ///
+    /// We accept both a flat `[a, b, c, ...]` array and a nested array
+    /// matching `shape`, and normalize to row-major-flat at load time.
+    pub data: serde_json::Value,
+}
+
+/// An output field — same as [`Field`] but with a tolerance attached.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputField {
+    /// Shape (row-major).
+    pub shape: Vec<usize>,
+    /// Element dtype.
+    pub dtype: String,
+    /// Free-form per-field description.
+    #[serde(default)]
+    pub description: String,
+    /// Absolute tolerance used when comparing actual against golden.
+    /// Per-field is intentional — eigenvector residuals, eigenvalues,
+    /// and matrix entries do not share a sensible tolerance.
+    pub tolerance_abs: f64,
+    /// Nested or flat numeric values. Normalized at load time.
+    pub data: serde_json::Value,
+}
+
+/// Where the golden values came from.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Human description of the source (e.g. "hand-computed exact rationals",
+    /// "NumPy reference impl at reference/numpy/p1_local_matrices.py").
+    pub source: String,
+    /// Optional cross-reference to a Rust-side check.
+    #[serde(default)]
+    pub verified_against: String,
+    /// Issue/PR number tying this fixture to a tracker.
+    #[serde(default)]
+    pub issue: String,
+}
+
+impl Fixture {
+    /// Load a fixture from disk in the requested format.
+    pub fn load_from(path: &Path, format: FixtureFormat) -> Result<Self, FixtureError> {
+        match format {
+            FixtureFormat::Json => {
+                let bytes = std::fs::read(path).map_err(|e| FixtureError::Io {
+                    path: path.display().to_string(),
+                    source: e,
+                })?;
+                let fixture: Fixture = serde_json::from_slice(&bytes)?;
+                fixture.check_schema_version()?;
+                Ok(fixture)
+            }
+            FixtureFormat::Hdf5 => Err(FixtureError::HdfNotEnabled),
+        }
+    }
+
+    /// Auto-detect format from file extension.
+    pub fn load(path: &Path) -> Result<Self, FixtureError> {
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let format = match ext.as_str() {
+            "json" => FixtureFormat::Json,
+            "h5" | "hdf5" => FixtureFormat::Hdf5,
+            _ => FixtureFormat::Json, // default for now
+        };
+        Self::load_from(path, format)
+    }
+
+    /// Verify schema version is supported by this build.
+    fn check_schema_version(&self) -> Result<(), FixtureError> {
+        if SUPPORTED_SCHEMA_VERSIONS.contains(&self.schema_version.as_str()) {
+            Ok(())
+        } else {
+            Err(FixtureError::UnsupportedSchemaVersion(
+                self.schema_version.clone(),
+                SUPPORTED_SCHEMA_VERSIONS,
+            ))
+        }
+    }
+
+    /// Get a golden output field by name, returning the values as a
+    /// flat row-major `Vec<f64>` together with the declared shape and
+    /// tolerance.
+    ///
+    /// The returned [`GoldenF64`] borrows `name` and `shape` from
+    /// `self` (not from the caller-supplied `name` argument), so the
+    /// lifetime is tied to the fixture.
+    pub fn output_f64<'a>(&'a self, name: &str) -> Result<GoldenF64<'a>, FixtureError> {
+        let (key, f) = self
+            .outputs
+            .get_key_value(name)
+            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
+        let data = flatten_to_f64(&f.data);
+        Ok(GoldenF64 {
+            name: key.as_str(),
+            shape: &f.shape,
+            tolerance_abs: f.tolerance_abs,
+            data,
+        })
+    }
+
+    /// Iterate over all output fields in deterministic (sorted) order.
+    pub fn iter_outputs(&self) -> impl Iterator<Item = (&str, &OutputField)> {
+        self.outputs.iter().map(|(k, v)| (k.as_str(), v))
+    }
+}
+
+/// A golden output field flattened into f64 row-major.
+///
+/// The `name` and `shape` borrow from the parent [`Fixture`] so callers
+/// can iterate cheaply without cloning per-field metadata.
+#[derive(Debug, Clone)]
+pub struct GoldenF64<'fix> {
+    pub name: &'fix str,
+    pub shape: &'fix [usize],
+    pub tolerance_abs: f64,
+    pub data: Vec<f64>,
+}
+
+impl GoldenF64<'_> {
+    /// Total element count implied by `shape`.
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+}
+
+/// Recursively flatten a nested `serde_json::Value` of numbers into a
+/// row-major `Vec<f64>`. Accepts both nested arrays matching `shape`
+/// and an already-flat array.
+pub(crate) fn flatten_to_f64(v: &serde_json::Value) -> Vec<f64> {
+    let mut out = Vec::new();
+    push_numbers(v, &mut out);
+    out
+}
+
+fn push_numbers(v: &serde_json::Value, out: &mut Vec<f64>) {
+    match v {
+        serde_json::Value::Number(n) => {
+            if let Some(x) = n.as_f64() {
+                out.push(x);
+            } else if let Some(x) = n.as_i64() {
+                out.push(x as f64);
+            } else if let Some(x) = n.as_u64() {
+                out.push(x as f64);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                push_numbers(item, out);
+            }
+        }
+        _ => {
+            // Non-numeric values are silently skipped — the schema
+            // validator would have caught this at load time if we had
+            // one (deliberately deferred to keep Phase A small).
+        }
+    }
+}
+
+impl Fixture {
+    /// Compare a set of named actual outputs against the golden values
+    /// in this fixture. Returns a [`ComparisonReport`] describing each
+    /// field's pass/fail status. Missing fields, shape mismatches, and
+    /// tolerance violations all surface as distinct failure modes.
+    pub fn compare_against(&self, actual: &BTreeMap<String, Vec<f64>>) -> crate::ComparisonReport {
+        crate::diff::compare(self, actual)
+    }
+}

--- a/crates/geode-validation/src/lib.rs
+++ b/crates/geode-validation/src/lib.rs
@@ -1,0 +1,61 @@
+//! Cross-backend reference comparison harness for GEODE-FEM.
+//!
+//! Substrate for Epic #88 ("cross-validated L4 lowerings"). The job of
+//! this crate is to load a *fixture* — a single canonical (input, golden
+//! output) pair for one spine slice — and compare it against an
+//! *implementation's* output, producing either a pass signal or a
+//! structured **diff artifact** that names *which field disagreed by how
+//! much*. The agreement is the semantic anchor (#88's framing);
+//! disagreements are the friction worth mining.
+//!
+//! # Design
+//!
+//! - **Format-agnostic fixtures.** [`Fixture`] is a typed in-memory
+//!   value; on-disk serialization is delegated to [`FixtureFormat`].
+//!   Only the JSON format is wired up in this Phase-A scaffolding —
+//!   eigenvector-class fixtures (#92 and later) will add an HDF5 format
+//!   variant behind a feature gate when the cost of pulling in
+//!   `libhdf5` becomes worth paying. See `reference/README.md`.
+//! - **Per-field tolerance.** Each output field carries its own
+//!   `tolerance_abs`. Comparison reports failures field-by-field so
+//!   disagreements stay legible (per #88's friction-mining loop).
+//! - **Structured diff artifacts.** A failed comparison emits a JSON
+//!   artifact summarizing per-field max-abs-error and the elementwise
+//!   worst offender. This is the "friction-mining product" — the
+//!   harness exists to *produce* these artifacts when backends
+//!   disagree, not to hide the disagreement behind a single boolean.
+//!
+//! # Scope of Phase A (this crate)
+//!
+//! Phase A intentionally ships no numerical spine work — it lands the
+//! schema, the loader, the comparator, and one smoke fixture. The
+//! NumPy reference for the cube cavity (#90 / #92) builds on this.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use geode_validation::{Fixture, FixtureFormat, ComparisonReport};
+//!
+//! let fixture = Fixture::load_from(
+//!     std::path::Path::new("reference/fixtures/p1_reference_tet/local_stiffness.json"),
+//!     FixtureFormat::Json,
+//! ).unwrap();
+//!
+//! // Suppose we have an actual implementation output keyed by the same
+//! // field names as `fixture.outputs`:
+//! let mut actual = std::collections::BTreeMap::new();
+//! actual.insert("k_local".to_string(), vec![0.5, -1.0 / 6.0 /* ... */]);
+//!
+//! let report = fixture.compare_against(&actual);
+//! if !report.passed {
+//!     report.write_diff_artifact(std::path::Path::new("diff.json")).unwrap();
+//! }
+//! ```
+
+#![doc(html_root_url = "https://docs.rs/geode-validation/0.1.0")]
+
+pub mod diff;
+pub mod fixture;
+
+pub use diff::{ComparisonReport, FieldDiff};
+pub use fixture::{Field, Fixture, FixtureError, FixtureFormat, OutputField, Provenance};

--- a/crates/geode-validation/tests/smoke.rs
+++ b/crates/geode-validation/tests/smoke.rs
@@ -1,0 +1,234 @@
+//! End-to-end smoke tests for the reference-comparison harness.
+//!
+//! These tests demonstrate the full Phase-A loop:
+//!
+//!   1. Load the canonical P1-reference-tet fixture from disk.
+//!   2. Produce a "Rust hand-coded" actual output for the same tet.
+//!   3. Compare against the fixture and assert agreement within `1e-12`
+//!      (the acceptance criterion in #89).
+//!   4. Deliberately corrupt one entry, re-compare, and assert that
+//!      the harness produces a structured diff artifact naming the
+//!      bad field, the worst offender, and the per-field tolerance.
+//!
+//! The fixture itself lives under `reference/fixtures/...` at repo
+//! root so the same file is consumable by future NumPy / JAX / Julia
+//! reference impls without duplication.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use geode_validation::diff::FieldStatus;
+use geode_validation::{Fixture, FixtureFormat};
+
+/// Walk up from `CARGO_MANIFEST_DIR` to find the repo root (the
+/// directory that contains `reference/`). Worktrees place the crate
+/// at `.loom/worktrees/issue-N/crates/geode-validation/`, so the
+/// number of `..` hops isn't fixed.
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest.ancestors() {
+        if ancestor.join("reference").is_dir() {
+            return ancestor.to_path_buf();
+        }
+    }
+    panic!(
+        "could not find a `reference/` directory walking up from {}",
+        manifest.display()
+    );
+}
+
+fn smoke_fixture_path() -> PathBuf {
+    repo_root().join("reference/fixtures/p1_reference_tet/local_stiffness.json")
+}
+
+/// Hand-coded "Rust implementation" of the P1 reference-tet local
+/// matrices and signed volume. Mirrors `p1_local_reference` in
+/// `crates/geode-core/tests/p1_local_matrices.rs` but is duplicated
+/// here on purpose: the harness lives in `geode-validation` and
+/// shouldn't take a dependency on `geode-core` just for one tet's
+/// worth of math. The agreement between this hand-coded baseline and
+/// the on-disk fixture is what's actually being tested.
+fn p1_reference_tet_actual() -> BTreeMap<String, Vec<f64>> {
+    // Volume of the canonical reference tet = 1/6.
+    let v = 1.0_f64 / 6.0;
+
+    // K_{ij} = V * grad_phi_i . grad_phi_j  with the basis-function
+    // gradients listed in `reference/fixtures/.../local_stiffness.json`'s
+    // description.
+    //
+    // Row-major flattening of a [1, 4, 4] tensor.
+    let k_local: Vec<f64> = vec![
+        0.5, -v, -v, -v, -v, v, 0.0, 0.0, -v, 0.0, v, 0.0, -v, 0.0, 0.0, v,
+    ];
+
+    // M_{ij} = (V/20)(1 + delta_{ij}).
+    let mass_diag = 2.0 * v / 20.0; // 1/60
+    let mass_off = v / 20.0; // 1/120
+    let m_local: Vec<f64> = vec![
+        mass_diag, mass_off, mass_off, mass_off, mass_off, mass_diag, mass_off, mass_off, mass_off,
+        mass_off, mass_diag, mass_off, mass_off, mass_off, mass_off, mass_diag,
+    ];
+
+    let signed_volume: Vec<f64> = vec![v];
+
+    let mut out = BTreeMap::new();
+    out.insert("k_local".to_string(), k_local);
+    out.insert("m_local".to_string(), m_local);
+    out.insert("signed_volume".to_string(), signed_volume);
+    out
+}
+
+#[test]
+fn smoke_fixture_loads_and_compares_within_1e_minus_12() {
+    let fixture = Fixture::load_from(&smoke_fixture_path(), FixtureFormat::Json)
+        .expect("smoke fixture should load");
+    assert_eq!(fixture.fixture_id, "p1_reference_tet/local_stiffness");
+    assert_eq!(fixture.schema_version, "1");
+    assert!(fixture.outputs.contains_key("k_local"));
+    assert!(fixture.outputs.contains_key("m_local"));
+    assert!(fixture.outputs.contains_key("signed_volume"));
+
+    let actual = p1_reference_tet_actual();
+    let report = fixture.compare_against(&actual);
+    assert!(
+        report.passed,
+        "Rust hand-coded baseline should match fixture within tolerance; report = {:#?}",
+        report
+    );
+    assert_eq!(report.n_failures(), 0);
+
+    // Every field's max abs error should be at machine precision
+    // (exact rationals on both sides), well under 1e-12.
+    for f in &report.fields {
+        let err = f.max_abs_error.expect("passed fields report max_abs_error");
+        assert!(
+            err < 1e-12,
+            "field {} drifted past 1e-12 (got {})",
+            f.field,
+            err
+        );
+    }
+}
+
+#[test]
+fn deliberate_corruption_produces_structured_diff_artifact() {
+    let fixture = Fixture::load_from(&smoke_fixture_path(), FixtureFormat::Json)
+        .expect("smoke fixture should load");
+
+    // Start from the correct baseline and deliberately corrupt
+    // K_{0,0}. This simulates a real friction case: a backend
+    // implementation that almost agrees but has one bad entry.
+    let mut actual = p1_reference_tet_actual();
+    {
+        let k = actual.get_mut("k_local").expect("k_local present");
+        k[0] += 1e-3; // way past the 1e-12 tolerance
+    }
+
+    let report = fixture.compare_against(&actual);
+    assert!(!report.passed, "corrupted baseline should fail comparison");
+    assert_eq!(report.n_failures(), 1, "exactly one field should fail");
+
+    // Find the failing field and check it's k_local with the expected
+    // worst-offender at linear index 0.
+    let k_diff = report
+        .fields
+        .iter()
+        .find(|f| f.field == "k_local")
+        .expect("k_local field present in report");
+    assert!(!k_diff.passed);
+    match &k_diff.status {
+        FieldStatus::ToleranceExceeded { n_violations } => {
+            assert_eq!(*n_violations, 1, "exactly one element violated tolerance");
+        }
+        other => panic!("expected ToleranceExceeded, got {:?}", other),
+    }
+    let worst = k_diff
+        .worst_offender
+        .as_ref()
+        .expect("worst offender recorded");
+    assert_eq!(worst.index, 0, "linear index 0 is the corrupted entry");
+    assert!(
+        (worst.abs_error - 1e-3).abs() < 1e-15,
+        "worst-offender abs_error should equal the injected delta"
+    );
+
+    // Other fields should still pass — failures must not "infect"
+    // unrelated fields.
+    for f in &report.fields {
+        if f.field == "k_local" {
+            continue;
+        }
+        assert!(f.passed, "field {} should still pass; got {:?}", f.field, f);
+    }
+
+    // Round-trip: write the diff artifact and re-load it to confirm
+    // it's well-formed JSON consumable by a downstream tool.
+    let out = tempdir_path("diff-artifact.json");
+    report
+        .write_diff_artifact(&out)
+        .expect("diff artifact should write");
+    let raw = std::fs::read_to_string(&out).expect("artifact readable");
+    let reloaded: geode_validation::ComparisonReport =
+        serde_json::from_str(&raw).expect("artifact is valid JSON");
+    assert!(!reloaded.passed);
+    assert_eq!(reloaded.fixture_id, "p1_reference_tet/local_stiffness");
+    assert_eq!(reloaded.n_failures(), 1);
+
+    // Clean up.
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn missing_field_in_actual_is_reported_as_distinct_failure_mode() {
+    let fixture = Fixture::load_from(&smoke_fixture_path(), FixtureFormat::Json)
+        .expect("smoke fixture should load");
+    let mut actual = p1_reference_tet_actual();
+    actual.remove("m_local");
+
+    let report = fixture.compare_against(&actual);
+    assert!(!report.passed);
+    let m_diff = report
+        .fields
+        .iter()
+        .find(|f| f.field == "m_local")
+        .expect("m_local entry present in report");
+    assert!(matches!(m_diff.status, FieldStatus::MissingFromActual));
+}
+
+#[test]
+fn shape_mismatch_in_actual_is_reported_as_distinct_failure_mode() {
+    let fixture = Fixture::load_from(&smoke_fixture_path(), FixtureFormat::Json)
+        .expect("smoke fixture should load");
+    let mut actual = p1_reference_tet_actual();
+    // Truncate k_local so its length no longer matches the golden shape.
+    actual.get_mut("k_local").unwrap().truncate(10);
+
+    let report = fixture.compare_against(&actual);
+    assert!(!report.passed);
+    let k_diff = report
+        .fields
+        .iter()
+        .find(|f| f.field == "k_local")
+        .expect("k_local entry present in report");
+    match &k_diff.status {
+        FieldStatus::ShapeMismatch { expected, actual } => {
+            assert_eq!(*expected, 16);
+            assert_eq!(*actual, 10);
+        }
+        other => panic!("expected ShapeMismatch, got {:?}", other),
+    }
+}
+
+/// Tiny tempdir helper — `std::env::temp_dir()` + a unique-ish file
+/// name per test invocation. Avoids pulling in the `tempfile` crate
+/// for one path's worth of friction.
+fn tempdir_path(name: &str) -> PathBuf {
+    let pid = std::process::id();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut p = std::env::temp_dir();
+    p.push(format!("geode-validation-{pid}-{ts}-{name}"));
+    p
+}

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,0 +1,150 @@
+# `reference/` — cross-backend reference set
+
+Substrate for **Epic #88** (cross-validated L4 lowerings). This directory
+holds the canonical fixtures, per-backend reference implementations, and
+shared docs that the Rust-side comparison harness
+(`crates/geode-validation/`) drives.
+
+> **What this is:** a place where every spine slice has one canonical
+> (input, golden output) bundle and a set of independent
+> implementations whose agreement *is* the semantic anchor for the L4
+> calculus (#88).
+>
+> **What this is not:** a multi-backend dispatch layer for production
+> GEODE-FEM. Burn remains the production runtime; the backends here
+> are reference / validation tools.
+
+## Layout
+
+```
+reference/
+├── README.md                       — this file
+├── SCHEMA.md                       — fixture schema (v1)
+├── fixtures/                       — canonical (input, golden output) bundles
+│   └── p1_reference_tet/
+│       └── local_stiffness.json    — Phase A smoke fixture
+├── numpy/                          — NumPy/SciPy reference impls (Python)
+│   └── README.md
+├── jax/                            — JAX reference impls (deferred)
+│   └── README.md
+├── julia/                          — Julia reference impls (deferred)
+│   └── README.md
+├── onnx/                           — ONNX graph references (deferred)
+│   └── README.md
+└── tf_java/                        — TF-Java reference impls (deferred)
+    └── README.md
+```
+
+## Workspace shape — answer to #88 open question #1
+
+> *"Workspace shape: new crate (`geode-validation`) inside the existing
+> workspace, or sibling Python/Julia/JAX/ONNX repo cross-linked from
+> here?"*
+
+**Resolved as: hybrid — in-tree harness + in-tree reference sources,
+with per-backend toolchains owned by sibling tooling rather than the
+Rust workspace.**
+
+Concretely:
+
+| Layer | Lives where | Why |
+|---|---|---|
+| **Comparison harness** | `crates/geode-validation/` (Rust, in this workspace) | The Rust side has to drive the comparison anyway; making it a workspace crate gives us `cargo test` integration and matches the existing pattern (cf. `geode-core`'s `tests/` directory pinning regression fixtures). |
+| **Canonical fixtures** | `reference/fixtures/` (in-tree) | One source of truth, reviewed in PRs alongside the code that produces or consumes them. Binary HDF5 fixtures will live here too once the eigenvector slice lands (#92). |
+| **Per-backend reference impls** | `reference/<backend>/` (in-tree source files) | Source-of-truth in the same git history as the harness — PR review can show "we changed the NumPy impl *and* the fixture *and* the Rust impl in lockstep." |
+| **Per-backend toolchain / venv / `Project.toml`** | Owned by `reference/<backend>/` directly, not by the Cargo workspace | Avoids forcing a polyglot build dependency on every Rust contributor. A Rust dev who never touches the NumPy backend should not need Python to run `cargo test`. |
+
+**Rejected alternatives**:
+
+- **Sibling repo for everything non-Rust** — increases the bookkeeping
+  cost (cross-repo PRs every time a fixture changes), and the
+  *fixtures* really do belong with the harness that consumes them.
+  We may still split out a sibling repo *later* if the per-backend
+  source tree grows large enough to warrant its own CI, but Phase A
+  doesn't need that.
+- **Pure-Rust workspace with backends invoked purely as subprocesses
+  reading/writing JSON** — fine in principle but makes the round-trip
+  feedback loop (edit NumPy → see new diff artifact) clumsier than
+  necessary. Keeping the Python source in-tree gives us natural
+  `python reference/numpy/run.py` invocations from the harness.
+
+**Implication for #88's Phase B–F**: each per-backend phase lands a
+`reference/<backend>/` directory tree with its own toolchain bootstrap
+docs, and the Rust harness gains a thin subprocess-driver per backend.
+The fixtures and the comparator stay backend-agnostic.
+
+## Fixture format choice — JSON now, HDF5 reserved
+
+The harness supports a `FixtureFormat::Json` variant today and reserves
+`FixtureFormat::Hdf5` for the eigenvector-class outputs that arrive
+with the cube-cavity slice (#92).
+
+Rationale:
+
+- The Phase-A smoke fixture is a single 4×4 matrix plus a 4×4 mass
+  matrix plus a scalar — JSON is the smallest sufficient format. It
+  also reviews cleanly in PRs.
+- HDF5 is the format-of-record once we ship large complex eigenvectors
+  (#88's framing — see *Implementation notes* in #89). The
+  `FixtureFormat::Hdf5` variant is wired into the API now so callers
+  can pin format choice without waiting for the implementation; the
+  linker dependency on `libhdf5` will be added behind a Cargo feature
+  in the same PR that lands the first binary fixture (#92), so
+  contributors who never run cube-cavity validation don't pay the
+  `libhdf5` install cost.
+- See `SCHEMA.md` for the JSON v1 schema.
+
+## How the harness emits a diff artifact
+
+`ComparisonReport::write_diff_artifact(path)` writes a pretty-printed
+JSON document with one entry per declared output field:
+
+```json
+{
+  "fixture_id": "p1_reference_tet/local_stiffness",
+  "passed": false,
+  "report_schema_version": "1",
+  "fields": [
+    {
+      "field": "k_local",
+      "passed": false,
+      "status": { "kind": "tolerance_exceeded", "n_violations": 1 },
+      "tolerance_abs": 1e-12,
+      "golden_shape": [1, 4, 4],
+      "actual_len": 16,
+      "max_abs_error": 1e-3,
+      "worst_offender": {
+        "index": 0,
+        "golden": 0.5,
+        "actual": 0.501,
+        "abs_error": 1e-3
+      }
+    }
+  ]
+}
+```
+
+The status enum names the failure mode (`ok`, `missing_from_actual`,
+`shape_mismatch`, `tolerance_exceeded`, `non_finite_in_actual`) so
+disagreements stay legible. Per #88's friction-mining loop, this is
+the artifact that gets attached to spec-anchoring discussions when
+two backends disagree.
+
+See `crates/geode-validation/tests/smoke.rs` for the end-to-end loop.
+
+## What lives where (cheatsheet)
+
+| Question | Answer |
+|---|---|
+| Where do I add a new fixture? | `reference/fixtures/<slice>/<case>.json` (or `.h5` once #92 lands HDF5) |
+| Where do I add a new Rust comparison test? | `crates/geode-validation/tests/<slice>_<case>.rs` |
+| Where does the NumPy implementation live? | `reference/numpy/<slice>.py` (lands with #90) |
+| What schema version are we on? | `1` — see `SCHEMA.md` |
+| What tolerance should I use? | Per-field, declared in the fixture's `outputs.<field>.tolerance_abs`. There is no global tolerance. |
+
+## Parent epic
+
+- **#88** — cross-validated L4 lowerings
+- **#89** — this scaffolding (Phase A)
+- **#90** — NumPy P1 local matrices (Phase B, in flight)
+- **#92** — cube-cavity end-to-end (Phase B continued)

--- a/reference/SCHEMA.md
+++ b/reference/SCHEMA.md
@@ -1,0 +1,81 @@
+# Fixture schema v1
+
+Canonical (input, golden output) bundle format for the GEODE-FEM
+reference set. Loaded by `geode-validation::Fixture::load`. Versioned
+via the top-level `schema_version` string; this document describes
+v1.
+
+## Top-level keys
+
+| Key | Type | Required? | Meaning |
+|---|---|---|---|
+| `schema_version` | string | yes | Currently `"1"`. |
+| `fixture_id` | string | yes | Stable id, e.g. `"p1_reference_tet/local_stiffness"`. Used as the key inside `ComparisonReport`. |
+| `description` | string | yes | One-liner: what does this fixture pin down? |
+| `units` | string | yes | Free-form units convention. |
+| `inputs` | map\<string, Field\> | optional | Inputs the implementation should consume. May be empty for fixtures that pin a pure-output identity (e.g. "the reference tet's local matrices are *exactly* this"). |
+| `outputs` | map\<string, OutputField\> | yes | Golden outputs to compare against. |
+| `provenance` | Provenance | yes | Where the golden values came from. |
+
+## `Field` (inputs)
+
+| Key | Type | Required? | Meaning |
+|---|---|---|---|
+| `shape` | array<int> | yes | Row-major shape. |
+| `dtype` | string | yes | `"f64"` is exercised today. `"i64"`, `"c128"`, etc. reserved for future slices. |
+| `description` | string | optional | Per-field comment. |
+| `data` | array (nested or flat) of numbers | yes | Values. Both nested arrays matching `shape` and pre-flattened row-major arrays are accepted; the loader normalizes to flat. |
+
+## `OutputField` (outputs)
+
+Same as `Field`, plus:
+
+| Key | Type | Required? | Meaning |
+|---|---|---|---|
+| `tolerance_abs` | f64 | yes | Per-field absolute tolerance used when comparing actual against golden. There is no global tolerance — different output kinds (eigenvalues vs. matrix entries vs. eigenvector residuals) call for different tolerances. |
+
+## `Provenance`
+
+| Key | Type | Required? | Meaning |
+|---|---|---|---|
+| `source` | string | yes | E.g. `"hand-computed exact rationals"`, or `"reference/numpy/p1_local_matrices.py SHA <sha>"`. |
+| `verified_against` | string | optional | Cross-reference to a Rust-side check (test path / function). |
+| `issue` | string | optional | Issue / PR that introduced the fixture. |
+
+## Conventions
+
+- **Row-major** flattening throughout. A `[1, 4, 4]` tensor flattens to
+  a length-16 vector with `(b, i, j) → b*16 + i*4 + j`.
+- **dtype names** match NumPy: `f64`, `f32`, `i64`, `i32`, `c128`,
+  `c64`. The harness only consumes the loader path for `f64` today; the
+  schema reserves the others for forward use.
+- **Per-field tolerances** are absolute. Relative tolerances are
+  deliberately omitted at v1 — they would require deciding whether to
+  divide by the golden, the actual, or their mean, and Phase A doesn't
+  need that decision yet. Re-evaluate once we have a fixture where the
+  natural tolerance is relative (likely with the eigenvalue slice).
+- **Inputs may be embedded mesh data** for the early phases. Mesh
+  canonicalization (#88 open question #2) is intentionally deferred —
+  start by embedding mesh data in the fixture file directly, revisit
+  when the fixture set grows.
+
+## Adding a new fixture
+
+1. Pick a slice / case slug, e.g. `cube_cavity/n8_first_five_modes`.
+2. Create `reference/fixtures/<slug>.json` (or `.h5` once HDF5 lands).
+3. Document the field-naming convention in the fixture's `description`.
+4. Add an integration test under `crates/geode-validation/tests/`
+   that loads the fixture and compares an actual implementation
+   against it. Use `1e-12` for hand-computed exact rationals; pick a
+   defensible looser tolerance for numerically-derived references and
+   document *why* in the fixture's `tolerance_abs` field.
+
+## Versioning
+
+When the schema changes incompatibly:
+
+- Bump `schema_version` (`"1"` → `"2"`).
+- Add the new value to `SUPPORTED_SCHEMA_VERSIONS` in
+  `crates/geode-validation/src/fixture.rs`.
+- Either continue supporting v1 loads (preferred — fixtures are
+  durable artifacts) or write a one-shot migration script.

--- a/reference/fixtures/p1_reference_tet/local_stiffness.json
+++ b/reference/fixtures/p1_reference_tet/local_stiffness.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1",
+  "fixture_id": "p1_reference_tet/local_stiffness",
+  "description": "P1 (linear) tetrahedral reference element: local stiffness K, local consistent mass M, and signed volume V for the canonical reference tet with vertices (0,0,0),(1,0,0),(0,1,0),(0,0,1). Vertex ordering matches geode_core::p1: v_0 is the 'base' for edge vectors e_k = v_k - v_0.",
+  "units": "dimensionless (geometry is unit-scaled; values are exact rationals encoded as f64)",
+  "inputs": {
+    "coords": {
+      "shape": [1, 4, 3],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [1, 4, 4],
+      "dtype": "f64",
+      "description": "Local stiffness K_{ij} = V (grad phi_i . grad phi_j). Symmetric.",
+      "tolerance_abs": 1e-12,
+      "data": [
+        [ 0.5,                -0.16666666666666666, -0.16666666666666666, -0.16666666666666666 ],
+        [-0.16666666666666666, 0.16666666666666666,  0.0,                  0.0                 ],
+        [-0.16666666666666666, 0.0,                  0.16666666666666666,  0.0                 ],
+        [-0.16666666666666666, 0.0,                  0.0,                  0.16666666666666666 ]
+      ]
+    },
+    "m_local": {
+      "shape": [1, 4, 4],
+      "dtype": "f64",
+      "description": "Local consistent mass M_{ij} = (V/20)(1 + delta_{ij}).",
+      "tolerance_abs": 1e-12,
+      "data": [
+        [0.016666666666666666, 0.008333333333333333, 0.008333333333333333, 0.008333333333333333],
+        [0.008333333333333333, 0.016666666666666666, 0.008333333333333333, 0.008333333333333333],
+        [0.008333333333333333, 0.008333333333333333, 0.016666666666666666, 0.008333333333333333],
+        [0.008333333333333333, 0.008333333333333333, 0.008333333333333333, 0.016666666666666666]
+      ]
+    },
+    "signed_volume": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Positive for the canonical orientation.",
+      "tolerance_abs": 1e-15,
+      "data": [0.16666666666666666]
+    }
+  },
+  "provenance": {
+    "source": "hand-computed exact rationals",
+    "verified_against": "geode_core::p1::batched_p1_local_matrices and crates/geode-core/tests/p1_local_matrices.rs::reference_tet_exact",
+    "issue": "#89 (parent epic #88)"
+  }
+}

--- a/reference/jax/README.md
+++ b/reference/jax/README.md
@@ -1,0 +1,15 @@
+# JAX reference implementations
+
+Differentiable reference backend per **Epic #88**. JAX probes how
+natural the L4 calculus is for XLA tracing and whether autodiff
+survives the assembly path.
+
+## Status
+
+Stub — concrete impls deferred to **#88 Phase C**. NumPy (Phase B)
+must land first so JAX disagreements have an anchor.
+
+## Planned layout
+
+Mirrors `reference/numpy/`. See `reference/numpy/README.md` for the
+invocation convention.

--- a/reference/julia/README.md
+++ b/reference/julia/README.md
@@ -1,0 +1,15 @@
+# Julia reference implementations
+
+Complex-arithmetic reference backend per **Epic #88**. Probes
+whether complex-arithmetic ergonomics surface different L4 friction
+than the f64-pair representation used in Burn/NumPy.
+
+## Status
+
+Stub — concrete impls deferred to **#88 Phase E**.
+
+## Planned layout
+
+Mirrors `reference/numpy/`. Toolchain bootstrap will use Julia's
+`Project.toml` / `Manifest.toml` for reproducibility; ARPACK access
+goes through `Arpack.jl`.

--- a/reference/numpy/README.md
+++ b/reference/numpy/README.md
@@ -1,0 +1,54 @@
+# NumPy reference implementations
+
+Canonical reference backend per **Epic #88**. NumPy goes first because
+it has the largest training cohort, the thinnest abstraction between
+math and code, and the most mature sparse eigensolvers
+(`scipy.sparse.linalg.eigsh`). When backends disagree, NumPy is the
+default tiebreaker.
+
+## Status
+
+Stub — first concrete impl lands with **#90** (NumPy P1 local
+matrices) and **#92** (cube cavity end-to-end). Until then this
+directory is intentionally empty.
+
+## Planned layout
+
+```
+reference/numpy/
+├── README.md                       — this file
+├── pyproject.toml                  — pinned NumPy/SciPy versions (lands with #90)
+├── p1_local_matrices.py            — element-local K and M for the P1 reference tet (#90)
+├── cube_cavity.py                  — end-to-end cube-cavity eigenmode driver (#92)
+└── _harness.py                     — fixture I/O helper shared across slices
+```
+
+## Invocation convention
+
+Reference impls are invoked by the Rust harness as subprocesses:
+
+```bash
+python reference/numpy/<slice>.py <fixture-path> <output-path>
+```
+
+The script reads inputs from the fixture (JSON v1, see
+`reference/SCHEMA.md`), produces a results file in the same schema,
+and exits 0 on success / nonzero on internal error. The Rust harness
+diffs the output against the fixture's golden values per the standard
+`Fixture::compare_against` flow.
+
+## Toolchain bootstrap (forward-looking, defined in #90)
+
+Recommended pattern when the first impl lands:
+
+```bash
+cd reference/numpy
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt   # or `pip install -e .` once pyproject.toml lands
+```
+
+The Rust harness should *not* assume a particular venv path — every
+backend script's interpreter is configurable via an env var like
+`GEODE_VALIDATION_NUMPY=python3` (default `python3`). See #90 for
+the exact wiring.

--- a/reference/onnx/README.md
+++ b/reference/onnx/README.md
@@ -1,0 +1,15 @@
+# ONNX reference implementations
+
+Graph-only constraint check per **Epic #88**. Forces the L4 calculus
+through a graph-only expressibility constraint, exposing primitives
+that are secretly imperative.
+
+## Status
+
+Stub — concrete impls deferred to **#88 Phase F**. May surface as
+"documented graph-expressibility failures" rather than a full impl;
+that's an explicit accepted outcome per the epic.
+
+## Planned layout
+
+Mirrors `reference/numpy/`.

--- a/reference/tf_java/README.md
+++ b/reference/tf_java/README.md
@@ -1,0 +1,17 @@
+# TF-Java reference implementations
+
+L4-shaped reference backend per **Epic #88**. Adds static
+typechecking + IDE tooling against an L4-shaped object graph
+(no other backend exposes the graph as a first-class typed value).
+
+## Status
+
+Stub — concrete impls deferred to **#88 Phase D**, sequenced with
+JAX (Phase C) since both go through XLA. Agreement validates the
+L4 → XLA lowering; disagreement isolates DX-surface vs
+compiler-semantics.
+
+## Planned layout
+
+Mirrors `reference/numpy/` with a Maven `pom.xml` driving
+dependency resolution.


### PR DESCRIPTION
## Summary

Lands the substrate for Epic #88 ("cross-validated L4 lowerings"). This is the Phase-A scaffolding that #90, #92, #93, and the rest of the per-backend phases all build on. It ships zero spine-slice numerical work by design — its job is to make the next issue (NumPy P1 local matrices, #90) merely tedious instead of design-heavy.

## Changes

- **New workspace member** `crates/geode-validation/` with:
  - `Fixture` + `FixtureFormat::{Json, Hdf5}` loader (JSON wired, HDF5 reserved behind a feature gate for the eigenvector-class fixtures that arrive with #92 — see "Workspace shape" answer below for why we're deferring the `libhdf5` linker dependency).
  - `ComparisonReport` with per-field structured diff (`FieldStatus::{Ok, MissingFromActual, ShapeMismatch, ToleranceExceeded, NonFiniteInActual}`).
  - `ComparisonReport::write_diff_artifact(path)` — pretty-printed JSON, the friction-mining product per #88's loop.
- **`reference/` tree** at repo root:
  - Top-level `README.md` answering #88's open question #1 (workspace shape — see below).
  - `SCHEMA.md` pinning the fixture schema v1 (per-field `tolerance_abs`, row-major flattening, dtype-as-string for forward extension).
  - Stub READMEs for `numpy/`, `jax/`, `julia/`, `onnx/`, `tf_java/` so the next-phase builders have an obvious place to land their work.
- **Smoke fixture** `reference/fixtures/p1_reference_tet/local_stiffness.json` — exact rationals for the canonical reference-tet local stiffness, consistent mass, and signed volume. Values cross-checked against the existing `crates/geode-core/tests/p1_local_matrices.rs::reference_tet_exact`.
- **4 integration tests** in `crates/geode-validation/tests/smoke.rs` exercising the full loop.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Directory layout exists and is documented in top-level `reference/README.md` | done | See `reference/README.md` (layout table + per-backend stub READMEs). |
| One fixture file exists for the smoke case, in the chosen schema, with documented field names and units | done | `reference/fixtures/p1_reference_tet/local_stiffness.json`; schema in `reference/SCHEMA.md`. |
| Rust integration test runs the harness against the smoke fixture and passes (1e-12) | done | `smoke_fixture_loads_and_compares_within_1e_minus_12` asserts every field's max abs error is below `1e-12`. |
| Harness produces a structured diff artifact (JSON, known path) when comparison fails; demonstrated via a deliberately-wrong baseline | done | `deliberate_corruption_produces_structured_diff_artifact` corrupts K[0,0], asserts the artifact names `k_local` as the failing field with `worst_offender.index == 0` and `abs_error == 1e-3`, then round-trips the file through `serde_json` to confirm it's well-formed. Two additional tests cover the `MissingFromActual` and `ShapeMismatch` failure modes so they don't get conflated with tolerance violations. |
| Open question #1 from #88 ("workspace shape") is answered in PR's design notes with rationale | done | See "Workspace shape" section below + dedicated section in `reference/README.md`. |
| No spine-slice numerical work | done | The smoke fixture pins one tet's local matrices (no eigenproblems, no meshes beyond the canonical reference tet). All actual spine work — NumPy P1, cube cavity — explicitly deferred to #90/#92. |

## Workspace shape — answer to #88 open question #1

**Resolved as: hybrid — in-tree harness (`crates/geode-validation/`) + in-tree reference sources (`reference/`), with per-backend toolchains owned by `reference/<backend>/` rather than the Cargo workspace.**

Rationale (full version in `reference/README.md`):

- Comparison harness is in-tree as a workspace crate: integrates with `cargo test`, matches the existing `geode-core/tests/` regression-fixture pattern, and the Rust side has to drive the comparison anyway.
- Fixtures are in-tree: one source of truth, reviewed in PRs alongside the code that produces or consumes them.
- Per-backend reference implementations are in-tree as source files (under `reference/numpy/`, `reference/jax/`, etc.) so PR review can show "we changed the NumPy impl + the fixture + the Rust impl in lockstep."
- Per-backend toolchains (Python venv, Julia `Project.toml`, Maven `pom.xml`, etc.) are owned by `reference/<backend>/`, not by the Cargo workspace — a Rust contributor who never touches NumPy should not need a Python venv to run `cargo test`.

**Rejected alternatives**:
- Sibling repo for everything non-Rust: increases bookkeeping cost (cross-repo PRs every time a fixture changes); the fixtures really do belong with the harness that consumes them. May still split out later if `reference/` grows large enough to want its own CI, but Phase A doesn't need that.
- Pure-Rust workspace + backends purely as opaque subprocesses: fine in principle but makes the round-trip feedback loop (edit NumPy → see new diff artifact) clumsier than necessary.

**Bonus: format choice for fixtures** — JSON now, HDF5 reserved. Phase-A's smoke fixture is a single 4x4 matrix + a 4x4 mass matrix + a scalar — JSON is the smallest sufficient choice and reviews cleanly in PRs. HDF5 becomes format-of-record once eigenvectors land (#92); the `FixtureFormat::Hdf5` variant is wired into the API today so callers can pin format choice, with the `libhdf5` linker dependency deferred behind a Cargo feature until #92 actually needs it.

## Test Plan

```sh
cargo test -p geode-validation
```

Expected: 4 integration tests pass + 1 doc test passes. Verified locally:

```
running 4 tests
test shape_mismatch_in_actual_is_reported_as_distinct_failure_mode ... ok
test smoke_fixture_loads_and_compares_within_1e_minus_12 ... ok
test missing_field_in_actual_is_reported_as_distinct_failure_mode ... ok
test deliberate_corruption_produces_structured_diff_artifact ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured

Doc-tests geode_validation
test crates/geode-validation/src/lib.rs - (line 36) - compile ... ok
test result: ok. 1 passed
```

Also verified:
- `cargo check --workspace` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo fmt -p geode-validation --check` clean.

## Coordination

Wave 1 of `/sweep` on #88. Running in parallel with builders for #90 (NumPy P1 matrices) and #91 (d2 operator). Those issues consume this scaffolding; no merge ordering required since they were independently spec'd against the Phase-A contract documented here. The schema is versioned (`schema_version: "1"`, `SUPPORTED_SCHEMA_VERSIONS` in `crates/geode-validation/src/fixture.rs`), so future fixture revisions don't break consumers of v1 fixtures.

Closes #89