### PR TITLE
docs: ONNX cube-cavity expressibility audit (Epic #88 Phase F.1) (#116)

### DIFF
--- a/reference/onnx/README.md
+++ b/reference/onnx/README.md
@@ -1,15 +1,141 @@
 # ONNX reference implementations
 
-Graph-only constraint check per **Epic #88**. Forces the L4 calculus
-through a graph-only expressibility constraint, exposing primitives
-that are secretly imperative.
+Graph-only constraint check per **Epic [#88](https://github.com/rjwalters/geode-fem/issues/88)**.
+Forces the L4 calculus through a graph-only expressibility constraint,
+exposing primitives that are secretly imperative — and, when the
+forcing is positive, surfacing cross-backend conventions (like "compute
+`idx` on the host") that none of the other reference backends needed
+to articulate explicitly.
 
 ## Status
 
-Stub — concrete impls deferred to **#88 Phase F**. May surface as
-"documented graph-expressibility failures" rather than a full impl;
-that's an explicit accepted outcome per the epic.
+Phase F is split into two sequenced issues under Epic #88:
 
-## Planned layout
+- **Phase F.1 — expressibility audit (issue [#116](https://github.com/rjwalters/geode-fem/issues/116))**:
+  the cube-cavity operator-by-operator audit. **Landed in this PR.**
+  Lives under [`audit/`](audit/) — Markdown gap-list plus three runnable
+  probe scripts. No CI gate; the audit *is* the deliverable.
+- **Phase F.2 — end-to-end cube-cavity ONNX assembly graph (planned)**:
+  the runtime payload (`cube_cavity/`), the sidecar driver
+  (`reference/driver/eigensolve_from_onnx.py` or a refactored
+  backend-agnostic shared driver), and the CI gate analogous to
+  `.github/workflows/tfjava-cube-cavity.yml`. Filed after this PR
+  merges so its curation can incorporate what F.1 actually learned.
 
-Mirrors `reference/numpy/`.
+## Boundary conventions inherited from the reference set
+
+These decisions are not ONNX-specific — they are convention-set across
+the Epic #88 reference backends and ONNX inherits them unchanged.
+
+- **Eigensolve lives in a host driver**, not inside the ONNX graph.
+  Same seam as TF-Java (which has no `Eig` op and emits a JSON sidecar
+  for SciPy ARPACK) and JAX (which puts `scipy.linalg.eigh` outside
+  the jit boundary). ONNX has no `Eigh` op either, but even if it did,
+  the convention would not change. See the Epic #88 Phase C wording:
+  *"differentiability of assembly tested (eigensolve boundary
+  allowed)"*.
+- **Complex arithmetic is deferred to the PML phase (Phase H).** The
+  cube-cavity case is real-symmetric throughout. ONNX's narrow
+  complex-tensor surface is the highest-yield friction-mining target
+  for PML, but is **not** exercised here. Filing that friction artifact
+  belongs to Phase H, not F.
+- **Dirichlet `idx` is host-computed.** This is one of the few
+  conventions Phase F.1 made *explicit* — see the audit table for the
+  reasoning. JAX and TF-Java already follow this convention implicitly;
+  ONNX's static-shape contract forces us to name it.
+
+## Layout
+
+```
+reference/onnx/
+├── README.md                          — this file
+├── requirements.txt                   — pinned onnx + onnxruntime + onnxscript
+├── audit/                             — Phase F.1 deliverable
+│   ├── cube_cavity_operator_audit.md  — the gap-list / operator inventory
+│   ├── probe_p1_local.py              — per-element P1 local matrices
+│   ├── probe_assembly_scatter.py      — global K/M scatter-add (ScatterND)
+│   └── probe_dirichlet_mask.py        — interior-DOF restriction (NonZero)
+└── (planned Phase F.2)
+    ├── cube_cavity/
+    │   ├── assembly_graph.py          — analog of tf_java/.../AssemblyGraph.java
+    │   └── gen_cube_cavity_reduced.py — emits reduced_kM.json sidecar
+```
+
+## Re-running the Phase F.1 probes
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt
+python3 audit/probe_p1_local.py
+python3 audit/probe_assembly_scatter.py
+python3 audit/probe_dirichlet_mask.py
+```
+
+Each probe ends with a one-screen verdict. The verdicts roll up into
+the audit table in [`audit/cube_cavity_operator_audit.md`](audit/cube_cavity_operator_audit.md).
+If a probe's verdict diverges from the table after a version bump,
+the table is stale — re-audit.
+
+## Phase F.1 headline finding (one paragraph)
+
+The cube-cavity assembly spine lowers to graph-only ONNX **cleanly**.
+Every L4 operator on stages 1–3 (per-element matrices, global scatter-
+add, Dirichlet restriction) either has a direct opset-18 equivalent or
+decomposes graph-only into a small number of lower-level ops. **No
+secretly-imperative L4 escape was surfaced.** The single audit finding
+worth highlighting is that `np.where(mask)[0]` lowers via ONNX
+`NonZero` but introduces a data-dependent shape — this is graph-only
+friction (the L4 verb IS expressible), but it forces an explicit
+host-side `idx` convention that JAX and TF-Java both follow implicitly.
+The ONNX path made the convention legible. This is the Phase F.1
+"forcing function" working as Epic #88 anticipated.
+
+The audit is therefore **green** for Phase F.2 to proceed: the
+end-to-end cube-cavity assembly graph is feasible, with no expected
+blockers above the documented graph-only frictions.
+
+## Friction artifacts filed on #5
+
+A roll-up of these findings — tagged with the L4 operator names and
+the recommendation for Phase F.2's graph design — is filed as a
+comment on the [whiteroom friction tracker (#5)](https://github.com/rjwalters/geode-fem/issues/5).
+Per Epic #88 §"Friction-mining feedback loop", #5 is where these
+artifacts accumulate for upstream
+[`crutcher/palace_whiteroom`](https://github.com/crutcher/palace_whiteroom)
+review.
+
+## Pointer to Phase F.2 planned layout
+
+The Phase F.2 issue (to be filed) will land:
+
+```
+reference/onnx/cube_cavity/
+├── assembly_graph.py                  — builds the ONNX assembly graph
+│                                        (analog of TF-Java AssemblyGraph.java).
+│                                        Graph inputs: nodes, tets, idx_int.
+│                                        Graph outputs: K_int, M_int.
+└── gen_cube_cavity_reduced.py         — runs onnxruntime over the graph
+                                        and emits reduced_kM.json (same schema
+                                        as TF-Java's sidecar).
+reference/driver/
+└── eigensolve_from_onnx.py            — near-clone of eigensolve_from_tfjava.py
+                                        (or refactored into a backend-agnostic
+                                        eigensolve_from_sidecar.py — decision
+                                        belongs in F.2's curation).
+.github/workflows/onnx-cube-cavity.yml — CI gate, mirroring tfjava-cube-cavity.yml
+                                        for three-way cross-IR agreement
+                                        (ONNX vs JAX vs NumPy at rtol=1e-5).
+```
+
+The F.2 design is **derived from**, not independent of, the audit
+deliverable in this directory.
+
+## Parent epic + related
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — cross-validated L4 lowerings.
+- Friction tracker [#5](https://github.com/rjwalters/geode-fem/issues/5) — friction artifacts roll up here.
+- This phase (F.1, audit): issue [#116](https://github.com/rjwalters/geode-fem/issues/116).
+- Sibling backends already shipped: NumPy ([#92](https://github.com/rjwalters/geode-fem/issues/92)),
+  JAX + TF-Java ([#93](https://github.com/rjwalters/geode-fem/issues/93)).
+- TF-Java CI gate (the pattern Phase F.2 will mirror):
+  `.github/workflows/tfjava-cube-cavity.yml`.

--- a/reference/onnx/audit/cube_cavity_operator_audit.md
+++ b/reference/onnx/audit/cube_cavity_operator_audit.md
@@ -1,0 +1,286 @@
+# Cube-cavity ONNX expressibility audit (Phase F.1)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase F.1
+deliverable. Tracking issue: [#116](https://github.com/rjwalters/geode-fem/issues/116).
+
+## Scope
+
+This audit catalogs the L4 operators on the **scalar-Helmholtz
+cube-cavity assembly spine** and records whether each lowers to a
+graph-only ONNX form. The cube-cavity case is real-symmetric throughout
+(no PML, no driven sources), so the complex-arithmetic friction surface
+is deliberately deferred to a later phase.
+
+The cube-cavity assembly spine — as defined by the reference
+implementations in [`reference/numpy/cube_cavity_minimal.py`](../../numpy/cube_cavity_minimal.py),
+[`reference/jax/cube_cavity.py`](../../jax/cube_cavity.py), and
+[`reference/tf_java/cube_cavity/.../AssemblyGraph.java`](../../tf_java/cube_cavity/src/main/java/dev/geodefem/refcubecavity/AssemblyGraph.java)
+— consists of these stages:
+
+1. **Per-element P1 local matrices** (`K_local`, `M_local`, shape
+   `(n_elem, 4, 4)`): edge vectors, cross products, dot products, scale
+   by `1/det` and `det/120`, plus a constant mass pattern.
+2. **Global K/M scatter-add** (shape `(n_nodes, n_nodes)`): scatter the
+   per-element entries into a zero buffer along the connectivity-table
+   indices.
+3. **Dirichlet restriction** (`K_int`, `M_int`, shape `(n_int, n_int)`):
+   drop the boundary rows/cols using an interior-DOF index set.
+4. **Generalized eigensolve** (`K_int v = λ M_int v`): solve for the
+   lowest `k` modes.
+
+Per the Epic #88 convention (Phase C wording: *"differentiability of
+assembly tested (eigensolve boundary allowed)"*), stage 4 lives in a
+host driver across all reference backends. ONNX inherits this
+convention unchanged — there is no `Eig`/`Eigh` op in ONNX Runtime,
+and adding one would not actually change the scope decision because
+the eigensolve is *already* a sidecar boundary in TF-Java
+([eigensolve_from_tfjava.py](../../driver/eigensolve_from_tfjava.py))
+and in JAX (`scipy.linalg.eigh` at the end of `solve_cube_cavity_jax`).
+
+The audit therefore covers stages **1–3**.
+
+## Pinned versions used for this audit
+
+| Package | Version |
+|---|---|
+| `onnx` | `1.21.0` |
+| `onnxruntime` | `1.26.0` |
+| `onnxscript` | `0.7.0` (available for authoring, not used in probes) |
+| Target opset | `18` |
+
+See [`reference/onnx/requirements.txt`](../requirements.txt) for the
+pinned `pip` line. The probes here use raw `onnx.helper` (not
+`onnxscript`) so that what shows up at the IR level is exactly what
+the audit reports — `onnxscript` is more ergonomic but can hide
+imperative sugar that the audit needs to surface.
+
+## Classification convention
+
+Each row in the operator table below is one of:
+
+| Marker | Meaning |
+|---|---|
+| **clean** | Direct opset-18 operator; lowers without any synthesis. |
+| **synth** | No native op, but a graph-only synthesis from lower-level ops works (e.g. cross product as `6 Mul + 3 Sub + 3 Unsqueeze + Concat`). Documentation, not a blocker. |
+| **caveat** | The op lowers, but introduces a downstream constraint (e.g. data-dependent shape) that materially affects the graph's static-shape inference. |
+| **graph-only friction** | Forced by the ONNX IR's static-graph form; the L4 operator IS expressible, the friction is overhead. |
+| **secretly imperative** | An L4 operator that relies on imperative escape; would block end-to-end lowering. **This is the high-value friction-mining outcome.** |
+
+## Operator table
+
+### Stage 1 — Per-element P1 local matrices
+
+Probe: [`probe_p1_local.py`](probe_p1_local.py).
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `v_i - v_j` (vector subtraction) | `Sub` | clean | Native. |
+| `e_i * e_j` (elementwise multiply) | `Mul` | clean | Native. |
+| `a + b` (add) | `Add` | clean | Native. |
+| `-x` (negate) | `Neg` | clean | Native. |
+| `\|x\|` (abs) | `Abs` | clean | Native. |
+| `a / b` (divide) | `Div` | clean | Native; broadcasts. |
+| `sum(...)` reduction along axis | `ReduceSum` | clean | Axis is a graph input (int64), not an attribute. |
+| Reshape `(N,) → (N, 1, 1)` | `Reshape` | clean | Native. |
+| Transpose last two axes (batched) | `Transpose(perm=[0, 2, 1])` | clean | Native. |
+| `stack([a, b, c], axis=1)` | **synth**: `Unsqueeze` each + `Concat` | graph-only friction | ONNX has no `Stack` op; the L4 verb decomposes to two ONNX ops. Same shape as TF-Java's hand-rolled stack inside `cross3`. |
+| `v[:, i]` (component extract, axis=1) | `Gather(axis=1)` | clean | Native; **int64 indices required**. |
+| `cross(a, b)` (3-vector cross product) | **synth**: `6 Mul + 3 Sub + 3 Unsqueeze + Concat` | graph-only friction | No native `Cross`. Same disposition as TF-Java (`AssemblyGraph.cross3`). Mathematically transparent; the synthesis is line-for-line. |
+| `A @ B` (rank-3 batched matmul) | `MatMul` | clean | **L4-native broadcasting**: opset 18 `MatMul` broadcasts over the leading batch dim of `(N, 4, 3) @ (N, 3, 4)` and returns `(N, 4, 4)` directly. Compare TF-Java, whose `tf.linalg.matMul` does **not** broadcast over a batch dim and forced a fallback to `einsum("eik,ejk->eij", gMat, gMat)`. This is one of the rare cases where ONNX is *less* friction than another XLA-shaped IR. |
+| Constant `mass_pattern` (4×4 baked) | `Constant` | clean | Native. |
+| Broadcast `(1, 4, 4) * (N, 1, 1)` → `(N, 4, 4)` | `Mul` | clean | Native (NumPy-style broadcasting). |
+
+Stage 1 numerical check: probe matches the NumPy reference at `max |K_onnx - K_numpy| = 0.000e+00` (bit-exact in f64 for the canonical reference tet).
+
+### Stage 2 — Global K/M scatter-add
+
+Probe: [`probe_assembly_scatter.py`](probe_assembly_scatter.py).
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Allocate zero buffer of shape `(n_nodes, n_nodes)` | `ConstantOfShape` | clean | Native (opset 9+). |
+| Stack `(rows, cols)` into a `(M, 2)` index table | `Unsqueeze` + `Concat` | clean | Same Stack-decomposition pattern as stage 1. |
+| **`buf.at[rows, cols].add(vals)` — scatter-add into dense buffer** | **`ScatterND(reduction="add")`** | **clean** | **This is the critical operator for Phase F.2 end-to-end assembly.** ONNX has had `ScatterND` since opset 11 and `reduction="add"` since opset 16. Semantics match JAX `.at[...].add(...)` and TF-Java `tf.scatterNd` on a zero buffer. **Non-destructive** (returns a new tensor — there is no in-place mutation here). |
+| Cast `int32` indices to `int64` | `Cast` | clean | `ScatterND` requires int64 indices in opset 18. Same friction as TF-Java (`tf.dtypes.cast(indexPairs, TInt64.class)`). Boundary cost, not a lowering blocker. |
+
+Stage 2 numerical check: probe matches an explicit NumPy `np.add.at(...)` scatter at `max err = 0.000e+00`.
+
+**Headline finding**: ScatterND-with-reduction-add is the
+single most consequential operator for Phase F.2, and it
+lowers cleanly. The end-to-end ONNX assembly graph is feasible
+through stage 2 inclusive.
+
+### Stage 3 — Dirichlet restriction (interior-DOF set)
+
+Probe: [`probe_dirichlet_mask.py`](probe_dirichlet_mask.py).
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `K[idx, :]` with precomputed `idx` (int64) | `Gather(axis=0)` | clean | Native. |
+| `K[:, idx]` with precomputed `idx` (int64) | `Gather(axis=1)` | clean | Native. |
+| `K[np.ix_(idx, idx)]` (outer-product fancy index) | `Gather(axis=0)` then `Gather(axis=1)` | clean | The L4 verb is two-axis fancy indexing; ONNX has no single op for that, but the obvious decomposition into successive axis-Gathers works. |
+| **`idx = np.where(mask)[0]`** | **`NonZero` then `Squeeze`** | **caveat** | The op lowers, BUT `NonZero` returns a shape `(rank, n_nonzero)` tensor whose `n_nonzero` axis is data-dependent. Everything downstream that consumes `idx` (the two `Gather`s, then any further reductions) inherits a `(None, None)` static shape. The graph remains valid; static-shape inference is lost. |
+
+#### Friction note on stage 3 (the most informative row in this audit)
+
+`np.where(mask)[0]` — building an index set from a boolean mask — is
+the operation we expected to surface as a "secretly imperative L4"
+escape. The audit finding is more nuanced than expected:
+
+- ONNX **has** `NonZero` (opset 9+), so the operator IS expressible
+  in a graph-only IR.
+- However, `NonZero`'s output shape depends on the input *values*, not
+  just the input *shape*. The ONNX type system marks the downstream
+  `idx` (and everything that consumes it) as having an unknown
+  intermediate axis. This propagates: `K_int` is typed `(None, None)`
+  rather than `(n_int, n_int)`. The graph is valid, but the
+  shape-inference contract that XLA-style IRs trade on collapses
+  downstream.
+- **Classification: graph-only friction, not secretly-imperative.**
+  The L4 verb (`where`) IS in the ONNX vocabulary; what's lost is the
+  *static* dimensional information that compile-time graph optimizers
+  use. This matches the JAX experience exactly: `jnp.nonzero` is a
+  `jit`-blocker for similar reasons, and the JAX reference
+  ([`cube_cavity.py`](../../jax/cube_cavity.py) lines 192–195) computes
+  `idx` on the **host side**, outside the jit boundary.
+- **Recommendation for Phase F.2**: the ONNX assembly graph should
+  accept `idx` as a *graph input* (computed by the host driver), not
+  derive it inside the graph. This:
+  - keeps the graph statically-shaped end-to-end,
+  - mirrors the JAX convention (which is the closest L4-shape sibling),
+  - mirrors the TF-Java convention (Dirichlet masking happens in the
+    JVM driver, not inside the assembly graph).
+
+This is the same conclusion the TF-Java reference reached implicitly,
+but ONNX's static-shape contract forces us to name it explicitly. **The
+"forcing function" worked exactly as Epic #88 anticipated** — putting
+the L4 calculus through a graph-only IR exposed a cross-backend
+convention that none of the existing backends needed to articulate.
+
+### Stage 4 — Generalized eigensolve (boundary, shared L4 friction)
+
+Not in this audit. Across the entire reference set:
+
+| Backend | Eigensolve location |
+|---|---|
+| NumPy | `scipy.sparse.linalg.eigsh` on host |
+| JAX | `scipy.linalg.eigh` outside the jit boundary |
+| TF-Java | `scipy.sparse.linalg.eigsh` via JSON sidecar |
+| ONNX (Phase F.2) | `scipy.sparse.linalg.eigsh` via JSON sidecar (planned, mirroring TF-Java) |
+| Burn | `FaerDenseEigensolver` or `arpack` FFI on host |
+
+The eigensolve is **shared L4 friction** — every backend offloads it
+to the same SciPy ARPACK boundary. There is no ONNX-specific gap to
+report here. (If ONNX's surface eventually grew an `Eigh` op, the
+audit would not change scope, because the seam is convention-set
+across the reference set, not ONNX-specific.)
+
+## Cross-cutting frictions
+
+Observations that apply across multiple stages of the audit:
+
+1. **Axis arguments are graph inputs, not attributes (opset 13+).**
+   Operations like `Unsqueeze`, `Squeeze`, `ReduceSum`, `Concat` take
+   their `axes`/`axis` arguments as `int64` tensor inputs. This
+   produces a lot of `Constant` int64 axis nodes scattered through
+   any non-trivial graph. The cost is verbosity, not expressibility.
+   `onnxscript` hides this; raw `onnx.helper` (as used in the probes)
+   makes it explicit. This is graph-only friction.
+2. **Index/shape dtypes must be int64.** Several ops (`Gather`,
+   `ScatterND`, `Reshape`, `Unsqueeze`'s axes) require int64
+   indices/shapes. JAX accepts int32 freely; NumPy converts silently;
+   TF-Java already had to cast (`tf.dtypes.cast(..., TInt64.class)`).
+   ONNX inherits this — cast at the I/O boundary.
+3. **No `Stack` op.** NumPy `np.stack`, JAX `jnp.stack`, TF-Java
+   `tf.stack` all exist as first-class verbs. ONNX views them as
+   imperative sugar and forces `Unsqueeze + Concat` (one
+   `Unsqueeze` per operand, then `Concat`). The decomposition is
+   shape-safe and graph-only — documentation, not a blocker.
+4. **`MatMul` broadcasts over the batch dim natively** — a rare case
+   where ONNX is *less* friction than another XLA-shaped IR (TF-Java
+   forced a fallback to `einsum`).
+5. **Static-shape preservation across the entire stage 1 + stage 2
+   path.** With `idx` passed as a graph input (per the stage 3
+   recommendation), the ONNX assembly graph stays statically shaped
+   from `nodes (n_nodes, 3)` and `tets (n_elem, 4)` through to
+   `K_global (n_nodes, n_nodes)`. This is the property Phase F.2
+   needs to validate end-to-end.
+6. **Complex arithmetic.** Deferred to the PML phase (Phase H). ONNX
+   has only narrow complex support (e.g. `DFT`, no general complex
+   tensor algebra). For cube-cavity (real symmetric), this is not
+   exercised.
+
+## Per-stage verdicts (one-line summary)
+
+| Stage | Verdict |
+|---|---|
+| 1. P1 local matrices | clean (modulo two synth ops: `Stack` and `cross`) |
+| 2. Global K/M scatter-add | clean (via `ScatterND(reduction="add")`) |
+| 3. Dirichlet restriction | clean *if* `idx` is host-computed; caveat (data-dependent shape) *if* derived in-graph via `NonZero` |
+| 4. Eigensolve | out of scope — shared L4 friction handled by host driver across all backends |
+
+## What this means for Phase F.2
+
+The Phase F.2 follow-on issue (cube-cavity end-to-end ONNX assembly
+graph + sidecar eigensolve) is **feasible**. The recommended design
+shape, derived from this audit:
+
+- Graph inputs: `nodes (n_nodes, 3) float64`, `tets (n_elem, 4) int64`,
+  `idx_int (n_int,) int64`.
+- Graph outputs: `K_int (n_int, n_int) float64`, `M_int (n_int, n_int)
+  float64`.
+- The Dirichlet step uses precomputed `idx`, exactly mirroring the
+  JAX and TF-Java conventions.
+- Eigensolve seam: ONNX Runtime emits a JSON sidecar identical in
+  schema to `reference/tf_java/cube_cavity/.../CubeCavityMain.java`'s
+  output, consumed by a near-clone of
+  `reference/driver/eigensolve_from_tfjava.py` (or by a refactored
+  backend-agnostic `eigensolve_from_sidecar.py` — design decision
+  belongs in F.2's curation pass).
+- CI gate: mirrors `.github/workflows/tfjava-cube-cavity.yml`; three-
+  way cross-IR agreement (ONNX vs JAX vs NumPy) at `rtol=1e-5`.
+
+**Operators that WOULD become CI assertions in Phase F.2**: every
+"clean" / "synth" row in the tables above. The only operator that
+is explicitly *excluded* from the F.2 graph (by audit recommendation)
+is `NonZero` — Dirichlet mask resolution happens host-side.
+
+## What this audit did NOT find
+
+- **No secretly-imperative L4 escape on the cube-cavity assembly spine.**
+  Every L4 operator on stages 1–3 either lowers cleanly to opset 18 or
+  decomposes graph-only. This is a positive Phase F.1 outcome: the
+  cube-cavity slice (real-symmetric, scalar Helmholtz, programmatic
+  mesh) is a *clean* L4 reference. Friction surfaces are deferred
+  to:
+  - **Phase G** (Nédélec elements / curl operator): higher-order edge
+    DOFs, RT/Nédélec lifts. To be audited when filed.
+  - **Phase H** (PML, complex arithmetic): ONNX's narrow complex-tensor
+    surface will be the next high-yield friction-mining target.
+
+## Acknowledgements / cross-references
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — overall
+  framing of cross-validated L4 lowerings, including the
+  "friction-mining feedback loop" wording this audit deliverable
+  inherits from.
+- Friction tracker [#5](https://github.com/rjwalters/geode-fem/issues/5)
+  — a roll-up of these findings is posted as a comment on #5 when this
+  PR lands.
+- JAX-side analog: [`reference/jax/cube_cavity.py`](../../jax/cube_cavity.py)
+  and the JAX-DX notes in [`reference/jax/README.md`](../../jax/README.md).
+- TF-Java analog: [`reference/tf_java/cube_cavity/src/main/java/dev/geodefem/refcubecavity/AssemblyGraph.java`](../../tf_java/cube_cavity/src/main/java/dev/geodefem/refcubecavity/AssemblyGraph.java).
+
+## Re-running this audit
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt
+python3 audit/probe_p1_local.py
+python3 audit/probe_assembly_scatter.py
+python3 audit/probe_dirichlet_mask.py
+```
+
+Each probe prints a one-screen verdict that should match the
+corresponding row(s) in this table. If a probe's verdict disagrees
+with the table after a version bump, the table is stale — re-audit.

--- a/reference/onnx/audit/probe_assembly_scatter.py
+++ b/reference/onnx/audit/probe_assembly_scatter.py
@@ -1,0 +1,238 @@
+"""Probe: ONNX expressibility of the global K/M scatter-add assembly step.
+
+Epic #88, Phase F.1 (issue #116). The cube-cavity assembly path
+finishes per-element K_local/M_local (shape (n_elem, 4, 4)) and then
+scatter-adds them into a dense (n_nodes, n_nodes) buffer, accumulating
+contributions from all shared nodes. This probe checks whether that
+step can be expressed in pure ONNX graph form.
+
+The closest analog in other backends:
+
+- NumPy: `scipy.sparse.coo_matrix((vals, (rows, cols)), shape=...).tocsr()`
+  (NOT a graph operation — uses CSR construction with duplicate-index
+  summation as a side effect).
+- JAX: `buf.at[rows, cols].add(vals)` — `.at[...].add(...)` is the
+  JAX scatter-add primitive and is L4-traceable through XLA.
+- TF-Java: `tf.scatterNd(indices, updates, shape)` on a zero-initialized
+  buffer; static-graph ScatterNd is the right operator.
+
+For ONNX, the candidate is `ScatterND` with `reduction="add"` (opset 16+).
+This probe builds a graph that:
+
+  1. Accepts `rows`, `cols`, `vals` flat (shape (n_elem*16,) each), plus
+     a baked-in `n_nodes`.
+  2. Constructs `indices` of shape (n_elem*16, 2) by Concat of
+     Unsqueeze'd rows and cols.
+  3. Creates a zero buffer of shape (n_nodes, n_nodes) via
+     ConstantOfShape.
+  4. Applies ScatterND with `reduction="add"` to scatter vals into the
+     buffer at the (row, col) coordinates.
+
+The probe asserts numerical agreement against an explicit NumPy
+scatter-add reference.
+
+This is the operator the Phase F.2 cube-cavity assembly graph will
+hinge on. If it fails to lower, the entire end-to-end ONNX assembly
+path collapses to a sidecar boundary at K_local/M_local rather than
+at reduced_kM.
+
+Run
+===
+
+    python3 reference/onnx/audit/probe_assembly_scatter.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+OPSET = 18
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_assembly_scatter_graph(n_nodes: int) -> onnx.ModelProto:
+    """Build a graph that scatter-adds (rows, cols, vals) into a
+    (n_nodes, n_nodes) buffer.
+
+    Inputs: rows (M,) int64, cols (M,) int64, vals (M,) f64
+    Output: k_global (n_nodes, n_nodes) f64
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    rows_vi = oh.make_tensor_value_info("rows", TensorProto.INT64, shape=["M"])
+    cols_vi = oh.make_tensor_value_info("cols", TensorProto.INT64, shape=["M"])
+    vals_vi = oh.make_tensor_value_info("vals", TensorProto.DOUBLE, shape=["M"])
+
+    # Reshape rows, cols to (M, 1) and Concat along axis=1 → (M, 2).
+    nodes.append(_const("axes_minus1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows", "axes_minus1"], ["rows_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["cols", "axes_minus1"], ["cols_col"]))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["rows_col", "cols_col"],
+        outputs=["indices"],
+        axis=1,
+    ))
+
+    # Zero buffer of shape (n_nodes, n_nodes) f64 via ConstantOfShape.
+    nodes.append(_const("shape_nn", np.array([n_nodes, n_nodes], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_buf"],
+        value=oh.make_tensor(
+            name="zero_value",
+            data_type=TensorProto.DOUBLE,
+            dims=[1],
+            vals=[0.0],
+        ),
+    ))
+
+    # ScatterND with reduction="add" — this is the L4 scatter-add.
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf", "indices", "vals"],
+        outputs=["k_global"],
+        reduction="add",
+    ))
+
+    k_vi = oh.make_tensor_value_info(
+        "k_global", TensorProto.DOUBLE, shape=[n_nodes, n_nodes]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="assembly_scatter_probe",
+        inputs=[rows_vi, cols_vi, vals_vi],
+        outputs=[k_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def numpy_scatter_add(rows: np.ndarray, cols: np.ndarray, vals: np.ndarray,
+                      n_nodes: int) -> np.ndarray:
+    out = np.zeros((n_nodes, n_nodes), dtype=np.float64)
+    np.add.at(out, (rows, cols), vals)
+    return out
+
+
+def main() -> int:
+    print("== Probe: assembly scatter-add (cube-cavity K, M → global) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Synthetic test: a tiny "mesh" with 2 elements over 5 nodes, with
+    # overlapping indices to exercise duplicate-coordinate summation.
+    n_nodes = 5
+    # Two "elements" each contributing 16 entries:
+    rows_e0 = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3], dtype=np.int64)
+    cols_e0 = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3], dtype=np.int64)
+    vals_e0 = np.arange(16, dtype=np.float64) + 1.0
+
+    rows_e1 = np.array([0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4], dtype=np.int64)
+    cols_e1 = np.array([0, 2, 3, 4, 0, 2, 3, 4, 0, 2, 3, 4, 0, 2, 3, 4], dtype=np.int64)
+    vals_e1 = (np.arange(16, dtype=np.float64) + 17.0) * 0.5
+
+    rows = np.concatenate([rows_e0, rows_e1])
+    cols = np.concatenate([cols_e0, cols_e1])
+    vals = np.concatenate([vals_e0, vals_e1])
+
+    # Build the graph.
+    model = build_assembly_scatter_graph(n_nodes)
+
+    try:
+        onnx.checker.check_model(model)
+        checker_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        checker_status = f"FAIL ({e!r})"
+
+    rt_status = "skipped"
+    max_err = float("nan")
+    try:
+        sess = ort.InferenceSession(model.SerializeToString())
+        out = sess.run(["k_global"], {"rows": rows, "cols": cols, "vals": vals})
+        k_onnx = out[0]
+
+        k_np = numpy_scatter_add(rows, cols, vals, n_nodes)
+        max_err = float(np.max(np.abs(k_onnx - k_np)))
+        rt_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        rt_status = f"FAIL ({e!r})"
+
+    print("Operator inventory for the assembly scatter-add step:")
+    print("--------------------------------------------------------------")
+    print("  ScatterND (reduction=\"add\")    lowers cleanly       (opset 16+ native)")
+    print("                                  — this is the critical op for")
+    print("                                    Phase F.2 end-to-end assembly. It IS")
+    print("                                    the L4 scatter-add primitive, and ONNX")
+    print("                                    has had it natively since opset 16.")
+    print("                                    Cf. TF-Java tf.scatterNd / JAX")
+    print("                                    buf.at[rows, cols].add(vals).")
+    print()
+    print("  ConstantOfShape                 lowers cleanly       (opset 9+ native)")
+    print("                                  — used to make the (n_nodes, n_nodes)")
+    print("                                    zero buffer.")
+    print()
+    print("  Concat / Unsqueeze              lowers cleanly       (opset 18 native)")
+    print("                                  — assembling the (M, 2) index table.")
+    print()
+    print("Cross-cutting frictions observed:")
+    print("--------------------------------------------------------------")
+    print("  - ScatterND indices dtype MUST be int64 (opset 18). JAX/NumPy")
+    print("    accept int32 freely; TF-Java required an explicit Cast to")
+    print("    int64 (see AssemblyGraph.java line 171). ONNX inherits the")
+    print("    same friction — cast at the I/O boundary.")
+    print("  - ScatterND with reduction=\"add\" is non-destructive (returns a")
+    print("    new tensor), matching the L4 semantics of JAX `.at[].add(...)`.")
+    print("    It is NOT secretly imperative.")
+    print("  - The (n_nodes, n_nodes) dense buffer is ~O(N^2) memory; for the")
+    print("    cube-cavity n=4 case (n_nodes=125, n_int=27) this is fine. For")
+    print("    larger meshes the graph would need to be a sparse representation,")
+    print("    but ONNX has no first-class sparse type — that is a Phase G/H")
+    print("    concern, not a Phase F friction.")
+    print()
+    print(f"onnx.checker.check_model: {checker_status}")
+    print(f"onnxruntime execution: {rt_status}")
+    if rt_status == "OK":
+        print(f"  max |K_onnx_scatter - K_numpy_scatter| = {max_err:.3e}")
+    print()
+    print("Verdict: global K/M scatter-add lowers CLEANLY via ScatterND with")
+    print("         reduction=\"add\". This is graph-only friction at most")
+    print("         (int32→int64 cast at the boundary); there is no")
+    print("         secretly-imperative L4 escape here. The end-to-end")
+    print("         Phase F.2 assembly graph is feasible.")
+
+    return 0 if checker_status == "OK" and rt_status == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/probe_dirichlet_mask.py
+++ b/reference/onnx/audit/probe_dirichlet_mask.py
@@ -1,0 +1,286 @@
+"""Probe: ONNX expressibility of the Dirichlet-mask / interior-DOF step.
+
+Epic #88, Phase F.1 (issue #116). After global K, M are assembled, the
+cube-cavity pipeline applies homogeneous Dirichlet BC by restricting to
+interior DOFs:
+
+  - NumPy:  `idx = np.where(mask)[0]; K_int = K_csr[idx, :][:, idx]`
+  - JAX:    `idx = np.where(mask)[0]; K_int = K_global[jnp.ix_(idx, idx)]`
+  - TF-Java: (deferred to the host-driver sidecar — Dirichlet masking
+              happens AFTER the assembly graph closes, not inside it.)
+
+This probe asks: can ONNX express the **interior restriction step
+itself** as a graph operator?
+
+Two distinct sub-questions:
+
+  (A) Given a precomputed `idx` array (int64, shape (n_int,)), can we
+      lower `K_int = K_global[idx, :][:, idx]` to a pure ONNX graph?
+      → Yes, via two `Gather` ops (one per axis). Tested below.
+
+  (B) Given a boolean `mask` (shape (n_nodes,)), can we lower the
+      `idx = np.where(mask)[0]` step to a pure ONNX graph?
+      → THIS IS THE INTERESTING ONE. `np.where`/`jnp.nonzero` returns
+      a tensor of *data-dependent shape* (its length depends on how
+      many `True` entries are in `mask`). ONNX has had `NonZero`
+      since opset 9, but it produces shapes that depend on input
+      values, which is a documented graph-only friction class (data-
+      dependent shapes are legal in ONNX but break many downstream
+      shape inference passes — most importantly, they prevent the
+      eigensolve boundary from seeing a statically-shaped K_int).
+
+The probe demonstrates BOTH paths and prints a verdict that
+distinguishes them.
+
+Run
+===
+
+    python3 reference/onnx/audit/probe_dirichlet_mask.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+OPSET = 18
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+        np.dtype("bool"): TensorProto.BOOL,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path A: precomputed idx → K_int via two Gather ops
+# ---------------------------------------------------------------------------
+
+
+def build_gather_restrict_graph(n_nodes: int) -> onnx.ModelProto:
+    """Inputs: K_global (n_nodes, n_nodes) f64, idx (n_int,) int64.
+    Output: K_int (n_int, n_int) f64.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    k_vi = oh.make_tensor_value_info("k_global", TensorProto.DOUBLE,
+                                     shape=[n_nodes, n_nodes])
+    idx_vi = oh.make_tensor_value_info("idx", TensorProto.INT64, shape=["n_int"])
+
+    # K_global[idx, :] = Gather along axis=0.
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["k_global", "idx"],
+        outputs=["k_rows"],
+        axis=0,
+    ))
+    # [:, idx] = Gather along axis=1.
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["k_rows", "idx"],
+        outputs=["k_int"],
+        axis=1,
+    ))
+
+    k_int_vi = oh.make_tensor_value_info(
+        "k_int", TensorProto.DOUBLE, shape=["n_int", "n_int"]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="gather_restrict_probe",
+        inputs=[k_vi, idx_vi],
+        outputs=[k_int_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path B: mask → idx via NonZero (data-dependent shape) → K_int
+# ---------------------------------------------------------------------------
+
+
+def build_mask_to_kint_graph(n_nodes: int) -> onnx.ModelProto:
+    """Inputs: K_global (n_nodes, n_nodes) f64, mask (n_nodes,) bool.
+    Output: K_int (?, ?) f64 — data-dependent shape.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    k_vi = oh.make_tensor_value_info("k_global", TensorProto.DOUBLE,
+                                     shape=[n_nodes, n_nodes])
+    mask_vi = oh.make_tensor_value_info("mask", TensorProto.BOOL, shape=[n_nodes])
+
+    # NonZero(mask) returns shape (rank, n_nonzero). For a 1-D input,
+    # that's (1, n_nonzero). Squeeze axis=0 to get (n_nonzero,).
+    nodes.append(oh.make_node("NonZero", ["mask"], ["nonzero_2d"]))
+    nodes.append(_const("axis0_const", np.array([0], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "Squeeze",
+        inputs=["nonzero_2d", "axis0_const"],
+        outputs=["idx"],
+    ))
+
+    # K_global[idx, :] then [:, idx] via two Gathers.
+    nodes.append(oh.make_node("Gather", ["k_global", "idx"], ["k_rows"], axis=0))
+    nodes.append(oh.make_node("Gather", ["k_rows", "idx"], ["k_int"], axis=1))
+
+    k_int_vi = oh.make_tensor_value_info(
+        "k_int", TensorProto.DOUBLE, shape=[None, None]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="mask_to_kint_probe",
+        inputs=[k_vi, mask_vi],
+        outputs=[k_int_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("== Probe: Dirichlet mask / interior-DOF restriction ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Synthetic test: 5x5 K_global with a 3-node interior mask.
+    n_nodes = 5
+    k_global = np.arange(n_nodes * n_nodes, dtype=np.float64).reshape(n_nodes, n_nodes)
+    mask_np = np.array([False, True, True, True, False])  # interior = nodes 1,2,3
+    idx_np = np.where(mask_np)[0].astype(np.int64)
+    k_int_ref = k_global[np.ix_(idx_np, idx_np)]
+
+    # ------- Path A: gather with precomputed idx. -------
+    print("Path A — precomputed `idx` (int64) → K_int via two Gathers")
+    print("--------------------------------------------------------------")
+    model_a = build_gather_restrict_graph(n_nodes)
+    try:
+        onnx.checker.check_model(model_a)
+        a_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_checker = f"FAIL ({e!r})"
+    a_rt = "skipped"
+    a_err = float("nan")
+    try:
+        sess_a = ort.InferenceSession(model_a.SerializeToString())
+        out_a = sess_a.run(["k_int"], {"k_global": k_global, "idx": idx_np})
+        a_err = float(np.max(np.abs(out_a[0] - k_int_ref)))
+        a_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_rt = f"FAIL ({e!r})"
+    print(f"  Gather(axis=0)         lowers cleanly       (opset 18 native)")
+    print(f"  Gather(axis=1)         lowers cleanly       (opset 18 native)")
+    print(f"  onnx.checker:          {a_checker}")
+    print(f"  onnxruntime execution: {a_rt}")
+    if a_rt == "OK":
+        print(f"  max |K_int_onnx - K_int_numpy| = {a_err:.3e}")
+    print()
+
+    # ------- Path B: mask → idx via NonZero. -------
+    print("Path B — boolean `mask` → idx via NonZero (data-dependent shape)")
+    print("--------------------------------------------------------------")
+    model_b = build_mask_to_kint_graph(n_nodes)
+    try:
+        onnx.checker.check_model(model_b)
+        b_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_checker = f"FAIL ({e!r})"
+    b_rt = "skipped"
+    b_err = float("nan")
+    try:
+        sess_b = ort.InferenceSession(model_b.SerializeToString())
+        out_b = sess_b.run(["k_int"], {"k_global": k_global, "mask": mask_np})
+        b_err = float(np.max(np.abs(out_b[0] - k_int_ref)))
+        b_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_rt = f"FAIL ({e!r})"
+    print(f"  NonZero                lowers cleanly       (opset 18 native)")
+    print(f"                         — BUT returns a data-dependent shape.")
+    print(f"                           See the friction note below.")
+    print(f"  Squeeze, Gather        lowers cleanly       (opset 18 native)")
+    print(f"  onnx.checker:          {b_checker}")
+    print(f"  onnxruntime execution: {b_rt}")
+    if b_rt == "OK":
+        print(f"  max |K_int_onnx - K_int_numpy| = {b_err:.3e}")
+    print()
+
+    print("Cross-cutting frictions observed:")
+    print("--------------------------------------------------------------")
+    print("  - `idx = np.where(mask)[0]` is the canonical 'secretly")
+    print("    imperative' L4 friction. In Python/JAX/NumPy it returns")
+    print("    a data-dependent-shape int tensor whose runtime size")
+    print("    cannot be inferred statically. ONNX `NonZero` lowers it")
+    print("    to the graph, but at the cost of breaking static shape")
+    print("    inference for everything downstream — K_int is then")
+    print("    typed `[None, None]` from ONNX's point of view, which")
+    print("    blocks compile-time tensor-shape validation.")
+    print()
+    print("    Classification: 'lowers with caveat'. ONNX has the")
+    print("    operator (NonZero), but it propagates dynamic shapes")
+    print("    through the rest of the graph. This is GRAPH-ONLY")
+    print("    friction, not a secretly-imperative escape — the L4")
+    print("    operator IS expressible, but the static-graph optimizer")
+    print("    loses its rank/shape grip downstream.")
+    print()
+    print("  - Practical lowering recommendation for Phase F.2: compute")
+    print("    `idx` on the host BEFORE entering the graph (mirroring")
+    print("    TF-Java, where the Dirichlet step happens in the JVM")
+    print("    sidecar). This keeps the assembly graph statically-")
+    print("    shaped end-to-end, and matches the eigensolve-at-the-")
+    print("    boundary convention adopted across the reference set.")
+    print()
+    print("  - JAX has the same issue with `jnp.nonzero` (returns")
+    print("    dynamic-shape arrays that defeat XLA static tracing),")
+    print("    and JAX's `cube_cavity.py` ALSO computes `idx` outside")
+    print("    the jit boundary. So this is shared L4 friction across")
+    print("    XLA-shaped IRs — not ONNX-specific.")
+    print()
+    print("  - The Burn analog (geode_core::dirichlet) computes the")
+    print("    mask imperatively on the host. The 'graph-only' phrasing")
+    print("    here is exposing that this is, in fact, an imperative")
+    print("    construction in every backend — only the ONNX path")
+    print("    forces us to name it explicitly.")
+    print()
+    print("Verdict: gathering with a precomputed `idx` (Path A) lowers CLEANLY.")
+    print("         The mask→idx step itself (Path B) lowers via NonZero, but")
+    print("         introduces a data-dependent shape that breaks downstream")
+    print("         static-shape inference. Recommended Phase F.2 disposition:")
+    print("         host-side `idx` construction (same as JAX, same as TF-Java);")
+    print("         the ONNX assembly graph accepts `idx` as a graph input.")
+
+    return 0 if a_checker == "OK" and a_rt == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/probe_p1_local.py
+++ b/reference/onnx/audit/probe_p1_local.py
@@ -1,0 +1,386 @@
+"""Probe: ONNX expressibility of P1 element-local matrices.
+
+Epic #88, Phase F.1 (issue #116). This probe builds a candidate ONNX
+graph that computes the per-element P1 stiffness and mass matrices for
+the cube-cavity slice, mirroring `reference/jax/cube_cavity.py`
+`_p1_local_one` (the JAX reference) and the TF-Java analog in
+`reference/tf_java/cube_cavity/.../AssemblyGraph.java`.
+
+Strategy
+========
+
+We hand-build the graph with `onnx.helper` (NOT `onnxscript`) so we can
+observe each ONNX-IR-level operator directly. Where a primitive that's
+native in NumPy/JAX has no ONNX equivalent, the probe records the
+synthesis used (e.g. cross product as 6 muls + 3 subs + Concat) and
+flags it as either:
+
+  (a) `lowers cleanly`              — direct opset 18 operator
+  (b) `lowers with synthesis`       — built from lower-level ops
+  (c) `does not lower (graph-only)` — fundamentally graph-only friction
+  (d) `does not lower (imperative)` — secretly-imperative L4 escape
+
+After building, the graph is:
+  1. Type-checked via `onnx.checker.check_model`.
+  2. Executed via `onnxruntime.InferenceSession` against a known input
+     (regular tet at the canonical reference coordinates).
+  3. Compared numerically against the NumPy reference
+     (`reference/numpy/p1_local_matrices.py`).
+
+The numerical comparison is a sanity check that the lowering produces
+the right answer — it is NOT a CI gate. The audit deliverable is the
+operator inventory printed at the end.
+
+Run
+===
+
+    python3 reference/onnx/audit/probe_p1_local.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+
+OPSET = 18
+
+
+# ---------------------------------------------------------------------------
+# Candidate ONNX graph: per-element P1 local matrices
+# ---------------------------------------------------------------------------
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    """Wrap a small NumPy array as a `Constant` node in the graph."""
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=TensorProto.FLOAT if np_arr.dtype == np.float32 else
+                      TensorProto.DOUBLE if np_arr.dtype == np.float64 else
+                      TensorProto.INT64,
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_p1_local_graph() -> onnx.ModelProto:
+    """Build a graph that takes `elem_coords` of shape (N, 4, 3) f64 and
+    returns `K_local` (N, 4, 4) and `M_local` (N, 4, 4)."""
+    nodes: list[onnx.NodeProto] = []
+
+    # ----- Input: elem_coords (N, 4, 3) f64. N is symbolic. -----
+    elem_coords_vi = oh.make_tensor_value_info(
+        "elem_coords",
+        TensorProto.DOUBLE,
+        shape=["N", 4, 3],
+    )
+
+    # ----- Slice out v0..v3 along axis=1 with Gather. -----
+    # Gather requires int64 indices in opset 18.
+    nodes.append(_const("axis1_idx_0", np.array(0, dtype=np.int64)))
+    nodes.append(_const("axis1_idx_1", np.array(1, dtype=np.int64)))
+    nodes.append(_const("axis1_idx_2", np.array(2, dtype=np.int64)))
+    nodes.append(_const("axis1_idx_3", np.array(3, dtype=np.int64)))
+
+    for i in range(4):
+        # Gather(input, indices, axis=1) — scalar index gives (N, 3).
+        nodes.append(oh.make_node(
+            "Gather",
+            inputs=["elem_coords", f"axis1_idx_{i}"],
+            outputs=[f"v{i}"],
+            axis=1,
+        ))
+
+    # ----- Edge vectors e1 = v1 - v0, e2 = v2 - v0, e3 = v3 - v0. -----
+    for i in (1, 2, 3):
+        nodes.append(oh.make_node("Sub", [f"v{i}", "v0"], [f"e{i}"]))
+
+    # ----- Per-row 3-vector cross products. -----
+    # ONNX has no `cross` op. We synthesize cross(a, b) as:
+    #   cx = ay*bz - az*by
+    #   cy = az*bx - ax*bz
+    #   cz = ax*by - ay*bx
+    # then Stack along axis=1 with Unsqueeze + Concat.
+    #
+    # Components are gathered with axis=1 (after Gather we get shape (N,)
+    # because the indexed axis collapses). Each component is later
+    # Unsqueeze'd back to (N, 1) before Concat'ing to (N, 3).
+    nodes.append(_const("axis_neg1_const", np.array([-1], dtype=np.int64)))
+    # Shared per-component scalar indices (one set, reused across all
+    # vector decompositions). Without caching, repeated calls to
+    # `emit_components` would attempt to re-emit identical constants
+    # and ONNX rejects the graph as non-SSA.
+    for c in range(3):
+        nodes.append(_const(f"comp_idx_{c}", np.array(c, dtype=np.int64)))
+
+    emitted_components: set[str] = set()
+
+    def emit_components(vec: str) -> tuple[str, str, str]:
+        """Emit per-component gathers (N,) for one (N, 3) vector. Idempotent."""
+        outs = []
+        for c in range(3):
+            out_name = f"{vec}_c{c}"
+            if out_name not in emitted_components:
+                nodes.append(oh.make_node(
+                    "Gather",
+                    inputs=[vec, f"comp_idx_{c}"],
+                    outputs=[out_name],
+                    axis=1,
+                ))
+                emitted_components.add(out_name)
+            outs.append(out_name)
+        return tuple(outs)  # type: ignore[return-value]
+
+    def emit_cross(a: str, b: str, out: str) -> None:
+        ax, ay, az = emit_components(a)
+        bx, by, bz = emit_components(b)
+
+        # cx = ay*bz - az*by
+        nodes.append(oh.make_node("Mul", [ay, bz], [f"{out}_t1"]))
+        nodes.append(oh.make_node("Mul", [az, by], [f"{out}_t2"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t1", f"{out}_t2"], [f"{out}_x"]))
+
+        # cy = az*bx - ax*bz
+        nodes.append(oh.make_node("Mul", [az, bx], [f"{out}_t3"]))
+        nodes.append(oh.make_node("Mul", [ax, bz], [f"{out}_t4"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t3", f"{out}_t4"], [f"{out}_y"]))
+
+        # cz = ax*by - ay*bx
+        nodes.append(oh.make_node("Mul", [ax, by], [f"{out}_t5"]))
+        nodes.append(oh.make_node("Mul", [ay, bx], [f"{out}_t6"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t5", f"{out}_t6"], [f"{out}_z"]))
+
+        # Stack components → (N, 3): Unsqueeze each to (N, 1), then Concat.
+        for comp in ("x", "y", "z"):
+            nodes.append(oh.make_node(
+                "Unsqueeze",
+                inputs=[f"{out}_{comp}", "axis_neg1_const"],
+                outputs=[f"{out}_{comp}_u"],
+            ))
+        nodes.append(oh.make_node(
+            "Concat",
+            inputs=[f"{out}_x_u", f"{out}_y_u", f"{out}_z_u"],
+            outputs=[out],
+            axis=1,
+        ))
+
+    emit_cross("e2", "e3", "g1")
+    emit_cross("e3", "e1", "g2")
+    emit_cross("e1", "e2", "g3")
+
+    # ----- g0 = -(g1 + g2 + g3). -----
+    nodes.append(oh.make_node("Add", ["g1", "g2"], ["g1_plus_g2"]))
+    nodes.append(oh.make_node("Add", ["g1_plus_g2", "g3"], ["g_sum"]))
+    nodes.append(oh.make_node("Neg", ["g_sum"], ["g0"]))
+
+    # ----- det = sum(e1 * g1) along axis=1. -----
+    nodes.append(oh.make_node("Mul", ["e1", "g1"], ["e1_g1"]))
+    nodes.append(_const("axis1_const", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ReduceSum",
+        inputs=["e1_g1", "axis1_const"],
+        outputs=["det"],
+        keepdims=0,
+    ))
+    nodes.append(oh.make_node("Abs", ["det"], ["abs_det"]))
+
+    # ----- gMat = stack(g0, g1, g2, g3) along axis=1 → (N, 4, 3). -----
+    # Reuse `axis1_const` (already defined for the ReduceSum above).
+    for g in ("g0", "g1", "g2", "g3"):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[g, "axis1_const"],
+            outputs=[f"{g}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["g0_u", "g1_u", "g2_u", "g3_u"],
+        outputs=["g_mat"],
+        axis=1,
+    ))
+
+    # ----- gg = g_mat @ g_mat^T per-batch.
+    # In ONNX, MatMul broadcasts over leading batch dims: with g_mat
+    # shape (N, 4, 3) and g_mat_T shape (N, 3, 4), MatMul gives (N, 4, 4).
+    # This is the L4-native behavior — no einsum trick required (unlike
+    # TF-Java, which lacks rank-3 MatMul broadcasting and required
+    # einsum). Documented in the audit.
+    nodes.append(oh.make_node(
+        "Transpose",
+        inputs=["g_mat"],
+        outputs=["g_mat_T"],
+        perm=[0, 2, 1],
+    ))
+    nodes.append(oh.make_node("MatMul", ["g_mat", "g_mat_T"], ["gg"]))
+
+    # ----- K_local = gg / (6 * abs_det). -----
+    nodes.append(_const("six_const", np.array(6.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["six_const", "abs_det"], ["six_abs_det"]))
+    # Reshape (N,) → (N, 1, 1) for broadcasting against (N, 4, 4).
+    nodes.append(_const("reshape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["six_abs_det", "reshape_n11"],
+        outputs=["six_abs_det_b"],
+    ))
+    nodes.append(oh.make_node("Div", ["gg", "six_abs_det_b"], ["k_local"]))
+
+    # ----- M_local = mass_pattern * (abs_det / 120). -----
+    mass_pattern = np.array(
+        [
+            [2.0, 1.0, 1.0, 1.0],
+            [1.0, 2.0, 1.0, 1.0],
+            [1.0, 1.0, 2.0, 1.0],
+            [1.0, 1.0, 1.0, 2.0],
+        ],
+        dtype=np.float64,
+    )
+    nodes.append(_const("mass_pattern", mass_pattern))
+    nodes.append(_const("one_twenty", np.array(120.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Div", ["abs_det", "one_twenty"], ["m_scale"]))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["m_scale", "reshape_n11"],
+        outputs=["m_scale_b"],
+    ))
+    # Mass pattern needs broadcasting on a leading batch dim. Reshape
+    # (4, 4) → (1, 4, 4); ONNX Mul then broadcasts (1, 4, 4) * (N, 1, 1).
+    nodes.append(_const("reshape_144", np.array([1, 4, 4], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["mass_pattern", "reshape_144"],
+        outputs=["mass_pattern_b"],
+    ))
+    nodes.append(oh.make_node("Mul", ["mass_pattern_b", "m_scale_b"], ["m_local"]))
+
+    # ----- Outputs. -----
+    k_vi = oh.make_tensor_value_info("k_local", TensorProto.DOUBLE, shape=["N", 4, 4])
+    m_vi = oh.make_tensor_value_info("m_local", TensorProto.DOUBLE, shape=["N", 4, 4])
+
+    graph = oh.make_graph(
+        nodes,
+        name="p1_local_probe",
+        inputs=[elem_coords_vi],
+        outputs=[k_vi, m_vi],
+    )
+    model = oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("== Probe: P1 local matrices (cube-cavity assembly spine, per-element step) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    model = build_p1_local_graph()
+
+    # 1. Checker: does the model type-check?
+    try:
+        onnx.checker.check_model(model)
+        checker_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        checker_status = f"FAIL ({e!r})"
+
+    # 2. Runtime: does the model execute and match NumPy?
+    rt_status = "skipped"
+    max_err_k = max_err_m = float("nan")
+    try:
+        sess = ort.InferenceSession(model.SerializeToString())
+        # Canonical reference tet (unit-volume P1 reference).
+        verts = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        elem_coords = verts.reshape(1, 4, 3)  # (N=1, 4, 3)
+
+        outs = sess.run(["k_local", "m_local"], {"elem_coords": elem_coords})
+        k_onnx, m_onnx = outs
+
+        k_np, m_np, _ = batched_p1_local_matrices(elem_coords)
+        max_err_k = float(np.max(np.abs(k_onnx - k_np)))
+        max_err_m = float(np.max(np.abs(m_onnx - m_np)))
+        rt_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        rt_status = f"FAIL ({e!r})"
+
+    # 3. Operator inventory printout.
+    print("Operator inventory for the per-element P1 spine:")
+    print("--------------------------------------------------------------")
+    print("  Sub                  lowers cleanly       (opset 18 native)")
+    print("  Mul                  lowers cleanly       (opset 18 native)")
+    print("  Add                  lowers cleanly       (opset 18 native)")
+    print("  Neg                  lowers cleanly       (opset 18 native)")
+    print("  Abs                  lowers cleanly       (opset 18 native)")
+    print("  Div                  lowers cleanly       (opset 18 native)")
+    print("  ReduceSum            lowers cleanly       (opset 18 native)")
+    print("  Reshape              lowers cleanly       (opset 18 native)")
+    print("  Transpose            lowers cleanly       (opset 18 native)")
+    print("  Concat               lowers cleanly       (opset 18 native)")
+    print("  Unsqueeze            lowers cleanly       (opset 18 native, axes-as-input form)")
+    print("  Gather (axis=1)      lowers cleanly       (opset 18 native, int64 indices)")
+    print("  MatMul (rank-3)      lowers cleanly       (opset 18 broadcasts batch dim;")
+    print("                                             cf. TF-Java which required einsum)")
+    print()
+    print("  cross product        lowers WITH SYNTHESIS")
+    print("                       (no native `Cross`; built as 6 Mul + 3 Sub + 3 Unsqueeze + Concat)")
+    print("                       — graph-only friction: same disposition as the TF-Java")
+    print("                         reference, which also hand-rolls this.")
+    print()
+    print("Cross-cutting frictions observed:")
+    print("--------------------------------------------------------------")
+    print("  - Constants must be int64 for Gather/Reshape/ReduceSum axis args;")
+    print("    Python ints default to int32 if not explicit, which ONNX rejects.")
+    print("    Same friction surfaces in the assembly probe — cast at the boundary.")
+    print("  - Unsqueeze takes its `axes` as a tensor INPUT in opset 13+, not as")
+    print("    an attribute (legacy form). Constant int64 axes nodes proliferate.")
+    print("  - `Stack` is not an ONNX op: we Unsqueeze + Concat to emulate it.")
+    print("    NumPy/JAX/TF-Java all have `stack`; ONNX views this as imperative")
+    print("    sugar and forces the IR-level decomposition. Documentation, not a blocker.")
+    print()
+    print(f"onnx.checker.check_model: {checker_status}")
+    print(f"onnxruntime execution: {rt_status}")
+    if rt_status == "OK":
+        print(f"  max |K_onnx - K_numpy| = {max_err_k:.3e}")
+        print(f"  max |M_onnx - M_numpy| = {max_err_m:.3e}")
+    print()
+    print("Verdict: P1 local matrices lower CLEANLY (modulo a hand-rolled cross product")
+    print("         and int64-axes constants), with no secretly-imperative L4 escape.")
+    print("         All friction here is graph-only and identical to the TF-Java case.")
+
+    # Exit code: zero if both checker and runtime are OK; non-zero is
+    # informational (the probe is not a CI gate).
+    return 0 if checker_status == "OK" and rt_status == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/requirements.txt
+++ b/reference/onnx/requirements.txt
@@ -1,0 +1,13 @@
+# ONNX expressibility audit (Epic #88 Phase F.1)
+#
+# Pinned versions used to record the probe verdicts in
+# `audit/cube_cavity_operator_audit.md`. When bumping, re-run all
+# probes and update the audit markdown — opset coverage and operator
+# semantics move between ONNX releases.
+#
+# All probes target ONNX opset 18. onnxruntime is the reference
+# execution layer; onnxscript is used for the readable graph builders.
+onnx==1.21.0
+onnxruntime==1.26.0
+onnxscript==0.7.0
+numpy>=1.26


### PR DESCRIPTION
Closes #116.

Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase F.1
deliverable: an operator-by-operator audit of which L4 operators on
the cube-cavity assembly spine lower cleanly to ONNX (graph-only)
vs which expose imperative structure. Per the curator pass on #116,
F.1 is an audit deliverable, not an end-to-end implementation — the
end-to-end ONNX assembly graph lives in the follow-on F.2 issue
(to be filed after this merges).

## Summary

- New audit tree at `reference/onnx/audit/`:
  - `cube_cavity_operator_audit.md` — the gap-list / operator inventory,
    classified per-row as `clean`, `synth`, or `caveat`, with explicit
    `graph-only friction` vs `secretly imperative` framing.
  - `probe_p1_local.py` — builds the per-element P1 stiffness/mass
    graph; checker + onnxruntime + numerical agreement vs the NumPy
    reference.
  - `probe_assembly_scatter.py` — builds a `ScatterND(reduction="add")`
    graph for the global K/M assembly step; checker + onnxruntime +
    numerical agreement vs explicit `np.add.at(...)`.
  - `probe_dirichlet_mask.py` — builds two variants of the Dirichlet
    restriction (host-side `idx` vs in-graph `NonZero`) and surfaces
    the data-dependent-shape friction class.
- `reference/onnx/README.md` expanded from stub to full F.1 entry
  point, including the eigensolve-at-the-boundary convention, the
  complex-arithmetic deferral, the friction-summary pointer to #5,
  and the planned Phase F.2 layout.
- `reference/onnx/requirements.txt` pins `onnx==1.21.0` /
  `onnxruntime==1.26.0` / `onnxscript==0.7.0` / opset 18.

## Headline finding

**The cube-cavity assembly spine lowers to graph-only ONNX cleanly.**
Every L4 operator on stages 1–3 (per-element matrices, global
scatter-add, Dirichlet restriction) either has a direct opset-18
equivalent (`Sub`, `Mul`, `Add`, `Neg`, `Abs`, `Div`, `ReduceSum`,
`Reshape`, `Transpose`, `Concat`, `Unsqueeze`, `Gather`, `MatMul`,
`ScatterND` with `reduction="add"`, `ConstantOfShape`, `NonZero`)
or decomposes graph-only (`Stack` → `Unsqueeze`+`Concat`; cross
product → 6 `Mul` + 3 `Sub` + 3 `Unsqueeze` + `Concat`).

**No secretly-imperative L4 escape was surfaced on this slice.**
The most informative row is `np.where(mask)[0]`: ONNX `NonZero`
lowers the operator, but introduces a data-dependent shape that
breaks downstream static-shape inference. This is graph-only
friction (the L4 verb IS expressible), but it forces an explicit
host-side `idx` convention that JAX and TF-Java both follow
implicitly. The audit makes this convention legible. This is the
Phase F.1 "forcing function" working as Epic #88 anticipated.

## What this means for Phase F.2

The audit is **green** for Phase F.2 to proceed:

- Graph inputs: `nodes`, `tets`, `idx_int`.
- Graph outputs: `K_int`, `M_int`.
- Eigensolve at the JSON-sidecar boundary, mirroring TF-Java.
- CI gate: three-way cross-IR agreement (ONNX vs JAX vs NumPy) at
  `rtol=1e-5`, mirroring `.github/workflows/tfjava-cube-cavity.yml`.

## What this audit did NOT find

- No PML friction (deferred to Phase H — cube-cavity is real-symmetric).
- No Nédélec friction (deferred to Phase G).
- No CI gating decision (deferred to F.2; the audit just sketches
  the design).

## Out of scope (per curator pass on #116)

- The ONNX assembly graph itself — F.2.
- Any CI gate — F.2.
- The eigensolve — shared host-driver convention across all backends.
- Complex arithmetic — Phase H.
- ONNX-runtime eigenvalue comparison against the JAX baseline — F.2.

## Test plan

- [x] `cd reference/onnx && python3 -m pip install -r requirements.txt`
      succeeds on a fresh checkout.
- [x] `python3 reference/onnx/audit/probe_p1_local.py` runs to
      completion and prints a verdict matching the audit markdown
      (K and M agree bit-exact with the NumPy reference on the
      canonical reference tet).
- [x] `python3 reference/onnx/audit/probe_assembly_scatter.py` runs
      to completion (ScatterND with `reduction="add"` agrees bit-exact
      with `np.add.at`).
- [x] `python3 reference/onnx/audit/probe_dirichlet_mask.py` runs to
      completion (both Path A and Path B agree bit-exact with
      `K[np.ix_(idx, idx)]`).
- [x] Audit markdown review: every spine operator appears in the
      table; every non-clean row has a one-paragraph explanation;
      every `secretly imperative` vs `graph-only friction` classification
      is explicit.
- [x] Friction-summary comment filed on #5 (link in this PR's
      review thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)