### PR TITLE
feat: Phase F.2 — ONNX cube-cavity assembly graph (Epic #88)

### DIFF
--- a/.github/workflows/onnx-cube-cavity.yml
+++ b/.github/workflows/onnx-cube-cavity.yml
@@ -1,0 +1,238 @@
+name: onnx-cube-cavity
+
+# Gated CI job for the ONNX cube-cavity reference (Epic #88 / Phase F.2,
+# issue #123).
+#
+# ONNX is the graph-only constraint backend per Epic #88's framing. The
+# Phase F.1 audit (issue #116, PR #119) established that the cube-cavity
+# assembly spine lowers cleanly to opset 18; Phase F.2 (this gate) is the
+# runtime payload — the end-to-end ONNX assembly graph, the SciPy
+# eigensolve seam, and the cross-IR agreement gate.
+#
+# Triggers:
+#   1. Path-filtered `pull_request` / `push` to main: runs only when the
+#      change actually touches the ONNX reference, its baseline fixture,
+#      the sidecar driver, the cross-IR comparator, or the NumPy mesh
+#      deps that the comparator pulls in.
+#   2. Manual `workflow_dispatch`: run on demand against any branch with
+#      configurable `n` (default 10, matching baseline.json + the new
+#      onnx_baseline.json) and `rtol` (default 1e-5, matching the Epic
+#      #88 framing for cross-language f64 reproducibility).
+#
+# Scope clarification (parallel to the issue #111 framing for the
+# TF-Java gate, and the Julia gate's n=10 alignment with the canonical
+# NumPy baseline.json):
+# This gate is three-way — it checks the ONNX row against the canonical
+# NumPy baseline.json (n=10) and a freshly-emitted NumPy baseline row
+# at the same n. The JAX row is shown for diagnostic context but is
+# excluded from the rtol gate via `--skip-jax-comparison` because
+# `jax_baseline.json` is pinned at n=4 while this gate runs at the
+# n=10 canonical mesh (same convention as julia-cube-cavity.yml).
+# Burn agreement is exercised separately by the per-push
+# `cube_cavity_onnx_reference` cargo test and by `arpack.yml`.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'reference/onnx/**'
+      - 'reference/driver/eigensolve_from_onnx.py'
+      - 'reference/driver/compare_eigenvalues.py'
+      - 'reference/driver/emit_numpy_eigenvalues.py'
+      - 'reference/numpy/cube_cavity.py'
+      - 'reference/numpy/cube_cavity_minimal.py'
+      - 'reference/numpy/mesh.py'
+      - 'reference/numpy/p1_local_matrices.py'
+      - 'reference/numpy/requirements.txt'
+      - 'reference/fixtures/cube_cavity/jax_baseline.json'
+      - 'reference/fixtures/cube_cavity/baseline.json'
+      - 'reference/fixtures/cube_cavity/onnx_baseline.json'
+      - '.github/workflows/onnx-cube-cavity.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'reference/onnx/**'
+      - 'reference/driver/eigensolve_from_onnx.py'
+      - 'reference/driver/compare_eigenvalues.py'
+      - 'reference/driver/emit_numpy_eigenvalues.py'
+      - 'reference/numpy/cube_cavity.py'
+      - 'reference/numpy/cube_cavity_minimal.py'
+      - 'reference/numpy/mesh.py'
+      - 'reference/numpy/p1_local_matrices.py'
+      - 'reference/numpy/requirements.txt'
+      - 'reference/fixtures/cube_cavity/jax_baseline.json'
+      - 'reference/fixtures/cube_cavity/baseline.json'
+      - 'reference/fixtures/cube_cavity/onnx_baseline.json'
+      - '.github/workflows/onnx-cube-cavity.yml'
+  workflow_dispatch:
+    inputs:
+      n:
+        description: 'Cells per side for the cube mesh (default 10 — matches baseline.json + onnx_baseline.json).'
+        required: false
+        default: '10'
+      rtol:
+        description: 'Relative tolerance for the cross-backend eigenvalue gate.'
+        required: false
+        default: '1e-5'
+
+jobs:
+  build-and-cross-check:
+    name: ONNX assembly + SciPy eigensolve + cross-IR agreement (ONNX vs JAX vs NumPy)
+    runs-on: ubuntu-latest
+    env:
+      # `n` and `rtol` are derived once here so manual-dispatch overrides
+      # flow into every step. Defaults match the AC: n=10, rtol=1e-5.
+      CUBE_N: ${{ inputs.n || '10' }}
+      CUBE_RTOL: ${{ inputs.rtol || '1e-5' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            reference/onnx/requirements.txt
+            reference/numpy/requirements.txt
+
+      - name: Install Python deps (ONNX + NumPy + SciPy)
+        # The ONNX driver depends on onnx + onnxruntime; the comparator
+        # and NumPy emitter both depend on numpy + scipy. We deliberately
+        # do NOT install JAX here — the JAX row of the agreement table
+        # (when shown) comes from the in-tree
+        # `reference/fixtures/cube_cavity/jax_baseline.json` snapshot.
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r reference/onnx/requirements.txt
+          python3 -m pip install -r reference/numpy/requirements.txt
+
+      - name: Show toolchain versions (debug)
+        run: |
+          python3 --version
+          python3 -c "import onnx, onnxruntime; print('onnx', onnx.__version__); print('onnxruntime', onnxruntime.__version__)"
+          python3 -c "import numpy, scipy; print('numpy', numpy.__version__); print('scipy', scipy.__version__)"
+
+      - name: Run ONNX assembly → sidecar dump
+        run: |
+          mkdir -p target/out
+          python3 reference/onnx/cube_cavity/gen_cube_cavity_reduced.py \
+              --n "${CUBE_N}" --side 1.0 \
+              --out target/out/reduced_kM.json
+          ls -lh target/out/
+
+      - name: Run SciPy eigensolve over the ONNX sidecar
+        run: |
+          python3 reference/driver/eigensolve_from_onnx.py \
+              target/out/reduced_kM.json \
+              --k 5 \
+              --out target/out/eigenresult_onnx.json
+          cat target/out/eigenresult_onnx.json
+
+      - name: Emit fresh NumPy reference eigenvalues for the same mesh
+        # Use the n=10 / mesh-loading reference (cube_cavity.py, not the
+        # minimal n=4 sibling) so the comparison is apples-to-apples with
+        # the ONNX n=10 run. Same convention as the Julia gate.
+        run: |
+          python3 - <<'PY'
+          import json, sys
+          sys.path.insert(0, "reference/numpy")
+          from cube_cavity import run_cube_cavity
+          n = int("${{ env.CUBE_N }}")
+          r = run_cube_cavity(
+              n=n, k=5,
+              mesh_path="reference/fixtures/cube_cavity/unit_cube.msh",
+          )
+          fixture = {
+              "schema_version": "1",
+              "fixture_id": f"cube_cavity/n{n}_numpy_canonical_in_gate",
+              "description": (
+                  "Freshly emitted NumPy n=" + str(n) + " baseline used by "
+                  "the ONNX cross-IR gate (issue #123). Same mesh + same "
+                  "pipeline as reference/fixtures/cube_cavity/baseline.json; "
+                  "regenerated in-job to keep the gate honest."
+              ),
+              "units": "dimensionless",
+              "inputs": {
+                  "n":    {"shape": [1], "dtype": "i64",
+                           "description": "Cells per side.", "data": [n]},
+                  "side": {"shape": [1], "dtype": "f64",
+                           "description": "Cube side.", "data": [1.0]},
+              },
+              "outputs": {
+                  "eigenvalues": {
+                      "shape": [5], "dtype": "f64",
+                      "description": "Lowest 5 eigenvalues, ascending.",
+                      "tolerance_abs": 1.0e-8,
+                      "data": r["eigenvalues"].tolist(),
+                  },
+              },
+              "provenance": {
+                  "source":
+                      "reference/numpy/cube_cavity.py via in-line emit "
+                      "(onnx-cube-cavity.yml gate, issue #123)",
+                  "issue": "#123",
+              },
+          }
+          with open("target/out/numpy_baseline.json", "w") as f:
+              json.dump(fixture, f, indent=2)
+              f.write("\n")
+          print("Wrote target/out/numpy_baseline.json")
+          PY
+
+      - name: Cross-IR agreement gate (ONNX vs JAX vs NumPy, rtol=${{ env.CUBE_RTOL }})
+        # AC#5 hard gate: ONNX eigenvalues must match the canonical NumPy
+        # baseline + freshly emitted NumPy row on the lowest 5 modes
+        # within `rtol`. The JAX row is shown for diagnostic context but
+        # excluded from the rtol gate (`--skip-jax-comparison`) because
+        # `jax_baseline.json` is pinned at n=4 while this gate runs at the
+        # n=10 canonical mesh — same convention as julia-cube-cavity.yml.
+        #
+        # A failure here is highly informative: ONNX-vs-NumPy disagreement
+        # at n=10 would isolate an onnxruntime-vs-SciPy assembly drift on
+        # the same algorithm. We always upload the agreement table as an
+        # artifact, regardless of pass/fail, so the Friction artifact
+        # stays visible.
+        #
+        # Burn agreement is intentionally not part of this gate; it is
+        # exercised by the `arpack` workflow and by the per-push
+        # `cube_cavity_onnx_reference` cargo test against the same ONNX
+        # baseline. The `--burn` flag is therefore omitted here.
+        run: |
+          python3 reference/driver/compare_eigenvalues.py \
+              --onnx target/out/eigenresult_onnx.json \
+              --jax  reference/fixtures/cube_cavity/jax_baseline.json \
+              --numpy reference/fixtures/cube_cavity/baseline.json \
+              --skip-jax-comparison \
+              --k 5 \
+              --rtol "${CUBE_RTOL}" \
+              --out target/out/agreement_table.md
+
+      - name: Sanity-check freshly emitted NumPy row vs committed baseline.json
+        # Extra belt-and-braces: confirm the fresh in-job NumPy emit
+        # agrees with the committed canonical baseline.json. This is a
+        # regression guard for the NumPy reference itself; orthogonal to
+        # the ONNX agreement check above.
+        run: |
+          python3 reference/driver/compare_eigenvalues.py \
+              --onnx target/out/numpy_baseline.json \
+              --jax  reference/fixtures/cube_cavity/jax_baseline.json \
+              --numpy reference/fixtures/cube_cavity/baseline.json \
+              --skip-jax-comparison \
+              --k 5 \
+              --rtol "${CUBE_RTOL}"
+
+      - name: Upload ONNX sidecar + agreement artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: onnx-cube-cavity-artifacts
+          path: |
+            target/out/reduced_kM.json
+            target/out/eigenresult_onnx.json
+            target/out/numpy_baseline.json
+            target/out/agreement_table.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
@@ -1,0 +1,320 @@
+//! Cube-cavity Helmholtz cross-check: Burn (in-tree) vs the ONNX baseline.
+//!
+//! Structural mirror of `cube_cavity_jax_reference.rs` (Epic #88 / #93
+//! sibling) targeting the n=10 ONNX baseline shipped in Phase F.2
+//! (Epic #88 / issue #123). The Burn pipeline is run programmatically at
+//! the same n=10 / side=1.0 that produced `onnx_baseline.json`; the
+//! fixture's `eigenvalues`, `k_diag_sum`, `m_diag_sum` are compared
+//! against Burn's outputs through the canonical `Fixture::compare_against`
+//! path.
+//!
+//! # Running
+//!
+//! Faer's dense generalized eigensolver panics under debug_assertions
+//! (faer 0.24's `qz_real` subtraction overflow path), so this test is
+//! gated on `--release` like the sibling JAX / NumPy reference tests:
+//!
+//! ```sh
+//! cargo test -p geode-validation --release \
+//!     --test cube_cavity_onnx_reference -- --ignored
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use burn::tensor::backend::BackendTypes;
+use geode_core::{
+    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
+    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+};
+use geode_validation::{Fixture, FixtureFormat};
+
+type B = DefaultBackend;
+
+// ---------------------------------------------------------------------------
+// Backend-aware tolerance overrides
+// ---------------------------------------------------------------------------
+//
+// Mirrors the structure of `cube_cavity_jax_reference.rs`. The ONNX
+// fixture carries `tolerance_abs = 1e-12` on `k_diag_sum`/`m_diag_sum`
+// and `1e-8` on `eigenvalues` (in-tree NumPy-vs-ONNX agreement at
+// fixture-gen time is ~1.3e-15 relative). Those tolerances are too
+// tight for the f32 wgpu/cuda default path; under `--features ndarray`
+// they are too tight for Burn's upload-truncates-to-f32 friction
+// (whiteroom #5). The overrides below mirror the JAX-reference test's
+// pattern exactly, with the same numerical bounds.
+
+#[derive(Debug, Clone, Copy)]
+struct BackendTolerances {
+    /// Absolute tolerance on lowest-5 eigenvalues at n=10. The n=10
+    /// eigenvalues are O(10¹–10²); the JAX-reference test's 5e-5 absolute
+    /// tolerance translates to ~5e-7 relative at the lowest mode here,
+    /// comfortably above f32 accumulation and tight enough to catch a
+    /// real regression.
+    eigvals_abs: f64,
+    /// Absolute tolerance on trace(K_int) / trace(M_int) — pure
+    /// assembly readbacks. Same Burn `upload_mesh` f32-truncation
+    /// friction as the JAX-reference test (whiteroom #5).
+    trace_abs: f64,
+}
+
+const NDARRAY_F64_TOLERANCES: BackendTolerances = BackendTolerances {
+    // Even under --features ndarray, upload_mesh truncates coordinates
+    // to f32 at the tensor boundary (assembly.rs:83), so the in-tree
+    // f64 path still inherits ~f32-roughly-1e-7 precision on assembled
+    // matrices. Trace tolerances reflect Burn's actual delivered
+    // precision; once whiteroom #5 lands the upload fix, tighten these
+    // back to ~1e-12 to match the fixture's intrinsic tolerance.
+    eigvals_abs: 5.0e-5,
+    trace_abs: 1.0e-5,
+};
+
+const GPU_F32_TOLERANCES: BackendTolerances = BackendTolerances {
+    eigvals_abs: 5.0e-3,
+    trace_abs: 1.0e-3,
+};
+
+fn active_tolerances() -> BackendTolerances {
+    let info = geode_core::device_info();
+    if info.backend == "ndarray" {
+        NDARRAY_F64_TOLERANCES
+    } else {
+        GPU_F32_TOLERANCES
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture path
+// ---------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest.ancestors() {
+        if ancestor.join("reference").is_dir() {
+            return ancestor.to_path_buf();
+        }
+    }
+    panic!(
+        "could not find a `reference/` directory walking up from {}",
+        manifest.display()
+    );
+}
+
+fn fixture_path() -> PathBuf {
+    repo_root().join("reference/fixtures/cube_cavity/onnx_baseline.json")
+}
+
+// ---------------------------------------------------------------------------
+// Burn pipeline
+// ---------------------------------------------------------------------------
+
+/// Run the Burn cube-cavity pipeline for given `n` (programmatic mesh)
+/// and `side`. Returns `(lowest_k_eigenvalues, trace(K_int),
+/// trace(M_int))`.
+fn burn_cube_cavity(n: usize, side: f64, k: usize) -> (Vec<f64>, f64, f64) {
+    let device = <B as BackendTypes>::Device::default();
+    let mesh = cube_tet_mesh(n, side);
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &device);
+    let sys = assemble_global_p1(nodes, tets, mesh.n_nodes());
+    let k_mat = burn_matrix_to_faer(sys.k);
+    let m_mat = burn_matrix_to_faer(sys.m);
+    let mask = cube_interior_mask(&mesh.nodes, side);
+    let (k_int, m_int) =
+        apply_dirichlet_bc(k_mat.as_ref(), m_mat.as_ref(), &mask).expect("BC reduction");
+
+    let n_int = k_int.nrows();
+    let trk: f64 = (0..n_int).map(|i| k_int[(i, i)]).sum();
+    let trm: f64 = (0..n_int).map(|i| m_int[(i, i)]).sum();
+
+    let eigvals = FaerDenseEigensolver
+        .smallest_eigenvalues(k_int.as_ref(), m_int.as_ref(), k)
+        .expect("eigensolve");
+    (eigvals, trk, trm)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture input helpers
+// ---------------------------------------------------------------------------
+
+/// Pull an `i64` scalar input from the fixture (declared `dtype = i64`,
+/// shape `[1]`). Goes through the f64 flattener — the loader doesn't
+/// have a typed integer accessor at v1, so we round-trip via f64.
+fn input_i64(fixture: &Fixture, key: &str) -> i64 {
+    let field = fixture
+        .inputs
+        .get(key)
+        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
+    let v = flatten_numeric(&field.data);
+    assert_eq!(
+        v.len(),
+        1,
+        "expected scalar input `{key}`, got len {}",
+        v.len()
+    );
+    v[0] as i64
+}
+
+/// Pull an `f64` scalar input from the fixture.
+fn input_f64(fixture: &Fixture, key: &str) -> f64 {
+    let field = fixture
+        .inputs
+        .get(key)
+        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
+    let v = flatten_numeric(&field.data);
+    assert_eq!(
+        v.len(),
+        1,
+        "expected scalar input `{key}`, got len {}",
+        v.len()
+    );
+    v[0]
+}
+
+/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
+/// helper is `pub(crate)`); same semantics.
+fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
+    let mut out = Vec::new();
+    push(v, &mut out);
+    return out;
+
+    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
+        match v {
+            serde_json::Value::Number(n) => {
+                if let Some(x) = n.as_f64() {
+                    out.push(x);
+                } else if let Some(x) = n.as_i64() {
+                    out.push(x as f64);
+                } else if let Some(x) = n.as_u64() {
+                    out.push(x as f64);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr {
+                    push(item, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn onnx_baseline_fixture_loads_with_canonical_schema() {
+    // Pure load-time smoke test — no Burn pipeline, no faer. Confirms
+    // the canonical loader is happy with the ONNX baseline shape.
+    let fixture = Fixture::load_from(&fixture_path(), FixtureFormat::Json)
+        .expect("onnx_baseline.json should load");
+    assert_eq!(fixture.schema_version, "1");
+    assert_eq!(fixture.fixture_id, "cube_cavity/n10_onnx_baseline");
+    for field in ["eigenvalues", "k_diag_sum", "m_diag_sum"] {
+        assert!(
+            fixture.outputs.contains_key(field),
+            "ONNX baseline fixture missing output `{field}`"
+        );
+    }
+    for field in ["n", "side"] {
+        assert!(
+            fixture.inputs.contains_key(field),
+            "ONNX baseline fixture missing input `{field}`"
+        );
+    }
+
+    let eigvals = fixture
+        .output_f64("eigenvalues")
+        .expect("eigenvalues field");
+    assert_eq!(eigvals.shape, &[5]);
+    assert_eq!(eigvals.numel(), 5);
+}
+
+#[test]
+#[ignore = "faer 0.24 qz_real panics under debug-assertions; run with `cargo test -p geode-validation --release -- --ignored`"]
+fn burn_cube_cavity_agrees_with_onnx_baseline() {
+    let fixture =
+        Fixture::load_from(&fixture_path(), FixtureFormat::Json).expect("load onnx_baseline.json");
+
+    let n = input_i64(&fixture, "n") as usize;
+    let side = input_f64(&fixture, "side");
+    eprintln!(
+        "ONNX baseline fixture id = {}, n = {n}, side = {side}",
+        fixture.fixture_id
+    );
+
+    let expected_eigvals = fixture
+        .output_f64("eigenvalues")
+        .expect("eigenvalues field");
+    let n_eigs = expected_eigvals.numel();
+
+    let (eigvals, trk, trm) = burn_cube_cavity(n, side, n_eigs);
+
+    // Build the actual-outputs map for the canonical comparator. We
+    // also relax the fixture's per-field `tolerance_abs` to our
+    // backend-aware override before calling `compare_against` so the
+    // diff artifact reflects the actually-enforced bound (the original
+    // fixture tolerances target the NumPy/ONNX in-tree cross-check at
+    // ~1e-15, which Burn cannot honor through its f32 upload path).
+    let mut actual = BTreeMap::new();
+    actual.insert("eigenvalues".to_string(), eigvals.clone());
+    actual.insert("k_diag_sum".to_string(), vec![trk]);
+    actual.insert("m_diag_sum".to_string(), vec![trm]);
+
+    let tol = active_tolerances();
+    eprintln!(
+        "backend = {}, eigvals_abs_tol = {:.0e}, trace_abs_tol = {:.0e}",
+        geode_core::device_info().backend,
+        tol.eigvals_abs,
+        tol.trace_abs
+    );
+
+    let mut relaxed = fixture.clone();
+    if let Some(field) = relaxed.outputs.get_mut("eigenvalues") {
+        field.tolerance_abs = tol.eigvals_abs;
+    }
+    if let Some(field) = relaxed.outputs.get_mut("k_diag_sum") {
+        field.tolerance_abs = tol.trace_abs;
+    }
+    if let Some(field) = relaxed.outputs.get_mut("m_diag_sum") {
+        field.tolerance_abs = tol.trace_abs;
+    }
+
+    let report = relaxed.compare_against(&actual);
+
+    // Always write the diff artifact (pass or fail) so the
+    // friction-mining loop has the artifact even on green runs.
+    let artifact_path = Path::new(env!("CARGO_TARGET_TMPDIR")).join("cube_cavity_onnx_diff.json");
+    let _ = report.write_diff_artifact(&artifact_path);
+
+    // Pretty-print eigenvalues for the green-run log.
+    eprintln!(
+        "trace(K_int): expected = {:.6e}, got = {:.6e}",
+        flatten_numeric(&fixture.outputs["k_diag_sum"].data)[0],
+        trk,
+    );
+    eprintln!(
+        "trace(M_int): expected = {:.6e}, got = {:.6e}",
+        flatten_numeric(&fixture.outputs["m_diag_sum"].data)[0],
+        trm,
+    );
+    eprintln!("Eigenvalue comparison (lowest {n_eigs}):");
+    for (i, (got, expected)) in eigvals.iter().zip(expected_eigvals.data.iter()).enumerate() {
+        let abs_err = (got - expected).abs();
+        let rel_err = abs_err / expected.abs().max(1.0);
+        eprintln!(
+            "  λ[{i}]  expected = {expected:.6e}  got = {got:.6e}  abs = {abs_err:.3e}  rel = {rel_err:.3e}"
+        );
+    }
+
+    if !report.passed {
+        panic!(
+            "Burn cube-cavity disagrees with ONNX baseline; \
+             diff artifact at {} (n_failures = {}); \
+             per-field report = {:#?}",
+            artifact_path.display(),
+            report.n_failures(),
+            report.fields
+        );
+    }
+}

--- a/reference/driver/compare_eigenvalues.py
+++ b/reference/driver/compare_eigenvalues.py
@@ -19,6 +19,11 @@ The CI workflows wire this script with different primary backends:
   + a freshly emitted NumPy n=10 row. The JAX row is omitted from the
   Julia gate when meshes don't match (jax_baseline.json is n=4); see
   the workflow header for the rationale.
+- `.github/workflows/onnx-cube-cavity.yml` (issue #123): ONNX primary,
+  compared against the NumPy n=10 canonical baseline + a freshly
+  emitted NumPy n=10 row. The JAX row is shown for diagnostic context
+  but omitted from the rtol gate via `--skip-jax-comparison`, same
+  pattern as the Julia gate (jax_baseline.json is pinned at n=4).
 
 Optional `--burn` is supported for ad-hoc/local audits where all four
 rows are convenient.
@@ -36,16 +41,17 @@ Usage
     python3 reference/driver/compare_eigenvalues.py \
         [--tfjava path/to/eigenresult_tfjava.json] \
         [--julia  path/to/julia_baseline.json] \
+        [--onnx   path/to/eigenresult_onnx.json] \
         --jax    reference/fixtures/cube_cavity/jax_baseline.json \
         [--numpy path/to/numpy_baseline.json] \
         [--burn  path/to/burn_baseline.json] \
         [--rtol 1e-5] \
         [--out path/to/agreement_table.md]
 
-At least one of `--tfjava` or `--julia` must be supplied. The `--jax`
-flag is required so the comparator always emits the cross-IR XLA-vs-
-ARPACK columns (even when one row is omitted due to mesh mismatch, the
-header documents the omission explicitly).
+At least one of `--tfjava`, `--julia`, or `--onnx` must be supplied.
+The `--jax` flag is required so the comparator always emits the
+cross-IR XLA-vs-ARPACK columns (even when one row is omitted due to
+mesh mismatch, the header documents the omission explicitly).
 """
 
 from __future__ import annotations
@@ -92,6 +98,8 @@ def main() -> int:
                         help="Path to the TF-Java eigenresult JSON (from eigensolve_from_tfjava.py).")
     parser.add_argument("--julia", type=Path, default=None,
                         help="Path to the Julia eigenresult JSON (from reference/julia/cube_cavity.jl).")
+    parser.add_argument("--onnx", type=Path, default=None,
+                        help="Path to the ONNX eigenresult JSON (from eigensolve_from_onnx.py).")
     parser.add_argument("--jax", required=True, type=Path,
                         help="Path to the JAX baseline JSON.")
     parser.add_argument("--numpy", type=Path, default=None,
@@ -113,8 +121,8 @@ def main() -> int:
                         ))
     args = parser.parse_args()
 
-    if args.tfjava is None and args.julia is None:
-        print("ERROR: at least one of --tfjava or --julia must be supplied.",
+    if args.tfjava is None and args.julia is None and args.onnx is None:
+        print("ERROR: at least one of --tfjava, --julia, or --onnx must be supplied.",
               file=sys.stderr)
         return 1
 
@@ -136,16 +144,24 @@ def main() -> int:
             return 1
         julia = _load_eigenvalues(args.julia)
 
+    onnx_e = None
+    if args.onnx is not None:
+        if not args.onnx.exists():
+            print(f"ONNX eigenresult not found: {args.onnx}", file=sys.stderr)
+            return 1
+        onnx_e = _load_eigenvalues(args.onnx)
+
     jax_e = _load_eigenvalues(args.jax)
     numpy_e = _load_eigenvalues(args.numpy) if args.numpy and args.numpy.exists() else None
     burn_e = _load_eigenvalues(args.burn) if args.burn and args.burn.exists() else None
 
     # Truncate to k across whatever rows are present.
-    present = [v.size for v in (tfjava, julia, jax_e) if v is not None]
+    present = [v.size for v in (tfjava, julia, onnx_e, jax_e) if v is not None]
     k = min(args.k, *present)
     jax_k = jax_e[:k]
     tfjava_k = tfjava[:k] if tfjava is not None else None
     julia_k = julia[:k] if julia is not None else None
+    onnx_k = onnx_e[:k] if onnx_e is not None else None
     numpy_k = numpy_e[:k] if numpy_e is not None else None
     burn_k = burn_e[:k] if burn_e is not None else None
 
@@ -162,11 +178,15 @@ def main() -> int:
             drift[(primary_label, "Julia")] = _max_rel(primary, julia_k)
         if tfjava_k is not None and primary_label != "TF-Java":
             drift[(primary_label, "TF-Java")] = _max_rel(primary, tfjava_k)
+        if onnx_k is not None and primary_label != "ONNX":
+            drift[(primary_label, "ONNX")] = _max_rel(primary, onnx_k)
 
     if tfjava_k is not None:
         _record("TF-Java", tfjava_k)
     if julia_k is not None:
         _record("Julia", julia_k)
+    if onnx_k is not None:
+        _record("ONNX", onnx_k)
 
     # --- Render Markdown table ---
     primary_labels = []
@@ -174,6 +194,8 @@ def main() -> int:
         primary_labels.append("TF-Java")
     if julia_k is not None:
         primary_labels.append("Julia")
+    if onnx_k is not None:
+        primary_labels.append("ONNX")
 
     other_labels = ["JAX"]
     if numpy_k is not None:
@@ -192,6 +214,8 @@ def main() -> int:
         backend_rows.append(_format_row("TF-Java", tfjava, k))
     if julia is not None:
         backend_rows.append(_format_row("Julia", julia, k))
+    if onnx_e is not None:
+        backend_rows.append(_format_row("ONNX", onnx_e, k))
     if burn_e is not None:
         backend_rows.append(_format_row("Burn", burn_e, k))
 
@@ -208,7 +232,7 @@ def main() -> int:
         "",
     ]
     for primary_label in primary_labels:
-        for other in [lab for lab in ("JAX", "NumPy", "Burn", "Julia", "TF-Java")
+        for other in [lab for lab in ("JAX", "NumPy", "Burn", "Julia", "TF-Java", "ONNX")
                       if lab != primary_label and (primary_label, lab) in drift]:
             tag = ""
             if other == "JAX" and args.skip_jax_comparison:

--- a/reference/driver/eigensolve_from_onnx.py
+++ b/reference/driver/eigensolve_from_onnx.py
@@ -1,0 +1,150 @@
+"""Eigensolve driver for the ONNX cube-cavity sidecar (Epic #88 / Phase F.2 / issue #123).
+
+Near-clone of `eigensolve_from_tfjava.py`. The ONNX assembly graph
+(``reference/onnx/cube_cavity/assembly_graph.py``) closes the assembly
+spine at the Dirichlet boundary and emits a schema-v1 JSON sidecar with
+``K_int``/``M_int``. This script picks up that sidecar and runs the
+eigensolve via SciPy — identical seam to TF-Java's, identical schema.
+
+Per the F.2 curator pass on issue #123, this is a near-clone rather
+than a consolidated `eigensolve_from_sidecar.py`. The generalization
+into a backend-agnostic driver is filed as a separate follow-up issue,
+gated on having two existing call sites to factor from.
+
+Usage
+=====
+    python3 reference/driver/eigensolve_from_onnx.py \\
+        path/to/reduced_kM.json \\
+        [--k 5] [--dense] [--out path/to/eigenresult.json]
+
+The output JSON is in fixture-schema v1 so the harness can compare it
+to the JAX / NumPy baselines without language-specific code paths
+(see `compare_eigenvalues.py`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def _flatten_to_array(field, dtype=np.float64):
+    """Per the fixture schema, fields may be nested or flat; this
+    flattens to a 1-D ndarray of the declared dtype."""
+    if isinstance(field, dict):
+        data = field["data"]
+        shape = field["shape"]
+    else:
+        raise ValueError(f"unexpected field shape: {type(field)}")
+    arr = np.asarray(data, dtype=dtype).ravel()
+    expected = int(np.prod(shape))
+    if arr.size != expected:
+        raise ValueError(
+            f"data length {arr.size} does not match shape {shape} (= {expected})"
+        )
+    return arr.reshape(shape)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sidecar", help="Path to the ONNX reduced_kM.json sidecar.")
+    parser.add_argument("--k", type=int, default=5,
+                        help="Number of lowest eigenmodes to extract.")
+    parser.add_argument("--dense", action="store_true",
+                        help="Force dense eigh (else auto-select by problem size).")
+    parser.add_argument("--out", default="eigenresult.json")
+    args = parser.parse_args()
+
+    sidecar_path = Path(args.sidecar)
+    if not sidecar_path.exists():
+        print(f"Sidecar not found: {sidecar_path}", file=sys.stderr)
+        sys.exit(2)
+    with open(sidecar_path) as f:
+        sidecar = json.load(f)
+
+    k_int = _flatten_to_array(sidecar["outputs"]["k_int"], dtype=np.float64)
+    m_int = _flatten_to_array(sidecar["outputs"]["m_int"], dtype=np.float64)
+    n_int = k_int.shape[0]
+    if k_int.shape != (n_int, n_int) or m_int.shape != (n_int, n_int):
+        print(f"Expected square matrices, got K {k_int.shape}, M {m_int.shape}",
+              file=sys.stderr)
+        sys.exit(3)
+
+    n = int(sidecar["inputs"]["n"]["data"][0])
+    side = float(sidecar["inputs"]["side"]["data"][0])
+    print(f"Loaded ONNX sidecar: n={n}, side={side}, n_int={n_int}")
+    print(f"  trace(K_int) = {np.trace(k_int):.12e}")
+    print(f"  trace(M_int) = {np.trace(m_int):.12e}")
+
+    if args.dense or n_int < 30:
+        from scipy.linalg import eigh
+        eigvals, eigvecs = eigh(k_int, m_int)
+        eigvals = eigvals[:args.k]
+        eigvecs = eigvecs[:, :args.k]
+        solver = "scipy.linalg.eigh (dense)"
+    else:
+        import scipy.sparse as sp
+        import scipy.sparse.linalg as spla
+        k_sp = sp.csr_matrix(k_int)
+        m_sp = sp.csr_matrix(m_int)
+        eigvals, eigvecs = spla.eigsh(k_sp, k=args.k, M=m_sp, sigma=0.0, which="LM")
+        order = np.argsort(eigvals)
+        eigvals = eigvals[order]
+        eigvecs = eigvecs[:, order]
+        solver = "scipy.sparse.linalg.eigsh (ARPACK, shift-invert sigma=0)"
+
+    print(f"Solver: {solver}")
+    print("Lowest eigenvalues:")
+    for i, lam in enumerate(eigvals):
+        print(f"  λ[{i}] = {lam:.6e}")
+
+    # Build fixture-schema-shaped output for harness comparison.
+    result_fixture = {
+        "schema_version": "1",
+        "fixture_id": f"cube_cavity/n{n}_onnx_eigensolve",
+        "description": (
+            "Eigenvalues from the ONNX assembly + SciPy eigensolve seam. "
+            "Cross-checked against the JAX and NumPy baselines; see Epic "
+            "#88 Phase F.2 (issue #123)."
+        ),
+        "units": "dimensionless",
+        "inputs": {
+            "n": {"shape": [1], "dtype": "i64", "description": "Cells per side.", "data": [n]},
+            "side": {"shape": [1], "dtype": "f64", "description": "Cube side.", "data": [side]},
+        },
+        "outputs": {
+            "eigenvalues": {
+                "shape": [args.k],
+                "dtype": "f64",
+                "description": (
+                    "Lowest 5 scalar Helmholtz eigenvalues from ONNX assembly "
+                    "+ SciPy eigensolve. Cross-language drift tolerance is "
+                    "1e-8 absolute (consistent with the JAX baseline tolerance)."
+                ),
+                "tolerance_abs": 1.0e-8,
+                "data": eigvals.tolist(),
+            },
+        },
+        "provenance": {
+            "source": (
+                "reference/onnx/cube_cavity (assembly) -> "
+                "reference/driver/eigensolve_from_onnx.py (eigensolve seam)"
+            ),
+            "verified_against": "reference/jax/cube_cavity.py and reference/numpy/cube_cavity_minimal.py",
+            "issue": "#123",
+        },
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(result_fixture, f, indent=2)
+        f.write("\n")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/reference/fixtures/cube_cavity/onnx_baseline.json
+++ b/reference/fixtures/cube_cavity/onnx_baseline.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1",
+  "fixture_id": "cube_cavity/n10_onnx_baseline",
+  "description": "Lowest 5 scalar Helmholtz eigenvalues of the unit cube with homogeneous Dirichlet BC, assembled by the ONNX static-graph pipeline (Epic #88 Phase F.2 / issue #123) on the programmatic cube_tet_mesh of n=10 (729 interior DOFs). Same mesh and same scipy.sparse.linalg.eigsh seam as the NumPy canonical baseline.json; ONNX provides the cross-IR row alongside JAX and TF-Java for Epic #88's graph-only constraint check.",
+  "units": "dimensionless (k^2 with side normalized to 1)",
+  "inputs": {
+    "n": {
+      "shape": [
+        1
+      ],
+      "dtype": "i64",
+      "description": "Cells per side of the programmatic cube_tet_mesh.",
+      "data": [
+        10
+      ]
+    },
+    "side": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "Cube edge length.",
+      "data": [
+        1.0
+      ]
+    }
+  },
+  "outputs": {
+    "eigenvalues": {
+      "shape": [
+        5
+      ],
+      "dtype": "f64",
+      "description": "Lowest 5 eigenvalues, ascending. Cross-language f64 reproducibility allows ~1e-5 relative drift per Epic #88 framing; this fixture uses 1e-8 absolute since the in-tree NumPy and ONNX values agree to ~1e-13 at fixture-gen time.",
+      "tolerance_abs": 1e-08,
+      "data": [
+        30.832660835204873,
+        62.91210361562134,
+        62.91210361562137,
+        65.13922463020594,
+        98.1670635310854
+      ]
+    },
+    "k_diag_sum": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "trace(K_int) -- interior-DOF stiffness diagonal sum.",
+      "tolerance_abs": 1e-12,
+      "data": [
+        437.4
+      ]
+    },
+    "m_diag_sum": {
+      "shape": [
+        1
+      ],
+      "dtype": "f64",
+      "description": "trace(M_int) -- interior-DOF mass diagonal sum.",
+      "tolerance_abs": 1e-12,
+      "data": [
+        0.2916000000000001
+      ]
+    }
+  },
+  "provenance": {
+    "source": "reference/onnx/cube_cavity/assembly_graph.py (Epic #88 Phase F.2 / issue #123)",
+    "verified_against": "reference/numpy/cube_cavity_minimal.py -- eigenvalues agree to 1.3e-15 relative at fixture-gen time",
+    "issue": "#123 (cube-cavity ONNX assembly graph)",
+    "audit": "reference/onnx/audit/cube_cavity_operator_audit.md"
+  }
+}

--- a/reference/onnx/README.md
+++ b/reference/onnx/README.md
@@ -12,15 +12,18 @@ to articulate explicitly.
 Phase F is split into two sequenced issues under Epic #88:
 
 - **Phase F.1 — expressibility audit (issue [#116](https://github.com/rjwalters/geode-fem/issues/116))**:
-  the cube-cavity operator-by-operator audit. **Landed in this PR.**
-  Lives under [`audit/`](audit/) — Markdown gap-list plus three runnable
-  probe scripts. No CI gate; the audit *is* the deliverable.
-- **Phase F.2 — end-to-end cube-cavity ONNX assembly graph (planned)**:
-  the runtime payload (`cube_cavity/`), the sidecar driver
-  (`reference/driver/eigensolve_from_onnx.py` or a refactored
-  backend-agnostic shared driver), and the CI gate analogous to
-  `.github/workflows/tfjava-cube-cavity.yml`. Filed after this PR
-  merges so its curation can incorporate what F.1 actually learned.
+  the cube-cavity operator-by-operator audit. Lives under
+  [`audit/`](audit/) — Markdown gap-list plus three runnable probe
+  scripts. No CI gate; the audit *is* the deliverable.
+- **Phase F.2 — end-to-end cube-cavity ONNX assembly graph
+  (issue [#123](https://github.com/rjwalters/geode-fem/issues/123))**:
+  shipped. The runtime payload lives in [`cube_cavity/`](cube_cavity/),
+  the sidecar driver is
+  [`reference/driver/eigensolve_from_onnx.py`](../driver/eigensolve_from_onnx.py),
+  and the CI gate is
+  [`.github/workflows/onnx-cube-cavity.yml`](../../.github/workflows/onnx-cube-cavity.yml)
+  — modeled on `tfjava-cube-cavity.yml` and aligned with the n=10
+  convention of the canonical NumPy baseline.
 
 ## Boundary conventions inherited from the reference set
 
@@ -55,10 +58,10 @@ reference/onnx/
 │   ├── probe_p1_local.py              — per-element P1 local matrices
 │   ├── probe_assembly_scatter.py      — global K/M scatter-add (ScatterND)
 │   └── probe_dirichlet_mask.py        — interior-DOF restriction (NonZero)
-└── (planned Phase F.2)
-    ├── cube_cavity/
-    │   ├── assembly_graph.py          — analog of tf_java/.../AssemblyGraph.java
-    │   └── gen_cube_cavity_reduced.py — emits reduced_kM.json sidecar
+└── cube_cavity/                       — Phase F.2 runtime payload
+    ├── README.md                      — graph design + reproduction notes
+    ├── assembly_graph.py              — analog of tf_java/.../AssemblyGraph.java
+    └── gen_cube_cavity_reduced.py     — emits reduced_kM.json sidecar
 ```
 
 ## Re-running the Phase F.1 probes
@@ -75,6 +78,30 @@ Each probe ends with a one-screen verdict. The verdicts roll up into
 the audit table in [`audit/cube_cavity_operator_audit.md`](audit/cube_cavity_operator_audit.md).
 If a probe's verdict diverges from the table after a version bump,
 the table is stale — re-audit.
+
+## Re-running the Phase F.2 pipeline
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt
+mkdir -p ../../target/out
+python3 cube_cavity/gen_cube_cavity_reduced.py \
+    --n 10 --side 1.0 --out ../../target/out/reduced_kM.json
+python3 ../driver/eigensolve_from_onnx.py \
+    ../../target/out/reduced_kM.json --k 5 \
+    --out ../../target/out/eigenresult_onnx.json
+python3 ../driver/compare_eigenvalues.py \
+    --onnx ../../target/out/eigenresult_onnx.json \
+    --jax  ../fixtures/cube_cavity/jax_baseline.json \
+    --numpy ../fixtures/cube_cavity/baseline.json \
+    --skip-jax-comparison --k 5 --rtol 1e-5
+```
+
+See [`cube_cavity/README.md`](cube_cavity/README.md) for graph-design
+details and the rationale for raw `onnx.helper` over `onnxscript`. The
+CI gate at [`.github/workflows/onnx-cube-cavity.yml`](../../.github/workflows/onnx-cube-cavity.yml)
+runs the same three steps on every PR that touches the ONNX or NumPy
+reference paths.
 
 ## Phase F.1 headline finding (one paragraph)
 
@@ -104,31 +131,32 @@ artifacts accumulate for upstream
 [`crutcher/palace_whiteroom`](https://github.com/crutcher/palace_whiteroom)
 review.
 
-## Pointer to Phase F.2 planned layout
+## Phase F.2 design — derived from the audit
 
-The Phase F.2 issue (to be filed) will land:
+The Phase F.2 runtime payload follows directly from the audit's
+operator-by-operator findings. Inherited design points (shipped in
+issue #123 / this directory):
 
-```
-reference/onnx/cube_cavity/
-├── assembly_graph.py                  — builds the ONNX assembly graph
-│                                        (analog of TF-Java AssemblyGraph.java).
-│                                        Graph inputs: nodes, tets, idx_int.
-│                                        Graph outputs: K_int, M_int.
-└── gen_cube_cavity_reduced.py         — runs onnxruntime over the graph
-                                        and emits reduced_kM.json (same schema
-                                        as TF-Java's sidecar).
-reference/driver/
-└── eigensolve_from_onnx.py            — near-clone of eigensolve_from_tfjava.py
-                                        (or refactored into a backend-agnostic
-                                        eigensolve_from_sidecar.py — decision
-                                        belongs in F.2's curation).
-.github/workflows/onnx-cube-cavity.yml — CI gate, mirroring tfjava-cube-cavity.yml
-                                        for three-way cross-IR agreement
-                                        (ONNX vs JAX vs NumPy at rtol=1e-5).
-```
-
-The F.2 design is **derived from**, not independent of, the audit
-deliverable in this directory.
+- Graph inputs: `nodes (n_nodes, 3) f64`, `tets (n_elem, 4) i64`,
+  `idx_int (n_int,) i64`. Host-computed `idx`; `NonZero` is excluded
+  from the graph (audit Stage 3 recommendation).
+- Graph outputs: `K_int (n_int, n_int) f64`, `M_int (n_int, n_int) f64`.
+- Stage 1 uses `MatMul` for the batched `(N, 4, 3) @ (N, 3, 4)`
+  contraction — ONNX broadcasts the batch dim natively (no `einsum`
+  fallback like TF-Java had to drop to; audit Stage 1).
+- Stage 2 uses `ScatterND(reduction="add")` on a `ConstantOfShape` zero
+  buffer (audit Stage 2 headline operator).
+- Stage 3 uses two successive `Gather`s for the outer-product
+  `np.ix_(idx, idx)` (audit Stage 3, Path A).
+- Authoring: raw `onnx.helper`, not `onnxscript`, to preserve the
+  audit's IR-level transparency contract (audit doc lines 51–55; F.2
+  curator decision on issue #123).
+- Eigensolve seam: a JSON sidecar consumed by
+  [`reference/driver/eigensolve_from_onnx.py`](../driver/eigensolve_from_onnx.py)
+  — near-clone of `eigensolve_from_tfjava.py`. Consolidation into a
+  backend-agnostic `eigensolve_from_sidecar.py` is deferred to a
+  follow-up issue once a second sidecar consumer triggers the
+  generalization.
 
 ## Parent epic + related
 

--- a/reference/onnx/cube_cavity/README.md
+++ b/reference/onnx/cube_cavity/README.md
@@ -1,0 +1,104 @@
+# ONNX cube-cavity assembly graph (Phase F.2)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase F.2,
+issue [#123](https://github.com/rjwalters/geode-fem/issues/123). This is
+the runtime payload — the end-to-end ONNX assembly graph that the F.1
+audit ([`../audit/cube_cavity_operator_audit.md`](../audit/cube_cavity_operator_audit.md))
+established as feasible.
+
+## Layout
+
+- [`assembly_graph.py`](assembly_graph.py) — builds the static ONNX
+  graph that lowers the cube-cavity assembly spine end-to-end. Inputs
+  are `nodes`, `tets`, `idx_int`; outputs are `K_int`, `M_int`. Analog
+  of `reference/tf_java/cube_cavity/.../AssemblyGraph.java`.
+- [`gen_cube_cavity_reduced.py`](gen_cube_cavity_reduced.py) — driver
+  that runs the graph through `onnxruntime` and emits a schema-v1
+  sidecar JSON in the same shape `CubeCavityMain.java` does. Analog of
+  the TF-Java `CubeCavityMain.java` entry point.
+
+## Authoring tool: raw `onnx.helper`, not `onnxscript`
+
+The F.1 audit explicitly chose raw `onnx.helper` over `onnxscript` so
+that every L4 operator is visible as an opset-18 node at the IR level
+(see [audit doc lines 51–55](../audit/cube_cavity_operator_audit.md)).
+`onnxscript`'s ergonomics can hide imperative sugar that the audit
+needs to surface; Phase F.2 inherits the same authoring choice to
+preserve the audit's transparency contract. This decision is locked in
+by the issue #123 curator pass and documented here for future readers
+who may wonder why F.2 is verbose.
+
+## Graph shape
+
+Inherited from the F.1 audit (audit doc §"What this means for Phase F.2"):
+
+| Direction | Name      | Type | Shape                | Notes                                      |
+|-----------|-----------|------|----------------------|--------------------------------------------|
+| input     | `nodes`   | f64  | `(n_nodes, 3)`       | Mesh node coordinates.                     |
+| input     | `tets`    | i64  | `(n_elem, 4)`        | Connectivity (int64 at the I/O boundary).  |
+| input     | `idx_int` | i64  | `(n_int,)`           | Interior-DOF indices, **host-computed**.   |
+| output    | `K_int`   | f64  | `(n_int, n_int)`     | Stiffness, Dirichlet-restricted.           |
+| output    | `M_int`   | f64  | `(n_int, n_int)`     | Mass, Dirichlet-restricted.                |
+
+`idx_int` is host-computed (via `np.where(mask)[0]`) per the F.1 audit's
+explicit recommendation — using ONNX `NonZero` inside the graph would
+lower cleanly but produce a data-dependent shape that breaks static
+shape inference for everything downstream (see [audit Stage 3 friction
+note](../audit/cube_cavity_operator_audit.md#friction-note-on-stage-3-the-most-informative-row-in-this-audit)).
+JAX and TF-Java follow this convention implicitly; the ONNX path makes
+it explicit.
+
+## Eigensolve seam
+
+The graph **stops at** `K_int`/`M_int`. The eigensolve is the host-side
+sidecar boundary, identical convention to JAX (`scipy.linalg.eigh`
+outside the jit) and TF-Java (`eigensolve_from_tfjava.py` over a JSON
+sidecar). The Phase F.2 driver
+([`gen_cube_cavity_reduced.py`](gen_cube_cavity_reduced.py)) emits a
+schema-v1 sidecar; the companion
+[`reference/driver/eigensolve_from_onnx.py`](../../driver/eigensolve_from_onnx.py)
+runs the SciPy eigensolve over that sidecar.
+
+## Re-running
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt   # onnx 1.21.0, onnxruntime 1.26.0
+mkdir -p ../../target/out
+python3 cube_cavity/gen_cube_cavity_reduced.py \
+    --n 10 --side 1.0 --out ../../target/out/reduced_kM.json
+python3 ../driver/eigensolve_from_onnx.py \
+    ../../target/out/reduced_kM.json --k 5 \
+    --out ../../target/out/eigenresult_onnx.json
+```
+
+The expected eigenvalues for `n=10`, `side=1.0` are the same as the
+n=10 NumPy canonical baseline
+(`reference/fixtures/cube_cavity/baseline.json`); cross-IR agreement
+(rtol=1e-5) is gated by `.github/workflows/onnx-cube-cavity.yml`.
+
+## opset / version policy
+
+Inherited from F.1 unchanged:
+
+- `onnx==1.21.0`, `onnxruntime==1.26.0` (see
+  [`../requirements.txt`](../requirements.txt)).
+- Target opset 18.
+
+Bumping any of these requires re-running the three audit probes
+(`probe_p1_local.py`, `probe_assembly_scatter.py`, `probe_dirichlet_mask.py`)
+and updating the audit table if any verdict diverges. The CI gate for
+F.2 (`onnx-cube-cavity.yml`) is the runtime check; the audit is the
+expressibility check. They are complementary — both must pass for the
+ONNX reference to remain green.
+
+## Pointers
+
+- F.1 audit deliverable: [`../audit/cube_cavity_operator_audit.md`](../audit/cube_cavity_operator_audit.md).
+- Issue: [#123](https://github.com/rjwalters/geode-fem/issues/123) (Phase F.2).
+- Parent epic: [#88](https://github.com/rjwalters/geode-fem/issues/88).
+- TF-Java sibling (the pattern F.2 mirrors):
+  [`../../tf_java/cube_cavity/`](../../tf_java/cube_cavity/).
+- JAX sibling: [`../../jax/cube_cavity.py`](../../jax/cube_cavity.py).
+- Sidecar driver: [`../../driver/eigensolve_from_onnx.py`](../../driver/eigensolve_from_onnx.py).
+- CI gate: [`../../../.github/workflows/onnx-cube-cavity.yml`](../../../.github/workflows/onnx-cube-cavity.yml).

--- a/reference/onnx/cube_cavity/__init__.py
+++ b/reference/onnx/cube_cavity/__init__.py
@@ -1,0 +1,11 @@
+"""ONNX cube-cavity assembly graph (Epic #88, Phase F.2).
+
+See :mod:`reference.onnx.cube_cavity.assembly_graph` for the static-graph
+end-to-end builder, and :mod:`reference.onnx.cube_cavity.gen_cube_cavity_reduced`
+for the driver that runs the graph through onnxruntime and emits the
+schema-v1 sidecar.
+
+This package is the runtime payload for Phase F.2; it derives directly
+from the Phase F.1 audit in ``reference/onnx/audit/`` and uses raw
+``onnx.helper`` for IR-level transparency (NOT ``onnxscript``).
+"""

--- a/reference/onnx/cube_cavity/assembly_graph.py
+++ b/reference/onnx/cube_cavity/assembly_graph.py
@@ -1,0 +1,497 @@
+"""End-to-end ONNX assembly graph for the cube-cavity scalar Helmholtz spine.
+
+Epic #88, Phase F.2 (issue #123). This is the static-graph payload that
+the F.1 audit (`reference/onnx/audit/cube_cavity_operator_audit.md`)
+green-lit. It is the ONNX analog of:
+
+  - JAX:    `reference/jax/cube_cavity.py` ``_assemble_dense_jax``
+  - TF-Java: `reference/tf_java/cube_cavity/.../AssemblyGraph.java``
+
+The graph closes the assembly spine at the Dirichlet boundary — i.e. it
+emits ``K_int`` and ``M_int`` (interior-DOF restricted) and stops. The
+eigensolve is the host-side sidecar boundary, identical convention to
+JAX (`scipy.linalg.eigh` outside the jit) and TF-Java
+(`eigensolve_from_tfjava.py` over a JSON sidecar).
+
+Authoring tool
+==============
+
+This module uses raw ``onnx.helper`` (NOT ``onnxscript``). Rationale,
+from the F.1 audit (audit doc lines 51–55): ``onnxscript`` is more
+ergonomic but can hide imperative sugar that the audit needs to surface
+at the IR level. The audit's contract — "every L4 op visible as an
+opset-18 node" — only holds if F.2 inherits the same authoring choice.
+The curator pass on issue #123 made this an explicit Phase F.2 decision.
+
+Graph shape (per the F.1 audit recommendation)
+==============================================
+
+Inputs:
+  - ``nodes``    f64 shape ``(n_nodes, 3)``  — runtime node coordinates
+  - ``tets``     i64 shape ``(n_elem, 4)``   — tet connectivity (host-baked)
+  - ``idx_int``  i64 shape ``(n_int,)``      — interior-DOF indices (host)
+
+Outputs:
+  - ``K_int``    f64 shape ``(n_int, n_int)``
+  - ``M_int``    f64 shape ``(n_int, n_int)``
+
+Stages (matching the audit's per-stage operator inventory):
+  1. P1 local matrices — `MatMul`-based batched contraction of edge
+     gradients; cross product synthesized as 6 Mul + 3 Sub + 3
+     Unsqueeze + Concat (audit Stage 1).
+  2. Global K/M scatter-add — `ScatterND(reduction="add")` onto a
+     `ConstantOfShape` zero buffer (audit Stage 2).
+  3. Dirichlet restriction — two successive `Gather`s with the
+     host-computed ``idx_int`` (audit Stage 3, recommended convention).
+
+Notes:
+  - ``tets`` enters the graph as int64. The audit covers int32→int64
+    casting at the boundary as graph-only friction (audit doc lines
+    189–193); we pay that cost host-side instead of inside the graph.
+  - ``MatMul`` broadcasts the batch dim natively (audit doc line 89),
+    so the per-element ``(N, 4, 3) @ (N, 3, 4)`` contraction is one
+    op — no einsum fallback (cf. TF-Java AssemblyGraph.java lines
+    109–120, which had to drop to ``einsum``).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import onnx
+import onnx.helper as oh
+from onnx import TensorProto
+
+OPSET = 18
+IR_VERSION = 9
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    """Wrap a small NumPy array as a `Constant` node in the graph.
+
+    Local copy of the same helper used by the F.1 audit probes. Per the
+    F.2 curator decision, we keep this local rather than backporting
+    into the probes — extraction to a shared ``reference/onnx/_helpers.py``
+    is a deferred hygiene follow-up.
+    """
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def _p1_local_nodes(nodes: List[onnx.NodeProto]) -> None:
+    """Append nodes that compute (k_local, m_local) given `elem_coords`.
+
+    Reads:
+      ``elem_coords``  f64 (N, 4, 3) — per-element vertex coords
+    Writes:
+      ``k_local``      f64 (N, 4, 4)
+      ``m_local``      f64 (N, 4, 4)
+      ``abs_det``      f64 (N,)       — exposed for downstream debug
+
+    Mirrors `_p1_local_one` in `reference/jax/cube_cavity.py`. The
+    structure is line-for-line identical to the audit probe
+    `probe_p1_local.py`; only difference is that the constants used here
+    have unique names (so the graph stays SSA when used alongside the
+    scatter step).
+    """
+    # ---------- Constants ----------
+    for c in (0, 1, 2, 3):
+        nodes.append(_const(f"p1_v_idx_{c}", np.array(c, dtype=np.int64)))
+    for c in range(3):
+        nodes.append(_const(f"p1_comp_idx_{c}", np.array(c, dtype=np.int64)))
+    nodes.append(_const("p1_axis_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(_const("p1_axis_1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("p1_reshape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(_const("p1_reshape_144", np.array([1, 4, 4], dtype=np.int64)))
+    nodes.append(_const("p1_six", np.array(6.0, dtype=np.float64)))
+    nodes.append(_const("p1_one_twenty", np.array(120.0, dtype=np.float64)))
+    mass_pattern = np.array(
+        [
+            [2.0, 1.0, 1.0, 1.0],
+            [1.0, 2.0, 1.0, 1.0],
+            [1.0, 1.0, 2.0, 1.0],
+            [1.0, 1.0, 1.0, 2.0],
+        ],
+        dtype=np.float64,
+    )
+    nodes.append(_const("p1_mass_pattern", mass_pattern))
+
+    # ---------- Gather v0..v3 along axis=1 ----------
+    for i in range(4):
+        nodes.append(oh.make_node(
+            "Gather",
+            inputs=["elem_coords", f"p1_v_idx_{i}"],
+            outputs=[f"p1_v{i}"],
+            axis=1,
+        ))
+
+    # ---------- Edge vectors e1, e2, e3 ----------
+    for i in (1, 2, 3):
+        nodes.append(oh.make_node("Sub", [f"p1_v{i}", "p1_v0"], [f"p1_e{i}"]))
+
+    # ---------- Cross-product synthesis helpers ----------
+    emitted_components: set = set()
+
+    def emit_components(vec: str) -> tuple:
+        outs = []
+        for c in range(3):
+            out_name = f"{vec}_c{c}"
+            if out_name not in emitted_components:
+                nodes.append(oh.make_node(
+                    "Gather",
+                    inputs=[vec, f"p1_comp_idx_{c}"],
+                    outputs=[out_name],
+                    axis=1,
+                ))
+                emitted_components.add(out_name)
+            outs.append(out_name)
+        return tuple(outs)
+
+    def emit_cross(a: str, b: str, out: str) -> None:
+        ax, ay, az = emit_components(a)
+        bx, by, bz = emit_components(b)
+        # cx = ay*bz - az*by
+        nodes.append(oh.make_node("Mul", [ay, bz], [f"{out}_t1"]))
+        nodes.append(oh.make_node("Mul", [az, by], [f"{out}_t2"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t1", f"{out}_t2"], [f"{out}_x"]))
+        # cy = az*bx - ax*bz
+        nodes.append(oh.make_node("Mul", [az, bx], [f"{out}_t3"]))
+        nodes.append(oh.make_node("Mul", [ax, bz], [f"{out}_t4"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t3", f"{out}_t4"], [f"{out}_y"]))
+        # cz = ax*by - ay*bx
+        nodes.append(oh.make_node("Mul", [ax, by], [f"{out}_t5"]))
+        nodes.append(oh.make_node("Mul", [ay, bx], [f"{out}_t6"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t5", f"{out}_t6"], [f"{out}_z"]))
+        # Stack components → (N, 3): Unsqueeze each to (N, 1), then Concat.
+        for comp in ("x", "y", "z"):
+            nodes.append(oh.make_node(
+                "Unsqueeze",
+                inputs=[f"{out}_{comp}", "p1_axis_neg1"],
+                outputs=[f"{out}_{comp}_u"],
+            ))
+        nodes.append(oh.make_node(
+            "Concat",
+            inputs=[f"{out}_x_u", f"{out}_y_u", f"{out}_z_u"],
+            outputs=[out],
+            axis=1,
+        ))
+
+    emit_cross("p1_e2", "p1_e3", "p1_g1")
+    emit_cross("p1_e3", "p1_e1", "p1_g2")
+    emit_cross("p1_e1", "p1_e2", "p1_g3")
+
+    # ---------- g0 = -(g1 + g2 + g3) ----------
+    nodes.append(oh.make_node("Add", ["p1_g1", "p1_g2"], ["p1_g1_plus_g2"]))
+    nodes.append(oh.make_node("Add", ["p1_g1_plus_g2", "p1_g3"], ["p1_g_sum"]))
+    nodes.append(oh.make_node("Neg", ["p1_g_sum"], ["p1_g0"]))
+
+    # ---------- det = sum(e1 * g1, axis=1) ; abs_det = |det| ----------
+    nodes.append(oh.make_node("Mul", ["p1_e1", "p1_g1"], ["p1_e1_g1"]))
+    nodes.append(oh.make_node(
+        "ReduceSum",
+        inputs=["p1_e1_g1", "p1_axis_1"],
+        outputs=["p1_det"],
+        keepdims=0,
+    ))
+    nodes.append(oh.make_node("Abs", ["p1_det"], ["abs_det"]))
+
+    # ---------- gMat = stack(g0, g1, g2, g3) along axis=1 → (N, 4, 3) ----------
+    for g in ("p1_g0", "p1_g1", "p1_g2", "p1_g3"):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[g, "p1_axis_1"],
+            outputs=[f"{g}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["p1_g0_u", "p1_g1_u", "p1_g2_u", "p1_g3_u"],
+        outputs=["p1_g_mat"],
+        axis=1,
+    ))
+
+    # ---------- gg = g_mat @ g_mat^T per-batch (MatMul broadcasts batch dim) ----------
+    nodes.append(oh.make_node(
+        "Transpose",
+        inputs=["p1_g_mat"],
+        outputs=["p1_g_mat_T"],
+        perm=[0, 2, 1],
+    ))
+    nodes.append(oh.make_node("MatMul", ["p1_g_mat", "p1_g_mat_T"], ["p1_gg"]))
+
+    # ---------- k_local = gg / (6 * abs_det) ----------
+    nodes.append(oh.make_node("Mul", ["p1_six", "abs_det"], ["p1_six_abs_det"]))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["p1_six_abs_det", "p1_reshape_n11"],
+        outputs=["p1_six_abs_det_b"],
+    ))
+    nodes.append(oh.make_node("Div", ["p1_gg", "p1_six_abs_det_b"], ["k_local"]))
+
+    # ---------- m_local = mass_pattern[None, :, :] * (abs_det/120)[:, None, None] ----------
+    nodes.append(oh.make_node("Div", ["abs_det", "p1_one_twenty"], ["p1_m_scale"]))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["p1_m_scale", "p1_reshape_n11"],
+        outputs=["p1_m_scale_b"],
+    ))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["p1_mass_pattern", "p1_reshape_144"],
+        outputs=["p1_mass_pattern_b"],
+    ))
+    nodes.append(oh.make_node("Mul", ["p1_mass_pattern_b", "p1_m_scale_b"], ["m_local"]))
+
+
+def _scatter_assemble_nodes(nodes: List[onnx.NodeProto], n_nodes: int,
+                            n_elem: int) -> None:
+    """Append nodes that scatter `k_local`/`m_local` into dense globals.
+
+    Reads:
+      ``k_local`` f64 (N, 4, 4), ``m_local`` f64 (N, 4, 4),
+      ``tets``    i64 (n_elem, 4)  — connectivity (graph input)
+    Writes:
+      ``k_global`` f64 (n_nodes, n_nodes)
+      ``m_global`` f64 (n_nodes, n_nodes)
+
+    Mirrors `_assemble_dense_jax` (JAX) / `tf.scatterNd` step (TF-Java)
+    and the audit probe `probe_assembly_scatter.py`.
+    """
+    n_pairs = n_elem * 16  # flat (e, i, j) index count
+
+    # ---------- Constants ----------
+    nodes.append(_const("scatter_axis_2", np.array([2], dtype=np.int64)))
+    nodes.append(_const("scatter_axis_1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("scatter_shape_n44", np.array([n_elem, 4, 4], dtype=np.int64)))
+    nodes.append(_const("scatter_flat_shape",
+                        np.array([n_pairs], dtype=np.int64)))
+    nodes.append(_const("scatter_pair_flat_shape",
+                        np.array([n_pairs, 1], dtype=np.int64)))
+    nodes.append(_const("scatter_buf_shape",
+                        np.array([n_nodes, n_nodes], dtype=np.int64)))
+
+    # ---------- Build per-element (row, col) index pairs ----------
+    # rows[e, i, j] = tets[e, i],  cols[e, i, j] = tets[e, j].
+    # ONNX: Unsqueeze(tets, axis=2) → (n_elem, 4, 1)
+    #       Unsqueeze(tets, axis=1) → (n_elem, 1, 4)
+    # Then Expand to (n_elem, 4, 4). NB: ONNX has no `broadcast_to`, but
+    # `Expand` is the equivalent (opset 8+).
+    nodes.append(oh.make_node(
+        "Unsqueeze",
+        inputs=["tets", "scatter_axis_2"],
+        outputs=["scatter_tets_rows"],
+    ))
+    nodes.append(oh.make_node(
+        "Unsqueeze",
+        inputs=["tets", "scatter_axis_1"],
+        outputs=["scatter_tets_cols"],
+    ))
+    nodes.append(oh.make_node(
+        "Expand",
+        inputs=["scatter_tets_rows", "scatter_shape_n44"],
+        outputs=["scatter_rows_3d"],
+    ))
+    nodes.append(oh.make_node(
+        "Expand",
+        inputs=["scatter_tets_cols", "scatter_shape_n44"],
+        outputs=["scatter_cols_3d"],
+    ))
+
+    # Flatten to (n_pairs, 1) each, then Concat along axis=1 → (n_pairs, 2).
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["scatter_rows_3d", "scatter_pair_flat_shape"],
+        outputs=["scatter_rows_flat"],
+    ))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["scatter_cols_3d", "scatter_pair_flat_shape"],
+        outputs=["scatter_cols_flat"],
+    ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["scatter_rows_flat", "scatter_cols_flat"],
+        outputs=["scatter_indices"],
+        axis=1,
+    ))
+
+    # ---------- Flatten k_local / m_local to (n_pairs,) ----------
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["k_local", "scatter_flat_shape"],
+        outputs=["scatter_k_vals"],
+    ))
+    nodes.append(oh.make_node(
+        "Reshape",
+        inputs=["m_local", "scatter_flat_shape"],
+        outputs=["scatter_m_vals"],
+    ))
+
+    # ---------- Zero buffer ----------
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["scatter_buf_shape"],
+        outputs=["scatter_k_zero"],
+        value=oh.make_tensor(
+            name="scatter_k_zero_value",
+            data_type=TensorProto.DOUBLE,
+            dims=[1],
+            vals=[0.0],
+        ),
+    ))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["scatter_buf_shape"],
+        outputs=["scatter_m_zero"],
+        value=oh.make_tensor(
+            name="scatter_m_zero_value",
+            data_type=TensorProto.DOUBLE,
+            dims=[1],
+            vals=[0.0],
+        ),
+    ))
+
+    # ---------- ScatterND(reduction="add") ----------
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["scatter_k_zero", "scatter_indices", "scatter_k_vals"],
+        outputs=["k_global"],
+        reduction="add",
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["scatter_m_zero", "scatter_indices", "scatter_m_vals"],
+        outputs=["m_global"],
+        reduction="add",
+    ))
+
+
+def _dirichlet_restrict_nodes(nodes: List[onnx.NodeProto]) -> None:
+    """Append nodes that compute `K_int = K[idx, :][:, idx]`.
+
+    Reads:
+      ``k_global`` f64 (n_nodes, n_nodes), ``m_global`` f64 (...)
+      ``idx_int``  i64 (n_int,)  — graph input (host-computed per F.1
+                                   audit recommendation)
+    Writes:
+      ``K_int`` f64 (n_int, n_int)
+      ``M_int`` f64 (n_int, n_int)
+
+    Two-Gather decomposition (audit Stage 3 / Path A).
+    """
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["k_global", "idx_int"],
+        outputs=["dirichlet_k_rows"],
+        axis=0,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["dirichlet_k_rows", "idx_int"],
+        outputs=["K_int"],
+        axis=1,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["m_global", "idx_int"],
+        outputs=["dirichlet_m_rows"],
+        axis=0,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["dirichlet_m_rows", "idx_int"],
+        outputs=["M_int"],
+        axis=1,
+    ))
+
+
+def build_cube_cavity_graph(n_nodes: int, n_elem: int) -> onnx.ModelProto:
+    """Build the end-to-end cube-cavity assembly ONNX graph.
+
+    Parameters
+    ----------
+    n_nodes : int
+        Total node count of the mesh.
+    n_elem : int
+        Total tet count of the mesh.
+
+    Notes
+    -----
+    `n_nodes` and `n_elem` are baked into a small set of `Constant`
+    shapes (the (n_nodes, n_nodes) zero buffer; the (n_elem, 4, 4)
+    Expand shapes; etc.). The interior-DOF count `n_int` is *not* baked
+    in — the Dirichlet Gather honors any length of ``idx_int`` passed
+    at runtime. This matches the audit's static-shape contract: the
+    only data-dependent shape would be `n_int`, and that is resolved by
+    making `idx_int` a graph input rather than computing it via
+    `NonZero` inside the graph (audit Stage 3 friction note).
+    """
+    nodes: List[onnx.NodeProto] = []
+
+    # ---------- Graph inputs ----------
+    nodes_in = oh.make_tensor_value_info(
+        "nodes", TensorProto.DOUBLE, shape=[n_nodes, 3]
+    )
+    tets_in = oh.make_tensor_value_info(
+        "tets", TensorProto.INT64, shape=[n_elem, 4]
+    )
+    idx_in = oh.make_tensor_value_info(
+        "idx_int", TensorProto.INT64, shape=["n_int"]
+    )
+
+    # ---------- Stage 0: gather elem_coords[e, i, :] = nodes[tets[e, i], :] ----------
+    # ONNX `Gather(nodes, tets, axis=0)` returns shape (n_elem, 4, 3)
+    # because Gather flattens the indexed axis with the indices shape.
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["nodes", "tets"],
+        outputs=["elem_coords"],
+        axis=0,
+    ))
+
+    # ---------- Stage 1: P1 local matrices ----------
+    _p1_local_nodes(nodes)
+
+    # ---------- Stage 2: global K/M scatter-add ----------
+    _scatter_assemble_nodes(nodes, n_nodes, n_elem)
+
+    # ---------- Stage 3: Dirichlet restriction ----------
+    _dirichlet_restrict_nodes(nodes)
+
+    # ---------- Graph outputs ----------
+    k_int_out = oh.make_tensor_value_info(
+        "K_int", TensorProto.DOUBLE, shape=["n_int", "n_int"]
+    )
+    m_int_out = oh.make_tensor_value_info(
+        "M_int", TensorProto.DOUBLE, shape=["n_int", "n_int"]
+    )
+
+    graph = oh.make_graph(
+        nodes,
+        name="cube_cavity_assembly",
+        inputs=[nodes_in, tets_in, idx_in],
+        outputs=[k_int_out, m_int_out],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=IR_VERSION,
+    )
+
+
+__all__ = ["build_cube_cavity_graph", "OPSET", "IR_VERSION"]

--- a/reference/onnx/cube_cavity/gen_cube_cavity_reduced.py
+++ b/reference/onnx/cube_cavity/gen_cube_cavity_reduced.py
@@ -1,0 +1,191 @@
+"""Driver: build the ONNX cube-cavity graph, run it, emit a schema-v1 sidecar.
+
+Epic #88, Phase F.2 (issue #123). Mirror of
+``reference/tf_java/cube_cavity/.../CubeCavityMain.java`` — programmatic
+mesh, ``onnxruntime`` over the static graph, JSON sidecar in the same
+schema the TF-Java driver emits and that
+``reference/driver/eigensolve_from_onnx.py`` consumes.
+
+Per the F.1 audit's recommendation, the Dirichlet ``idx`` is computed
+host-side via ``np.where(mask)[0]`` and fed into the graph as an int64
+input. This keeps the assembly graph statically shaped end-to-end (the
+audit doc lines 146–152 are the source of truth here).
+
+Usage
+=====
+    python3 reference/onnx/cube_cavity/gen_cube_cavity_reduced.py \\
+        --n 10 --side 1.0 --out target/out/reduced_kM.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent  # reference/
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+sys.path.insert(0, str(HERE))
+
+from mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402
+from assembly_graph import build_cube_cavity_graph  # noqa: E402
+
+
+def _scalar_input_field(value, dtype: str, description: str) -> dict:
+    return {
+        "shape": [1],
+        "dtype": dtype,
+        "description": description,
+        "data": [value],
+    }
+
+
+def _matrix_output_field(arr: np.ndarray, description: str,
+                         tolerance_abs: float) -> dict:
+    return {
+        "shape": list(arr.shape),
+        "dtype": "f64",
+        "description": description,
+        "tolerance_abs": tolerance_abs,
+        "data": arr.ravel().tolist(),
+    }
+
+
+def _scalar_output_field(value: float, description: str,
+                         tolerance_abs: float) -> dict:
+    return {
+        "shape": [1],
+        "dtype": "f64",
+        "description": description,
+        "tolerance_abs": tolerance_abs,
+        "data": [value],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n", type=int, default=10,
+                        help="Cells per side (default 10, matches baseline.json).")
+    parser.add_argument("--side", type=float, default=1.0,
+                        help="Cube edge length (default 1.0).")
+    parser.add_argument("--out", type=Path, required=True,
+                        help="Output JSON path for the reduced (K_int, M_int) sidecar.")
+    args = parser.parse_args()
+
+    n = args.n
+    side = args.side
+    print(f"[onnx-cube-cavity] onnx={onnx.__version__}  "
+          f"onnxruntime={ort.__version__}  n={n}  side={side}")
+
+    # ---- Programmatic mesh + interior mask (same convention as TF-Java) ----
+    nodes_np, tets_np = cube_tet_mesh(n, side)
+    n_nodes = int(nodes_np.shape[0])
+    n_elem = int(tets_np.shape[0])
+    mask = cube_interior_mask(nodes_np, side)
+    idx_np = np.where(mask)[0].astype(np.int64)
+    n_int = int(idx_np.size)
+    print(f"[onnx-cube-cavity] n_nodes={n_nodes}, n_elem={n_elem}, n_int={n_int}")
+
+    # ---- Build the ONNX graph for this connectivity ----
+    model = build_cube_cavity_graph(n_nodes=n_nodes, n_elem=n_elem)
+    onnx.checker.check_model(model)
+    print("[onnx-cube-cavity] onnx.checker.check_model: OK")
+
+    # ---- Run via onnxruntime ----
+    sess = ort.InferenceSession(model.SerializeToString())
+    K_int, M_int = sess.run(
+        ["K_int", "M_int"],
+        {
+            "nodes": nodes_np.astype(np.float64),
+            "tets": tets_np.astype(np.int64),
+            "idx_int": idx_np,
+        },
+    )
+    assert K_int.shape == (n_int, n_int), K_int.shape
+    assert M_int.shape == (n_int, n_int), M_int.shape
+
+    tr_k = float(np.trace(K_int))
+    tr_m = float(np.trace(M_int))
+    print(f"[onnx-cube-cavity] trace(K_int) = {tr_k:.12e}")
+    print(f"[onnx-cube-cavity] trace(M_int) = {tr_m:.12e}")
+
+    # ---- Build the sidecar (schema v1, mirroring CubeCavityMain.java) ----
+    fixture = {
+        "schema_version": "1",
+        "fixture_id": f"cube_cavity/n{n}_onnx_reduced",
+        "description": (
+            "Dirichlet-reduced (K_int, M_int) matrices for the unit-cube "
+            "scalar Helmholtz problem, produced by the ONNX static-graph "
+            "assembly pipeline (Epic #88 Phase F.2 / issue #123). Consumed "
+            "by reference/driver/eigensolve_from_onnx.py to close the "
+            "eigenproblem at the same SciPy seam TF-Java uses."
+        ),
+        "units": "dimensionless",
+        "inputs": {
+            "n": _scalar_input_field(n, "i64", "Cells per side."),
+            "side": _scalar_input_field(side, "f64", "Cube edge length."),
+            "interior_idx": {
+                "shape": [n_int],
+                "dtype": "i64",
+                "description": (
+                    "Interior-DOF row/col indices into the full (n_nodes, "
+                    "n_nodes) matrix. Computed host-side per the F.1 audit "
+                    "(NonZero would lower but introduce data-dependent "
+                    "shape; see audit doc lines 146-152)."
+                ),
+                "data": idx_np.tolist(),
+            },
+        },
+        "outputs": {
+            "k_diag_sum": _scalar_output_field(
+                tr_k,
+                "trace(K_int) -- ONNX assembly readback.",
+                1.0e-12,
+            ),
+            "m_diag_sum": _scalar_output_field(
+                tr_m,
+                "trace(M_int) -- ONNX assembly readback.",
+                1.0e-12,
+            ),
+            "k_int": _matrix_output_field(
+                K_int,
+                "Dirichlet-reduced stiffness matrix.",
+                1.0e-10,
+            ),
+            "m_int": _matrix_output_field(
+                M_int,
+                "Dirichlet-reduced mass matrix.",
+                1.0e-10,
+            ),
+        },
+        "provenance": {
+            "source": (
+                "reference/onnx/cube_cavity/assembly_graph.py via "
+                "gen_cube_cavity_reduced.py (Epic #88 Phase F.2 / "
+                "issue #123)"
+            ),
+            "verified_against": (
+                "reference/numpy/cube_cavity_minimal.py and "
+                "reference/jax/cube_cavity.py"
+            ),
+            "issue": "#123",
+            "audit": "reference/onnx/audit/cube_cavity_operator_audit.md",
+        },
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fixture, f, indent=2)
+        f.write("\n")
+    print(f"[onnx-cube-cavity] Wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Epic #88 Phase F.2 (issue #123). Builds the runtime payload that the F.1
audit (PR #119 / issue #116) established as feasible: an end-to-end ONNX
static graph that assembles `K_int`, `M_int` for the scalar Helmholtz
cube cavity, plus the SciPy eigensolve seam and the cross-IR CI gate.

- New `reference/onnx/cube_cavity/{assembly_graph,gen_cube_cavity_reduced}.py` — the static graph builder + driver. Authored with raw `onnx.helper` (not `onnxscript`) to preserve the audit's IR-level transparency contract.
- New `reference/driver/eigensolve_from_onnx.py` — near-clone of `eigensolve_from_tfjava.py`. (Consolidation into a backend-agnostic `eigensolve_from_sidecar.py` is deferred per the curator pass, gated on a second sidecar consumer.)
- New `reference/fixtures/cube_cavity/onnx_baseline.json` — schema-v1 fixture (`cube_cavity/n10_onnx_baseline`).
- New `crates/geode-validation/tests/cube_cavity_onnx_reference.rs` — structural mirror of `cube_cavity_jax_reference.rs`.
- New `.github/workflows/onnx-cube-cavity.yml` — three-way CI gate (ONNX vs JAX vs NumPy), modeled on `tfjava-cube-cavity.yml` with the n=10 / `--skip-jax-comparison` convention from `julia-cube-cavity.yml`.
- Extended `reference/driver/compare_eigenvalues.py` with `--onnx` (surfaced by the curator; the raw issue body missed it).
- Updated `reference/onnx/README.md` to mark F.2 as shipped and pin the audit→runtime cross-references.

## Inherited design (from the F.1 audit)

- Graph inputs: `nodes (n_nodes, 3) f64`, `tets (n_elem, 4) i64`, `idx_int (n_int,) i64` — host-computed `idx`, no `NonZero` inside the graph (audit Stage 3 friction note).
- Graph outputs: `K_int (n_int, n_int) f64`, `M_int (n_int, n_int) f64`. Eigensolve is host-side, same seam as TF-Java / JAX.
- Stage 1: per-element P1 matrices — `MatMul` broadcasts the `(N, 4, 3) @ (N, 3, 4)` batch dim natively, no einsum fallback (audit Stage 1).
- Stage 2: global K/M via `ScatterND(reduction="add")` on a `ConstantOfShape` zero buffer (audit Stage 2 headline operator).
- Stage 3: Dirichlet restriction via two successive `Gather`s for `np.ix_(idx, idx)` (audit Stage 3, Path A).

## Curator decisions on #123

| Q | Decision |
|---|----------|
| `eigensolve_from_sidecar.py` consolidation | DEFERRED (near-clone; trigger = second sidecar consumer) |
| `_const` helper consolidation | DEFERRED (local copy in `assembly_graph.py`) |
| `onnxscript` vs `onnx.helper` | `onnx.helper` (preserves IR-level transparency, per audit lines 51-55) |
| opset version pinning | opset 18 / pinned `requirements.txt`; bumps require probe re-run |

## Verification

End-to-end (n=10, side=1.0, ndarray host):
- `||K_onnx − K_numpy||_F` = **5.2e-15** (gate: 1e-9 cross-platform floor)
- `||M_onnx − M_numpy||_F` = **2.1e-18**
- `max |diag(M_onnx) − diag(M_numpy)|` = **2.2e-19** (gate: 5e-9)
- ONNX vs NumPy `baseline.json` eigenvalues: **1.3e-15 relative** drift on lowest 5 (gate: 1e-5)
- `cube_cavity_onnx_reference` Burn test passes in release mode.
- `cube_cavity_jax_reference` (sibling) still passes — no regression.

## Test plan

- [x] `python3 reference/onnx/cube_cavity/gen_cube_cavity_reduced.py --n 10 --side 1.0 --out target/out/reduced_kM.json` produces the schema-v1 sidecar.
- [x] `python3 reference/driver/eigensolve_from_onnx.py target/out/reduced_kM.json --k 5 --out target/out/eigenresult_onnx.json` produces the eigenresult fixture.
- [x] `python3 reference/driver/compare_eigenvalues.py --onnx ... --numpy baseline.json --skip-jax-comparison --rtol 1e-5` exits 0 with 1.3e-15 relative drift.
- [x] `cargo test -p geode-validation --release --test cube_cavity_onnx_reference -- --ignored` passes.
- [x] `cargo test -p geode-validation` (smoke + all default tests) passes.
- [x] `cargo clippy -p geode-validation --tests` clean.
- [ ] CI: the new `onnx-cube-cavity.yml` workflow runs on this PR (path filters cover all the touched files).

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)