### PR TITLE
style: collapse multi-line assert in derham_divergence.rs

### DIFF
--- a/crates/geode-core/tests/derham_divergence.rs
+++ b/crates/geode-core/tests/derham_divergence.rs
@@ -52,11 +52,7 @@ fn shape_is_n_tets_by_n_faces() {
     let n_tets = mesh.n_tets();
     let n_faces = mesh.faces().len();
 
-    assert_eq!(
-        d2.shape(),
-        (n_tets, n_faces),
-        "d² must be n_tets × n_faces"
-    );
+    assert_eq!(d2.shape(), (n_tets, n_faces), "d² must be n_tets × n_faces");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Collapses the multi-line `assert_eq!` at `crates/geode-core/tests/derham_divergence.rs:52` to a single line, restoring `cargo fmt --check` cleanliness on `main`.
- The multi-line form was a rustfmt regression introduced by PR #95 (issue #91, d² discrete divergence operator).
- Trivial 1-insertion / 5-deletion diff scoped to a single file.

## Test plan

- [x] `cargo fmt --check` is clean (no output on worktree).
- [x] `cargo test -p geode-core --test derham_divergence` — all 8 tests pass.
- [x] `git diff --stat` confirms only `crates/geode-core/tests/derham_divergence.rs` was touched.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)