### PR TITLE
feat: discrete divergence d² in geode_core::derham (#91)

### DIFF
--- a/crates/geode-core/src/derham.rs
+++ b/crates/geode-core/src/derham.rs
@@ -1,7 +1,7 @@
 //! Discrete de Rham complex operators on a tetrahedral mesh.
 //!
-//! This module provides the first two maps of the discrete de Rham
-//! complex on a tetrahedral mesh:
+//! This module provides the full discrete de Rham complex on a
+//! tetrahedral mesh:
 //!
 //! ```text
 //! ℝ^{n_nodes}  --d⁰-->  ℝ^{n_edges}  --d¹-->  ℝ^{n_faces}  --d²-->  ℝ^{n_tets}
@@ -14,13 +14,20 @@
 //!   matrix that sends an edge-DOF field (a discrete 1-form / Nédélec
 //!   tangential line integral) to its face DOFs (a discrete 2-form /
 //!   Raviart–Thomas normal flux).
+//! - [`divergence_map`] is `d²`: the discrete divergence / face-tet
+//!   incidence matrix that sends a face-DOF field (a discrete 2-form /
+//!   Raviart–Thomas normal flux) to its volume DOFs (a discrete 3-form
+//!   / piecewise-constant volume density).
 //!
-//! Together, `(d⁰, d¹)` form the algebraic backbone of the U(1)
+//! Together, `(d⁰, d¹, d²)` form the algebraic backbone of the U(1)
 //! gauge-symmetry test battery: the Nédélec curl-curl operator must
 //! annihilate anything in the image of `d⁰` (gradients are curl-free),
-//! and the composition `d¹ ∘ d⁰ ≡ 0` certifies the complex is exact at
-//! the edge level. The bit-exact identity `curl_map · gradient_map = 0`
-//! is the Phase 2.B acceptance test of Epic #57.
+//! and the compositions `d¹ ∘ d⁰ ≡ 0` and `d² ∘ d¹ ≡ 0` certify the
+//! complex is exact at the edge and face levels respectively. The
+//! bit-exact identity `curl_map · gradient_map = 0` is the Phase 2.B
+//! acceptance test of Epic #57; the matching bit-exact identity
+//! `divergence_map · curl_map = 0` is the deferred-`d²` follow-up
+//! (issue #91).
 //!
 //! # The `d⁰` operator
 //!
@@ -67,6 +74,24 @@
 //! convention matched here is Raviart–Thomas normal flux on the
 //! ascending-cycle orientation of the face.
 //!
+//! # The `d²` operator
+//!
+//! For a mesh with `n_faces` faces and `n_tets` tets, `d²` is the
+//! `n_tets × n_faces` integer incidence matrix. Each **row** is a tet,
+//! and its four nonzeros are the signed face-incidence values pulled
+//! directly from [`TetMesh::tet_faces`]: row `i` has a `±1` in the
+//! column of each of the four global faces of tet `i`, where the sign
+//! is `+1` when the local ascending-cycle orientation of the face
+//! agrees with the global ascending cycle on the face's three vertex
+//! tags, and `-1` otherwise (equivalently, the parity of the
+//! permutation that sorts the local-face vertex triple).
+//!
+//! Applied to a face-DOF field `q` (Raviart–Thomas normal flux), row
+//! `i` yields the signed sum `Σ_{f ∈ ∂T_i} σ_{T,f} q_f`, the discrete
+//! flux out of tet `T_i` summed over its four faces — the
+//! divergence-theorem value `∫_{T_i} ∇·q dV = ∮_{∂T_i} q · n dA` in
+//! Whitney-`H(div)`-conforming form.
+//!
 //! # The composition `d¹ ∘ d⁰`
 //!
 //! On every global face `(a, b, c)` with `a < b < c`, the column-`k`
@@ -79,6 +104,21 @@
 //! for every `k`. The identity is bit-exact in `f64` because every term
 //! is `±1.0` and the partial sums fit well below `2^{53}`.
 //!
+//! # The composition `d² ∘ d¹`
+//!
+//! On every tet `T`, the row of `d² · d¹` is the sum of the signed
+//! 1-cycles bounding each of the four faces of `T`. Each interior edge
+//! of `T` (every one of the six tet edges sits on exactly two of `T`'s
+//! four faces) is traversed once in each of the two face-boundary
+//! cycles, in opposite directions induced by the two faces' opposite
+//! outward normals on the shared edge — so the two contributions cancel
+//! at every column. The composition is therefore the `n_tets × n_edges`
+//! zero matrix bit-exactly: each entry is an integer sum of at most
+//! `4 faces · 3 edges-per-face = 12` terms drawn from `{-1, 0, +1}`,
+//! well below `2^{53}`. This is the "boundary of a boundary is zero"
+//! identity at the face level, the second exactness identity of the
+//! discrete de Rham complex.
+//!
 //! # References for the sign conventions
 //!
 //! The lower-tag-first edge / face orientations and the signed-incidence
@@ -90,25 +130,28 @@
 //!   forms") for `d⁰` as the signed node–edge incidence matrix; §4
 //!   ("Higher order forms" / face conventions) for `d¹` as the signed
 //!   edge–face incidence matrix and the lift to Raviart–Thomas face
-//!   DOFs.
+//!   DOFs, and `d²` as the signed face–tet incidence matrix.
 //! - D. N. Arnold, R. S. Falk, R. Winther, *Finite element exterior
 //!   calculus, homological techniques, and applications*, Acta Numerica
-//!   15 (2006), 1–155, §1.2 ("The de Rham complex"): `d⁰` and `d¹` as
-//!   the transposes of the simplicial boundary operators, with the sign
-//!   convention given by the induced orientation of each oriented
-//!   simplex's boundary.
+//!   15 (2006), 1–155, §1.2 ("The de Rham complex"): `d⁰`, `d¹`, and
+//!   `d²` as the transposes of the simplicial boundary operators, with
+//!   the sign convention given by the induced orientation of each
+//!   oriented simplex's boundary; the bit-exact `dᵏ⁺¹ ∘ dᵏ ≡ 0`
+//!   identities follow from `∂² = 0` on the corresponding chain
+//!   complex.
 //!
 //! # Value type
 //!
-//! `d⁰` and `d¹` are mathematically *integer* matrices, but `faer`'s
-//! sparse constructors require the value type to implement `faer`'s
-//! `ComplexField`, which `i32` does not. We therefore store the entries
-//! as `f64` (the exactly-representable integers `±1.0`). This keeps the
-//! operators usable in `faer`'s sparse linear algebra and lets the
-//! sparse product `d¹ · d⁰` be formed directly; for the small integers
-//! involved the product stays exact in `f64` (bit-exact integer sums
-//! hold below `2^{53}`). It also matches the value type of the rest of
-//! the sparse pipeline ([`crate::sparse::SparseSystem`]).
+//! `d⁰`, `d¹`, and `d²` are mathematically *integer* matrices, but
+//! `faer`'s sparse constructors require the value type to implement
+//! `faer`'s `ComplexField`, which `i32` does not. We therefore store
+//! the entries as `f64` (the exactly-representable integers `±1.0`).
+//! This keeps the operators usable in `faer`'s sparse linear algebra
+//! and lets the sparse products `d¹ · d⁰` and `d² · d¹` be formed
+//! directly; for the small integers involved the products stay exact
+//! in `f64` (bit-exact integer sums hold below `2^{53}`). It also
+//! matches the value type of the rest of the sparse pipeline
+//! ([`crate::sparse::SparseSystem`]).
 
 use faer::sparse::{SparseColMat, Triplet};
 
@@ -202,8 +245,10 @@ pub fn apply_gradient(mesh: &TetMesh, nodal: &[f64]) -> Vec<f64> {
 /// `(a, b, c)` in the ascending cycle gives the three triplets directly,
 /// independent of any local tet's orientation. The per-tet view
 /// ([`TetMesh::tet_faces`] / [`crate::mesh::TET_LOCAL_FACE_EDGES`]) is
-/// reserved for the eventual `d²` operator that will scatter signed
-/// face DOFs into volume DOFs.
+/// the source-of-truth for the `d²` operator ([`divergence_map`]),
+/// which scatters signed face DOFs into volume DOFs and whose
+/// per-tet `(global_face_idx, sign)` table pins
+/// `divergence_map(mesh) · curl_map(mesh) ≡ 0` bit-exactly.
 ///
 /// # Panics
 ///
@@ -246,4 +291,154 @@ pub fn curl_map(mesh: &TetMesh) -> SparseColMat<usize, f64> {
 
     SparseColMat::<usize, f64>::try_new_from_triplets(n_faces, n_edges, &triplets)
         .expect("d¹ triplets are well-formed: in-range indices, distinct per face")
+}
+
+/// Build the discrete divergence operator `d²` for `mesh`.
+///
+/// Returns an `n_tets × n_faces` sparse matrix in `faer`'s column-major
+/// (CSC) format. Row `i` corresponds to tet `i` of [`TetMesh::tets`]
+/// (and of [`TetMesh::tet_faces`]). Each row has exactly **four**
+/// nonzeros, one per local face of the tet, with column index the
+/// global face index from [`TetMesh::tet_faces`] and value
+///
+/// ```text
+/// d²[tet_idx, global_face_idx] = (−1)^k · sign_k
+/// ```
+///
+/// where `k ∈ {0, 1, 2, 3}` is the local-face slot (face `k` is
+/// opposite local vertex `k`; see [`crate::mesh::TET_LOCAL_FACES`])
+/// and `sign_k = mesh.tet_faces()[tet_idx][k].1 ∈ {+1, −1}` is the
+/// permutation parity of the local-face vertex triple against the
+/// global ascending order.
+///
+/// # Why the `(−1)^k` factor
+///
+/// The signed simplicial boundary of an oriented 3-simplex `[v0, v1,
+/// v2, v3]` is
+///
+/// ```text
+/// ∂[v0,v1,v2,v3] = [v1,v2,v3] − [v0,v2,v3] + [v0,v1,v3] − [v0,v1,v2],
+/// ```
+///
+/// i.e. the face opposite local vertex `k` carries sign `(−1)^k`. The
+/// faces in this expression are written in *increasing local-vertex*
+/// order — which is exactly what [`crate::mesh::TET_LOCAL_FACES`]
+/// emits. The further factor `sign_k` from [`TetMesh::tet_faces`]
+/// converts the local-vertex-order face into the global ascending
+/// face triple `(a, b, c)` with `a < b < c` used as the row of
+/// [`curl_map`]; it is the parity of the permutation that sorts the
+/// local-face vertex triple into ascending global order. Multiplying
+/// the two gives the `d²` entry on the global ascending face
+/// orientation.
+///
+/// Without the `(−1)^k`, two tets sharing an interior face would
+/// contribute the *same* sign to that face's column (both signs
+/// reflect the same permutation parity since both tets see the same
+/// global face triple), and the `d²·d¹` cancellation argument would
+/// fail row-by-row. With the `(−1)^k` factor included, the two
+/// sharing tets get opposite contributions (their local-vertex
+/// orientation around the shared face is reversed when one tet sits
+/// on the "+ side" and the other on the "− side" of the face's
+/// outward normal), and the second exactness identity `d² · d¹ ≡ 0`
+/// holds bit-exactly.
+///
+/// The mesh-side scaffolding ([`TetMesh::tet_faces`]) deliberately
+/// exposes only the global-orientation parity `sign_k` — the
+/// alternating `(−1)^k` factor is operator-specific (it is part of
+/// the de Rham `d²` convention, not of the face-DOF orientation
+/// convention itself) and so lives here.
+///
+/// # Sign convention pins `d² · d¹ ≡ 0`
+///
+/// This sign convention pins `divergence_map(mesh) · curl_map(mesh)
+/// ≡ 0` bit-exactly on any mesh — the second exactness identity of
+/// the discrete de Rham complex (see the [module docs](crate::derham)
+/// and Hiptmair §4, Arnold–Falk–Winther §1.2).
+///
+/// # Sparsity structure
+///
+/// - Every row has exactly four `±1.0` entries.
+/// - Every interior face column has exactly two nonzeros, one per
+///   sharing tet, with **opposite signs** (the two outward normals on
+///   a shared face point in opposite directions, so the `(−1)^k ·
+///   sign_k` contributions from the two tets disagree).
+/// - Every boundary face column has exactly one nonzero (the unique
+///   tet whose face is on `∂Ω`).
+///
+/// # Panics
+///
+/// Panics if `faer` rejects the constructed triplets (only possible on
+/// an internal invariant violation — tet indices are bounded by
+/// `n_tets`, face indices come from `tet_faces` which only emits
+/// indices in `0..n_faces`, and the four (tet_idx, face_idx) pairs per
+/// tet are distinct because the four local faces of a tet have
+/// distinct vertex sets).
+pub fn divergence_map(mesh: &TetMesh) -> SparseColMat<usize, f64> {
+    let tet_faces = mesh.tet_faces();
+    let n_tets = mesh.n_tets();
+    let n_faces = mesh.faces().len();
+
+    // Four triplets per tet: one per local face. Column is the global
+    // face index from `TetMesh::tet_faces`; value is the local-face
+    // alternating sign `(−1)^k` times the global-orientation parity
+    // `sign_k` from `tet_faces`. See the function docstring for why
+    // both factors are needed for `d² · d¹ ≡ 0`.
+    let mut triplets: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(4 * n_tets);
+    for (tet_idx, faces_of_tet) in tet_faces.iter().enumerate() {
+        for (local_face_k, &(global_face_idx, sign_k)) in faces_of_tet.iter().enumerate() {
+            let alt_sign: f64 = if local_face_k % 2 == 0 { 1.0 } else { -1.0 };
+            let entry = alt_sign * (sign_k as f64);
+            triplets.push(Triplet::new(tet_idx, global_face_idx as usize, entry));
+        }
+    }
+
+    SparseColMat::<usize, f64>::try_new_from_triplets(n_tets, n_faces, &triplets)
+        .expect("d² triplets are well-formed: in-range indices, distinct per tet")
+}
+
+/// Apply `d²` to a face-DOF field without materializing the sparse
+/// matrix.
+///
+/// Returns `d² · q`, the vector of volume DOFs of the discrete
+/// divergence: for tet `T_i`,
+///
+/// ```text
+/// out[i] = Σ_{k=0..4}  (−1)^k · sign_k · q[global_face_idx_k]
+/// ```
+///
+/// where the four `(global_face_idx_k, sign_k)` pairs are read from
+/// `mesh.tet_faces()[i]`. The output length is `mesh.n_tets()` and
+/// entry `i` matches row `i` of [`divergence_map`]. See
+/// [`divergence_map`] for the full sign-convention rationale.
+///
+/// Prefer this over `divergence_map(mesh)` followed by a sparse mat-vec
+/// when you only need the divergence values and not the operator
+/// itself.
+///
+/// # Panics
+///
+/// Panics if `face_field.len() != mesh.faces().len()`.
+pub fn apply_divergence(mesh: &TetMesh, face_field: &[f64]) -> Vec<f64> {
+    let n_faces = mesh.faces().len();
+    assert_eq!(
+        face_field.len(),
+        n_faces,
+        "face field length {} disagrees with mesh face count {}",
+        face_field.len(),
+        n_faces
+    );
+
+    mesh.tet_faces()
+        .iter()
+        .map(|faces_of_tet| {
+            faces_of_tet
+                .iter()
+                .enumerate()
+                .map(|(local_face_k, &(global_face_idx, sign_k))| {
+                    let alt_sign: f64 = if local_face_k % 2 == 0 { 1.0 } else { -1.0 };
+                    alt_sign * (sign_k as f64) * face_field[global_face_idx as usize]
+                })
+                .sum()
+        })
+        .collect()
 }

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use assembly::{
 };
 pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
-pub use derham::{apply_gradient, curl_map, gradient_map};
+pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
     FaerDenseEigensolver,

--- a/crates/geode-core/tests/derham_divergence.rs
+++ b/crates/geode-core/tests/derham_divergence.rs
@@ -1,0 +1,369 @@
+//! Tests for the discrete divergence operator `d²`
+//! (`geode_core::derham::divergence_map`).
+//!
+//! Covers the four acceptance checks from issue #91:
+//!   1. Shape: `d²` is `n_tets × n_faces`.
+//!   2. Sparsity: every row has exactly four nonzeros, each `±1.0`.
+//!   3. Internal-face columns have exactly two entries with opposite
+//!      signs; boundary-face columns have exactly one entry.
+//!   4. Single reference-tet hand check (single all-boundary tet → row
+//!      of four +1s).
+//!
+//! Plus an early-warning bit-exact `d² · d¹ = 0` sanity check on the
+//! reference tet and the cube `n=2` fixture. The formal acceptance
+//! tests on the cube `n=8` and sphere PML fixtures live in
+//! `derham_exact_sequence.rs`, alongside the `d¹ · d⁰ = 0` ones, so
+//! both bit-exact compositions read at one site.
+//!
+//! # Why this file is not `#[ignore]`d
+//!
+//! The test is pure host-side sparse linear algebra (construct
+//! `SparseColMat<usize, f64>` operators, multiply, walk the result).
+//! It never touches faer's `gevd::qz_real` and so does not trip the
+//! `debug-assertions` panic that forces other geode-core tests
+//! (`eigensolver`, `sphere_pec_eigenmode`, …) to require `--release`.
+//! Same reasoning as `derham_exact_sequence.rs` (#78 / PR #80) and
+//! `derham_curl.rs` (#77 / PR #79).
+
+use std::collections::{BTreeMap, HashMap};
+
+use geode_core::{apply_divergence, cube_tet_mesh, curl_map, divergence_map, TetMesh};
+
+/// A single tet on nodes 0..4. Connectivity is all that matters for
+/// `d²`; the coordinates below form a unit reference tet for good
+/// measure.
+fn reference_tet() -> TetMesh {
+    TetMesh {
+        nodes: vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        tets: vec![[0, 1, 2, 3]],
+        physical_groups: BTreeMap::new(),
+    }
+}
+
+#[test]
+fn shape_is_n_tets_by_n_faces() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d2 = divergence_map(&mesh);
+    let n_tets = mesh.n_tets();
+    let n_faces = mesh.faces().len();
+
+    assert_eq!(
+        d2.shape(),
+        (n_tets, n_faces),
+        "d² must be n_tets × n_faces"
+    );
+}
+
+#[test]
+fn every_row_has_four_signed_unit_nonzeros() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d2 = divergence_map(&mesh);
+    let dense = d2.to_dense();
+
+    let n_tets = mesh.n_tets();
+    let n_faces = mesh.faces().len();
+
+    for r in 0..n_tets {
+        let mut nnz = 0usize;
+        let mut plus = 0usize;
+        let mut minus = 0usize;
+        for c in 0..n_faces {
+            let v = dense[(r, c)];
+            if v != 0.0 {
+                nnz += 1;
+                if v == 1.0 {
+                    plus += 1;
+                } else if v == -1.0 {
+                    minus += 1;
+                } else {
+                    panic!("row {r}, col {c}: unexpected entry {v}, expected ±1");
+                }
+            }
+        }
+        assert_eq!(nnz, 4, "row {r} must have exactly 4 nonzeros");
+        assert_eq!(
+            plus + minus,
+            4,
+            "row {r}: every stored value must be exactly ±1.0 (bit-exact)"
+        );
+    }
+}
+
+#[test]
+fn single_reference_tet_matches_hand_tabulated_row() {
+    let mesh = reference_tet();
+    let d2 = divergence_map(&mesh);
+
+    // 1 tet, 4 faces.
+    assert_eq!(d2.shape(), (1, 4));
+    assert_eq!(
+        mesh.faces(),
+        vec![[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]],
+        "face enumeration must match the canonical ascending order"
+    );
+
+    // For the trivially-ordered reference tet [0,1,2,3], every local
+    // face's ascending-local cycle (from TET_LOCAL_FACES) is *already*
+    // the ascending-global cycle, so `tet_faces[0]` returns all four
+    // `sign_k` values as +1 (verified independently in `mesh::tests::
+    // tet_faces_on_reference_tet_have_positive_signs`).
+    //
+    // The divergence row therefore reduces to the alternating
+    // `(−1)^k · 1` pattern over local-face slots `k = 0..4`. Mapped to
+    // global face indices, that is:
+    //
+    //   local k=0 (face opp v0 = {1,2,3} = global face 3): (−1)^0 = +1
+    //   local k=1 (face opp v1 = {0,2,3} = global face 2): (−1)^1 = −1
+    //   local k=2 (face opp v2 = {0,1,3} = global face 1): (−1)^2 = +1
+    //   local k=3 (face opp v3 = {0,1,2} = global face 0): (−1)^3 = −1
+    //
+    // so the d² row, indexed by global face column, is:
+    //   col 0 (face {0,1,2}):  −1
+    //   col 1 (face {0,1,3}):  +1
+    //   col 2 (face {0,2,3}):  −1
+    //   col 3 (face {1,2,3}):  +1
+    //
+    // This is the signed simplicial boundary of [v0,v1,v2,v3]:
+    //   ∂[v0,v1,v2,v3] = [v1,v2,v3] − [v0,v2,v3] + [v0,v1,v3] − [v0,v1,v2]
+    // — see the `divergence_map` docstring for the full argument.
+    let dense = d2.to_dense();
+    let expected_row = [-1.0, 1.0, -1.0, 1.0];
+    for (c, &want) in expected_row.iter().enumerate() {
+        assert_eq!(
+            dense[(0, c)],
+            want,
+            "d²[0, {c}] = {} but expected {want}",
+            dense[(0, c)]
+        );
+    }
+}
+
+#[test]
+fn internal_face_columns_have_signed_pair_boundary_faces_have_single() {
+    // On a closed-tet mesh every interior face is shared by exactly
+    // two tets and every boundary face by exactly one. The d² column
+    // for an interior face must therefore have two nonzeros with
+    // opposite signs (the two tets' outward normals on the shared face
+    // disagree, so their `tet_faces` signs disagree); a boundary-face
+    // column must have exactly one nonzero.
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d2 = divergence_map(&mesh);
+    let dense = d2.to_dense();
+
+    let n_tets = mesh.n_tets();
+    let n_faces = mesh.faces().len();
+
+    // Independent ground truth: count for each face the number of tets
+    // that touch it (1 = boundary, 2 = interior).
+    const LOCAL_FACES: [[usize; 3]; 4] = [[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]];
+    let face_index: HashMap<(u32, u32, u32), usize> = mesh
+        .faces()
+        .iter()
+        .enumerate()
+        .map(|(i, f)| ((f[0], f[1], f[2]), i))
+        .collect();
+    let mut tets_per_face = vec![0usize; n_faces];
+    for tet in &mesh.tets {
+        for lf in &LOCAL_FACES {
+            let mut tri = [tet[lf[0]], tet[lf[1]], tet[lf[2]]];
+            tri.sort_unstable();
+            let key = (tri[0], tri[1], tri[2]);
+            let idx = face_index[&key];
+            tets_per_face[idx] += 1;
+        }
+    }
+
+    let mut n_interior = 0usize;
+    let mut n_boundary = 0usize;
+    for c in 0..n_faces {
+        let mut nnz = 0usize;
+        let mut sum = 0.0f64;
+        for r in 0..n_tets {
+            let v = dense[(r, c)];
+            if v != 0.0 {
+                nnz += 1;
+                sum += v;
+                assert!(
+                    v == 1.0 || v == -1.0,
+                    "d²[{r}, {c}] = {v}, expected ±1 (bit-exact)"
+                );
+            }
+        }
+        match tets_per_face[c] {
+            1 => {
+                assert_eq!(
+                    nnz, 1,
+                    "boundary face column {c} must have exactly 1 nonzero, got {nnz}"
+                );
+                n_boundary += 1;
+            }
+            2 => {
+                assert_eq!(
+                    nnz, 2,
+                    "interior face column {c} must have exactly 2 nonzeros, got {nnz}"
+                );
+                assert_eq!(
+                    sum, 0.0,
+                    "interior face column {c}: the two ±1 entries must cancel \
+                     (sum = {sum} ≠ 0 means same-sign, which would break d²·d¹=0)"
+                );
+                n_interior += 1;
+            }
+            other => panic!(
+                "face column {c}: {other} tets touch this face on a closed tet mesh \
+                 (expected 1 or 2)"
+            ),
+        }
+    }
+
+    // Sanity: the cube at n=2 has both interior and boundary faces.
+    assert!(
+        n_interior > 0,
+        "cube n=2: expected at least one interior face"
+    );
+    assert!(
+        n_boundary > 0,
+        "cube n=2: expected at least one boundary face"
+    );
+}
+
+#[test]
+fn divergence_of_curl_is_zero_on_reference_tet() {
+    // d² ∘ d¹ ≡ 0 — the second discrete de Rham exactness identity.
+    // On the reference tet, the product is the 1×6 zero row bit-exactly.
+    let mesh = reference_tet();
+    let d1 = curl_map(&mesh);
+    let d2 = divergence_map(&mesh);
+
+    let product = &d2 * &d1;
+    let dense = product.to_dense();
+
+    let (n_rows, n_cols) = product.shape();
+    assert_eq!(
+        (n_rows, n_cols),
+        (1, 6),
+        "d² · d¹ on the reference tet must be n_tets × n_edges = 1 × 6"
+    );
+    for r in 0..n_rows {
+        for c in 0..n_cols {
+            let v = dense[(r, c)];
+            assert_eq!(v, 0.0, "(d²·d¹)[{r}, {c}] = {v}, expected 0 (bit-exact)");
+        }
+    }
+}
+
+#[test]
+fn divergence_of_curl_is_zero_on_cube_fixture() {
+    // Same identity on the 2×2×2 hex-split cube — early-warning sibling
+    // of the formal acceptance test in `derham_exact_sequence.rs`.
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d1 = curl_map(&mesh);
+    let d2 = divergence_map(&mesh);
+
+    let product = &d2 * &d1;
+    let dense = product.to_dense();
+
+    let (n_rows, n_cols) = product.shape();
+    assert_eq!(n_rows, mesh.n_tets());
+    assert_eq!(n_cols, mesh.edges().len());
+
+    for r in 0..n_rows {
+        for c in 0..n_cols {
+            let v = dense[(r, c)];
+            assert_eq!(
+                v, 0.0,
+                "(d²·d¹)[{r}, {c}] = {v} on cube fixture, expected 0 (bit-exact)"
+            );
+        }
+    }
+}
+
+#[test]
+fn apply_divergence_matches_sparse_matvec() {
+    // The bare-vector convenience must agree exactly with the
+    // materialised sparse mat-vec — identical sign and ordering
+    // contract.
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d2 = divergence_map(&mesh);
+    let n_faces = mesh.faces().len();
+
+    // Deterministic non-trivial test field.
+    let face_field: Vec<f64> = (0..n_faces).map(|i| (i as f64) - 7.0).collect();
+
+    let got = apply_divergence(&mesh, &face_field);
+
+    // Hand-rolled sparse mat-vec via the dense expansion (the matrix is
+    // tiny on n=2). Matches the convention used elsewhere in the test
+    // suite (e.g. `derham_curl.rs::sparse_to_dense_vec`).
+    let dense = d2.to_dense();
+    let n_tets = mesh.n_tets();
+    let mut want = vec![0.0f64; n_tets];
+    for r in 0..n_tets {
+        for c in 0..n_faces {
+            want[r] += dense[(r, c)] * face_field[c];
+        }
+    }
+
+    assert_eq!(got.len(), n_tets);
+    for (i, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+        assert_eq!(g, w, "tet {i}: apply_divergence={g} ≠ matvec={w}");
+    }
+}
+
+#[test]
+fn apply_divergence_of_apply_gradient_via_curl_chain_is_zero() {
+    // End-to-end identity on the convenience functions: a nodal field
+    // φ has zero divergence after gradient + curl because curl of a
+    // gradient is zero. Reuses `apply_gradient` from #58 / PR #74.
+    // (This is a sanity check on the function-level convenience APIs;
+    // the operator-level identity is verified in
+    // `derham_exact_sequence.rs`.)
+    let mesh = cube_tet_mesh(2, 1.0);
+    let d1 = curl_map(&mesh);
+    let n_nodes = mesh.n_nodes();
+    let n_edges = mesh.edges().len();
+
+    // Deterministic non-trivial nodal field.
+    let phi: Vec<f64> = (0..n_nodes).map(|i| (i as f64) * 0.5 - 1.0).collect();
+
+    // edge field = gradient(φ)
+    let edge_field = geode_core::apply_gradient(&mesh, &phi);
+    assert_eq!(edge_field.len(), n_edges);
+
+    // face field = d¹ · edge_field (via dense expansion; same matvec
+    // convention as `apply_divergence_matches_sparse_matvec`).
+    let d1_dense = d1.to_dense();
+    let n_faces = mesh.faces().len();
+    let mut face_field = vec![0.0f64; n_faces];
+    for r in 0..n_faces {
+        for c in 0..n_edges {
+            face_field[r] += d1_dense[(r, c)] * edge_field[c];
+        }
+    }
+
+    // Sanity: ensure d¹·d⁰ produces a truly zero face field before we
+    // exercise apply_divergence on it (the chain is already exercised
+    // operator-side in `derham_exact_sequence.rs`, but checking it
+    // here makes the failure mode of the final assertion much easier
+    // to localise).
+    for (i, &v) in face_field.iter().enumerate() {
+        assert_eq!(
+            v, 0.0,
+            "face field component {i} = {v} is nonzero — d¹·d⁰ should give bit-exact zero"
+        );
+    }
+
+    // div(curl(grad φ)) = 0 elementwise.
+    let div_field = apply_divergence(&mesh, &face_field);
+    for (i, &v) in div_field.iter().enumerate() {
+        assert_eq!(
+            v, 0.0,
+            "tet {i}: apply_divergence(apply_curl(apply_gradient(φ))) = {v}, expected 0"
+        );
+    }
+}

--- a/crates/geode-core/tests/derham_exact_sequence.rs
+++ b/crates/geode-core/tests/derham_exact_sequence.rs
@@ -1,20 +1,24 @@
 //! Discrete de Rham exactness — bit-exact `d¹ ∘ d⁰ ≡ 0` (issue #78,
-//! Phase 2.B of Epic #57).
+//! Phase 2.B of Epic #57) and `d² ∘ d¹ ≡ 0` (issue #91, the deferred-
+//! `d²` follow-up).
 //!
-//! With `gradient_map` (d⁰, #58 / PR #74) and `curl_map` (d¹, #77 /
-//! PR #79) both on `main`, the discrete de Rham identity reduces to a
-//! one-line algebraic claim: the sparse matrix product `d¹ · d⁰` must
-//! be **exactly** the zero matrix.
+//! With `gradient_map` (d⁰, #58 / PR #74), `curl_map` (d¹, #77 / PR
+//! #79), and `divergence_map` (d², #91) all on `main`, both discrete
+//! de Rham exactness identities reduce to one-line algebraic claims:
+//! the sparse matrix products `d¹ · d⁰` and `d² · d¹` must each be
+//! **exactly** the zero matrix.
 //!
-//! This is strictly stronger than the Phase 1.B numerical
-//! near-zero statement (#59, residual ratio ~1e-12 on f64): every
-//! stored value in the product (and every entry of the dense
-//! expansion) must equal `0.0` bit-for-bit.
+//! This is strictly stronger than the Phase 1.B numerical near-zero
+//! statement (#59, residual ratio ~1e-12 on f64): every stored value
+//! in each product (and every entry of the dense expansion) must equal
+//! `0.0` bit-for-bit.
 //!
-//! The product is bit-exact because both d⁰ and d¹ store entries in
-//! `{-1, 0, +1}`, so every entry of the matrix product is an integer
-//! sum of at most a small constant number of `±1` terms — well below
-//! 2⁵³, the f64 exact-integer ceiling.
+//! The products are bit-exact because all three operators store
+//! entries in `{-1, 0, +1}`, so every entry of either matrix product
+//! is an integer sum of at most a small constant number of `±1` terms
+//! — well below 2⁵³, the f64 exact-integer ceiling. (At most 6 terms
+//! for `d¹·d⁰` and at most 12 terms for `d²·d¹`; cf. the per-row
+//! nonzero counts of `d⁰`, `d¹`, and `d²`.)
 //!
 //! # Why this file is not `#[ignore]`d
 //!
@@ -24,27 +28,107 @@
 //! `debug-assertions` panic that forces other geode-core tests
 //! (`eigensolver`, `sphere_pec_eigenmode`, …) to require `--release`.
 //! Same reasoning as `derham_gradient_kernel.rs` (#59 / PR #75) and
-//! the early-warning identity tests in `derham_curl.rs` (#77).
+//! the early-warning identity tests in `derham_curl.rs` (#77) and
+//! `derham_divergence.rs` (#91).
 //!
 //! # Fixtures
 //!
 //! - Cube PEC at `n=8` (the canonical eigenmode/gauge-test
 //!   refinement) — wider than the `n=2` cube case already in
-//!   `derham_curl.rs`.
+//!   `derham_curl.rs` and `derham_divergence.rs`.
 //! - The bundled sphere PML fixture (`read_sphere_fixture()`). The
-//!   PML lives in `M`, not `K`, so the de Rham identity is a
-//!   property of the mesh alone — no PML setup is required; we just
-//!   read `f.mesh` and call `gradient_map` / `curl_map`.
+//!   PML lives in `M`, not `K`, so both de Rham identities are
+//!   properties of the mesh alone — no PML setup is required; we just
+//!   read `f.mesh` and call `gradient_map` / `curl_map` /
+//!   `divergence_map`.
 
 use faer::sparse::SparseColMat;
-use geode_core::{cube_tet_mesh, curl_map, gradient_map, read_sphere_fixture, TetMesh};
+use geode_core::{
+    cube_tet_mesh, curl_map, divergence_map, gradient_map, read_sphere_fixture, TetMesh,
+};
 
-/// Compute `d¹ · d⁰` on `mesh` and assert that every entry of the
-/// result is bit-exact zero (both the stored sparse values and the
-/// dense expansion). On failure, prints the offending
-/// `(face_index, node_index, value)` triple so a sign-convention
-/// regression in `gradient_map` or `curl_map` surfaces with an
-/// actionable diagnostic (issue #78 acceptance criterion).
+/// Assert that `&a * &b` is bit-exactly the zero matrix of shape
+/// `expected_shape = (a.n_rows, b.n_cols)`. Walks both the stored CSC
+/// value slice and the dense expansion (in that order); a hypothetical
+/// future faer that strips structural zeros after multiplication is
+/// caught by the dense walk.
+///
+/// `name` and the row/col labels are interpolated into failure
+/// messages so a sign-convention regression in any of the three
+/// operators surfaces with an actionable diagnostic.
+///
+/// Returns the number of stored nonzeros in the product (for
+/// diagnostic reporting via `eprintln!`).
+fn assert_composition_is_bit_exact_zero(
+    name: &str,
+    a: &SparseColMat<usize, f64>,
+    b: &SparseColMat<usize, f64>,
+    expected_shape: (usize, usize),
+    row_label: &str,
+    col_label: &str,
+) -> usize {
+    let (a_rows, a_cols) = a.shape();
+    let (b_rows, b_cols) = b.shape();
+    assert_eq!(
+        a_cols, b_rows,
+        "{name}: shape mismatch (a is {a_rows}×{a_cols}, b is {b_rows}×{b_cols})"
+    );
+    assert_eq!(
+        (a_rows, b_cols),
+        expected_shape,
+        "{name}: product shape ({a_rows}×{b_cols}) disagrees with expected \
+         ({} × {})",
+        expected_shape.0,
+        expected_shape.1
+    );
+
+    // faer 0.24: `&SparseColMat * &SparseColMat` is the canonical
+    // sparse-product form (see #77 / PR #79 for the verified usage
+    // pattern; same call site shape as `derham_curl.rs`).
+    let product: SparseColMat<usize, f64> = a * b;
+
+    assert_eq!(
+        product.shape(),
+        expected_shape,
+        "{name}: product shape disagrees with expected after multiply"
+    );
+
+    // First sweep: walk the stored value slice directly (faer 0.24
+    // exposes it via `.val()` on the CSC reference). faer does not
+    // strip structural zeros after multiplication in general, so a
+    // numeric-zero entry can still appear in the slice — we require
+    // each such entry to be `== 0.0` bit-for-bit. We do not paper
+    // over this with a tolerance; the point of this test is the
+    // algebraic identity.
+    let stored_nnz = product.as_ref().val().len();
+    for (k, &v) in product.as_ref().val().iter().enumerate() {
+        assert_eq!(
+            v, 0.0,
+            "{name}: stored value #{k} of product = {v}, expected 0 (bit-exact)"
+        );
+    }
+
+    // Second sweep: dense expansion catches anything the structural
+    // walk might miss (e.g. a hypothetical future faer that does
+    // strip structural zeros — the dense walk is invariant to that).
+    let dense = product.to_dense();
+    let (n_rows, n_cols) = expected_shape;
+    for r in 0..n_rows {
+        for c in 0..n_cols {
+            let v = dense[(r, c)];
+            assert_eq!(
+                v, 0.0,
+                "{name}: product[{row_label}={r}, {col_label}={c}] = {v}, \
+                 expected 0 (bit-exact)"
+            );
+        }
+    }
+
+    stored_nnz
+}
+
+/// Compute `d¹ · d⁰` on `mesh` and assert that every entry is
+/// bit-exact zero. Returns `(n_faces, n_nodes, stored_nnz)`.
 fn assert_d1_d0_is_bit_exact_zero(mesh: &TetMesh, label: &str) -> (usize, usize, usize) {
     let d0 = gradient_map(mesh);
     let d1 = curl_map(mesh);
@@ -64,49 +148,47 @@ fn assert_d1_d0_is_bit_exact_zero(mesh: &TetMesh, label: &str) -> (usize, usize,
         "{label}: d¹ must be n_faces × n_edges"
     );
 
-    // faer 0.24: `&SparseColMat * &SparseColMat` is the canonical
-    // sparse-product form (see #77 / PR #79 for the verified usage
-    // pattern; same call site shape as `derham_curl.rs`).
-    let product: SparseColMat<usize, f64> = &d1 * &d0;
+    let stored = assert_composition_is_bit_exact_zero(
+        &format!("{label} d¹·d⁰"),
+        &d1,
+        &d0,
+        (n_faces, n_nodes),
+        "face",
+        "node",
+    );
+    (n_faces, n_nodes, stored)
+}
+
+/// Compute `d² · d¹` on `mesh` and assert that every entry is
+/// bit-exact zero. Returns `(n_tets, n_edges, stored_nnz)`.
+fn assert_d2_d1_is_bit_exact_zero(mesh: &TetMesh, label: &str) -> (usize, usize, usize) {
+    let d1 = curl_map(mesh);
+    let d2 = divergence_map(mesh);
+
+    let n_tets = mesh.n_tets();
+    let n_edges = mesh.edges().len();
+    let n_faces = mesh.faces().len();
 
     assert_eq!(
-        product.shape(),
-        (n_faces, n_nodes),
-        "{label}: d¹·d⁰ must be n_faces × n_nodes"
+        d1.shape(),
+        (n_faces, n_edges),
+        "{label}: d¹ must be n_faces × n_edges"
+    );
+    assert_eq!(
+        d2.shape(),
+        (n_tets, n_faces),
+        "{label}: d² must be n_tets × n_faces"
     );
 
-    // First sweep: walk the stored value slice directly (faer 0.24
-    // exposes it via `.val()` on the CSC reference). faer does not
-    // strip structural zeros after multiplication in general, so a
-    // numeric-zero entry can still appear in the slice — we require
-    // each such entry to be `== 0.0` bit-for-bit. We do not paper
-    // over this with a tolerance; the point of this test is the
-    // algebraic identity.
-    let stored_nnz = product.as_ref().val().len();
-    for (k, &v) in product.as_ref().val().iter().enumerate() {
-        assert_eq!(
-            v, 0.0,
-            "{label}: stored value #{k} of d¹·d⁰ = {v}, expected 0 (bit-exact)"
-        );
-    }
-
-    // Second sweep: dense expansion catches anything the structural
-    // walk might miss (e.g. a hypothetical future faer that does
-    // strip structural zeros — the dense walk is invariant to that).
-    // Mirrors the assertion style used in `derham_curl.rs`'s
-    // `curl_of_gradient_is_zero_on_*` tests (#77 / PR #79).
-    let dense = product.to_dense();
-    for r in 0..n_faces {
-        for c in 0..n_nodes {
-            let v = dense[(r, c)];
-            assert_eq!(
-                v, 0.0,
-                "{label}: (d¹·d⁰)[face={r}, node={c}] = {v}, expected 0 (bit-exact)"
-            );
-        }
-    }
-
-    (n_faces, n_nodes, stored_nnz)
+    let stored = assert_composition_is_bit_exact_zero(
+        &format!("{label} d²·d¹"),
+        &d2,
+        &d1,
+        (n_tets, n_edges),
+        "tet",
+        "edge",
+    );
+    (n_tets, n_edges, stored)
 }
 
 #[test]
@@ -117,7 +199,7 @@ fn cube_pec_d1_d0_exact_sequence() {
     let mesh = cube_tet_mesh(8, 1.0);
     let (n_faces, n_nodes, stored) = assert_d1_d0_is_bit_exact_zero(&mesh, "cube n=8");
     eprintln!(
-        "cube n=8: n_nodes={n_nodes}, n_edges={}, n_faces={n_faces}, stored_nnz={stored}",
+        "cube n=8 d¹·d⁰: n_nodes={n_nodes}, n_edges={}, n_faces={n_faces}, stored_nnz={stored}",
         mesh.edges().len()
     );
 
@@ -142,12 +224,54 @@ fn sphere_pml_d1_d0_exact_sequence() {
     let f = read_sphere_fixture().expect("sphere fixture load");
     let (n_faces, n_nodes, stored) = assert_d1_d0_is_bit_exact_zero(&f.mesh, "sphere PML");
     eprintln!(
-        "sphere PML: n_nodes={n_nodes}, n_edges={}, n_faces={n_faces}, stored_nnz={stored}",
+        "sphere PML d¹·d⁰: n_nodes={n_nodes}, n_edges={}, n_faces={n_faces}, stored_nnz={stored}",
         f.mesh.edges().len()
     );
 
     assert!(
         n_faces > 0 && n_nodes > 0,
         "sphere PML: mesh must be nonempty (got n_faces={n_faces}, n_nodes={n_nodes})"
+    );
+}
+
+#[test]
+fn cube_pec_d2_d1_exact_sequence() {
+    // Same canonical n=8 cube refinement, second exactness identity:
+    // `d² · d¹ ≡ 0` (issue #91). Argument: each row of `d¹` is the
+    // signed boundary 1-cycle of a face; each row of `d²` is the
+    // signed boundary 2-chain of a tet. Their composition computes
+    // the boundary of a boundary, which is zero — and because every
+    // term is an integer sum of at most 12 terms in {-1, 0, +1}
+    // (4 faces · 3 edges per face), the sum stays well below 2⁵³ and
+    // is bit-exact in f64.
+    let mesh = cube_tet_mesh(8, 1.0);
+    let (n_tets, n_edges, stored) = assert_d2_d1_is_bit_exact_zero(&mesh, "cube n=8");
+    eprintln!(
+        "cube n=8 d²·d¹: n_tets={n_tets}, n_faces={}, n_edges={n_edges}, stored_nnz={stored}",
+        mesh.faces().len()
+    );
+
+    assert!(
+        n_tets > 0 && n_edges > 0,
+        "cube n=8: mesh must be nonempty (got n_tets={n_tets}, n_edges={n_edges})"
+    );
+}
+
+#[test]
+fn sphere_pml_d2_d1_exact_sequence() {
+    // The bundled sphere fixture — same reasoning as
+    // `sphere_pml_d1_d0_exact_sequence`. The second exactness identity
+    // depends only on the mesh connectivity, not on the PML; we just
+    // read `f.mesh` and call the three cochain operators.
+    let f = read_sphere_fixture().expect("sphere fixture load");
+    let (n_tets, n_edges, stored) = assert_d2_d1_is_bit_exact_zero(&f.mesh, "sphere PML");
+    eprintln!(
+        "sphere PML d²·d¹: n_tets={n_tets}, n_faces={}, n_edges={n_edges}, stored_nnz={stored}",
+        f.mesh.faces().len()
+    );
+
+    assert!(
+        n_tets > 0 && n_edges > 0,
+        "sphere PML: mesh must be nonempty (got n_tets={n_tets}, n_edges={n_edges})"
     );
 }


### PR DESCRIPTION
## Summary

Adds `divergence_map` and `apply_divergence` to `geode_core::derham`, completing the discrete de Rham chain on a tetrahedral mesh:

```
ℝ^{n_nodes} --d⁰--> ℝ^{n_edges} --d¹--> ℝ^{n_faces} --d²--> ℝ^{n_tets}
    H¹             H(curl)          H(div)          L²
```

- `divergence_map(mesh)` is the `n_tets × n_faces` signed face-tet incidence matrix; each row has exactly four ±1 entries with column from `TetMesh::tet_faces()` and value `(−1)^k · sign_k`.
- `apply_divergence(mesh, face_field)` is the matrix-free shape-matching convenience (mirrors `apply_gradient`).
- Re-exports both from `geode-core/src/lib.rs` alongside `gradient_map` / `curl_map`.
- Module-level docstring extended with the `d²` operator's sign-convention rationale, composition with `d¹`, and the Hiptmair §4 / Arnold–Falk–Winther §1.2 references.

## Sign-convention rationale

The `(−1)^k` factor is the standard simplicial-boundary sign — face opposite local vertex `k` carries sign `(−1)^k` in `∂[v0,v1,v2,v3]`. The `sign_k` from `TetMesh::tet_faces` converts the local-vertex-order face into the global ascending face triple `(a,b,c)` with `a<b<c` used as the row of `curl_map`. Without the alternation, two tets sharing an interior face would contribute the same sign to that column (both see the same global ascending triple), and the `d²·d¹` cancellation argument would fail row-by-row. The mesh-side scaffolding `TetMesh::tet_faces` is untouched — the alternating factor is operator-specific and lives in `divergence_map`. Worked through against the textbook simplicial-boundary formula and verified bit-exact on cube `n=8` and the sphere PML fixture.

## Tests

`crates/geode-core/tests/derham_divergence.rs` (new, 8 tests):
- Shape `n_tets × n_faces`.
- Every row has exactly four ±1.0 entries.
- Interior face columns: exactly 2 entries with opposite signs; boundary face columns: exactly 1 entry. Boundary/interior classification independently rebuilt from per-tet face counts.
- Reference-tet hand check: row is `[−1, +1, −1, +1]`, worked out against the simplicial-boundary formula in test docs.
- Early-warning `d²·d¹ ≡ 0` on reference tet and cube `n=2`.
- `apply_divergence` agrees exactly with `divergence_map` mat-vec on a non-trivial face field.
- `apply_divergence(apply_curl(apply_gradient(φ))) = 0` chain test.

`crates/geode-core/tests/derham_exact_sequence.rs` (extended):
- Adds `cube_pec_d2_d1_exact_sequence` and `sphere_pml_d2_d1_exact_sequence` — bit-exact `d²·d¹ ≡ 0` on the canonical cube `n=8` and sphere PML fixtures.
- Generalises the existing `assert_d1_d0_is_bit_exact_zero` helper into `assert_composition_is_bit_exact_zero`, so both compositions share one code path and one failure-diagnostic style.

Like `derham_exact_sequence.rs` (#78 / PR #80) and `derham_curl.rs` (#77 / PR #79), the new tests are pure host-side sparse linear algebra and run cleanly in plain `cargo test` — no `--release`, no `#[ignore]`. Documented in both test-file module headers.

## Test plan

- [x] `cargo test -p geode-core --no-default-features --features ndarray --test derham_divergence` — 8/8 green
- [x] `cargo test -p geode-core --no-default-features --features ndarray --test derham_exact_sequence` — 4/4 green (both `d¹·d⁰` and `d²·d¹` on cube n=8 and sphere PML)
- [x] `cargo clippy -p geode-core --tests --no-default-features --features ndarray -- -D warnings` — clean
- [x] `cargo test -p geode-core --no-default-features --features ndarray --test derham_curl --test derham_gradient --test derham_gradient_kernel` — no regressions in sibling derham tests

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)