### PR TITLE
cleanup: rename TF-Java CI gate to reflect three-way scope (#111)

### DIFF
--- a/.github/workflows/tfjava-cube-cavity.yml
+++ b/.github/workflows/tfjava-cube-cavity.yml
@@ -15,9 +15,18 @@ name: tfjava-cube-cavity
 #      e.g. when bumping TF-Java versions or auditing cross-XLA drift.
 #
 # Per #102 acceptance: this closes the loop on #93 AC#3 (TF-Java reference
-# builds and runs end-to-end) and #93 AC#4 (four-way NumPy / JAX / TF-Java
-# / Burn agreement table) by actually exercising the pipeline in CI and
+# builds and runs end-to-end) and #93 AC#4 (cross-IR NumPy / JAX / TF-Java
+# agreement table) by actually exercising the pipeline in CI and
 # asserting agreement to 1e-5 relative on the lowest 5 modes.
+#
+# Scope clarification (issue #111): this gate is three-way — it checks the
+# TF-Java row against the JAX baseline fixture and a freshly-emitted
+# NumPy baseline. The Burn row is exercised separately by the `arpack`
+# workflow (`.github/workflows/arpack.yml`) and by the per-push
+# `cube_cavity_jax_reference` cargo test, both of which compare Burn
+# against the same JAX baseline this gate uses. We deliberately do not
+# rebuild `geode-core` with `--features arpack` inside this JVM-heavy job;
+# keeping the toolchains decoupled keeps both gates fast.
 
 on:
   push:
@@ -57,7 +66,7 @@ on:
 
 jobs:
   build-and-cross-check:
-    name: TF-Java assembly + SciPy eigensolve + four-way agreement
+    name: TF-Java assembly + SciPy eigensolve + cross-IR agreement (TF-Java vs JAX vs NumPy)
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: "-Xmx2g"
@@ -110,7 +119,7 @@ jobs:
         # `-Plinux-x86_64` activates the linux-x86_64 native classifier
         # for `tensorflow-core-native`, matching the ubuntu-latest runner.
         # `-DskipTests` because the Maven project has no JUnit tests yet
-        # (the validation contract is the four-way agreement table below,
+        # (the validation contract is the cross-IR agreement table below,
         # not in-JVM unit tests).
         run: |
           mvn -B -Plinux-x86_64 -DskipTests package
@@ -140,7 +149,7 @@ jobs:
               --n "${CUBE_N}" --side 1.0 --k 5 \
               --out reference/tf_java/cube_cavity/target/out/numpy_baseline.json
 
-      - name: Four-way agreement gate (TF-Java vs JAX vs NumPy, rtol=${{ env.CUBE_RTOL }})
+      - name: Cross-IR agreement gate (TF-Java vs JAX vs NumPy, rtol=${{ env.CUBE_RTOL }})
         # This is the AC#5 hard gate: TF-Java eigenvalues must match the
         # JAX and NumPy baselines on the lowest 5 modes within `rtol`.
         # A failure here is the most-informative possible outcome — an
@@ -148,6 +157,11 @@ jobs:
         # genuine compiler-semantics drift on the same algorithm. We
         # always upload the agreement table as an artifact, regardless
         # of pass/fail, so the Friction artifact stays visible.
+        #
+        # Burn agreement is intentionally not part of this gate; it is
+        # exercised by the `arpack` workflow and by the per-push
+        # `cube_cavity_jax_reference` cargo test against the same JAX
+        # baseline. The `--burn` flag is therefore omitted here.
         run: |
           python3 reference/driver/compare_eigenvalues.py \
               --tfjava reference/tf_java/cube_cavity/target/out/eigenresult_tfjava.json \

--- a/reference/driver/compare_eigenvalues.py
+++ b/reference/driver/compare_eigenvalues.py
@@ -1,13 +1,20 @@
-"""Four-way eigenvalue comparison for the cube-cavity reference (Epic #88 / #93).
+"""Cross-IR eigenvalue comparison for the cube-cavity reference (Epic #88 / #93).
 
 Given a TF-Java eigenresult JSON (produced by `eigensolve_from_tfjava.py`)
 and the in-tree JAX baseline JSON (`reference/fixtures/cube_cavity/jax_baseline.json`),
 plus an optional NumPy result computed in-process from
 `reference/numpy/cube_cavity_minimal.py`, this script writes a
-four-way agreement table and asserts the TF-Java eigenvalues agree
+cross-IR agreement table and asserts the TF-Java eigenvalues agree
 with the JAX/NumPy baselines on the lowest 5 modes within a relative
 tolerance (default 1e-5, per the Epic #88 framing comment on
 cross-language f64 reproducibility).
+
+When invoked from the TF-Java CI job (`tfjava-cube-cavity.yml`) the
+`--burn` argument is not supplied — that gate is intentionally three-way
+(TF-Java vs JAX vs NumPy). Burn agreement against the same JAX baseline
+is exercised separately by the `arpack` workflow and by the per-push
+`cube_cavity_jax_reference` cargo test. Passing `--burn` here is still
+supported for ad-hoc/local audits where all four rows are convenient.
 
 Exit code:
     0 — agreement within tolerance.
@@ -16,7 +23,7 @@ Exit code:
 This script is intentionally framework-light (only numpy + stdlib) so it
 runs inside the TF-Java CI job without dragging JAX into the JVM-side
 container. The Burn row is read from a fixture-shaped JSON if provided,
-or omitted with a clearly-marked dash.
+or omitted with a footnote pointing at where Burn agreement is checked.
 
 Usage
 =====
@@ -27,6 +34,11 @@ Usage
         [--burn  path/to/burn_baseline.json] \
         [--rtol 1e-5] \
         [--out path/to/agreement_table.md]
+
+Note: `--burn` is optional and is NOT wired in by `tfjava-cube-cavity.yml`.
+The CI gate is three-way (TF-Java vs JAX vs NumPy); Burn agreement against
+the same JAX baseline is exercised by the `arpack` workflow and the
+`cube_cavity_jax_reference` cargo test.
 """
 
 from __future__ import annotations
@@ -115,17 +127,32 @@ def main() -> int:
         max_rel_tj_burn = float(np.max(rel_tfjava_vs_burn))
 
     # --- Render Markdown table ---
+    # Title reflects the actual gate scope: cross-IR agreement among the
+    # backends that were actually provided. When `--burn` is not supplied
+    # (the default in the TF-Java CI workflow), the Burn row is omitted
+    # entirely and replaced by an explicit footnote pointing at where
+    # Burn agreement is checked. See issue #111.
+    if burn_e is not None:
+        title = "## Cube-cavity cross-IR eigenvalue agreement (TF-Java vs JAX vs NumPy vs Burn)"
+    else:
+        title = "## Cube-cavity cross-IR eigenvalue agreement (TF-Java vs JAX vs NumPy)"
+
+    backend_rows = [
+        _format_row("NumPy", numpy_e, k),
+        _format_row("JAX",   jax_e, k),
+        _format_row("TF-Java", tfjava, k),
+    ]
+    if burn_e is not None:
+        backend_rows.append(_format_row("Burn", burn_e, k))
+
     lines = [
-        "## Cube-cavity four-way eigenvalue agreement",
+        title,
         "",
         f"Lowest {k} modes; rtol gate = {args.rtol:g}",
         "",
         "| Backend  | " + " | ".join(f"λ[{i}]" for i in range(k)) + " |",
         "|----------|" + "|".join(["----------------"] * k) + "|",
-        _format_row("NumPy", numpy_e, k),
-        _format_row("JAX",   jax_e, k),
-        _format_row("TF-Java", tfjava, k),
-        _format_row("Burn",  burn_e, k),
+        *backend_rows,
         "",
         "### Relative drift vs JAX (XLA-vs-XLA)",
         "",
@@ -135,6 +162,15 @@ def main() -> int:
         lines.append(f"- max |TF-Java − NumPy| / |NumPy| over {k} modes: **{max_rel_tj_np:.3e}**")
     if max_rel_tj_burn is not None:
         lines.append(f"- max |TF-Java − Burn|  / |Burn|  over {k} modes: **{max_rel_tj_burn:.3e}**")
+    else:
+        lines.extend([
+            "",
+            "> **Note:** the Burn row is not included in this gate. Burn agreement",
+            "> against the same JAX baseline is exercised by `cargo test --features arpack`",
+            "> (see `.github/workflows/arpack.yml`) and by the default-CI",
+            "> `cube_cavity_jax_reference` cargo test. See issue #111 for the",
+            "> decoupling rationale.",
+        ])
 
     table_md = "\n".join(lines) + "\n"
     print(table_md)

--- a/reference/driver/emit_numpy_eigenvalues.py
+++ b/reference/driver/emit_numpy_eigenvalues.py
@@ -41,7 +41,7 @@ def main() -> int:
         "fixture_id": f"cube_cavity/n{args.n}_numpy_minimal_eigensolve",
         "description": (
             "Lowest k cube-cavity eigenvalues from reference/numpy/cube_cavity_minimal.py. "
-            "Emitted in fixture-schema form so the four-way agreement table in "
+            "Emitted in fixture-schema form so the cross-IR agreement table in "
             "reference/driver/compare_eigenvalues.py can consume it without "
             "language-specific code paths (Epic #88 / #93)."
         ),

--- a/reference/tf_java/README.md
+++ b/reference/tf_java/README.md
@@ -125,3 +125,29 @@ The CI job:
    the Friction artifact stays visible. An XLA-vs-XLA disagreement
    between TF-Java and JAX is the most informative possible outcome —
    that's the surface this CI job exists to monitor.
+
+### Scope of the TF-Java CI gate (issue #111)
+
+The `tfjava-cube-cavity.yml` workflow's agreement gate is **cross-IR
+three-way**: it compares TF-Java against JAX (XLA-vs-XLA) and NumPy
+(structured-sparse reference). It does **not** include the Burn row.
+
+Burn agreement is checked in two other places against the same
+JAX baseline fixture, so the cross-language coverage is not actually
+narrower — only the per-run artifact:
+
+- `cargo test -p geode-validation --release --test cube_cavity_jax_reference -- --ignored`
+  runs in the default per-push CI matrix without ARPACK; it asserts
+  the Burn-side eigenvalues agree with the in-tree JAX baseline.
+- `.github/workflows/arpack.yml` exercises the same Burn lowering with
+  the opt-in `arpack` Cargo feature (sparse generalized eigensolver
+  FFI to libarpack-ng) and runs the gated `sparse_eigensolver`
+  acceptance test.
+
+Keeping the JVM-heavy TF-Java gate separate from the Rust/ARPACK build
+means a TF-Java version bump or XLA drift fails fast on the JVM side
+without rebuilding `geode-core` with `arpack`, and a Rust/ARPACK
+regression fails fast on the cargo side without pulling ~200 MB of
+TF-Java natives. `compare_eigenvalues.py` still accepts `--burn` for
+local audits where it is convenient to render all four backends in
+one table.


### PR DESCRIPTION
## Summary

Closes #111.

**Path chosen: A (rename only).** The TF-Java cube-cavity CI gate's job/step were labeled "four-way agreement" but only ever populated three rows (TF-Java, JAX, NumPy). The Burn row was a placeholder `—`; Burn is exercised separately by `.github/workflows/arpack.yml` and by the default-CI `cube_cavity_jax_reference` cargo test, both of which compare Burn against the **same** JAX baseline fixture this gate uses. Cross-language coverage is therefore not actually narrower — only the per-run artifact was. Path B (wiring Burn into this same job) would require rebuilding `geode-core --features arpack,ndarray` inside the JVM-heavy workflow, which is the exact toolchain decoupling we currently rely on to keep both gates fast and to localize regressions; the issue body explicitly recommends Path A unless Path B turns out to be trivial, and it's not.

## Changes

- `.github/workflows/tfjava-cube-cavity.yml`
  - Job name: `TF-Java assembly + SciPy eigensolve + cross-IR agreement (TF-Java vs JAX vs NumPy)`.
  - Gate step name: `Cross-IR agreement gate (TF-Java vs JAX vs NumPy, rtol=...)`.
  - Header comment and step comments updated to spell out the three-way scope and point at where Burn agreement is checked instead. No matrix or new dependencies.
- `reference/driver/compare_eigenvalues.py`
  - Title now reflects the backends actually present (`... (TF-Java vs JAX vs NumPy)` when `--burn` is absent, `... (TF-Java vs JAX vs NumPy vs Burn)` when it is supplied).
  - The Burn row is **omitted entirely** when `--burn` is not passed (no more `—` placeholder).
  - When the Burn row is absent the rendered Markdown emits an explicit footnote pointing at `.github/workflows/arpack.yml` and the default-CI `cube_cavity_jax_reference` cargo test. The `--burn` flag is still supported for local audits.
- `reference/driver/emit_numpy_eigenvalues.py`
  - Stray "four-way" reference in the fixture description scrubbed.
- `reference/tf_java/README.md`
  - New "Scope of the TF-Java CI gate (issue #111)" subsection explains the three-way scope, documents the two places Burn agreement is checked, and states the toolchain-decoupling rationale.

## Acceptance criteria (Path A)

- [x] Rename the gate step in `.github/workflows/tfjava-cube-cavity.yml` to `Cross-IR agreement gate (TF-Java vs JAX vs NumPy, rtol=...)`.
- [x] Drop the Burn `—` row from `agreement_table.md` artifact; the gate's footnote now points at where Burn agreement is checked.
- [x] Update `reference/tf_java/README.md` to clarify the gate's actual scope (TF-Java / JAX / NumPy) and where Burn is checked.
- [x] No new dependencies, no new CI cost.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tfjava-cube-cavity.yml'))"` — passes.
- [x] `ast.parse` on `reference/driver/compare_eigenvalues.py` — passes.
- [x] Local smoke test of `compare_eigenvalues.py` in both 3-way (no `--burn`) and 4-way (with `--burn`) modes — both render the correct title, the correct rows, and exit 0 on identical fixtures.
- [x] `grep -nr 'four-way\|Four-way'` in the tree — no matches remain.
- [ ] The `tfjava-cube-cavity` workflow run on this PR will exercise the renamed job/step end-to-end (path-filter triggers because the YAML itself changed). The agreement table artifact will show the new title with the Burn row absent and the footnote present.

Generated with Claude Code