### PR TITLE
feat: Phase G.1 — Nédélec local curl-curl + mass, NumPy reference vs Burn (#117)

### DIFF
--- a/crates/geode-core/src/nedelec.rs
+++ b/crates/geode-core/src/nedelec.rs
@@ -234,18 +234,26 @@ pub fn batched_nedelec_local_matrices<B: Backend>(coords: Tensor<B, 3>) -> Nedel
     for &(a, b) in TET_LOCAL_EDGES.iter() {
         for &(c, d) in TET_LOCAL_EDGES.iter() {
             // K_ij = (2/3) · (gg_ac gg_bd − gg_ad gg_bc) / |det|^3
+            //
+            // The `2/3` scalar is computed in f64 — using an `f32` literal
+            // truncates the ratio to single precision *before* upcasting,
+            // costing ~5e-8 of accuracy on the f64 backend and dragging the
+            // backend-agnostic tolerance floor down to 1e-7. The
+            // f32-backend `mul_scalar` still converts to f32 internally.
             let k_term = gg_entry(a, c).mul(gg_entry(b, d)) - gg_entry(a, d).mul(gg_entry(b, c));
-            let k_val = k_term.mul(inv_abs_det3.clone()).mul_scalar(2.0_f32 / 3.0);
+            let k_val = k_term.mul(inv_abs_det3.clone()).mul_scalar(2.0_f64 / 3.0);
             k_entries.push(k_val);
 
             // M_ij = (V/20) [ (1 + δ_ac) G_bd − (1 + δ_ad) G_bc
             //              − (1 + δ_bc) G_ad + (1 + δ_bd) G_ac ]
             // With (V/20) G_pq = gg_pq / (120 |det|), each prefactor (1 + δ)
-            // is a constant we fold into a scalar multiply.
-            let f_ac = if a == c { 2.0_f32 } else { 1.0_f32 };
-            let f_ad = if a == d { 2.0_f32 } else { 1.0_f32 };
-            let f_bc = if b == c { 2.0_f32 } else { 1.0_f32 };
-            let f_bd = if b == d { 2.0_f32 } else { 1.0_f32 };
+            // is a constant we fold into a scalar multiply. (`1.0` and
+            // `2.0` are exact in f32, so the literal type only matters
+            // for code-doc consistency with the K block above.)
+            let f_ac = if a == c { 2.0_f64 } else { 1.0_f64 };
+            let f_ad = if a == d { 2.0_f64 } else { 1.0_f64 };
+            let f_bc = if b == c { 2.0_f64 } else { 1.0_f64 };
+            let f_bd = if b == d { 2.0_f64 } else { 1.0_f64 };
 
             let m_term = gg_entry(b, d).mul_scalar(f_ac)
                 - gg_entry(b, c).mul_scalar(f_ad)

--- a/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
@@ -1,0 +1,573 @@
+//! Cross-backend Nédélec local-matrices agreement test: Burn (in-tree) vs. NumPy.
+//!
+//! Sister of `p1_local_numpy_reference.rs` (issue #90 / PR #96, migrated
+//! onto the canonical `geode-validation` harness in PR #105). This file
+//! is the Phase G.1 cross-check for the vector spine (issue #117 /
+//! Epic #88), validating the closed-form 6×6 curl-curl and mass kernels
+//! in `crates/geode-core/src/nedelec.rs:51-74` against a faithful NumPy
+//! transcription at `reference/numpy/nedelec_local_matrices.py`.
+//!
+//! # Edge-orientation contract
+//!
+//! The NumPy reference treats every local edge as oriented from the
+//! lower-index local vertex to the higher (`s_i = +1` for all six
+//! edges). Each fixture pins this convention via an
+//! `inputs.tet_local_edge_signs` field of shape `(1, 6)`. The Burn-side
+//! kernel `batched_nedelec_local_matrices` uses the same canonical local
+//! ordering — `TET_LOCAL_EDGES = [(0,1),(0,2),(0,3),(1,2),(1,3),(2,3)]`
+//! — so for G.1 the comparison is identity-on-signs. We still read the
+//! sign vector out of the fixture and apply the documented `s_i s_j`
+//! correction (`nedelec.rs:30-34`) to the Burn output BEFORE comparing,
+//! so the moment G.2 introduces non-trivial signs (the global edge
+//! table builder) this harness needs zero changes.
+//!
+//! # Per-backend tolerance discipline
+//!
+//! Same pattern as `p1_local_numpy_reference.rs` (PR #105 / issue #101):
+//!
+//! | Backend  | Burn dtype | rel_tol | abs_tol |
+//! |----------|------------|---------|---------|
+//! | ndarray  | f64        | 1e-10   | 1e-12   |
+//! | wgpu/cuda| f32        | 5e-5    | 1e-6    |
+//!
+//! The fixture's own `tolerance_abs` (per OutputField) is layered as a
+//! per-field absolute floor: the effective tolerance for each entry is
+//! ``max(tol.abs + tol.rel * |want|, fixture.tolerance_abs)``. For the
+//! four well-conditioned tets the fixture floor is loose-but-real
+//! (~1e-4) and the tight backend-aware mixed envelope is what fires.
+//! For ``near_degenerate_sliver`` — where the Nédélec curl-curl closed
+//! form has an intrinsic ``gg * gg - gg * gg`` catastrophic cancellation
+//! inside a ``1/|det|^3`` amplification, *regardless* of impl — the
+//! fixture declares ``tolerance_abs = 1e2`` on K, which the harness
+//! respects rather than flagging an algorithmically-unavoidable
+//! disagreement as a bug. This is the lever the spec gives us:
+//! ``reference/SCHEMA.md`` documents per-field absolute tolerances as
+//! the durable "loose tripwire" for known-stress regimes.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use burn::tensor::backend::BackendTypes;
+use burn::tensor::{Tensor, TensorData};
+
+use geode_core::{batched_nedelec_local_matrices, DefaultBackend};
+use geode_validation::{Fixture, FixtureFormat};
+
+type B = DefaultBackend;
+
+// ---------------------------------------------------------------------------
+// Tolerances (backend-aware, mirrors p1_local_numpy_reference.rs)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+struct MixedTol {
+    rel: f64,
+    abs: f64,
+}
+
+/// Backend-aware tolerances — read the active Burn backend at runtime
+/// rather than `cfg(feature = …)` so the geode-validation crate doesn't
+/// need to mirror geode-core's feature flags.
+fn active_tolerances() -> MixedTol {
+    let info = geode_core::device_info();
+    if info.backend == "ndarray" {
+        // f64 path — issue #117 acceptance criterion.
+        MixedTol {
+            rel: 1.0e-10,
+            abs: 1.0e-12,
+        }
+    } else {
+        // f32 GPU path — looser bound per #88 dtype-honesty friction.
+        MixedTol {
+            rel: 5.0e-5,
+            abs: 1.0e-6,
+        }
+    }
+}
+
+/// Mixed absolute/relative tolerance check with an optional per-field
+/// absolute floor from the fixture's own declared `tolerance_abs`. The
+/// effective tolerance is the looser of (a) the backend-aware mixed
+/// abs/rel envelope and (b) the fixture-declared absolute floor.
+///
+/// This per-field floor matters for the `near_degenerate_sliver` case:
+/// the Nédélec curl-curl closed form has a ``gg_ac gg_bd - gg_ad gg_bc``
+/// catastrophic-cancellation step inside a ``1/|det|^3`` amplification,
+/// so even in pure-f64 the sliver's K entries lose ~6 decimal digits to
+/// roundoff regardless of impl. The fixture declares ``tolerance_abs =
+/// 1e2`` on K there, encoding that *intrinsic* loss; the tight
+/// ``1e-10 rel / 1e-12 abs`` check is meaningful for the four
+/// well-conditioned cases but unrealistic for the sliver.
+fn check_close(
+    got: f64,
+    want: f64,
+    tol: MixedTol,
+    fixture_floor: f64,
+    label: &str,
+) -> Result<(), String> {
+    let abs_err = (got - want).abs();
+    let mixed = tol.abs + tol.rel * want.abs();
+    let allowed = mixed.max(fixture_floor);
+    if abs_err <= allowed {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label}: got {got:.17e}, want {want:.17e}, |err| = {abs_err:.3e} \
+             (allowed {allowed:.3e} = max(mixed {mixed:.3e}, fixture_floor {fixture_floor:.3e}); \
+             rel_tol={:.0e}, abs_tol={:.0e})",
+            tol.rel, tol.abs
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture discovery + path helpers
+// ---------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest.ancestors() {
+        if ancestor.join("reference").is_dir() {
+            return ancestor.to_path_buf();
+        }
+    }
+    panic!(
+        "could not find a `reference/` directory walking up from {}",
+        manifest.display()
+    );
+}
+
+fn fixture_dir() -> PathBuf {
+    repo_root().join("reference/fixtures/nedelec_local")
+}
+
+fn fixture_path(case: &str) -> PathBuf {
+    fixture_dir().join(format!("{case}.json"))
+}
+
+/// The five canonical nedelec_local cases. Test failures cite case
+/// names, so this list is the canonical case manifest.
+const CASES: &[&str] = &[
+    "canonical_reference_tet",
+    "regular_tet",
+    "anisotropic_well_shaped",
+    "near_degenerate_sliver",
+    "inverted_tet",
+];
+
+// ---------------------------------------------------------------------------
+// Burn driver
+// ---------------------------------------------------------------------------
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// Build a `[1, 4, 3]` Burn tensor of the backend's float type from a
+/// single tet's vertex array (flat `Vec<f64>` of length 12, row-major).
+fn coords_tensor(vertices_flat: &[f64]) -> Tensor<B, 3> {
+    assert_eq!(vertices_flat.len(), 12, "expected 12 f64 entries (1 tet)");
+    let info = geode_core::device_info();
+    if info.backend == "ndarray" {
+        let data = TensorData::new(vertices_flat.to_vec(), [1, 4, 3]);
+        Tensor::<B, 3>::from_data(data, &device())
+    } else {
+        let flat32: Vec<f32> = vertices_flat.iter().map(|&x| x as f32).collect();
+        let data = TensorData::new(flat32, [1, 4, 3]);
+        Tensor::<B, 3>::from_data(data, &device())
+    }
+}
+
+/// Read a tensor of arbitrary rank back into a flat `Vec<f64>`, upcasting
+/// the f32 path at readback so comparisons happen in f64 space.
+fn tensor_to_vec_f64<const D: usize>(t: Tensor<B, D>) -> Vec<f64> {
+    let info = geode_core::device_info();
+    let data = t.into_data();
+    if info.backend == "ndarray" {
+        data.to_vec::<f64>().expect("readback f64")
+    } else {
+        data.to_vec::<f32>()
+            .expect("readback f32")
+            .into_iter()
+            .map(f64::from)
+            .collect()
+    }
+}
+
+/// Run the Burn pipeline for one case and apply the per-edge sign
+/// correction `s_i s_j` to the [6×6] K and M matrices before returning.
+///
+/// G.1 fixtures use all-+1 signs, so this is identity today; the
+/// machinery is in place for the G.2 fixtures which exercise the
+/// global edge-table builder's non-trivial sign vectors.
+fn burn_actual(fixture: &Fixture) -> BTreeMap<String, Vec<f64>> {
+    let coords_field = fixture
+        .inputs
+        .get("coords")
+        .expect("fixture has `inputs.coords`");
+    let coords_flat = flatten_numeric(&coords_field.data);
+    assert_eq!(
+        coords_flat.len(),
+        12,
+        "fixture {} has unexpected coords length {}",
+        fixture.fixture_id,
+        coords_flat.len()
+    );
+
+    let signs_field = fixture
+        .inputs
+        .get("tet_local_edge_signs")
+        .expect("fixture has `inputs.tet_local_edge_signs`");
+    let signs_flat = flatten_numeric(&signs_field.data);
+    assert_eq!(
+        signs_flat.len(),
+        6,
+        "fixture {} has unexpected tet_local_edge_signs length {} (want 6)",
+        fixture.fixture_id,
+        signs_flat.len()
+    );
+    let mut signs = [1.0_f64; 6];
+    for (i, &s) in signs_flat.iter().enumerate() {
+        // Defensive: signs must be ±1 exactly.
+        assert!(
+            s == 1.0 || s == -1.0,
+            "fixture {} tet_local_edge_signs[{i}] = {s} is not ±1",
+            fixture.fixture_id
+        );
+        signs[i] = s;
+    }
+
+    let coords = coords_tensor(&coords_flat);
+    let result = batched_nedelec_local_matrices(coords);
+
+    let mut k_flat = tensor_to_vec_f64(result.k_local);
+    let mut m_flat = tensor_to_vec_f64(result.m_local);
+    let v_flat = tensor_to_vec_f64(result.signed_volumes);
+
+    assert_eq!(k_flat.len(), 36, "Burn K should be [1, 6, 6] = 36 entries");
+    assert_eq!(m_flat.len(), 36, "Burn M should be [1, 6, 6] = 36 entries");
+
+    // Apply the per-edge sign correction K[i,j] *= s_i s_j (and ditto
+    // for M). The NumPy reference is written for all-+1 local signs,
+    // so this matches the reference convention before comparison.
+    for i in 0..6 {
+        for j in 0..6 {
+            let idx = i * 6 + j;
+            let s_ij = signs[i] * signs[j];
+            k_flat[idx] *= s_ij;
+            m_flat[idx] *= s_ij;
+        }
+    }
+
+    let mut out = BTreeMap::new();
+    out.insert("k_local".to_string(), k_flat);
+    out.insert("m_local".to_string(), m_flat);
+    out.insert("signed_volume".to_string(), v_flat);
+    out
+}
+
+/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
+/// helper is `pub(crate)`); same semantics — recursively flatten nested
+/// or pre-flat JSON arrays of numbers into row-major f64.
+fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
+    let mut out = Vec::new();
+    push(v, &mut out);
+    return out;
+
+    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
+        match v {
+            serde_json::Value::Number(n) => {
+                if let Some(x) = n.as_f64() {
+                    out.push(x);
+                } else if let Some(x) = n.as_i64() {
+                    out.push(x as f64);
+                } else if let Some(x) = n.as_u64() {
+                    out.push(x as f64);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr {
+                    push(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_nedelec_local_fixtures_load_and_have_canonical_shape() {
+    // Pure load-time smoke test — no Burn pipeline. Confirms each
+    // per-case fixture parses, advertises schema v1, the right
+    // fixture_id, and has the expected input/output fields.
+    for case in CASES {
+        let path = fixture_path(case);
+        let fixture = Fixture::load_from(&path, FixtureFormat::Json).unwrap_or_else(|e| {
+            panic!("failed to load fixture {}: {e}", path.display());
+        });
+
+        assert_eq!(fixture.schema_version, "1");
+        assert_eq!(fixture.fixture_id, format!("nedelec_local/{case}"));
+        for field in ["k_local", "m_local", "signed_volume"] {
+            assert!(
+                fixture.outputs.contains_key(field),
+                "fixture {} missing output `{field}`",
+                fixture.fixture_id
+            );
+        }
+        for field in ["coords", "tet_local_edge_signs"] {
+            assert!(
+                fixture.inputs.contains_key(field),
+                "fixture {} missing input `{field}`",
+                fixture.fixture_id
+            );
+        }
+    }
+}
+
+/// Cases for which the f32 GPU backends (wgpu / cuda) cannot
+/// meaningfully represent the closed-form Nédélec output. The sliver
+/// tet's K kernel is intrinsically a ``gg * gg - gg * gg`` cancellation
+/// amplified by ``1/|det|^3 ~ 1e18``; f64 absorbs the loss but f32
+/// blows up by 5+ orders of magnitude even when the algorithm is
+/// bit-perfect. Skipping in f32 is more honest than baking a huge
+/// fixture-floor to mask it. The sliver still runs in f64 (where the
+/// ``1e-10`` rel acceptance criterion fires meaningfully on the four
+/// well-conditioned cases).
+fn case_skipped_on_f32(case: &str) -> bool {
+    case == "near_degenerate_sliver"
+}
+
+#[test]
+fn burn_agrees_with_numpy_baseline_on_all_nedelec_local_cases() {
+    let tol = active_tolerances();
+    let backend = geode_core::device_info().backend;
+    let is_f64_path = backend == "ndarray";
+    eprintln!(
+        "nedelec_local test: backend = {backend}, rel_tol = {:.0e}, abs_tol = {:.0e}",
+        tol.rel, tol.abs
+    );
+
+    // Collect ALL per-case diff artifacts; emit one combined report on
+    // failure so a reviewer can see every disagreement at once.
+    let artifact_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    let mut per_case_diffs: Vec<(String, Vec<String>)> = Vec::new();
+
+    for case in CASES {
+        if !is_f64_path && case_skipped_on_f32(case) {
+            eprintln!(
+                "  - skipping case {case} on f32 backend (kernel is \
+                 numerically infeasible in single precision; see \
+                 `case_skipped_on_f32` for rationale)"
+            );
+            continue;
+        }
+
+        let path = fixture_path(case);
+        let fixture = Fixture::load_from(&path, FixtureFormat::Json)
+            .unwrap_or_else(|e| panic!("load fixture {}: {e}", path.display()));
+
+        let actual = burn_actual(&fixture);
+
+        // First: structural pass via the canonical harness. The fixture's
+        // own `tolerance_abs` is the loose tripwire; failures here mean
+        // the discrepancy is bigger than even the f32 GPU envelope
+        // expects. Always write the diff artifact (pass or fail) so the
+        // friction-mining loop has the artifact even on green runs.
+        let report = fixture.compare_against(&actual);
+        let artifact_path = artifact_dir.join(format!("nedelec_local_{case}_diff.json"));
+        let _ = report.write_diff_artifact(&artifact_path);
+
+        if !report.passed {
+            per_case_diffs.push((
+                case.to_string(),
+                vec![format!(
+                    "Fixture tripwire failed (n_failures = {}); diff artifact at {}; per-field report = {:#?}",
+                    report.n_failures(),
+                    artifact_path.display(),
+                    report.fields
+                )],
+            ));
+            continue;
+        }
+
+        // Second: tighter backend-aware rel/abs check (acceptance
+        // criteria #117 — `1e-10` rel under f64, `5e-5` under f32).
+        let mut case_failures: Vec<String> = Vec::new();
+
+        // signed_volume (scalar).
+        let want_v_field = fixture
+            .output_f64("signed_volume")
+            .expect("signed_volume present");
+        let want_v = want_v_field.data[0];
+        let got_v = actual["signed_volume"][0];
+        if let Err(msg) = check_close(
+            got_v,
+            want_v,
+            tol,
+            want_v_field.tolerance_abs,
+            "signed_volume",
+        ) {
+            case_failures.push(msg);
+        }
+
+        // K_{ij}, 6×6.
+        let want_k = fixture.output_f64("k_local").expect("k_local present");
+        let got_k = &actual["k_local"];
+        for i in 0..6 {
+            for j in 0..6 {
+                let idx = i * 6 + j;
+                if let Err(msg) = check_close(
+                    got_k[idx],
+                    want_k.data[idx],
+                    tol,
+                    want_k.tolerance_abs,
+                    &format!("k_local[{i}][{j}]"),
+                ) {
+                    case_failures.push(msg);
+                }
+            }
+        }
+
+        // M_{ij}, 6×6.
+        let want_m = fixture.output_f64("m_local").expect("m_local present");
+        let got_m = &actual["m_local"];
+        for i in 0..6 {
+            for j in 0..6 {
+                let idx = i * 6 + j;
+                if let Err(msg) = check_close(
+                    got_m[idx],
+                    want_m.data[idx],
+                    tol,
+                    want_m.tolerance_abs,
+                    &format!("m_local[{i}][{j}]"),
+                ) {
+                    case_failures.push(msg);
+                }
+            }
+        }
+
+        if !case_failures.is_empty() {
+            per_case_diffs.push((case.to_string(), case_failures));
+        }
+    }
+
+    if !per_case_diffs.is_empty() {
+        let mut report = String::from(
+            "Burn / NumPy disagreement in Nédélec local matrices:\n\
+             (per-backend rel_tol/abs_tol from active_tolerances())\n",
+        );
+        for (case, diffs) in &per_case_diffs {
+            report.push_str(&format!("\ncase: {case}\n"));
+            for d in diffs {
+                report.push_str(&format!("  - {d}\n"));
+            }
+        }
+        panic!("{report}");
+    }
+}
+
+#[test]
+fn canonical_reference_tet_pins_hand_verified_entries() {
+    // Hand-verified entries on the canonical reference tet [(0,0,0),
+    // (1,0,0), (0,1,0), (0,0,1)] for the issue #117 acceptance
+    // criterion ("at least one hand-verified entry … documented in the
+    // fixture comments"). The math behind these values:
+    //
+    //   grad(lambda_0) = (-1, -1, -1)   grad(lambda_1) = (1, 0, 0)
+    //   grad(lambda_2) = (0, 1, 0)      grad(lambda_3) = (0, 0, 1)
+    //   V = 1/6,  det(J) = 1.
+    //
+    //   gram G is then
+    //          [  3 -1 -1 -1 ]
+    //     G =  [ -1  1  0  0 ]
+    //          [ -1  0  1  0 ]
+    //          [ -1  0  0  1 ]
+    //
+    //   Edge 0 = (a, b) = (0, 1):
+    //     K[0, 0] = 4 V (G_00 G_11 - G_01 G_01)
+    //             = (4/6) (3*1 - (-1)^2) = (4/6)*2 = 4/3.
+    //     M[0, 0] = (V/20) [ (1 + delta_00) G_11 - (1) G_10
+    //                        - (1) G_10 + (1 + delta_11) G_00 ]
+    //             = (1/120) [ 2*1 - (-1) - (-1) + 2*3 ]
+    //             = (1/120) * 10 = 1/12.
+    //
+    //   Edge 5 = (a, b) = (2, 3) — last edge in TET_LOCAL_EDGES:
+    //     K[5, 5] = 4 V (G_22 G_33 - G_23 G_23)
+    //             = (4/6) (1*1 - 0*0) = 2/3.
+    //     M[5, 5] = (V/20) [ (1 + delta_22) G_33 - (1) G_23
+    //                        - (1) G_23 + (1 + delta_33) G_22 ]
+    //             = (1/120) [ 2*1 - 0 - 0 + 2*1 ] = (1/120)*4 = 1/30.
+    let path = fixture_path("canonical_reference_tet");
+    let fixture = Fixture::load_from(&path, FixtureFormat::Json).expect("load canonical fixture");
+    let k = fixture.output_f64("k_local").expect("k_local present");
+    let m = fixture.output_f64("m_local").expect("m_local present");
+    let v = fixture.output_f64("signed_volume").expect("signed_volume");
+
+    let tight = MixedTol {
+        rel: 1.0e-12,
+        abs: 1.0e-14,
+    };
+    // Hand-verified spot checks bypass the fixture floor — these are
+    // exact rational values, no intrinsic precision loss to absorb.
+    // Row-major 6×6 flat index: idx(i, j) = i * 6 + j.
+    check_close(v.data[0], 1.0 / 6.0, tight, 0.0, "fixture V").unwrap();
+    check_close(k.data[0], 4.0 / 3.0, tight, 0.0, "fixture K[0,0]").unwrap();
+    check_close(m.data[0], 1.0 / 12.0, tight, 0.0, "fixture M[0,0]").unwrap();
+    check_close(k.data[5 * 6 + 5], 2.0 / 3.0, tight, 0.0, "fixture K[5,5]").unwrap();
+    check_close(m.data[5 * 6 + 5], 1.0 / 30.0, tight, 0.0, "fixture M[5,5]").unwrap();
+}
+
+#[test]
+fn inverted_tet_signed_volume_is_negative() {
+    // Targeted regression: the inverted case is the only one designed
+    // to exercise the negative-signed-volume diagnostic path. If this
+    // assertion ever fires, somebody has reordered or regenerated the
+    // fixture incorrectly.
+    let path = fixture_path("inverted_tet");
+    let fixture = Fixture::load_from(&path, FixtureFormat::Json).expect("load inverted fixture");
+    let signed_v = fixture.output_f64("signed_volume").expect("signed_volume");
+    assert!(
+        signed_v.data[0] < 0.0,
+        "inverted_tet fixture signed_volume is not negative: {}",
+        signed_v.data[0]
+    );
+
+    let actual = burn_actual(&fixture);
+    let burn_v = actual["signed_volume"][0];
+    assert!(
+        burn_v < 0.0,
+        "Burn computed positive signed_volume {burn_v} for inverted_tet (expected negative)"
+    );
+}
+
+#[test]
+fn all_g1_fixtures_use_unit_local_edge_signs() {
+    // G.1 contract: the local kernel comparison is decoupled from the
+    // global edge-table builder by pinning all-+1 local edge signs in
+    // every fixture. G.2 (issue #118) will introduce non-trivial signs.
+    // This assertion firing means somebody regenerated a G.1 fixture
+    // with a non-canonical sign convention — likely a bug.
+    for case in CASES {
+        let path = fixture_path(case);
+        let fixture = Fixture::load_from(&path, FixtureFormat::Json)
+            .unwrap_or_else(|e| panic!("load fixture {}: {e}", path.display()));
+        let signs_field = fixture
+            .inputs
+            .get("tet_local_edge_signs")
+            .expect("fixture has tet_local_edge_signs");
+        let signs_flat = flatten_numeric(&signs_field.data);
+        assert_eq!(signs_flat.len(), 6, "case {case}: expected 6 edge signs");
+        for (i, &s) in signs_flat.iter().enumerate() {
+            assert_eq!(
+                s, 1.0,
+                "case {case}: tet_local_edge_signs[{i}] = {s}, expected +1.0 \
+                 (G.1 fixtures all use canonical lower-vertex-to-higher orientation)"
+            );
+        }
+    }
+}

--- a/reference/fixtures/nedelec_local/anisotropic_well_shaped.json
+++ b/reference/fixtures/nedelec_local/anisotropic_well_shaped.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "fixture_id": "nedelec_local/anisotropic_well_shaped",
+  "description": "N\u00e9d\u00e9lec edge-element local matrices for the reference tet scaled by (1, 0.5, 0.25) per axis \u2014 anisotropic but well-shaped. K entries scale up as the smaller axis shrinks.",
+  "units": "dimensionless",
+  "inputs": {
+    "coords": {
+      "shape": [
+        1,
+        4,
+        3
+      ],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.5,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.25
+          ]
+        ]
+      ]
+    },
+    "tet_local_edge_signs": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Per-element, per-edge sign s_i in {+1, -1} recording whether each local edge's orientation (lower local vertex index \u2192 higher) agrees with the global edge direction. NumPy reference always uses +1 for all six edges; the Rust harness multiplies the Burn output's [i, j] entry by s_i * s_j before comparing (per nedelec.rs:30-34). Edge order is canonical: [(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)].",
+      "data": [
+        [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) for the 6 edges in TET_LOCAL_EDGES order. Tolerance is loose absolute (f32-friendly tripwire); the Rust comparator layers a backend-aware mixed abs/rel check on top.",
+      "tolerance_abs": 0.001,
+      "data": [
+        [
+          [
+            1.6666666666666665,
+            -0.3333333333333333,
+            -1.3333333333333333,
+            0.3333333333333333,
+            1.3333333333333333,
+            0.0
+          ],
+          [
+            -0.3333333333333333,
+            5.666666666666666,
+            -5.333333333333333,
+            -0.3333333333333333,
+            0.0,
+            5.333333333333333
+          ],
+          [
+            -1.3333333333333333,
+            -5.333333333333333,
+            6.666666666666666,
+            0.0,
+            -1.3333333333333333,
+            -5.333333333333333
+          ],
+          [
+            0.3333333333333333,
+            -0.3333333333333333,
+            0.0,
+            0.3333333333333333,
+            0.0,
+            0.0
+          ],
+          [
+            1.3333333333333333,
+            0.0,
+            -1.3333333333333333,
+            0.0,
+            1.3333333333333333,
+            0.0
+          ],
+          [
+            0.0,
+            5.333333333333333,
+            -5.333333333333333,
+            0.0,
+            0.0,
+            5.333333333333333
+          ]
+        ]
+      ]
+    },
+    "m_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local Whitney 1-form mass M_{ij} per nedelec.rs:67-74. Same edge order and sign convention as k_local.",
+      "tolerance_abs": 1e-06,
+      "data": [
+        [
+          [
+            0.04791666666666667,
+            0.027083333333333334,
+            0.03958333333333333,
+            0.00625,
+            0.03125,
+            0.0125
+          ],
+          [
+            0.027083333333333334,
+            0.06041666666666667,
+            0.042708333333333334,
+            0.00625,
+            0.015625,
+            0.025
+          ],
+          [
+            0.03958333333333333,
+            0.042708333333333334,
+            0.11041666666666666,
+            0.003125,
+            0.03125,
+            0.025
+          ],
+          [
+            0.00625,
+            0.00625,
+            0.003125,
+            0.010416666666666666,
+            0.0010416666666666667,
+            -0.004166666666666667
+          ],
+          [
+            0.03125,
+            0.015625,
+            0.03125,
+            0.0010416666666666667,
+            0.035416666666666666,
+            0.016666666666666666
+          ],
+          [
+            0.0125,
+            0.025,
+            0.025,
+            -0.004166666666666667,
+            0.016666666666666666,
+            0.041666666666666664
+          ]
+        ]
+      ]
+    },
+    "signed_volume": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Negative for inverted tets; use |signed_volume| for assembly weighting.",
+      "tolerance_abs": 1e-06,
+      "data": [
+        0.020833333333333332
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/numpy/nedelec_local_matrices.py via reference/numpy/gen_nedelec_local_per_case.py @ acb7be7",
+    "verified_against": "crates/geode-validation/tests/nedelec_local_numpy_reference.rs",
+    "issue": "#117 (Epic #88 Phase G.1)"
+  }
+}

--- a/reference/fixtures/nedelec_local/canonical_reference_tet.json
+++ b/reference/fixtures/nedelec_local/canonical_reference_tet.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "fixture_id": "nedelec_local/canonical_reference_tet",
+  "description": "N\u00e9d\u00e9lec edge-element local matrices for the canonical reference tet [(0,0,0),(1,0,0),(0,1,0),(0,0,1)] \u2014 the affine identity. On this tet the per-edge entry K[0,0] = 4/3 exactly and M[0,0] = 1/12 exactly; the rest of K and M follow from the closed-form math in crates/geode-core/src/nedelec.rs:51-74. Spot-check entries are documented in the file's `description` and verified at NumPy generation time.",
+  "units": "dimensionless",
+  "inputs": {
+    "coords": {
+      "shape": [
+        1,
+        4,
+        3
+      ],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            1.0
+          ]
+        ]
+      ]
+    },
+    "tet_local_edge_signs": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Per-element, per-edge sign s_i in {+1, -1} recording whether each local edge's orientation (lower local vertex index \u2192 higher) agrees with the global edge direction. NumPy reference always uses +1 for all six edges; the Rust harness multiplies the Burn output's [i, j] entry by s_i * s_j before comparing (per nedelec.rs:30-34). Edge order is canonical: [(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)].",
+      "data": [
+        [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) for the 6 edges in TET_LOCAL_EDGES order. Tolerance is loose absolute (f32-friendly tripwire); the Rust comparator layers a backend-aware mixed abs/rel check on top.",
+      "tolerance_abs": 0.0001,
+      "data": [
+        [
+          [
+            1.3333333333333333,
+            -0.6666666666666666,
+            -0.6666666666666666,
+            0.6666666666666666,
+            0.6666666666666666,
+            0.0
+          ],
+          [
+            -0.6666666666666666,
+            1.3333333333333333,
+            -0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666
+          ],
+          [
+            -0.6666666666666666,
+            -0.6666666666666666,
+            1.3333333333333333,
+            0.0,
+            -0.6666666666666666,
+            -0.6666666666666666
+          ],
+          [
+            0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666,
+            0.0,
+            0.0
+          ],
+          [
+            0.6666666666666666,
+            0.0,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666,
+            0.0
+          ],
+          [
+            0.0,
+            0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.0,
+            0.6666666666666666
+          ]
+        ]
+      ]
+    },
+    "m_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local Whitney 1-form mass M_{ij} per nedelec.rs:67-74. Same edge order and sign convention as k_local.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        [
+          [
+            0.08333333333333333,
+            0.041666666666666664,
+            0.041666666666666664,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.041666666666666664,
+            0.08333333333333333,
+            0.041666666666666664,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.041666666666666664,
+            0.041666666666666664,
+            0.08333333333333333,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            0.03333333333333333,
+            0.008333333333333333,
+            -0.008333333333333333
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            0.008333333333333333,
+            0.03333333333333333,
+            0.008333333333333333
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            -0.008333333333333333,
+            0.008333333333333333,
+            0.03333333333333333
+          ]
+        ]
+      ]
+    },
+    "signed_volume": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Negative for inverted tets; use |signed_volume| for assembly weighting.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        0.16666666666666666
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/numpy/nedelec_local_matrices.py via reference/numpy/gen_nedelec_local_per_case.py @ acb7be7",
+    "verified_against": "crates/geode-validation/tests/nedelec_local_numpy_reference.rs",
+    "issue": "#117 (Epic #88 Phase G.1)"
+  }
+}

--- a/reference/fixtures/nedelec_local/inverted_tet.json
+++ b/reference/fixtures/nedelec_local/inverted_tet.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "fixture_id": "nedelec_local/inverted_tet",
+  "description": "N\u00e9d\u00e9lec edge-element local matrices for the reference tet with vertices 2 and 3 swapped \u2014 same |V| as canonical_reference_tet but negative signed volume. K and M are computed from V = |det|/6 (the absolute volume), so the K and M entries are the *same shape* as the canonical case modulo edge-index permutation; the signed volume is the only diagnostic that flips sign.",
+  "units": "dimensionless",
+  "inputs": {
+    "coords": {
+      "shape": [
+        1,
+        4,
+        3
+      ],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            1.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "tet_local_edge_signs": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Per-element, per-edge sign s_i in {+1, -1} recording whether each local edge's orientation (lower local vertex index \u2192 higher) agrees with the global edge direction. NumPy reference always uses +1 for all six edges; the Rust harness multiplies the Burn output's [i, j] entry by s_i * s_j before comparing (per nedelec.rs:30-34). Edge order is canonical: [(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)].",
+      "data": [
+        [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) for the 6 edges in TET_LOCAL_EDGES order. Tolerance is loose absolute (f32-friendly tripwire); the Rust comparator layers a backend-aware mixed abs/rel check on top.",
+      "tolerance_abs": 0.0001,
+      "data": [
+        [
+          [
+            1.3333333333333333,
+            -0.6666666666666666,
+            -0.6666666666666666,
+            0.6666666666666666,
+            0.6666666666666666,
+            0.0
+          ],
+          [
+            -0.6666666666666666,
+            1.3333333333333333,
+            -0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666
+          ],
+          [
+            -0.6666666666666666,
+            -0.6666666666666666,
+            1.3333333333333333,
+            0.0,
+            -0.6666666666666666,
+            -0.6666666666666666
+          ],
+          [
+            0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666,
+            0.0,
+            0.0
+          ],
+          [
+            0.6666666666666666,
+            0.0,
+            -0.6666666666666666,
+            0.0,
+            0.6666666666666666,
+            0.0
+          ],
+          [
+            0.0,
+            0.6666666666666666,
+            -0.6666666666666666,
+            0.0,
+            0.0,
+            0.6666666666666666
+          ]
+        ]
+      ]
+    },
+    "m_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local Whitney 1-form mass M_{ij} per nedelec.rs:67-74. Same edge order and sign convention as k_local.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        [
+          [
+            0.08333333333333333,
+            0.041666666666666664,
+            0.041666666666666664,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.041666666666666664,
+            0.08333333333333333,
+            0.041666666666666664,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.041666666666666664,
+            0.041666666666666664,
+            0.08333333333333333,
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            0.03333333333333333,
+            0.008333333333333333,
+            -0.008333333333333333
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            0.008333333333333333,
+            0.03333333333333333,
+            0.008333333333333333
+          ],
+          [
+            0.0,
+            0.0,
+            0.0,
+            -0.008333333333333333,
+            0.008333333333333333,
+            0.03333333333333333
+          ]
+        ]
+      ]
+    },
+    "signed_volume": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Negative for inverted tets; use |signed_volume| for assembly weighting.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        -0.16666666666666666
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/numpy/nedelec_local_matrices.py via reference/numpy/gen_nedelec_local_per_case.py @ acb7be7",
+    "verified_against": "crates/geode-validation/tests/nedelec_local_numpy_reference.rs",
+    "issue": "#117 (Epic #88 Phase G.1)"
+  }
+}

--- a/reference/fixtures/nedelec_local/near_degenerate_sliver.json
+++ b/reference/fixtures/nedelec_local/near_degenerate_sliver.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "fixture_id": "nedelec_local/near_degenerate_sliver",
+  "description": "N\u00e9d\u00e9lec edge-element local matrices for a near-coplanar sliver tet (v3.z = 1e-6) \u2014 small but strictly positive volume. Stress case for numerical stability of the closed-form K/M; K entries reach O(1e6) and M entries O(1e4) here as 1/|det| amplifies the gram values through both the curl-curl gradient products and the Whitney mass (V/20) G_pq = gg_pq / (120 |det|) lift.",
+  "units": "dimensionless",
+  "inputs": {
+    "coords": {
+      "shape": [
+        1,
+        4,
+        3
+      ],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [
+          [
+            0.0,
+            0.0,
+            0.0
+          ],
+          [
+            1.0,
+            0.0,
+            0.0
+          ],
+          [
+            0.0,
+            1.0,
+            0.0
+          ],
+          [
+            0.3,
+            0.3,
+            1e-06
+          ]
+        ]
+      ]
+    },
+    "tet_local_edge_signs": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Per-element, per-edge sign s_i in {+1, -1} recording whether each local edge's orientation (lower local vertex index \u2192 higher) agrees with the global edge direction. NumPy reference always uses +1 for all six edges; the Rust harness multiplies the Burn output's [i, j] entry by s_i * s_j before comparing (per nedelec.rs:30-34). Edge order is canonical: [(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)].",
+      "data": [
+        [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) for the 6 edges in TET_LOCAL_EDGES order. Tolerance is loose absolute (f32-friendly tripwire); the Rust comparator layers a backend-aware mixed abs/rel check on top.",
+      "tolerance_abs": 100.0,
+      "data": [
+        [
+          [
+            386666.39334827836,
+            280001.7162574164,
+            -666665.79664106,
+            -79998.50781814643,
+            466663.7446841074,
+            200002.05195695267
+          ],
+          [
+            280001.7162574164,
+            386669.8627952303,
+            -666665.79664106,
+            80001.9772650984,
+            199997.4260276834,
+            466672.99654264597
+          ],
+          [
+            -666665.79664106,
+            -666665.79664106,
+            1333322.3414235818,
+            -4.625929269271485,
+            -666661.1707117909,
+            -666670.4225703294
+          ],
+          [
+            -79998.50781814643,
+            80001.9772650984,
+            -4.625929269271485,
+            120000.07469185429,
+            -199997.4260276834,
+            199999.73899231805
+          ],
+          [
+            466663.7446841074,
+            199997.4260276834,
+            -666661.1707117909,
+            -199997.4260276834,
+            666661.1707117909,
+            0.0
+          ],
+          [
+            200002.05195695267,
+            466672.99654264597,
+            -666670.4225703294,
+            199999.73899231805,
+            0.0,
+            666670.4225703294
+          ]
+        ]
+      ]
+    },
+    "m_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local Whitney 1-form mass M_{ij} per nedelec.rs:67-74. Same edge order and sign convention as k_local.",
+      "tolerance_abs": 10.0,
+      "data": [
+        [
+          [
+            2166.6666667333334,
+            833.3333333666668,
+            -1333.3333333083328,
+            -999.9999999999997,
+            4416.6666666500005,
+            1083.333333325
+          ],
+          [
+            833.3333333666668,
+            2166.666666733334,
+            -1333.3333333083328,
+            1000.0000000000002,
+            1083.3333333250002,
+            4416.6666666500005
+          ],
+          [
+            -1333.3333333083328,
+            -1333.3333333083328,
+            26000.000000033335,
+            1.1564823173178715e-13,
+            16166.666666650002,
+            16166.666666650002
+          ],
+          [
+            -999.9999999999997,
+            1000.0000000000002,
+            3.469446951953614e-13,
+            1500.0000000333334,
+            -2499.9999999916663,
+            2499.9999999916663
+          ],
+          [
+            4416.66666665,
+            1083.3333333250002,
+            16166.66666665,
+            -2499.9999999916668,
+            23166.66666668333,
+            14833.333333333334
+          ],
+          [
+            1083.3333333250002,
+            4416.66666665,
+            16166.66666665,
+            2499.9999999916663,
+            14833.333333333334,
+            23166.66666668333
+          ]
+        ]
+      ]
+    },
+    "signed_volume": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Negative for inverted tets; use |signed_volume| for assembly weighting.",
+      "tolerance_abs": 1e-11,
+      "data": [
+        1.6666666666666665e-07
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/numpy/nedelec_local_matrices.py via reference/numpy/gen_nedelec_local_per_case.py @ acb7be7",
+    "verified_against": "crates/geode-validation/tests/nedelec_local_numpy_reference.rs",
+    "issue": "#117 (Epic #88 Phase G.1)"
+  }
+}

--- a/reference/fixtures/nedelec_local/regular_tet.json
+++ b/reference/fixtures/nedelec_local/regular_tet.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "fixture_id": "nedelec_local/regular_tet",
+  "description": "N\u00e9d\u00e9lec edge-element local matrices for a regular tetrahedron (unit edge length, centered at origin). Same geometry as the P1 regular_tet fixture; included so the two reference sets can be compared on identical tets.",
+  "units": "dimensionless",
+  "inputs": {
+    "coords": {
+      "shape": [
+        1,
+        4,
+        3
+      ],
+      "dtype": "f64",
+      "description": "Per-element vertex coordinates [n_elem, 4 vertices, 3 spatial dims].",
+      "data": [
+        [
+          [
+            0.35355339059327373,
+            0.35355339059327373,
+            0.35355339059327373
+          ],
+          [
+            -0.35355339059327373,
+            -0.35355339059327373,
+            0.35355339059327373
+          ],
+          [
+            -0.35355339059327373,
+            0.35355339059327373,
+            -0.35355339059327373
+          ],
+          [
+            0.35355339059327373,
+            -0.35355339059327373,
+            -0.35355339059327373
+          ]
+        ]
+      ]
+    },
+    "tet_local_edge_signs": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Per-element, per-edge sign s_i in {+1, -1} recording whether each local edge's orientation (lower local vertex index \u2192 higher) agrees with the global edge direction. NumPy reference always uses +1 for all six edges; the Rust harness multiplies the Burn output's [i, j] entry by s_i * s_j before comparing (per nedelec.rs:30-34). Edge order is canonical: [(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)].",
+      "data": [
+        [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      ]
+    }
+  },
+  "outputs": {
+    "k_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) for the 6 edges in TET_LOCAL_EDGES order. Tolerance is loose absolute (f32-friendly tripwire); the Rust comparator layers a backend-aware mixed abs/rel check on top.",
+      "tolerance_abs": 0.001,
+      "data": [
+        [
+          [
+            0.9428090415820631,
+            -0.47140452079103157,
+            -0.47140452079103157,
+            0.47140452079103157,
+            0.47140452079103157,
+            0.0
+          ],
+          [
+            -0.47140452079103157,
+            0.9428090415820631,
+            -0.47140452079103157,
+            -0.47140452079103157,
+            0.0,
+            0.47140452079103157
+          ],
+          [
+            -0.47140452079103157,
+            -0.47140452079103157,
+            0.9428090415820631,
+            0.0,
+            -0.47140452079103157,
+            -0.47140452079103157
+          ],
+          [
+            0.47140452079103157,
+            -0.47140452079103157,
+            0.0,
+            0.9428090415820631,
+            -0.47140452079103157,
+            0.47140452079103157
+          ],
+          [
+            0.47140452079103157,
+            0.0,
+            -0.47140452079103157,
+            -0.47140452079103157,
+            0.9428090415820631,
+            -0.47140452079103157
+          ],
+          [
+            0.0,
+            0.47140452079103157,
+            -0.47140452079103157,
+            0.47140452079103157,
+            -0.47140452079103157,
+            0.9428090415820631
+          ]
+        ]
+      ]
+    },
+    "m_local": {
+      "shape": [
+        1,
+        6,
+        6
+      ],
+      "dtype": "f64",
+      "description": "Local Whitney 1-form mass M_{ij} per nedelec.rs:67-74. Same edge order and sign convention as k_local.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        [
+          [
+            0.04124789556921526,
+            0.008838834764831842,
+            0.008838834764831842,
+            -0.008838834764831842,
+            -0.008838834764831842,
+            0.0
+          ],
+          [
+            0.008838834764831842,
+            0.04124789556921526,
+            0.008838834764831842,
+            0.008838834764831844,
+            0.0,
+            -0.008838834764831842
+          ],
+          [
+            0.008838834764831842,
+            0.008838834764831842,
+            0.04124789556921526,
+            0.0,
+            0.008838834764831844,
+            0.008838834764831844
+          ],
+          [
+            -0.008838834764831842,
+            0.008838834764831844,
+            0.0,
+            0.04124789556921526,
+            0.008838834764831842,
+            -0.008838834764831842
+          ],
+          [
+            -0.008838834764831842,
+            0.0,
+            0.008838834764831844,
+            0.008838834764831842,
+            0.04124789556921526,
+            0.008838834764831844
+          ],
+          [
+            0.0,
+            -0.008838834764831842,
+            0.008838834764831844,
+            -0.008838834764831842,
+            0.008838834764831844,
+            0.04124789556921526
+          ]
+        ]
+      ]
+    },
+    "signed_volume": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Signed element volume V = det(J)/6. Negative for inverted tets; use |signed_volume| for assembly weighting.",
+      "tolerance_abs": 1e-05,
+      "data": [
+        0.11785113019775789
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/numpy/nedelec_local_matrices.py via reference/numpy/gen_nedelec_local_per_case.py @ acb7be7",
+    "verified_against": "crates/geode-validation/tests/nedelec_local_numpy_reference.rs",
+    "issue": "#117 (Epic #88 Phase G.1)"
+  }
+}

--- a/reference/numpy/gen_nedelec_local_per_case.py
+++ b/reference/numpy/gen_nedelec_local_per_case.py
@@ -1,0 +1,324 @@
+"""Generate per-case canonical fixtures under ``fixtures/nedelec_local/<case>.json``.
+
+Mirror of ``gen_p1_local_per_case.py`` for the Nédélec curl-conforming
+edge-element kernel. Five canonical cases — same tet geometry as the
+P1 fixture set, so a reviewer can hold the P1 and Nédélec fixtures
+side-by-side for the same tet and see how the edge-element math
+differs from the nodal-P1 math on identical geometry.
+
+The five cases (per issue #117 acceptance criteria) are:
+
+  1. Canonical reference tet ``[(0,0,0), (1,0,0), (0,1,0), (0,0,1)]``.
+  2. Regular tet (vertices of a regular tetrahedron, centered at origin,
+     unit edge length).
+  3. Anisotropic-but-well-shaped tet (1 x 0.5 x 0.25 axis stretch on the
+     reference tet — well-conditioned, but with non-unit aspect ratio).
+  4. Near-degenerate sliver tet (three vertices nearly coplanar; small
+     positive volume, condition number is bad but determinant is not zero).
+  5. Inverted tet (vertices 2 and 3 swapped on the reference tet → the
+     orientation flips, signed volume becomes negative).
+
+Per-case canonical schema (per issue #101 / #117)
+-------------------------------------------------
+Each output file is in the canonical schema v1 documented in
+``reference/SCHEMA.md``. The Rust comparator at
+``crates/geode-validation/tests/nedelec_local_numpy_reference.rs``
+layers a backend-aware mixed abs/rel check on top to enforce the
+``1e-10`` rel / ``1e-12`` abs acceptance criterion under ``ndarray``
+(f64) and ``5e-5`` rel / ``1e-6`` abs under f32 GPU backends.
+
+Edge-orientation contract
+-------------------------
+The NumPy reference treats every local edge as oriented from the
+lower-index local vertex to the higher (``s_i = +1`` for all i). The
+fixture pins this explicitly via a ``tet_local_edge_signs`` input field
+of shape ``(1, 6)`` so the Rust harness can apply the documented
+``s_i s_j`` sign correction (``nedelec.rs:30-34``) to the Burn output
+before comparing. This decouples the local-kernel test from the
+global edge-table builder (a Phase G.2 concern).
+
+Run
+---
+    python3 reference/numpy/gen_nedelec_local_per_case.py
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent  # reference/ -> repo root
+FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "nedelec_local"
+
+# Add this dir to sys.path so we can import the sibling module under the
+# same name regardless of cwd.
+sys.path.insert(0, str(HERE))
+from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+
+
+def _ref_tet():
+    """Canonical reference tet — the affine map identity."""
+    return np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+
+
+def _regular_tet():
+    """Regular tetrahedron, unit edge length, centered at origin."""
+    raw = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [-1.0, -1.0, 1.0],
+            [-1.0, 1.0, -1.0],
+            [1.0, -1.0, -1.0],
+        ],
+        dtype=np.float64,
+    )
+    raw /= 2.0 * math.sqrt(2.0)
+    return raw
+
+
+def _anisotropic_tet():
+    """Reference tet stretched anisotropically (1, 0.5, 0.25)."""
+    base = _ref_tet()
+    scale = np.array([1.0, 0.5, 0.25], dtype=np.float64)
+    return base * scale
+
+
+def _sliver_tet():
+    """Near-degenerate sliver tet — v3 barely lifted out of the xy plane."""
+    return np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.3, 0.3, 1.0e-6],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _inverted_tet():
+    """Reference tet with vertices 2 and 3 swapped — negative signed volume."""
+    return np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+
+
+# Each tuple: (case_slug, builder_fn, description, per-field tolerance_abs).
+# Tolerances are loose absolute (catch catastrophic regression /
+# structural mistakes); the Rust comparator layers a tighter
+# backend-aware mixed abs/rel check on top.
+#
+# Scale notes (for picking absolute tolerances):
+#   - K entries on the reference tet are O(1); regular tet O(10); the
+#     anisotropic case is O(10) too. We use 1e-4 to clear the f32
+#     5e-5 relative envelope on entries of magnitude 1.
+#   - M entries on the reference tet are O(1e-2); on the sliver, the
+#     M scale collapses to O(V) = O(1e-7), so absolute 1e-12 is
+#     ~5e-5 of the max entry there.
+#   - K on the sliver is O(1 / V) = O(1e6); 1e2 ~ 5e-5 of max.
+CASES = [
+    (
+        "canonical_reference_tet",
+        _ref_tet,
+        "Nédélec edge-element local matrices for the canonical reference tet "
+        "[(0,0,0),(1,0,0),(0,1,0),(0,0,1)] — the affine identity. On this tet "
+        "the per-edge entry K[0,0] = 4/3 exactly and M[0,0] = 1/12 exactly; "
+        "the rest of K and M follow from the closed-form math in "
+        "crates/geode-core/src/nedelec.rs:51-74. Spot-check entries are "
+        "documented in the file's `description` and verified at NumPy generation time.",
+        {"k_local": 1.0e-4, "m_local": 1.0e-5, "signed_volume": 1.0e-5},
+    ),
+    (
+        "regular_tet",
+        _regular_tet,
+        "Nédélec edge-element local matrices for a regular tetrahedron "
+        "(unit edge length, centered at origin). Same geometry as the P1 "
+        "regular_tet fixture; included so the two reference sets can be "
+        "compared on identical tets.",
+        {"k_local": 1.0e-3, "m_local": 1.0e-5, "signed_volume": 1.0e-5},
+    ),
+    (
+        "anisotropic_well_shaped",
+        _anisotropic_tet,
+        "Nédélec edge-element local matrices for the reference tet scaled "
+        "by (1, 0.5, 0.25) per axis — anisotropic but well-shaped. K "
+        "entries scale up as the smaller axis shrinks.",
+        {"k_local": 1.0e-3, "m_local": 1.0e-6, "signed_volume": 1.0e-6},
+    ),
+    (
+        "near_degenerate_sliver",
+        _sliver_tet,
+        "Nédélec edge-element local matrices for a near-coplanar sliver tet "
+        "(v3.z = 1e-6) — small but strictly positive volume. Stress case "
+        "for numerical stability of the closed-form K/M; K entries reach "
+        "O(1e6) and M entries O(1e4) here as 1/|det| amplifies the gram "
+        "values through both the curl-curl gradient products and the "
+        "Whitney mass (V/20) G_pq = gg_pq / (120 |det|) lift.",
+        # K entries max O(1.3e6); 5e-5 * 1.3e6 ~ 65 → use 1e2 absolute.
+        # M entries max O(2.6e4); 5e-5 * 2.6e4 ~ 1.3 → use 1e1 absolute.
+        # V is O(1.7e-7); 1e-11 is ~6e-5 relative.
+        {"k_local": 1.0e2, "m_local": 1.0e1, "signed_volume": 1.0e-11},
+    ),
+    (
+        "inverted_tet",
+        _inverted_tet,
+        "Nédélec edge-element local matrices for the reference tet with "
+        "vertices 2 and 3 swapped — same |V| as canonical_reference_tet "
+        "but negative signed volume. K and M are computed from V = |det|/6 "
+        "(the absolute volume), so the K and M entries are the *same shape* "
+        "as the canonical case modulo edge-index permutation; the signed "
+        "volume is the only diagnostic that flips sign.",
+        {"k_local": 1.0e-4, "m_local": 1.0e-5, "signed_volume": 1.0e-5},
+    ),
+]
+
+
+def _git_commit() -> str:
+    """Return current git HEAD short SHA, or 'unknown'."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _nested(a: np.ndarray) -> list:
+    return a.tolist()
+
+
+def main():
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    sha = _git_commit()
+
+    summary = []
+    for slug, builder, description, tols in CASES:
+        verts = builder()
+        coords = verts[None, :, :]  # (1, 4, 3)
+        k, m, v = batched_nedelec_local_matrices(coords)
+
+        # Pin the local-edge-sign vector for this case. G.1 always uses
+        # all-+1 (lower-vertex-to-higher); G.2 will introduce non-trivial
+        # signs when the global edge-table builder is exercised.
+        edge_signs = np.ones((1, 6), dtype=np.float64)
+
+        fixture = {
+            "schema_version": "1",
+            "fixture_id": f"nedelec_local/{slug}",
+            "description": description,
+            "units": "dimensionless",
+            "inputs": {
+                "coords": {
+                    "shape": [1, 4, 3],
+                    "dtype": "f64",
+                    "description": (
+                        "Per-element vertex coordinates "
+                        "[n_elem, 4 vertices, 3 spatial dims]."
+                    ),
+                    "data": _nested(coords),
+                },
+                "tet_local_edge_signs": {
+                    "shape": [1, 6],
+                    "dtype": "f64",
+                    "description": (
+                        "Per-element, per-edge sign s_i in {+1, -1} recording "
+                        "whether each local edge's orientation (lower local "
+                        "vertex index → higher) agrees with the global edge "
+                        "direction. NumPy reference always uses +1 for all "
+                        "six edges; the Rust harness multiplies the Burn "
+                        "output's [i, j] entry by s_i * s_j before comparing "
+                        "(per nedelec.rs:30-34). Edge order is canonical: "
+                        "[(0,1), (0,2), (0,3), (1,2), (1,3), (2,3)]."
+                    ),
+                    "data": _nested(edge_signs),
+                },
+            },
+            "outputs": {
+                "k_local": {
+                    "shape": [1, 6, 6],
+                    "dtype": "f64",
+                    "description": (
+                        "Local curl-curl K_{ij} = 4 V (G_ac G_bd - G_ad G_bc) "
+                        "for the 6 edges in TET_LOCAL_EDGES order. Tolerance "
+                        "is loose absolute (f32-friendly tripwire); the Rust "
+                        "comparator layers a backend-aware mixed abs/rel "
+                        "check on top."
+                    ),
+                    "tolerance_abs": tols["k_local"],
+                    "data": _nested(k),
+                },
+                "m_local": {
+                    "shape": [1, 6, 6],
+                    "dtype": "f64",
+                    "description": (
+                        "Local Whitney 1-form mass M_{ij} per "
+                        "nedelec.rs:67-74. Same edge order and sign "
+                        "convention as k_local."
+                    ),
+                    "tolerance_abs": tols["m_local"],
+                    "data": _nested(m),
+                },
+                "signed_volume": {
+                    "shape": [1],
+                    "dtype": "f64",
+                    "description": (
+                        "Signed element volume V = det(J)/6. Negative for "
+                        "inverted tets; use |signed_volume| for assembly "
+                        "weighting."
+                    ),
+                    "tolerance_abs": tols["signed_volume"],
+                    "data": [float(v[0])],
+                },
+            },
+            "provenance": {
+                "source": (
+                    "reference/numpy/nedelec_local_matrices.py via "
+                    f"reference/numpy/gen_nedelec_local_per_case.py @ {sha}"
+                ),
+                "verified_against": (
+                    "crates/geode-validation/tests/"
+                    "nedelec_local_numpy_reference.rs"
+                ),
+                "issue": "#117 (Epic #88 Phase G.1)",
+            },
+        }
+
+        out_path = FIXTURE_DIR / f"{slug}.json"
+        with open(out_path, "w") as f:
+            json.dump(fixture, f, indent=2, sort_keys=False)
+            f.write("\n")
+
+        signed_v = float(v[0])
+        summary.append(
+            (slug, out_path, signed_v, float(k.max()), float(np.abs(m).max()), os.path.getsize(out_path))
+        )
+
+    print(f"Wrote {len(summary)} per-case canonical fixtures to {FIXTURE_DIR}")
+    for slug, path, signed_v, k_max, m_max, size in summary:
+        print(
+            f"  - {slug:30s} V_signed = {signed_v:+.6e}  "
+            f"max|K| = {k_max:.3e}  max|M| = {m_max:.3e}  ({size} bytes)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/numpy/nedelec_local_matrices.py
+++ b/reference/numpy/nedelec_local_matrices.py
@@ -1,0 +1,272 @@
+"""NumPy reference for batched Nédélec edge-element local curl-curl and mass.
+
+Faithful transcription of the closed-form expressions documented in
+``crates/geode-core/src/nedelec.rs`` (module-level docstring, lines 51-74).
+Sister of ``reference/numpy/p1_local_matrices.py``: same geometry, same
+``[n_elem, 4, 3]`` input shape, same affine machinery — but the per-element
+output is the 6x6 Whitney edge-element pair, one entry per ordered edge
+pair in ``TET_LOCAL_EDGES``.
+
+Per issue #117 / Epic #88 phase G.1, this is intentionally *not* a clever
+vectorized rewrite. It is the math, in code, in NumPy, with named
+intermediates that match the symbols in the Rust docstring one-for-one.
+Cross-checkability against ``nedelec.rs:51-74`` is the point — a reader
+should be able to put this file side-by-side with the Burn-side kernel
+and read the same formula in both.
+
+The math
+========
+
+For a tet with vertices ``v_0, v_1, v_2, v_3``, the P1 nodal basis has
+gradients ``grad(lambda_p) = g_p / det(J)`` where ``g_p`` is the same
+"area-weighted gradient" used by the P1 reference. The gram matrix on
+the physical gradients is
+
+    G_pq = grad(lambda_p) . grad(lambda_q) = (g_p . g_q) / det(J)^2.
+
+We deliberately *don't* form ``G`` explicitly. Instead, the documented
+cofactor reformulation in ``nedelec.rs:199-210`` folds the
+``1/det(J)^2`` factor into the per-entry K and M scales, keeping the
+gram entries ``gg_pq = g_p . g_q`` at modest magnitude even on
+near-degenerate tets where ``det(J) -> 0``. This matters in practice:
+on the ``near_degenerate_sliver`` case (``det ~ 1e-6``), forming
+``G_33 = gg_33/det^2`` directly costs ~6 decimal digits of mantissa to
+the ``G*G - G*G`` cancellation in K, while the cofactor form keeps the
+``gg*gg - gg*gg`` step well-conditioned and concentrates the blowup in
+a clean ``1/|det|^3`` broadcast.
+
+The 6 local edges, in the canonical ``TET_LOCAL_EDGES`` order, are
+
+    edge 0: (a, b) = (0, 1)
+    edge 1: (a, b) = (0, 2)
+    edge 2: (a, b) = (0, 3)
+    edge 3: (a, b) = (1, 2)
+    edge 4: (a, b) = (1, 3)
+    edge 5: (a, b) = (2, 3)
+
+This reference treats every local edge as oriented from the lower-index
+local vertex ``a`` to the higher-index local vertex ``b`` — i.e. all
+local edge signs ``s_i = +1``. The global sign-flip step (per-tet
+``s_i s_j`` row/column scaling, ``nedelec.rs:30-34``) is decoupled from
+this local kernel and lives in the Rust harness.
+
+With ``i = (a, b)``, ``j = (c, d)`` ordered pairs and
+``V = |det(J)| / 6``,
+
+Curl-curl (cofactor form, exact rewrite of ``4 V (G_ac G_bd - G_ad G_bc)``)::
+
+    K_{ij} = (2 / 3) * (gg_ac gg_bd - gg_ad gg_bc) / |det|^3.   (eq. K)
+
+Mass (Whitney 1-form integrated through ``int lambda_p lambda_q = (V/20)(1 + delta_pq)``,
+also in cofactor form, with ``(V/20) G_pq = gg_pq / (120 |det|)``)::
+
+    M_{ij} = (1 / (120 |det|)) [   (1 + delta_ac) gg_bd
+                                 - (1 + delta_ad) gg_bc
+                                 - (1 + delta_bc) gg_ad
+                                 + (1 + delta_bd) gg_ac ].      (eq. M)
+
+These are exact. No quadrature is required: the Whitney curl
+``grad x N_i = 2 (grad lambda_a x grad lambda_b)`` is piecewise constant
+per tet, and the four-Kronecker mass expansion above is the exact lift
+of the cubic ``N_i . N_j`` polynomial under the standard tet moment
+formula.
+
+Public API
+==========
+
+``batched_nedelec_local_matrices(coords) -> (k_local, m_local, signed_volumes)``
+
+``TET_LOCAL_EDGES`` — the 6-pair canonical ordering, exported for use by
+the per-case fixture generator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+# Reuse the P1 reference's signed-volume / area-weighted-gradient
+# helpers verbatim. This is by design — the issue acceptance criteria
+# call out that the signed-volume computation should not be duplicated.
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+
+# Canonical local edge order on a tet. Mirrors
+# ``crates/geode-core/src/mesh/mod.rs::TET_LOCAL_EDGES``; the order is
+# fixed across the codebase and used by both the host-side edge-table
+# builder and the batched local-matrix kernel.
+TET_LOCAL_EDGES: tuple[tuple[int, int], ...] = (
+    (0, 1),
+    (0, 2),
+    (0, 3),
+    (1, 2),
+    (1, 3),
+    (2, 3),
+)
+
+
+def _cofactor_gram(coords: np.ndarray):
+    """Return ``(gg, det, signed_volumes)`` for a batch of tets.
+
+    ``gg`` has shape ``(n_elem, 4, 4)`` with ``gg[e, p, q] = g_p . g_q``,
+    the **cofactor** gradient gram (i.e. the physical gradient
+    ``grad(lambda_p)`` scaled by ``det(J)``). The physical gram is
+    ``G_pq = gg_pq / det^2`` — but we deliberately *don't* form ``G`` here
+    because the explicit divide-by-``det^2`` is numerically catastrophic
+    on near-degenerate tets where ``det -> 0``. Instead, the divide is
+    folded into the per-entry K and M scales (``1/|det|^3`` and
+    ``1/|det|`` respectively, exactly matching the documented
+    reformulation in ``crates/geode-core/src/nedelec.rs:199-210``).
+
+    ``signed_volumes`` is taken from the P1 reference to avoid
+    duplicating the ``det(J) / 6`` helper across two files.
+    """
+    coords = np.asarray(coords, dtype=np.float64)
+    if coords.ndim != 3 or coords.shape[1:] != (4, 3):
+        raise ValueError(
+            f"expected coords shape (n_elem, 4, 3), got {coords.shape}"
+        )
+
+    # Per-vertex slices, each (n_elem, 3).
+    v0 = coords[:, 0, :]
+    v1 = coords[:, 1, :]
+    v2 = coords[:, 2, :]
+    v3 = coords[:, 3, :]
+
+    # Edge vectors from v0, each (n_elem, 3).
+    e1 = v1 - v0
+    e2 = v2 - v0
+    e3 = v3 - v0
+
+    # Area-weighted basis gradients g_1, g_2, g_3 (each (n_elem, 3)).
+    g1 = np.cross(e2, e3)
+    g2 = np.cross(e3, e1)
+    g3 = np.cross(e1, e2)
+    # g_0 = -(g_1 + g_2 + g_3), shape (n_elem, 3).
+    g0 = -(g1 + g2 + g3)
+
+    # det(J) per element = e_1 . g_1, shape (n_elem,).
+    det = np.einsum("ij,ij->i", e1, g1)
+
+    # Stack g_p into a (n_elem, 4, 3) array.
+    g_mat = np.stack([g0, g1, g2, g3], axis=1)
+
+    # gg[e, p, q] = g_p . g_q via per-batch G @ G^T. Modest magnitudes
+    # even on near-degenerate tets — the small-`det` blowup is moved
+    # entirely to the per-entry K and M scale factors.
+    gg = np.einsum("eik,ejk->eij", g_mat, g_mat)
+
+    # Defer signed_volume to the P1 reference: V_signed = det(J) / 6.
+    _, _, signed_volumes = batched_p1_local_matrices(coords)
+
+    return gg, det, signed_volumes
+
+
+def batched_nedelec_local_matrices(coords):
+    """Compute Nédélec local curl-curl, mass, and signed volume per tet.
+
+    Parameters
+    ----------
+    coords : ndarray, shape ``(n_elem, 4, 3)``, dtype float64
+        Per-element tet vertex coordinates.
+
+    Returns
+    -------
+    k_local : ndarray, shape ``(n_elem, 6, 6)``, dtype float64
+        Local curl-curl stiffness ``K_{ij} = 4 V (G_ac G_bd - G_ad G_bc)``
+        per the canonical edge order in :data:`TET_LOCAL_EDGES`. All
+        local edge signs are treated as ``+1`` (lower-vertex-to-higher);
+        the global ``s_i s_j`` correction is the caller's responsibility.
+    m_local : ndarray, shape ``(n_elem, 6, 6)``, dtype float64
+        Local mass matrix per equation (M) above. Same orientation
+        convention as ``k_local``.
+    signed_volumes : ndarray, shape ``(n_elem,)``, dtype float64
+        Signed element volume ``det(J) / 6``. Negative for inverted tets.
+    """
+    coords = np.asarray(coords, dtype=np.float64)
+    if coords.ndim != 3 or coords.shape[1:] != (4, 3):
+        raise ValueError(
+            f"expected coords shape (n_elem, 4, 3), got {coords.shape}"
+        )
+
+    n_elem = coords.shape[0]
+
+    gg, det, signed_volumes = _cofactor_gram(coords)
+    abs_det = np.abs(det)  # |det(J)|, shape (n_elem,)
+
+    # Per-entry scale factors (mirror nedelec.rs:228-229). The blowup at
+    # det -> 0 is concentrated in these scalar broadcasts; the gg entries
+    # themselves stay O(1) on the sliver, so the gg*gg - gg*gg
+    # cancellation in K stays well-conditioned and we don't lose 6+
+    # digits of mantissa the way a precomputed G = gg/det^2 would.
+    inv_abs_det = 1.0 / abs_det
+    inv_abs_det3 = inv_abs_det * inv_abs_det * inv_abs_det
+
+    k_local = np.zeros((n_elem, 6, 6), dtype=np.float64)
+    m_local = np.zeros((n_elem, 6, 6), dtype=np.float64)
+
+    for i, (a, b) in enumerate(TET_LOCAL_EDGES):
+        for j, (c, d) in enumerate(TET_LOCAL_EDGES):
+            # Per-element cofactor-gram entries: each shape (n_elem,).
+            gg_ac = gg[:, a, c]
+            gg_ad = gg[:, a, d]
+            gg_bc = gg[:, b, c]
+            gg_bd = gg[:, b, d]
+
+            # Curl-curl in the documented cofactor reformulation
+            # (nedelec.rs:199-210):
+            #   K_{ij} = (2/3) * (gg_ac gg_bd - gg_ad gg_bc) / |det|^3.
+            # Mathematically identical to `4 V (G_ac G_bd - G_ad G_bc)`
+            # but numerically far better behaved on near-degenerate tets.
+            k_local[:, i, j] = (
+                (2.0 / 3.0)
+                * (gg_ac * gg_bd - gg_ad * gg_bc)
+                * inv_abs_det3
+            )
+
+            # Mass: four Kronecker-delta-lifted terms, each (1 + delta) G_pq.
+            # Folding (V/20) G_pq = (|det|/120)(gg_pq/det²) = gg_pq/(120|det|)
+            # into a single scalar multiply (nedelec.rs:208-210).
+            f_ac = 2.0 if a == c else 1.0
+            f_ad = 2.0 if a == d else 1.0
+            f_bc = 2.0 if b == c else 1.0
+            f_bd = 2.0 if b == d else 1.0
+            m_term = (
+                f_ac * gg_bd
+                - f_ad * gg_bc
+                - f_bc * gg_ad
+                + f_bd * gg_ac
+            )
+            m_local[:, i, j] = m_term * inv_abs_det / 120.0
+
+    return k_local, m_local, signed_volumes
+
+
+if __name__ == "__main__":
+    # Self-check on the canonical reference tet. With
+    # grad(lambda_0) = (-1, -1, -1), grad(lambda_1) = (1, 0, 0),
+    # grad(lambda_2) = (0, 1, 0), grad(lambda_3) = (0, 0, 1) and V = 1/6,
+    # edge (0,1) = (a,b) = (0,1) gives
+    #   K[0,0] = 4 V (G_00 G_11 - G_01 G_01)
+    #          = (4/6) (3 * 1 - (-1)^2)
+    #          = (4/6) * 2 = 4/3.
+    # M[0,0] = (V/20) [ (1 + delta_00) G_11 - (1 + 0) G_10
+    #                   - (1 + 0) G_10 + (1 + delta_11) G_00 ]
+    #        = (1/120) [ 2*1 - (-1) - (-1) + 2*3 ]
+    #        = (1/120) * 10 = 1/12.
+    ref = np.array(
+        [[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+        dtype=np.float64,
+    )
+    k, m, v = batched_nedelec_local_matrices(ref)
+    print("K (ref tet):")
+    print(k[0])
+    print("M (ref tet):")
+    print(m[0])
+    print(f"V (ref tet, signed) = {v[0]}")
+    print(f"Expected K[0,0] = 4/3 = {4.0 / 3.0}; got {k[0, 0, 0]}")
+    print(f"Expected M[0,0] = 1/12 = {1.0 / 12.0}; got {m[0, 0, 0]}")


### PR DESCRIPTION
## Summary

Phase G.1 of Epic #88 (multi-backend reference set) — the vector-spine
analog of #90 / PR #96 for P1, now consolidated onto the
`geode-validation` harness pattern from PR #105.

Pins the closed-form Nédélec 6×6 curl-curl and mass kernels in
`crates/geode-core/src/nedelec.rs:51-74` against a faithful NumPy
transcription. Five canonical schema-v1 fixtures, backend-aware mixed
abs/rel comparator, full edge-orientation contract decoupled from the
global edge-table builder (G.2 / #118).

### Files

- `reference/numpy/nedelec_local_matrices.py` — 6×6 closed-form K and M in the cofactor reformulation documented at `nedelec.rs:199-210`.
- `reference/numpy/gen_nedelec_local_per_case.py` — emits five per-case fixtures, mirroring `gen_p1_local_per_case.py`.
- `reference/fixtures/nedelec_local/{canonical_reference_tet,regular_tet,anisotropic_well_shaped,near_degenerate_sliver,inverted_tet}.json` — canonical schema-v1, each pins a per-case `tet_local_edge_signs` field documenting the local-edge-sign convention (G.1 uses all-+1 lower-vertex-to-higher).
- `crates/geode-validation/tests/nedelec_local_numpy_reference.rs` — backend-aware mixed abs/rel comparator (`1e-10` rel / `1e-12` abs under ndarray f64; `5e-5` rel / `1e-6` abs under f32 GPU). Layers the fixture's declared `tolerance_abs` as a per-field absolute floor so the intrinsic-precision-loss sliver case isn't masked behind a magic per-backend constant. The sliver is skipped under f32 with an explicit rationale (the `gg*gg - gg*gg` cancellation amplified by `1/|det|^3 ~ 1e18` cannot be represented in single precision regardless of impl).
- Hand-verified spot checks on the canonical reference tet (K[0,0]=4/3, M[0,0]=1/12, K[5,5]=2/3, M[5,5]=1/30, V=1/6) pinned via `canonical_reference_tet_pins_hand_verified_entries`.

### Drive-by precision fix

`crates/geode-core/src/nedelec.rs:238` previously used `2.0_f32 / 3.0`, truncating the ratio to single precision *before* upcasting on the f64 backend. That cost ~5e-8 of accuracy on `ndarray` (well above the `1e-10` rel acceptance criterion) without affecting the f32 path. Switched to `2.0_f64 / 3.0`; same for the mass `(1 + δ)` prefactors for code-doc consistency. Burn's `mul_scalar` still converts to the backend element type at apply time, so the wgpu/cuda paths are byte-identical.

## Test plan

- [x] `cargo test -p geode-validation --no-default-features --features geode-core/ndarray --test nedelec_local_numpy_reference` — 5/5 pass under ndarray f64.
- [x] `cargo test -p geode-validation --test nedelec_local_numpy_reference` — 5/5 pass under wgpu f32 (sliver auto-skipped with rationale).
- [x] `cargo test -p geode-core --no-default-features --features ndarray --test nedelec` — 12/12 existing integration tests still pass after the f32-literal fix.
- [x] `cargo test -p geode-core --test nedelec` — 12/12 under wgpu.
- [x] `cargo clippy --workspace --no-default-features --features geode-core/ndarray --tests` — clean.
- [x] `cargo fmt --check` — no diffs in files touched by this PR (4 pre-existing diffs in `crates/geode-core/tests/{p1_local_matrices.rs,nedelec.rs,assembly.rs}` left untouched).

## Out of scope (G.2 / #118)

- Global edge enumeration + sign convention (`TetMesh::tet_edges`).
- Global gather/scatter assembly to a sparse `[n_edges, n_edges]` system.
- Gmsh `.msh` parsing with physical-group tags.
- PEC Dirichlet edge masking.
- Generalized eigensolve + spurious-mode cluster identification.
- Sphere PEC spectrum cross-check.

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)