### PR TITLE
cleanup: migrate to_vec::<f32> sites onto readback_f64 helper

### DIFF
--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -182,7 +182,7 @@ fn default_device_label() -> String {
 /// elementwise sum within tolerance; `Err` otherwise. Failure here
 /// indicates a backend wiring problem (driver, adapter, feature flag).
 pub fn smoke_add() -> Result<DeviceInfo, String> {
-    use burn::tensor::TensorData;
+    use burn::tensor::{ElementConversion, TensorData};
 
     type B = DefaultBackend;
     let device = <B as BackendTypes>::Device::default();
@@ -191,12 +191,20 @@ pub fn smoke_add() -> Result<DeviceInfo, String> {
     let b = Tensor::<B, 1>::from_data(TensorData::from([4.0f32, 3.0, 2.0, 1.0]), &device);
     let c = a + b;
 
+    // Read back at `B::FloatElem` (which may be `f32` or `f64` depending
+    // on the backend selected via feature flags) and upcast to `f64` so
+    // the comparison logic is backend-agnostic. The previous
+    // `to_vec::<f32>()` panicked with `TypeMismatch` on the f64
+    // `ndarray` backend.
     let data = c.into_data();
-    let values: Vec<f32> = data
-        .to_vec::<f32>()
-        .map_err(|e| format!("tensor readback failed: {e:?}"))?;
+    let values: Vec<f64> = data
+        .to_vec::<<B as BackendTypes>::FloatElem>()
+        .map_err(|e| format!("tensor readback failed: {e:?}"))?
+        .into_iter()
+        .map(|x| x.elem::<f64>())
+        .collect();
 
-    let expected = [5.0f32; 4];
+    let expected = [5.0f64; 4];
     if values.len() != expected.len()
         || values
             .iter()

--- a/crates/geode-core/tests/assembly.rs
+++ b/crates/geode-core/tests/assembly.rs
@@ -14,11 +14,14 @@
 //!      probe at a single picked node within a coarse tolerance.
 
 use burn::backend::Autodiff;
-use burn::tensor::backend::{Backend, BackendTypes};
+use burn::tensor::backend::BackendTypes;
 use burn::tensor::ElementConversion;
 use burn::tensor::{Int, Tensor, TensorData};
 
 use geode_core::{assemble_global_p1, cube_tet_mesh, upload_mesh, DefaultBackend};
+
+mod common;
+use common::readback_f64;
 
 type B = DefaultBackend;
 type Ad = Autodiff<B>;
@@ -31,19 +34,6 @@ fn device() -> <B as BackendTypes>::Device {
 
 fn ad_device() -> <Ad as BackendTypes>::Device {
     <Ad as BackendTypes>::Device::default()
-}
-
-/// Read a 2-D float Burn tensor back to host as `Vec<f64>`, regardless
-/// of whether the active backend's `B::FloatElem` is `f32` or `f64`.
-/// `to_vec::<E>` requires the storage element type to match exactly, so
-/// we read at `B::FloatElem` and upcast to `f64` for the test logic.
-fn readback_f64<BB: Backend, const D: usize>(t: Tensor<BB, D>) -> Vec<f64> {
-    t.into_data()
-        .to_vec::<BB::FloatElem>()
-        .expect("readback at B::FloatElem")
-        .into_iter()
-        .map(|x| x.elem::<f64>())
-        .collect()
 }
 
 // --- CPU reference assembler -------------------------------------------------

--- a/crates/geode-core/tests/common/mod.rs
+++ b/crates/geode-core/tests/common/mod.rs
@@ -1,0 +1,29 @@
+//! Shared test utilities for `geode-core` integration tests.
+//!
+//! This module lives under `tests/common/` so Cargo does not compile it
+//! as its own test binary — only files at the top level of `tests/`
+//! become test binaries. Consumers pull it in with `mod common;` at
+//! the top of each test file.
+
+use burn::tensor::backend::Backend;
+use burn::tensor::{ElementConversion, Tensor};
+
+/// Read a `D`-dimensional float Burn tensor back to host as `Vec<f64>`,
+/// regardless of whether the active backend's `B::FloatElem` is `f32`
+/// or `f64`.
+///
+/// `TensorData::to_vec::<E>` requires the storage element type to match
+/// exactly, so we read at `B::FloatElem` and upcast each entry to `f64`
+/// for the test logic. This is the canonical readback pattern across
+/// the `geode-core` test surface — the previous `to_vec::<f32>()`
+/// anti-pattern panics on the f64 `ndarray` backend with
+/// `TypeMismatch (expected F64, got F32)`.
+#[allow(dead_code)] // some test binaries only use a subset of helpers
+pub fn readback_f64<BB: Backend, const D: usize>(t: Tensor<BB, D>) -> Vec<f64> {
+    t.into_data()
+        .to_vec::<BB::FloatElem>()
+        .expect("readback at B::FloatElem")
+        .into_iter()
+        .map(|x| x.elem::<f64>())
+        .collect()
+}

--- a/crates/geode-core/tests/nedelec.rs
+++ b/crates/geode-core/tests/nedelec.rs
@@ -18,6 +18,9 @@ use geode_core::{
     cube_tet_mesh, tet_edges, upload_mesh, DefaultBackend, TetMesh,
 };
 
+mod common;
+use common::readback_f64;
+
 type B = DefaultBackend;
 
 /// f32 tolerance — Burn's default float backend is f32, reference is f64.
@@ -35,10 +38,6 @@ fn coords_tensor_from_vec(tets: &[[[f64; 3]; 4]]) -> Tensor<B, 3> {
         .collect();
     let data = TensorData::new(flat, [n, 4, 3]);
     Tensor::<B, 3>::from_data(data, &device())
-}
-
-fn tensor_to_vec_f32<const D: usize>(t: Tensor<B, D>) -> Vec<f32> {
-    t.into_data().to_vec::<f32>().expect("readback f32")
 }
 
 // --- CPU reference -----------------------------------------------------------
@@ -160,7 +159,7 @@ fn reference_unit_tet_k_matches_hand_tabulated() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_nedelec_local_matrices(coords);
 
-    let k = tensor_to_vec_f32(result.k_local);
+    let k = readback_f64(result.k_local);
 
     let c = [
         [0.0, -2.0, 2.0],
@@ -181,7 +180,7 @@ fn reference_unit_tet_k_matches_hand_tabulated() {
 
     for i in 0..6 {
         for j in 0..6 {
-            let g = k[i * 6 + j] as f64;
+            let g = k[i * 6 + j];
             let e = expected[i][j];
             assert!(
                 (g - e).abs() < F32_TOL * (1.0 + e.abs()),
@@ -203,7 +202,7 @@ fn reference_unit_tet_m_matches_hand_tabulated() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_nedelec_local_matrices(coords);
 
-    let m = tensor_to_vec_f32(result.m_local);
+    let m = readback_f64(result.m_local);
     let (_, m_ref, _) = nedelec_local_reference(&ref_tet);
 
     // Independent spot checks of two entries we computed by hand in
@@ -221,7 +220,7 @@ fn reference_unit_tet_m_matches_hand_tabulated() {
 
     for i in 0..6 {
         for j in 0..6 {
-            let g = m[i * 6 + j] as f64;
+            let g = m[i * 6 + j];
             let e = m_ref[i][j];
             assert!(
                 (g - e).abs() < F32_TOL * (1.0 + e.abs()),
@@ -237,9 +236,9 @@ fn reference_unit_tet_signed_volume_is_one_sixth() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_nedelec_local_matrices(coords);
 
-    let v = tensor_to_vec_f32(result.signed_volumes);
+    let v = readback_f64(result.signed_volumes);
     assert_eq!(v.len(), 1);
-    assert!(((v[0] - 1.0f32 / 6.0) as f64).abs() < F32_TOL);
+    assert!((v[0] - 1.0 / 6.0).abs() < F32_TOL);
 }
 
 #[test]
@@ -250,14 +249,14 @@ fn batched_random_tets_match_cpu_reference() {
     let coords = coords_tensor_from_vec(&tets);
     let result = batched_nedelec_local_matrices(coords);
 
-    let k_flat = tensor_to_vec_f32(result.k_local);
-    let m_flat = tensor_to_vec_f32(result.m_local);
-    let v_flat = tensor_to_vec_f32(result.signed_volumes);
+    let k_flat = readback_f64(result.k_local);
+    let m_flat = readback_f64(result.m_local);
+    let v_flat = readback_f64(result.signed_volumes);
 
     for (e_idx, tet) in tets.iter().enumerate() {
         let (k_ref, m_ref, v_ref) = nedelec_local_reference(tet);
 
-        let v_got = v_flat[e_idx] as f64;
+        let v_got = v_flat[e_idx];
         let v_tol = F32_TOL * (1.0 + v_ref.abs());
         assert!(
             (v_got - v_ref).abs() < v_tol,
@@ -266,7 +265,7 @@ fn batched_random_tets_match_cpu_reference() {
 
         for i in 0..6 {
             for j in 0..6 {
-                let k_got = k_flat[(e_idx * 36) + i * 6 + j] as f64;
+                let k_got = k_flat[(e_idx * 36) + i * 6 + j];
                 let k_ref_ij = k_ref[i][j];
                 let k_tol = 1e-4 * (1.0 + k_ref_ij.abs());
                 assert!(
@@ -274,7 +273,7 @@ fn batched_random_tets_match_cpu_reference() {
                     "elem {e_idx} K[{i},{j}]: got {k_got}, ref {k_ref_ij}"
                 );
 
-                let m_got = m_flat[(e_idx * 36) + i * 6 + j] as f64;
+                let m_got = m_flat[(e_idx * 36) + i * 6 + j];
                 let m_ref_ij = m_ref[i][j];
                 let m_tol = 1e-4 * (1.0 + m_ref_ij.abs());
                 assert!(
@@ -315,20 +314,20 @@ fn k_invariant_under_rigid_motion() {
     let res_ref = batched_nedelec_local_matrices(coords_ref);
     let res_moved = batched_nedelec_local_matrices(coords_moved);
 
-    let k_ref = tensor_to_vec_f32(res_ref.k_local);
-    let k_moved = tensor_to_vec_f32(res_moved.k_local);
-    let m_ref = tensor_to_vec_f32(res_ref.m_local);
-    let m_moved = tensor_to_vec_f32(res_moved.m_local);
+    let k_ref = readback_f64(res_ref.k_local);
+    let k_moved = readback_f64(res_moved.k_local);
+    let m_ref = readback_f64(res_ref.m_local);
+    let m_moved = readback_f64(res_moved.m_local);
 
     for (a, b) in k_ref.iter().zip(k_moved.iter()) {
         assert!(
-            ((a - b) as f64).abs() < 1e-4,
+            (a - b).abs() < 1e-4,
             "K not invariant under rigid motion: {a} vs {b}"
         );
     }
     for (a, b) in m_ref.iter().zip(m_moved.iter()) {
         assert!(
-            ((a - b) as f64).abs() < 1e-4,
+            (a - b).abs() < 1e-4,
             "M not invariant under rigid motion: {a} vs {b}"
         );
     }
@@ -350,10 +349,10 @@ fn m_scales_linearly_with_uniform_dilation() {
     let coords = coords_tensor_from_vec(&[scaled]);
     let result = batched_nedelec_local_matrices(coords);
     let (_, m_ref, _) = nedelec_local_reference(&scaled);
-    let m_got = tensor_to_vec_f32(result.m_local);
+    let m_got = readback_f64(result.m_local);
     for i in 0..6 {
         for j in 0..6 {
-            let g = m_got[i * 6 + j] as f64;
+            let g = m_got[i * 6 + j];
             let e = m_ref[i][j];
             assert!(
                 (g - e).abs() < 1e-3 * (1.0 + e.abs()),
@@ -503,21 +502,21 @@ fn shared_edge_assembly_signs_apply_correctly() {
         .collect();
 
     let sys = assemble_global_nedelec(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges);
-    let k: Vec<f32> = sys.k.into_data().to_vec().expect("readback");
-    let m: Vec<f32> = sys.m.into_data().to_vec().expect("readback");
+    let k = readback_f64(sys.k);
+    let m = readback_f64(sys.m);
 
     for i in 0..n_edges {
         for j in (i + 1)..n_edges {
             let kij = k[i * n_edges + j];
             let kji = k[j * n_edges + i];
             assert!(
-                ((kij - kji) as f64).abs() < 1e-4,
+                (kij - kji).abs() < 1e-4,
                 "K not symmetric ({i},{j}): {kij} vs {kji}"
             );
             let mij = m[i * n_edges + j];
             let mji = m[j * n_edges + i];
             assert!(
-                ((mij - mji) as f64).abs() < 1e-5,
+                (mij - mji).abs() < 1e-5,
                 "M not symmetric ({i},{j}): {mij} vs {mji}"
             );
         }
@@ -544,8 +543,8 @@ fn cube_assembly_k_symmetric_and_m_total_mass_positive() {
     let (nodes, tets) = upload_mesh::<B>(&mesh, &device());
     let sys = assemble_global_nedelec(nodes, tets, &tet_idx, &tet_sign, n_edges);
 
-    let k: Vec<f32> = sys.k.into_data().to_vec().expect("readback k");
-    let m: Vec<f32> = sys.m.clone().into_data().to_vec().expect("readback m");
+    let k = readback_f64(sys.k);
+    let m = readback_f64(sys.m);
 
     // K and M symmetric.
     for i in 0..n_edges {
@@ -553,13 +552,13 @@ fn cube_assembly_k_symmetric_and_m_total_mass_positive() {
             let kij = k[i * n_edges + j];
             let kji = k[j * n_edges + i];
             assert!(
-                ((kij - kji) as f64).abs() < 1e-4,
+                (kij - kji).abs() < 1e-4,
                 "K not symmetric ({i},{j})"
             );
             let mij = m[i * n_edges + j];
             let mji = m[j * n_edges + i];
             assert!(
-                ((mij - mji) as f64).abs() < 1e-5,
+                (mij - mji).abs() < 1e-5,
                 "M not symmetric ({i},{j})"
             );
         }
@@ -671,7 +670,7 @@ fn assembly_preserves_autodiff_smoke() {
     let dnodes = nodes
         .grad(&grads)
         .expect("gradient w.r.t. nodes should exist");
-    let dnodes_vec: Vec<f32> = dnodes.into_data().to_vec().expect("readback");
+    let dnodes_vec = readback_f64(dnodes);
     let mut finite = 0;
     let mut nonzero = 0;
     for &g in &dnodes_vec {

--- a/crates/geode-core/tests/p1_local_matrices.rs
+++ b/crates/geode-core/tests/p1_local_matrices.rs
@@ -14,6 +14,9 @@ use burn::tensor::{Tensor, TensorData};
 
 use geode_core::{batched_p1_local_matrices, DefaultBackend, GmshReader, MeshReader};
 
+mod common;
+use common::readback_f64;
+
 type B = DefaultBackend;
 
 const UNIT_CUBE_MSH: &[u8] = include_bytes!("fixtures/unit_cube.msh");
@@ -33,10 +36,6 @@ fn coords_tensor_from_vec(tets: &[[[f64; 3]; 4]]) -> Tensor<B, 3> {
         .collect();
     let data = TensorData::new(flat, [n, 4, 3]);
     Tensor::<B, 3>::from_data(data, &device())
-}
-
-fn tensor_to_vec_f32<const D: usize>(t: Tensor<B, D>) -> Vec<f32> {
-    t.into_data().to_vec::<f32>().expect("readback f32")
 }
 
 /// CPU reference for a single tet — used as ground truth for the batched test.
@@ -125,15 +124,15 @@ fn reference_unit_tet_stiffness_matches_analytic() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_p1_local_matrices(coords);
 
-    let k = tensor_to_vec_f32(result.k_local);
+    let k = readback_f64(result.k_local);
     // Analytic K for the reference tet, row-major.
     let expected = [
-        3.0, -1.0, -1.0, -1.0, -1.0, 1.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 1.0,
+        3.0_f64, -1.0, -1.0, -1.0, -1.0, 1.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 1.0,
     ];
     for (idx, (g, e)) in k.iter().zip(expected.iter()).enumerate() {
-        let want = (e / 6.0) as f32;
+        let want = e / 6.0;
         assert!(
-            ((g - want) as f64).abs() < F32_TOL,
+            (g - want).abs() < F32_TOL,
             "K[{idx}] = {g}, want {want}"
         );
     }
@@ -145,15 +144,15 @@ fn reference_unit_tet_mass_matches_analytic() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_p1_local_matrices(coords);
 
-    let m = tensor_to_vec_f32(result.m_local);
+    let m = readback_f64(result.m_local);
     // Analytic M = (V/20)*(I + ones) with V = 1/6, row-major.
     let pattern = [
-        2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0,
+        2.0_f64, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0,
     ];
     for (idx, (g, e)) in m.iter().zip(pattern.iter()).enumerate() {
-        let want = (e / 120.0) as f32; // (V/20) = 1/120, times pattern entry
+        let want = e / 120.0; // (V/20) = 1/120, times pattern entry
         assert!(
-            ((g - want) as f64).abs() < F32_TOL,
+            (g - want).abs() < F32_TOL,
             "M[{idx}] = {g}, want {want}"
         );
     }
@@ -165,9 +164,9 @@ fn reference_unit_tet_signed_volume_is_one_sixth() {
     let coords = coords_tensor_from_vec(&[ref_tet]);
     let result = batched_p1_local_matrices(coords);
 
-    let v = tensor_to_vec_f32(result.signed_volumes);
+    let v = readback_f64(result.signed_volumes);
     assert_eq!(v.len(), 1);
-    assert!(((v[0] - 1.0f32 / 6.0) as f64).abs() < F32_TOL);
+    assert!((v[0] - 1.0 / 6.0).abs() < F32_TOL);
 }
 
 #[test]
@@ -178,14 +177,14 @@ fn batched_random_tets_match_cpu_reference() {
     let coords = coords_tensor_from_vec(&tets);
     let result = batched_p1_local_matrices(coords);
 
-    let k_flat = tensor_to_vec_f32(result.k_local);
-    let m_flat = tensor_to_vec_f32(result.m_local);
-    let v_flat = tensor_to_vec_f32(result.signed_volumes);
+    let k_flat = readback_f64(result.k_local);
+    let m_flat = readback_f64(result.m_local);
+    let v_flat = readback_f64(result.signed_volumes);
 
     for (e_idx, tet) in tets.iter().enumerate() {
         let (k_ref, m_ref, v_ref) = p1_local_reference(tet);
 
-        let v_got = v_flat[e_idx] as f64;
+        let v_got = v_flat[e_idx];
         let v_tol = F32_TOL * (1.0 + v_ref.abs());
         assert!(
             (v_got - v_ref).abs() < v_tol,
@@ -194,7 +193,7 @@ fn batched_random_tets_match_cpu_reference() {
 
         for i in 0..4 {
             for j in 0..4 {
-                let k_got = k_flat[(e_idx * 16) + i * 4 + j] as f64;
+                let k_got = k_flat[(e_idx * 16) + i * 4 + j];
                 let k_ref_ij = k_ref[i][j];
                 // Stiffness magnitudes can be O(1/V) — scale tolerance to reference.
                 let k_tol = F32_TOL * (1.0 + k_ref_ij.abs());
@@ -203,7 +202,7 @@ fn batched_random_tets_match_cpu_reference() {
                     "elem {e_idx} K[{i},{j}]: got {k_got}, ref {k_ref_ij}"
                 );
 
-                let m_got = m_flat[(e_idx * 16) + i * 4 + j] as f64;
+                let m_got = m_flat[(e_idx * 16) + i * 4 + j];
                 let m_ref_ij = m_ref[i][j];
                 let m_tol = F32_TOL * (1.0 + m_ref_ij.abs());
                 assert!(
@@ -232,8 +231,8 @@ fn unit_cube_fixture_volume_conservation() {
 
     let coords = coords_tensor_from_vec(&tets);
     let result = batched_p1_local_matrices(coords);
-    let volumes = tensor_to_vec_f32(result.signed_volumes);
-    let total: f64 = volumes.iter().map(|&v| v as f64).sum();
+    let volumes = readback_f64(result.signed_volumes);
+    let total: f64 = volumes.iter().sum();
     assert!(
         (total.abs() - 1.0).abs() < 1e-5,
         "|sum signed volumes| = {} (expected 1.0)",
@@ -259,12 +258,12 @@ fn unit_cube_fixture_invariants() {
     let coords = coords_tensor_from_vec(&tets);
     let result = batched_p1_local_matrices(coords);
 
-    let k_flat = tensor_to_vec_f32(result.k_local);
-    let m_flat = tensor_to_vec_f32(result.m_local);
-    let v_flat = tensor_to_vec_f32(result.signed_volumes);
+    let k_flat = readback_f64(result.k_local);
+    let m_flat = readback_f64(result.m_local);
+    let v_flat = readback_f64(result.signed_volumes);
 
     for e in 0..tets.len() {
-        let v_e = (v_flat[e] as f64).abs();
+        let v_e = v_flat[e].abs();
 
         // K symmetric
         for i in 0..4 {
@@ -272,7 +271,7 @@ fn unit_cube_fixture_invariants() {
                 let kij = k_flat[e * 16 + i * 4 + j];
                 let kji = k_flat[e * 16 + j * 4 + i];
                 assert!(
-                    ((kij - kji) as f64).abs() < 1e-5,
+                    (kij - kji).abs() < 1e-5,
                     "K not symmetric at elem {e} ({i},{j}): {kij} vs {kji}"
                 );
             }
@@ -280,16 +279,16 @@ fn unit_cube_fixture_invariants() {
 
         // K row sums equal zero (partition of unity: ∇1 = 0 ⇒ K·1 = 0).
         for i in 0..4 {
-            let row_sum: f32 = (0..4).map(|j| k_flat[e * 16 + i * 4 + j]).sum();
+            let row_sum: f64 = (0..4).map(|j| k_flat[e * 16 + i * 4 + j]).sum();
             assert!(
-                ((row_sum) as f64).abs() < 1e-4,
+                row_sum.abs() < 1e-4,
                 "K row {i} of elem {e} sums to {row_sum} (expected 0)"
             );
         }
 
         // M row sums equal V_e (consistent mass: ∫_T φ_i dV = V/4, summed = V).
         for i in 0..4 {
-            let row_sum: f64 = (0..4).map(|j| m_flat[e * 16 + i * 4 + j] as f64).sum();
+            let row_sum: f64 = (0..4).map(|j| m_flat[e * 16 + i * 4 + j]).sum();
             assert!(
                 (row_sum - v_e / 4.0).abs() < 1e-5 * (1.0 + v_e),
                 "M row {i} of elem {e}: row_sum={row_sum}, expected V/4 = {}",


### PR DESCRIPTION
## Summary

Replaces the `to_vec::<f32>()` readback anti-pattern across `crates/geode-core/` with a `B::FloatElem`-aware helper. The old pattern panicked with `TypeMismatch (expected F64, got F32)` on the f64 `ndarray` backend; the new helper reads at `B::FloatElem` and upcasts each entry to `f64` so test logic stays backend-agnostic.

## Changes

- **`tests/common/mod.rs`** (new): promoted `readback_f64<BB: Backend, const D: usize>` from `tests/assembly.rs` into a shared subdirectory module. Cargo treats files under `tests/common/` as non-test subdirectories — only top-level `.rs` files in `tests/` become test binaries — so the helper can be shared without being its own test binary.
- **`tests/assembly.rs`**: drops inline `readback_f64`, imports from `common`.
- **`tests/p1_local_matrices.rs`**: replaces local `tensor_to_vec_f32 -> Vec<f32>` with `readback_f64 -> Vec<f64>`. Each call site loses its now-redundant `as f64` cast; literals are retyped to `f64`.
- **`tests/nedelec.rs`**: same migration. Also fixed five related sites that used the broader `let v: Vec<f32> = t.into_data().to_vec().expect(...)` pattern (no explicit generic, but type-inferred as `f32`) — same root cause, same fix.
- **`src/lib.rs::smoke_add`**: production code, not a test, so the fix is inline. Reads at `<B as BackendTypes>::FloatElem` and upcasts via `ElementConversion::elem`.

## Design note: shared module location

Three test files needed the helper, so per the acceptance criteria we promoted it to `crates/geode-core/tests/common/mod.rs`. Going with `tests/common/` rather than a `cfg(test)`-gated `src/test_utils.rs` because:
1. The helper is purely for integration test binaries; it doesn't belong in the public crate surface.
2. Each consuming test file pulls it in with `mod common;` — idiomatic Cargo pattern.
3. Avoids re-exposing burn type internals from `src/`.

The `src/lib.rs::smoke_add` fix is inline (not factored out) because it's the only non-test consumer and it's in production code.

## Audit

After this PR:

```
$ rg 'to_vec::<f32>' crates/geode-core/
crates/geode-core/src/lib.rs:197:    // `to_vec::<f32>()` panicked ...   # comment
crates/geode-core/tests/common/mod.rs:18:/// the previous `to_vec::<f32>()` ...   # docstring
```

Zero live call sites; the two remaining hits are explanatory comments.

## Test plan

- [x] `cargo test -p geode-core` (default `wgpu`): all tests pass (no regression).
- [x] `cargo test --no-default-features --features ndarray -p geode-core`: all tests pass, including the previously broken `cube_assembly_k_symmetric_and_m_total_mass_positive`, `shared_edge_assembly_signs_apply_correctly`, `assembly_preserves_autodiff_smoke`, the 6 `p1_local_matrices` tests, and the `smoke_add_runs_on_default_backend` lib test.
- [x] `cargo clippy -p geode-core --tests` clean on both feature configurations.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)