### PR TITLE
refactor: factor cube-cavity NumPy mesh primitives into reference/numpy/mesh.py (#103)

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -37,10 +37,11 @@ reference/
 ├── numpy/                          — NumPy/SciPy reference impls (Python)
 │   ├── README.md
 │   ├── requirements.txt            — pinned NumPy + scipy + meshio versions (#90, #92)
+│   ├── mesh.py                     — shared mesh builders (cube_tet_mesh, cube_interior_mask, load_msh, write_msh) (#103)
 │   ├── p1_local_matrices.py        — P1 element-local K and M (#90)
 │   ├── gen_p1_local_per_case.py    — regenerates `fixtures/p1_local/<case>.json` (#90 / #101)
-│   ├── cube_cavity.py              — cube-cavity end-to-end driver (#92)
-│   ├── cube_cavity_minimal.py      — minimal programmatic-mesh NumPy cube-cavity (#93 sibling, n=4)
+│   ├── cube_cavity.py              — cube-cavity end-to-end driver, n=10 + Gmsh-fixture path (#92)
+│   ├── cube_cavity_minimal.py      — sibling cube-cavity driver, programmatic n=4 path (#93)
 │   └── gen_cube_cavity_baseline.py — regenerates `fixtures/cube_cavity/baseline.json` (#92)
 ├── jax/                            — JAX reference impls (Python)
 │   ├── README.md                   — DX friction notes (per #88 JAX-DX follow-up)

--- a/reference/numpy/cube_cavity.py
+++ b/reference/numpy/cube_cavity.py
@@ -8,7 +8,9 @@ The pipeline
 
 1. Mesh I/O — either generate the canonical tet-split cube
    (``cube_tet_mesh(n)``) or load a ``.msh`` via ``meshio``
-   (``load_msh(path)``).
+   (``load_msh(path)``). Both live in :mod:`mesh` (issue #103) and are
+   re-exported here for backward compatibility with consumers like
+   ``gen_cube_cavity_baseline.py``.
 2. P1 local matrices — delegated to :mod:`p1_local_matrices` (NumPy
    reference shared with issue #90; pinned by the per-case fixtures
    under ``reference/fixtures/p1_local/<case>.json`` per #101).
@@ -42,10 +44,15 @@ error — the residual being the standard P1 discretization error
 Public API
 ==========
 
+Mesh primitives (re-exported from :mod:`mesh` for backward compat):
+
 - :func:`cube_tet_mesh(n)` — generate the tet-split cube mesh.
 - :func:`load_msh(path)` — read a Gmsh ``.msh`` file via ``meshio``.
 - :func:`write_msh(path, nodes, tets)` — write a Gmsh ``.msh`` file.
 - :func:`cube_interior_mask(nodes)` — boolean mask of interior nodes.
+
+Assembly + eigensolve:
+
 - :func:`assemble_global_p1(nodes, tets)` — assembled ``(K, M)`` as
   scipy CSR matrices.
 - :func:`apply_dirichlet(K, M, mask)` — restrict K, M to interior DOFs.
@@ -63,135 +70,20 @@ import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg
 
-# Allow `python3 cube_cavity.py` to find the sibling module regardless of cwd.
+# Allow `python3 cube_cavity.py` to find the sibling modules regardless of cwd.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
-
-# --------------------------------------------------------------------------- #
-# Mesh generation / I/O
-# --------------------------------------------------------------------------- #
-
-
-def cube_tet_mesh(n: int, side: float = 1.0):
-    """Generate the n-per-side tet-split unit cube.
-
-    Faithful NumPy mirror of ``geode_core::cube_tet_mesh`` (see
-    ``crates/geode-core/src/mesh/mod.rs``). For each ``n × n × n`` hex
-    cell we emit 6 right-handed tets sharing the long diagonal
-    ``c[0] → c[6]``. Node order matches Burn so the same node-indexed
-    Dirichlet mask works on both backends.
-
-    Parameters
-    ----------
-    n : int
-        Hexes per side.
-    side : float
-        Cube side length (default 1.0).
-
-    Returns
-    -------
-    nodes : ndarray, shape ``((n+1)**3, 3)``, dtype float64
-        Node coordinates in lexicographic ``(i, j, k)`` order with ``i``
-        fastest.
-    tets : ndarray, shape ``(6 * n**3, 4)``, dtype int64
-        Tet connectivity, 0-based linear node indices.
-    """
-    nps = n + 1
-    h = side / n
-
-    nodes = np.zeros((nps**3, 3), dtype=np.float64)
-    for k in range(nps):
-        for j in range(nps):
-            for i in range(nps):
-                nodes[i + j * nps + k * nps * nps] = [i * h, j * h, k * h]
-
-    def node_idx(i, j, k):
-        return i + j * nps + k * nps * nps
-
-    tets = np.empty((6 * n**3, 4), dtype=np.int64)
-    t = 0
-    for k in range(n):
-        for j in range(n):
-            for i in range(n):
-                c = [
-                    node_idx(i, j, k),
-                    node_idx(i + 1, j, k),
-                    node_idx(i + 1, j + 1, k),
-                    node_idx(i, j + 1, k),
-                    node_idx(i, j, k + 1),
-                    node_idx(i + 1, j, k + 1),
-                    node_idx(i + 1, j + 1, k + 1),
-                    node_idx(i, j + 1, k + 1),
-                ]
-                # 6-tet split sharing diagonal c[0] -> c[6]. All right-handed.
-                tets[t + 0] = [c[0], c[1], c[2], c[6]]
-                tets[t + 1] = [c[0], c[2], c[3], c[6]]
-                tets[t + 2] = [c[0], c[3], c[7], c[6]]
-                tets[t + 3] = [c[0], c[7], c[4], c[6]]
-                tets[t + 4] = [c[0], c[4], c[5], c[6]]
-                tets[t + 5] = [c[0], c[5], c[1], c[6]]
-                t += 6
-
-    return nodes, tets
-
-
-def load_msh(path):
-    """Read a Gmsh ``.msh`` file and return ``(nodes, tets)`` as ndarrays.
-
-    Uses ``meshio`` (well-tested cross-format mesh I/O). Only ``tetra``
-    cells are kept — surface triangles and lines are silently dropped
-    (they are valid inputs but not the volume elements we want here).
-    """
-    import meshio
-
-    m = meshio.read(path)
-    nodes = np.asarray(m.points, dtype=np.float64)
-    tets_blocks = [c.data for c in m.cells if c.type == "tetra"]
-    if not tets_blocks:
-        raise ValueError(f"no tet cells in {path}")
-    tets = np.concatenate(tets_blocks, axis=0).astype(np.int64)
-    return nodes, tets
-
-
-def write_msh(path, nodes, tets):
-    """Write a Gmsh ``.msh`` file (MSH 4.1 ASCII) via ``meshio``.
-
-    The output is consumable by ``geode_core::GmshReader`` and by any
-    cross-backend reference impl (issue #93's JAX/TF-Java pipeline
-    consumes the same file).
-    """
-    import meshio
-
-    nodes = np.asarray(nodes, dtype=np.float64)
-    tets = np.asarray(tets, dtype=np.int64)
-    m = meshio.Mesh(points=nodes, cells=[("tetra", tets)])
-    meshio.write(path, m, file_format="gmsh", binary=False)
-
-
-# --------------------------------------------------------------------------- #
-# Dirichlet boundary mask
-# --------------------------------------------------------------------------- #
-
-
-def cube_interior_mask(nodes, side: float = 1.0):
-    """Boolean mask: True if the node is strictly inside the cube.
-
-    Mirrors ``geode_core::cube_interior_mask``. A node is "boundary"
-    iff any coordinate is within ``1e-9 * max(side, 1)`` of 0 or
-    ``side``.
-    """
-    nodes = np.asarray(nodes, dtype=np.float64)
-    tol = 1e-9 * max(side, 1.0)
-    on_boundary = (
-        (nodes[:, 0] < tol)
-        | (np.abs(nodes[:, 0] - side) < tol)
-        | (nodes[:, 1] < tol)
-        | (np.abs(nodes[:, 1] - side) < tol)
-        | (nodes[:, 2] < tol)
-        | (np.abs(nodes[:, 2] - side) < tol)
-    )
-    return ~on_boundary
+# Mesh primitives live in `mesh.py` (issue #103) and are re-exported
+# here so existing callers (`gen_cube_cavity_baseline.py`, downstream
+# tests) keep importing `cube_tet_mesh`, `load_msh`, `write_msh`, and
+# `cube_interior_mask` from `cube_cavity` without churn.
+from mesh import (  # noqa: E402, F401
+    cube_interior_mask,
+    cube_tet_mesh,
+    load_msh,
+    write_msh,
+)
 
 
 # --------------------------------------------------------------------------- #

--- a/reference/numpy/cube_cavity_minimal.py
+++ b/reference/numpy/cube_cavity_minimal.py
@@ -1,22 +1,20 @@
-"""Minimal NumPy cube-cavity Helmholtz pipeline (for #93's parallel coordination).
+"""Minimal NumPy cube-cavity Helmholtz pipeline (programmatic-mesh sibling).
 
-This module exists so the JAX (#93) and TF-Java (#93) implementations
-have a self-contained, reproducible NumPy baseline to agree with *before*
-issue #92 lands its canonical `reference/numpy/cube_cavity.py` with the
-full Gmsh-fixture flow. When #92 merges, this module becomes a thin
-wrapper around (or is replaced by) #92's canonical implementation; the
-shape of inputs/outputs is intentionally aligned so the migration is
-mechanical.
+This module is the NumPy oracle for the programmatic-mesh cube-cavity
+spine slice (issue #93). It is the sibling of
+:mod:`cube_cavity` — same assembly math, same eigensolve, different
+mesh source: the programmatic ``cube_tet_mesh(n)`` rather than the
+Gmsh-fixture ``unit_cube.msh`` at n=10. The JAX (#93) and TF-Java
+(#93) backends consume the same programmatic mesh so the cross-backend
+comparison is not contaminated by mesh-reader friction.
 
-Why duplicate?
-==============
-
-The sweep that scheduled #93 ran wave 2 in parallel with #92. The honest
-answer to that scheduling decision is to ship *both* pipelines and let
-the harness verify they agree. If #92's eventual baseline differs from
-this one, that disagreement is itself an Epic #88 friction artifact (it
-implies a meshing or normalization convention drift between sibling
-references — informative, by design).
+Issue #103 factored the mesh primitives (``cube_tet_mesh``,
+``cube_interior_mask``, ``load_msh``, ``write_msh``) into the shared
+:mod:`mesh` module so the two cube-cavity entry points share one source
+of truth. This module re-exports ``cube_tet_mesh`` and
+``cube_interior_mask`` so the existing JAX consumer
+(``reference/jax/cube_cavity.py``) keeps importing them from
+``cube_cavity_minimal`` without churn.
 
 What this is
 ============
@@ -25,9 +23,8 @@ A faithful, line-by-line NumPy transcription of the *same* assembly
 math the Burn path runs:
 
 - Mesh: the programmatic `cube_tet_mesh(n, side=1.0)` from
-  `geode-core::mesh` — `(n+1)^3` nodes, `6 * n^3` tets, each hex split
-  on the long diagonal. Re-implemented here in NumPy to keep this file
-  zero-dependency on the Rust side.
+  :mod:`mesh` — `(n+1)^3` nodes, `6 * n^3` tets, each hex split on the
+  long diagonal. NumPy mirror of `geode_core::mesh::cube_tet_mesh`.
 - Local matrices: `reference/numpy/p1_local_matrices.py` (already
   landed by #90).
 - Global assembly: COO triples → CSR via `scipy.sparse`.
@@ -68,69 +65,11 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
-
-def cube_tet_mesh(n: int, side: float = 1.0):
-    """Mirror `geode_core::mesh::cube_tet_mesh` in NumPy.
-
-    Returns (nodes, tets) where:
-      - nodes: ndarray shape ((n+1)**3, 3) of vertex coordinates
-      - tets: ndarray shape (6 * n**3, 4) of int connectivity
-
-    Each hex is split into 6 right-handed tets sharing the long diagonal
-    c[0] → c[6]. Vertex ordering matches the Rust path exactly.
-    """
-    nps = n + 1
-    h = side / n
-    # Build nodes in (k, j, i) order so node_idx(i, j, k) = i + j*nps + k*nps^2.
-    coords = np.empty((nps**3, 3), dtype=np.float64)
-    for k in range(nps):
-        for j in range(nps):
-            for i in range(nps):
-                lin = i + j * nps + k * nps * nps
-                coords[lin] = [i * h, j * h, k * h]
-
-    def node_idx(i, j, k):
-        return i + j * nps + k * nps * nps
-
-    tets = []
-    for k in range(n):
-        for j in range(n):
-            for i in range(n):
-                c = [
-                    node_idx(i, j, k),
-                    node_idx(i + 1, j, k),
-                    node_idx(i + 1, j + 1, k),
-                    node_idx(i, j + 1, k),
-                    node_idx(i, j, k + 1),
-                    node_idx(i + 1, j, k + 1),
-                    node_idx(i + 1, j + 1, k + 1),
-                    node_idx(i, j + 1, k + 1),
-                ]
-                tets.append([c[0], c[1], c[2], c[6]])
-                tets.append([c[0], c[2], c[3], c[6]])
-                tets.append([c[0], c[3], c[7], c[6]])
-                tets.append([c[0], c[7], c[4], c[6]])
-                tets.append([c[0], c[4], c[5], c[6]])
-                tets.append([c[0], c[5], c[1], c[6]])
-    return coords, np.asarray(tets, dtype=np.int64)
-
-
-def cube_interior_mask(nodes: np.ndarray, side: float = 1.0):
-    """Mirror `geode_core::eigen::cube_interior_mask`.
-
-    True = interior (free DOF). False = on any face of [0, side]^3.
-    """
-    tol = 1e-9 * max(side, 1.0)
-    x, y, z = nodes[:, 0], nodes[:, 1], nodes[:, 2]
-    on_boundary = (
-        (x < tol)
-        | (np.abs(x - side) < tol)
-        | (y < tol)
-        | (np.abs(y - side) < tol)
-        | (z < tol)
-        | (np.abs(z - side) < tol)
-    )
-    return ~on_boundary
+# Mesh primitives live in `mesh.py` (issue #103) — re-exported here so
+# the JAX consumer (`reference/jax/cube_cavity.py`) keeps importing
+# `cube_tet_mesh` and `cube_interior_mask` from this module without
+# churn.
+from mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402, F401
 
 
 def assemble_global_p1(nodes: np.ndarray, tets: np.ndarray):

--- a/reference/numpy/mesh.py
+++ b/reference/numpy/mesh.py
@@ -1,0 +1,162 @@
+"""Shared NumPy mesh builders for the cube-cavity reference set.
+
+Issue #103: factored out of ``cube_cavity.py`` and
+``cube_cavity_minimal.py`` so both NumPy entry points (and the JAX +
+TF-Java siblings that consume the programmatic builder) share a single
+source of truth for mesh generation, mesh I/O, and the Dirichlet
+boundary mask.
+
+Public API
+==========
+
+- :func:`cube_tet_mesh(n, side=1.0)` — generate the canonical n-per-side
+  tet-split unit cube. Mirror of ``geode_core::mesh::cube_tet_mesh``.
+- :func:`cube_interior_mask(nodes, side=1.0)` — boolean mask, True for
+  interior (free-DOF) nodes of ``[0, side]^3``. Mirror of
+  ``geode_core::eigen::cube_interior_mask``.
+- :func:`load_msh(path)` — read a Gmsh ``.msh`` file via ``meshio`` and
+  return ``(nodes, tets)`` ndarrays.
+- :func:`write_msh(path, nodes, tets)` — write a Gmsh ``.msh`` file via
+  ``meshio``; output is consumable by ``geode_core::GmshReader``.
+
+Both ``cube_cavity.py`` (n=10 + Gmsh-fixture path, issue #92) and
+``cube_cavity_minimal.py`` (programmatic n=4 path, issue #93) re-export
+these symbols so existing consumers (the JAX backend, the TF-Java
+sidecar driver, and ``gen_cube_cavity_baseline.py``) keep working
+without churn.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Programmatic mesh generation
+# --------------------------------------------------------------------------- #
+
+
+def cube_tet_mesh(n: int, side: float = 1.0):
+    """Generate the n-per-side tet-split unit cube.
+
+    Faithful NumPy mirror of ``geode_core::cube_tet_mesh`` (see
+    ``crates/geode-core/src/mesh/mod.rs``). For each ``n x n x n`` hex
+    cell we emit 6 right-handed tets sharing the long diagonal
+    ``c[0] -> c[6]``. Node order matches Burn so the same node-indexed
+    Dirichlet mask works on both backends.
+
+    Parameters
+    ----------
+    n : int
+        Hexes per side.
+    side : float
+        Cube side length (default 1.0).
+
+    Returns
+    -------
+    nodes : ndarray, shape ``((n+1)**3, 3)``, dtype float64
+        Node coordinates in lexicographic ``(i, j, k)`` order with ``i``
+        fastest.
+    tets : ndarray, shape ``(6 * n**3, 4)``, dtype int64
+        Tet connectivity, 0-based linear node indices.
+    """
+    nps = n + 1
+    h = side / n
+
+    nodes = np.zeros((nps**3, 3), dtype=np.float64)
+    for k in range(nps):
+        for j in range(nps):
+            for i in range(nps):
+                nodes[i + j * nps + k * nps * nps] = [i * h, j * h, k * h]
+
+    def node_idx(i, j, k):
+        return i + j * nps + k * nps * nps
+
+    tets = np.empty((6 * n**3, 4), dtype=np.int64)
+    t = 0
+    for k in range(n):
+        for j in range(n):
+            for i in range(n):
+                c = [
+                    node_idx(i, j, k),
+                    node_idx(i + 1, j, k),
+                    node_idx(i + 1, j + 1, k),
+                    node_idx(i, j + 1, k),
+                    node_idx(i, j, k + 1),
+                    node_idx(i + 1, j, k + 1),
+                    node_idx(i + 1, j + 1, k + 1),
+                    node_idx(i, j + 1, k + 1),
+                ]
+                # 6-tet split sharing diagonal c[0] -> c[6]. All right-handed.
+                tets[t + 0] = [c[0], c[1], c[2], c[6]]
+                tets[t + 1] = [c[0], c[2], c[3], c[6]]
+                tets[t + 2] = [c[0], c[3], c[7], c[6]]
+                tets[t + 3] = [c[0], c[7], c[4], c[6]]
+                tets[t + 4] = [c[0], c[4], c[5], c[6]]
+                tets[t + 5] = [c[0], c[5], c[1], c[6]]
+                t += 6
+
+    return nodes, tets
+
+
+# --------------------------------------------------------------------------- #
+# Dirichlet boundary mask
+# --------------------------------------------------------------------------- #
+
+
+def cube_interior_mask(nodes, side: float = 1.0):
+    """Boolean mask: True if the node is strictly inside the cube.
+
+    Mirrors ``geode_core::cube_interior_mask``. A node is "boundary"
+    iff any coordinate is within ``1e-9 * max(side, 1)`` of 0 or
+    ``side``.
+    """
+    nodes = np.asarray(nodes, dtype=np.float64)
+    tol = 1e-9 * max(side, 1.0)
+    on_boundary = (
+        (nodes[:, 0] < tol)
+        | (np.abs(nodes[:, 0] - side) < tol)
+        | (nodes[:, 1] < tol)
+        | (np.abs(nodes[:, 1] - side) < tol)
+        | (nodes[:, 2] < tol)
+        | (np.abs(nodes[:, 2] - side) < tol)
+    )
+    return ~on_boundary
+
+
+# --------------------------------------------------------------------------- #
+# Gmsh ``.msh`` I/O via meshio
+# --------------------------------------------------------------------------- #
+
+
+def load_msh(path):
+    """Read a Gmsh ``.msh`` file and return ``(nodes, tets)`` as ndarrays.
+
+    Uses ``meshio`` (well-tested cross-format mesh I/O). Only ``tetra``
+    cells are kept — surface triangles and lines are silently dropped
+    (they are valid inputs but not the volume elements we want here).
+    """
+    import meshio
+
+    m = meshio.read(path)
+    nodes = np.asarray(m.points, dtype=np.float64)
+    tets_blocks = [c.data for c in m.cells if c.type == "tetra"]
+    if not tets_blocks:
+        raise ValueError(f"no tet cells in {path}")
+    tets = np.concatenate(tets_blocks, axis=0).astype(np.int64)
+    return nodes, tets
+
+
+def write_msh(path, nodes, tets):
+    """Write a Gmsh ``.msh`` file (MSH 4.1 ASCII) via ``meshio``.
+
+    The output is consumable by ``geode_core::GmshReader`` and by any
+    cross-backend reference impl (issue #93's JAX/TF-Java pipeline
+    consumes the same file).
+    """
+    import meshio
+
+    nodes = np.asarray(nodes, dtype=np.float64)
+    tets = np.asarray(tets, dtype=np.int64)
+    m = meshio.Mesh(points=nodes, cells=[("tetra", tets)])
+    meshio.write(path, m, file_format="gmsh", binary=False)


### PR DESCRIPTION
## Summary

Factor the shared mesh primitives out of the two NumPy cube-cavity entry points (`cube_cavity.py` from #92 and `cube_cavity_minimal.py` from #93) into a new `reference/numpy/mesh.py` module so both consumers share one source of truth.

- New: `reference/numpy/mesh.py` — owns `cube_tet_mesh`, `cube_interior_mask`, `load_msh`, `write_msh`
- `cube_cavity.py` re-exports all four for backward compat with `gen_cube_cavity_baseline.py`
- `cube_cavity_minimal.py` re-exports `cube_tet_mesh` and `cube_interior_mask` for backward compat with `reference/jax/cube_cavity.py`
- `reference/README.md` layout updated; only the file listing changed

## Choice: Option A (factor) over Option B (merge)

The two entry points have *different* end-to-end APIs:

- `cube_cavity.py::run_cube_cavity` returns a dict keyed by `n_int`, `k_int_frobenius`, `m_int_frobenius`, `k_int_diag`, `m_int_diag` for the n=10 Gmsh-fixture path that drives `gen_cube_cavity_baseline.py`.
- `cube_cavity_minimal.py::solve_cube_cavity` returns a dict keyed by `n_dofs_interior`, `k_diag_sum`, `m_diag_sum` (different shape — sum traces, not per-row diags) for the programmatic n=4 path the JAX (#93) and TF-Java (#93) siblings cross-check against.

Merging would either break one of these consumer surfaces or force a dual API in a single file. Factoring the shared *mesh* primitives instead lets each entry point keep its own characteristic eigensolve/orchestrator API while collapsing the actual duplicate code (the meshing + Dirichlet-mask primitives).

## Verification

**Symbol identity** (in-process smoke test): `cube_tet_mesh` is the *same* function object when imported from `cube_cavity`, `cube_cavity_minimal`, or `mesh` — proves the factoring landed correctly and there is no longer any duplicated implementation.

**JAX import paths preserved**: replicated `from cube_cavity_minimal import cube_interior_mask, cube_tet_mesh` (from `reference/jax/cube_cavity.py`) and `from cube_cavity_minimal import solve_cube_cavity` (from `reference/jax/gen_cube_cavity_fixture.py`) — both resolve to the expected symbols.

**TF-Java**: only documentation references touched the minimal file; the Java code (`reference/tf_java/cube_cavity/src/main/java/dev/geodefem/refcubecavity/CubeMesh.java`) is a self-contained Java port and is unaffected.

**Rust harness tests**: `cargo test -p geode-validation --release --test cube_cavity_numpy_reference` and `cargo test -p geode-validation --release --test cube_cavity_jax_reference` produce the same pass/fail composition as on `origin/main`. The `cube_cavity_burn_matches_numpy_reference_at_all_substages` test is a pre-existing failure on `origin/main` (Burn `m_int_diag` drifts ~2.5e-10 against fixture tolerance 1e-14, a Burn-side floating-point precision issue, not a Python issue) — verified by checking out `origin/main`'s `reference/` tree under the same fixtures and reproducing the same failure.

## Test plan

- [x] All in-tree `cargo test -p geode-validation --release --test cube_cavity_numpy_reference` non-ignored tests pass.
- [x] `cargo test -p geode-validation --release --test cube_cavity_jax_reference` non-ignored test passes.
- [x] `python3 reference/numpy/cube_cavity_minimal.py --n 4` (CLI) runs and prints the lowest-5 eigenvalues.
- [x] `python3 -c "from cube_cavity import run_cube_cavity; print(run_cube_cavity(n=3, k=5)['n_int'])"` (importable surface used by `gen_cube_cavity_baseline.py`) works.
- [x] JAX import lines (`from cube_cavity_minimal import cube_tet_mesh, cube_interior_mask, solve_cube_cavity`) all resolve from `reference/jax/`.

Closes #103