### PR TITLE
feat: Phase G.6 — ONNX expressibility audit: Nédélec sphere PEC operators (Epic #88)

### DIFF
--- a/reference/onnx/audit/sphere_pec/nedelec_operator_audit.md
+++ b/reference/onnx/audit/sphere_pec/nedelec_operator_audit.md
@@ -1,0 +1,392 @@
+# Nédélec sphere-PEC ONNX expressibility audit (Phase G.6)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase G.6
+deliverable. Tracking issue: [#135](https://github.com/rjwalters/geode-fem/issues/135).
+
+## Scope
+
+This audit catalogs the L4 operators on the **vector-Nédélec sphere-PEC
+assembly spine** and records whether each lowers to a graph-only ONNX
+form. The sphere-PEC case uses Whitney edge elements (Nédélec H(curl)),
+making it structurally richer than the cube-cavity P1 scalar case audited
+in Phase F.1 ([cube_cavity_operator_audit.md](../cube_cavity_operator_audit.md)).
+
+The sphere-PEC assembly spine — as defined by the NumPy reference in
+[`reference/numpy/sphere_pec.py`](../../../numpy/sphere_pec.py) and the
+Burn implementation in `crates/geode-core/src/nedelec_assembly.rs` —
+consists of these stages:
+
+1. **ε_r assignment** (`build_epsilon_r`): per-tet relative permittivity
+   from physical-group tags. Shape: `(n_tets,)`.
+2. **Edge enumeration** (`build_edges`): build globally-oriented edge
+   table `edges (n_edges, 2)` and per-tet edge-sign tables
+   `tet_edge_idx (n_tets, 6)`, `tet_edge_sign (n_tets, 6)`. This is
+   the Nédélec-specific preprocessing that has no P1 analog.
+3. **Per-element Nédélec local matrices** (shape `(n_tets, 6, 6)`):
+   cofactor-Gram construction, curl-curl stiffness K, ε-scaled mass M.
+4. **PEC boundary mask** (`sphere_pec_interior_edges`): edge mask derived
+   from node positions (ReduceL2 + threshold).
+5. **Global K/M scatter-add** (shape `(n_edges, n_edges)`): scatter the
+   per-element 6×6 signed blocks into a dense buffer.
+6. **Dirichlet restriction** (`apply_dirichlet`): restrict K, M to the
+   interior edges by row+column extraction.
+7. **Generalized eigensolve**: `scipy.sparse.linalg.eigsh` on host
+   (out of scope — same L4 boundary as cube-cavity).
+
+The d⁰-rank spurious-mode classifier (`spurious_dim_from_derham`) is
+host-imperative and out of scope for the same reason as the eigensolve.
+
+This audit covers **stages 1–6** (stage 7 is shared L4 friction across
+all backends).
+
+## Pinned versions used for this audit
+
+Same as Phase F.1:
+
+| Package | Version |
+|---|---|
+| `onnx` | `1.21.0` |
+| `onnxruntime` | `1.26.0` |
+| Target opset | `18` |
+
+See [`reference/onnx/requirements.txt`](../../requirements.txt) for the
+pinned `pip` line.
+
+## Classification convention
+
+Inherits the Phase F.1 classification scheme:
+
+| Marker | Meaning |
+|---|---|
+| **clean** | Direct opset-18 operator; lowers without any synthesis. |
+| **synth** | No native op, but a graph-only synthesis from lower-level ops works. Documentation, not a blocker. |
+| **caveat** | The op lowers, but introduces a downstream constraint (e.g. data-dependent shape). |
+| **graph-only friction** | Forced by the ONNX IR's static-graph form; the L4 operator IS expressible, the friction is overhead. |
+| **secretly imperative** | An L4 operator that relies on imperative escape; would block end-to-end lowering. **This is the high-value friction-mining outcome.** |
+
+## Operator table
+
+### Stage 1 — ε_r assignment
+
+No probe required (this is a simple conditional broadcast: no ONNX
+friction beyond `Where` opset-18 native). Inherits from Stage 1 of F.1
+(scalar broadcast).
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `where(tags == PHYS_ID, n², 1.0)` | `Equal` + `Where` | clean | Native. |
+| Scalar broadcast `(n_tets,)` | — | clean | No shape friction. |
+
+### Stage 2 — Edge enumeration (`build_edges`)
+
+Probe: [`probe_edge_enumeration.py`](probe_edge_enumeration.py).
+
+#### Stage 2a — Local pair extraction + canonicalization (steps 1–2)
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `tets[:, la_arr]` (gather per-local-edge endpoints) | `Gather(axis=1)` | clean | Native; int64 indices. |
+| `min(a, b)`, `max(a, b)` (orient lo-hi) | `Min`, `Max` | clean | Native elementwise. |
+| `reshape(-1)` (flatten) | `Reshape` | clean | Native. |
+| `stack([lo, hi], axis=1)` | `Unsqueeze` + `Concat` | graph-only friction | Same Stack synthesis as cube-cavity. |
+
+Probe result: checker OK, runtime OK, max err = 0.000e+00.
+
+#### Stage 2b — Deduplication + inverse map (steps 3–5)
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `np.unique(pair_flat, axis=0)` (deduplicate row-wise) | `Unique` (1D encoded form) | **secretly imperative** | `Unique` exists for 1D flat arrays; 2D row-dedup requires encoding as a scalar key. Output `n_edges` is **data-dependent** — the ONNX graph types it as `[None]`. More critically, the Python `dict` lookup `edge_to_idx[(lo, hi)]` (steps 4–5) has no ONNX operator equivalent. This is an imperative escape. |
+| `{(lo,hi): i ...}` (hash-map construction) | **None** | **secretly imperative** | No ONNX operator for sorted-rank / inverse-permutation construction. |
+| Per-tet for-loop with dict lookup (fill `tet_edge_idx`, `tet_edge_sign`) | **None** | **secretly imperative** | Data-dependent scatter with variable stride. Cannot be expressed in a static graph. |
+
+#### Stage 2 verdict
+
+**NOT EXPRESSIBLE** for steps 3–5. The local pair extraction (steps 1–2)
+lowers cleanly, but the deduplication, hash-map inverse, and per-tet
+sign-fill are fundamentally host-imperative.
+
+**This is the most important finding of Phase G.6.** The P1 cube-cavity
+assembly had no equivalent step — node DOFs map directly from the
+connectivity table without deduplication. Edge DOFs require a
+topological sort + inverse-map step that is **Nédélec-specific** and
+has no analogue in the P1 reference. Every backend computes `build_edges`
+outside any traced/compiled function boundary. ONNX makes this explicit.
+
+**Design implication**: `edges (n_edges, 2)`, `tet_edge_idx (n_tets, 6)`,
+and `tet_edge_sign (n_tets, 6)` must be **host-computed graph inputs**
+for any Nédélec ONNX assembly graph.
+
+### Stage 3 — Per-element Nédélec local matrices
+
+Probe: [`probe_nedelec_local.py`](probe_nedelec_local.py).
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `v_i - v_j` (vertex subtraction) | `Sub` | clean | Same as P1. |
+| `cross(a, b)` (3-vector cross product) | **synth**: `6 Mul + 3 Sub + 3 Unsqueeze + Concat` | graph-only friction | Same as P1 cube-cavity. No native `Cross`. |
+| `einsum("eik,ejk->eij", g_mat, g_mat)` (cofactor Gram matrix) | `Einsum` | clean | Native opset 12+. **Preferred over MatMul+Transpose here** because the named-index form matches the formula in `nedelec.rs:199-210` one-for-one. |
+| `Abs(det)` | `Abs` | clean | Native. |
+| `ReduceSum` (det = sum along axis=1) | `ReduceSum` | clean | Axes-as-input form (opset 13+). |
+| `Gather(gg, axis=1, idx=p)` + `Gather(axis=1, idx=q)` → `gg_pq` | `Gather` × 2 | clean | 4×4 Gram entry extraction for each of 36 edge pairs. |
+| `gg_ac * gg_bd - gg_ad * gg_bc` (K_ij numerator) | `Mul` + `Sub` | clean | 2 muls + 1 sub per entry; 36 entries. |
+| `f_ac * gg_bd - ... + f_bd * gg_ac` (M_ij terms) | `Mul` + `Sub` + `Add` × 2 | clean | Kronecker factors `f_pq` baked as scalar `Constant` nodes. 4 muls + 3 add/subs per entry; 36 entries. |
+| `(2/3) / abs_det³` broadcast scale | `Div` + `Mul` × 2 + `Reshape` | clean | Scale precomputed as `inv_abs_det3`; reshaped to (N, 1, 1) for broadcast. |
+| `1/(120 * abs_det)` broadcast scale | `Div` + `Reshape` | clean | Same broadcast pattern. |
+| Stack 36 (N,) entries → (N, 6, 6) | `Unsqueeze` × 36 + `Concat` + `Reshape` | graph-only friction | The 36-entry `Unsqueeze + Concat` chain is verbose but graph-safe. Same disposition as Stage 1's 4-entry version in cube-cavity. |
+
+Probe result: checker OK, runtime OK, max |K_onnx − K_numpy| = 0.000e+00,
+max |M_onnx − M_numpy| = 0.000e+00 (bit-exact in f64).
+
+#### Stage 3 — P1 vs. Nédélec structural comparison
+
+| Dimension | P1 (cube-cavity) | Nédélec (sphere-PEC) |
+|---|---|---|
+| Output shape per element | (N, 4, 4) — 16 entries | (N, 6, 6) — 36 entries |
+| Index structure | Node pairs (4×4) | Edge pairs via TET_LOCAL_EDGES (6×6) |
+| Gram pivot | g_mat @ g_mat^T via MatMul+Transpose | same via `Einsum("eik,ejk->eij")` |
+| Scale formula | `gg / (6 * |det|)` for K | `(2/3) * (gg_ac gg_bd - gg_ad gg_bc) / |det|³` for K |
+| Mass formula | constant pattern × det/120 | four-Kronecker-delta terms / (120 |det|) |
+| Graph-only friction | cross synth + Stack | same + 2.25× more Gather/Mul nodes |
+| Secretly imperative | none | none |
+
+**Stage 3 verdict: EXPRESSIBLE** — the 6×6 index structure is fixed for
+all tets and baked as graph-level constants. No dynamic dispatch; the
+graph size grows by ~2.25× vs. P1 but the classification is unchanged.
+
+### Stage 4 — PEC boundary mask
+
+Probe: [`probe_pec_mask.py`](probe_pec_mask.py).
+
+#### Stage 4a — Mask computation (steps 1–4)
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `np.linalg.norm(nodes, axis=1)` (node radii) | `ReduceL2(axis=1)` | clean | Native opset 18. |
+| `abs(r - r_outer) < tol` (boundary threshold) | `Sub` + `Abs` + `Less` | clean | Broadcast constant `r_outer`; all native. |
+| `on_boundary[edges[:, 0]]` (endpoint flag lookup) | `Gather(axis=0)` | clean | Native; same as Dirichlet Gather in F.1 Stage 3. |
+| `~(a_on & b_on)` (interior = not both on wall) | `And` + `Not` | clean | Native boolean ops. |
+
+Probe result: checker OK, runtime OK, mask matches NumPy reference exactly.
+
+#### Stage 4b — Index derivation (step 5 onward)
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `idx = np.flatnonzero(interior_mask)` | `NonZero` + `Squeeze` | **caveat** | Output shape is `(None,)` — data-dependent. Propagates `(None, None)` shape downstream to K_int, M_int. Same classification as cube-cavity Stage 3 (F.1). |
+| `K[idx, :][:, idx]` with precomputed `idx` | `Gather(axis=0)` + `Gather(axis=1)` | clean | If `idx` is a graph input (host-computed), this lowers cleanly. Recommended design. |
+
+**Stage 4 verdict: EXPRESSIBLE** — the mask computation (steps 1–4)
+lowers cleanly. Deriving `idx` in-graph via NonZero introduces a
+data-dependent shape (caveat, not secretly-imperative). Recommended
+design: host-compute `interior_idx` from the mask and pass as a graph
+input, mirroring the JAX and TF-Java conventions.
+
+**New finding vs. P1**: the Nédélec PEC mask IS derivable *inside* the
+ONNX graph from node positions (ReduceL2 + threshold), unlike the P1
+case where the Dirichlet mask comes from an external tag. The mask
+computation itself is graph-only; only the index extraction breaks
+static shape. This is a qualitative improvement over the P1 case (where
+the entire mask was typically precomputed on the host).
+
+### Stage 5 — Global K/M scatter-add
+
+Probe: [`probe_nedelec_scatter.py`](probe_nedelec_scatter.py).
+
+#### Stage 5 — Static-shape version (n_edges known at build time)
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `sign[e,i] * sign[e,j]` (outer product) | `Unsqueeze(ax=2)` + `Unsqueeze(ax=1)` + `Mul` | clean | Broadcasting (N,6,1) × (N,1,6) → (N,6,6). New vs. P1. |
+| `k_local * sign_outer` (sign correction) | `Mul` | clean | Native elementwise. |
+| `m_local * sign_outer * eps` (sign + ε scaling) | `Mul` × 2 + `Reshape` | clean | `eps` reshaped to (N,1,1) for broadcast. |
+| `tet_edge_idx[:, :, None]` broadcast → rows | `Unsqueeze(ax=2)` + `Expand` | clean | Native. |
+| `tet_edge_idx[:, None, :]` broadcast → cols | `Unsqueeze(ax=1)` + `Expand` | clean | Native. |
+| Flatten rows, cols, vals to 1-D | `Reshape` | clean | Native. |
+| Build `(M, 2)` index table | `Unsqueeze` + `Concat` | clean | Same pattern as cube-cavity. |
+| `np.zeros((n_edges, n_edges))` zero buffer | `ConstantOfShape` | clean | Native opset 9+. |
+| `buf.at[rows, cols].add(vals)` scatter-add | `ScatterND(reduction="add")` | clean | Same as cube-cavity; the critical op for phase assembly. |
+
+Probe result: checker OK, runtime OK, max |K_onnx − K_numpy| = 0.000e+00,
+max |M_onnx − M_numpy| = 0.000e+00 (bit-exact).
+
+#### Stage 5 — Dynamic-shape friction (real pipeline)
+
+The static-shape test passes perfectly. In the real pipeline, `n_edges`
+is the output of `build_edges` (stage 2: NOT EXPRESSIBLE) and is a
+runtime value not known at graph-build time. This means:
+
+| Sub-issue | Impact |
+|---|---|
+| `n_edges` unknown at graph-build time | `ConstantOfShape` must accept a dynamic shape tensor; buffer is typed `(n_edges, n_edges)` where `n_edges` is `None` from static-shape inference. |
+| K_global, M_global output types | `(None, None)` downstream; breaks compile-time tensor-shape validation. |
+| Downstream Dirichlet Gather | Inherits the dynamic first axis from K_global. |
+
+**Stage 5 verdict: PARTIAL** — the scatter-add mechanics (ScatterND +
+sign outer product) lower cleanly when `n_edges` is a static constant.
+In the real pipeline, `n_edges` is data-dependent (from `build_edges`),
+which propagates a dynamic-shape axis through the global matrices.
+This is graph-only friction (not secretly-imperative — the scatter
+mechanism itself is correct), inherited from the `build_edges` escape.
+
+### Stage 6 — Dirichlet restriction (interior edge set)
+
+No separate probe required; this is structurally identical to the cube-
+cavity Stage 3 (F.1), applied to edges instead of nodes.
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `K[interior_idx, :]` with precomputed `idx` | `Gather(axis=0)` | clean | Same as F.1. |
+| `K[:, interior_idx]` | `Gather(axis=1)` | clean | Same as F.1. |
+| `idx = np.flatnonzero(interior_mask)` | `NonZero` + `Squeeze` | caveat | Data-dependent shape; same as F.1. |
+
+Design recommendation: identical to cube-cavity. Accept `interior_idx
+(n_int,) int64` as a host-computed graph input. This keeps the
+restricted matrices `K_int (n_int, n_int)`, `M_int (n_int, n_int)`
+statically-shaped at the eigensolve boundary.
+
+Note: there is an additional complication not present in P1 — `n_int`
+(number of interior edges) depends on `n_edges` (which is already
+data-dependent from `build_edges`). Even with `interior_idx` as a
+graph input, the shape of `K_int` depends on `len(interior_idx)` which
+is a runtime value. This means `K_int` is `(None, None)` regardless.
+The recommended mitigation is to specialize the graph per mesh (baking
+`n_edges` and `n_int` as constants at graph generation time), which is
+how the cube-cavity end-to-end graph in Phase F.2 is constructed.
+
+### Stage 7 — Generalized eigensolve (boundary, shared L4 friction)
+
+Not in this audit. Same disposition as cube-cavity Stage 4: all backends
+offload to SciPy ARPACK or an equivalent on the host. ONNX has no
+`Eigh` op; this is shared L4 friction across the reference set.
+
+## Cross-cutting frictions: F.1 vs. G.6 comparison
+
+| Friction | F.1 (cube-cavity P1) | G.6 (sphere-PEC Nédélec) | Change |
+|---|---|---|---|
+| No `Stack` op (`Unsqueeze + Concat`) | graph-only | graph-only | **Unchanged** |
+| Int64 axes required | graph-only | graph-only | **Unchanged** |
+| `MatMul` broadcasts batch dim | clean | — (uses `Einsum` instead) | **Einsum is cleaner for named-index formulas** |
+| `ScatterND(reduction="add")` | clean | clean | **Unchanged** |
+| `NonZero` (mask→idx) introduces data-dep shape | caveat | caveat | **Unchanged; same recommendation** |
+| **`build_edges` deduplication + inverse map** | **N/A (no edge DOFs)** | **secretly imperative** | **NEW in G.6 — Nédélec-specific escape** |
+| **Sign outer product (s_i s_j correction)** | **N/A** | graph-only friction | **NEW in G.6 — expressible but more complex** |
+| **Global buffer size `(n_edges, n_edges)`** | static (n_nodes known) | **data-dependent** | **NEW in G.6 — inherited from build_edges** |
+| Complex arithmetic | deferred (P1 real-symmetric) | deferred (PEC no PML) | **Unchanged** |
+
+## Per-stage verdicts (one-line summary)
+
+| Stage | Verdict |
+|---|---|
+| 1. ε_r assignment | clean (Equal + Where) |
+| 2a. Local pair extraction | clean (Gather + Min/Max) |
+| 2b. Deduplication + inverse map | NOT EXPRESSIBLE — secretly-imperative escape (dict lookup + topological sort) |
+| 3. Nédélec local 6×6 matrices | EXPRESSIBLE — same graph-only friction as P1; 2.25× more nodes |
+| 4a. PEC mask computation | EXPRESSIBLE — ReduceL2 + threshold + boolean ops |
+| 4b. PEC mask → interior idx | caveat — NonZero introduces data-dependent shape (same as F.1 Stage 3) |
+| 5. Global K/M scatter-add (static n_edges) | EXPRESSIBLE — ScatterND(reduction="add") + sign outer product |
+| 5. Global K/M scatter-add (real pipeline) | PARTIAL — data-dependent shape from n_edges; scatter mechanics are correct |
+| 6. Dirichlet restriction | clean (two Gathers) if interior_idx is host-computed; caveat if derived in-graph |
+| 7. Eigensolve | out of scope — shared L4 friction |
+
+## What this audit found (summary for L4 calculus)
+
+### New findings vs. Phase F.1
+
+**1. `build_edges` is the first secretly-imperative L4 escape on the
+sphere-PEC assembly spine.** The cube-cavity P1 audit found no
+secretly-imperative operators. The Nédélec case immediately hits one in
+stage 2: the deduplication + inverse-map construction is not expressible
+in any static-graph IR (ONNX, XLA, or TF-Java). This is not
+ONNX-specific — it is inherent to the L4 Nédélec abstraction.
+The edge DOF table is a combinatorial artifact of H(curl) elements.
+
+**2. The global buffer size becomes data-dependent.** In P1, `n_nodes`
+is a static integer (the number of input vertices). In Nédélec,
+`n_edges` is the output of `build_edges`, which is not expressible in
+the graph. This cascades: the zero buffer, K_global, M_global, and
+K_int/M_int all have a dynamic first axis in the real pipeline.
+
+**3. The sign outer product is a new friction surface.** The Nédélec
+assembly requires a per-tet s_i × s_j outer product (from `tet_edge_sign`)
+applied to the 6×6 local blocks. This IS expressible (via Unsqueeze +
+Mul broadcasting) but is absent from the P1 case. Classification:
+graph-only friction.
+
+**4. The PEC mask computation is *more* graph-expressible than the P1
+Dirichlet mask.** In the cube-cavity case, the Dirichlet mask comes from
+an external tagging (not computed in the graph). The Nédélec PEC mask
+is derived from node positions inside the ONNX graph (ReduceL2 +
+threshold), which IS graph-expressible. Only the subsequent idx
+derivation breaks static shape — and the same caveat applies to both
+cases.
+
+### What is expressible in the Nédélec ONNX graph
+
+Given pre-computed host inputs `edges`, `tet_edge_idx`, `tet_edge_sign`,
+and `interior_idx` (and static constants `n_edges`, `n_int` baked at
+graph-generation time):
+
+- Per-element 6×6 K_local and M_local: fully expressible (Stage 3).
+- Sign correction and ε scaling: fully expressible (Stage 5).
+- COO index construction and scatter-add: fully expressible (Stage 5).
+- PEC mask computation: expressible for the boolean mask (Stage 4a).
+- Dirichlet restriction with precomputed idx: fully expressible (Stage 6).
+
+### What is not expressible (must be host-computed)
+
+- `build_edges` (Stage 2b): deduplication, inverse map, sign fill.
+  These are host inputs: `edges`, `tet_edge_idx`, `tet_edge_sign`.
+- `interior_idx` derivation from the boolean mask: host-computed via
+  `np.flatnonzero(interior_mask)`.
+- `spurious_dim_from_derham` (SVD-based rank computation): host imperative.
+- Eigensolve: host imperative (shared L4 friction across all backends).
+
+## Recommended design for a future Nédélec ONNX assembly graph
+
+Graph inputs:
+- `nodes (n_nodes, 3) float64` — mesh vertex coordinates
+- `tets (n_tets, 4) int64` — tet connectivity
+- `tet_edge_idx (n_tets, 6) int64` — HOST-COMPUTED (from `build_edges`)
+- `tet_edge_sign (n_tets, 6) float64` — HOST-COMPUTED (from `build_edges`)
+- `epsilon_r (n_tets,) float64` — HOST-COMPUTED (from `build_epsilon_r`)
+- `interior_idx (n_int,) int64` — HOST-COMPUTED (from `flatnonzero(pec_mask)`)
+
+Graph constants (baked at generation time, not from host inputs):
+- `n_edges: int` — from `len(edges)` (output of `build_edges`)
+- `n_int: int` — from `len(interior_idx)` (output of `flatnonzero`)
+
+Graph outputs:
+- `K_int (n_int, n_int) float64`
+- `M_int (n_int, n_int) float64`
+
+Eigensolve seam: same JSON-sidecar pattern as Phase F.2. Host driver
+calls `scipy.sparse.linalg.eigsh` on the ONNX-produced K_int, M_int.
+
+## Acknowledgements / cross-references
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — overall
+  framing and Phase G.6 scope.
+- Phase F.1 analog: [`cube_cavity_operator_audit.md`](../cube_cavity_operator_audit.md)
+  — the baseline comparison for all F.1 vs. G.6 rows above.
+- Friction tracker [#5](https://github.com/rjwalters/geode-fem/issues/5)
+  — a roll-up of these findings is posted as a comment on #5 when this
+  PR lands.
+- NumPy sphere-PEC reference: [`reference/numpy/sphere_pec.py`](../../../numpy/sphere_pec.py).
+- NumPy Nédélec local matrices: [`reference/numpy/nedelec_local_matrices.py`](../../../numpy/nedelec_local_matrices.py).
+- Burn-side kernel: `crates/geode-core/src/nedelec_assembly.rs`.
+
+## Re-running this audit
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt
+python3 audit/sphere_pec/probe_nedelec_local.py
+python3 audit/sphere_pec/probe_edge_enumeration.py
+python3 audit/sphere_pec/probe_nedelec_scatter.py
+python3 audit/sphere_pec/probe_pec_mask.py
+```
+
+Each probe prints a one-screen verdict that should match the
+corresponding row(s) in this table. If a probe's verdict disagrees
+with the table after a version bump, the table is stale — re-audit.

--- a/reference/onnx/audit/sphere_pec/probe_edge_enumeration.py
+++ b/reference/onnx/audit/sphere_pec/probe_edge_enumeration.py
@@ -1,0 +1,359 @@
+"""Probe: ONNX expressibility of edge enumeration (build_edges).
+
+Epic #88, Phase G.6 (issue #135). This probe asks whether the
+`build_edges` step from `reference/numpy/sphere_pec.py` can be
+expressed as a pure ONNX graph.
+
+What build_edges does
+=====================
+
+Given `tets` of shape (n_tets, 4) (tet connectivity table), it:
+
+  1. Extracts the 6 local-edge vertex-index pairs per tet, flattened to
+     (n_tets * 6, 2), using the fixed `TET_LOCAL_EDGES` ordering.
+  2. Canonicalizes each pair to (lo, hi) = (min(a,b), max(a,b)).
+  3. Deduplicates the resulting (lo, hi) pairs using a sort + unique step
+     to get a globally-indexed edge list of shape (n_edges, 2).
+  4. Builds a (lo, hi) -> global edge index lookup map (a Python dict).
+  5. Fills per-tet tables: `tet_edge_idx (n_tets, 6)` and
+     `tet_edge_sign (n_tets, 6)` by iterating over all (tet, local-edge)
+     pairs and looking up the canonical index.
+
+Why this is NOT expressible
+============================
+
+Steps 3-5 are the blockers:
+
+  (A) `np.unique(..., axis=0)` — ONNX has no deduplication op. This step
+      takes a (n_tets*6, 2) table of (lo, hi) pairs and returns only the
+      distinct rows, in sorted order. The output shape is data-dependent:
+      `n_edges` depends on which edges are shared between tets, which is a
+      topological property of the mesh that cannot be inferred statically.
+      ONNX cannot express this.
+
+  (B) The hash-map lookup `edge_to_idx[(lo, hi)]` — building a sorted
+      rank/relabeling map from the deduplicated edge list is a topological
+      sort / sparse encoding step. ONNX has no sorted-unique-with-inverse
+      operator. The closest analog would be a sequence of Sort + NonZero
+      ops, but the output of NonZero has data-dependent shape, and the
+      composition (sort the pairs, find the inverse permutation) is not
+      expressible as a static graph.
+
+  (C) The double for-loop (tet, local edge) with dict lookup to fill
+      `tet_edge_idx` — this is a data-dependent scatter with variable
+      stride (each tet contributes to different global edge indices
+      depending on the mesh topology). The global edge indices are not
+      computable without completing step (A) first.
+
+The probe demonstrates this by showing:
+  - Step 1+2 (local pair extraction + canonicalization) ARE expressible
+    via Gather + Min + Max.
+  - Step 3 (unique) causes an explicit failure because ONNX has no
+    `Unique` op that returns the full sorted-unique-rows output for 2D
+    inputs in a static-shape-safe way. (ONNX does have `Unique` for 1D
+    flat inputs but not for 2D row-deduplication with pair keys.)
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pec/probe_edge_enumeration.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+from sphere_pec import build_edges  # noqa: E402
+
+OPSET = 18
+
+# Canonical local-edge pair indices as constants.
+LOCAL_A = np.array([a for a, _ in TET_LOCAL_EDGES], dtype=np.int64)  # (6,)
+LOCAL_B = np.array([b for _, b in TET_LOCAL_EDGES], dtype=np.int64)  # (6,)
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_local_pairs_graph(n_tets: int) -> onnx.ModelProto:
+    """Build the EXPRESSIBLE part: local pair extraction + canonicalization.
+
+    Inputs: tets (n_tets, 4) int64
+    Output: lo_hi_pairs (n_tets * 6, 2) int64 — canonicalized (min, max) pairs.
+
+    This is ONLY steps 1+2 of build_edges. Step 3 (deduplication) cannot
+    follow in a static graph.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    tets_vi = oh.make_tensor_value_info("tets", TensorProto.INT64, shape=[n_tets, 4])
+
+    # Bake local edge vertex indices as constants
+    nodes.append(_const("local_a", LOCAL_A))  # (6,)
+    nodes.append(_const("local_b", LOCAL_B))  # (6,)
+
+    # Gather vertex_a = tets[:, local_a] -> (n_tets, 6)
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["tets", "local_a"],
+        outputs=["vert_a"],
+        axis=1,
+    ))
+    # Gather vertex_b = tets[:, local_b] -> (n_tets, 6)
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["tets", "local_b"],
+        outputs=["vert_b"],
+        axis=1,
+    ))
+
+    # Canonicalize: lo = min(a, b), hi = max(a, b)
+    nodes.append(oh.make_node("Min", ["vert_a", "vert_b"], ["lo"]))
+    nodes.append(oh.make_node("Max", ["vert_a", "vert_b"], ["hi"]))
+
+    # Flatten to (n_tets * 6,) then unsqueeze + concat to (n_tets * 6, 2)
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["lo", "shape_flat"], ["lo_flat"]))
+    nodes.append(oh.make_node("Reshape", ["hi", "shape_flat"], ["hi_flat"]))
+    nodes.append(_const("axis_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["lo_flat", "axis_neg1"], ["lo_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["hi_flat", "axis_neg1"], ["hi_col"]))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["lo_col", "hi_col"],
+        outputs=["lo_hi_pairs"],
+        axis=1,
+    ))
+
+    pairs_vi = oh.make_tensor_value_info(
+        "lo_hi_pairs", TensorProto.INT64, shape=[n_tets * 6, 2]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="local_pairs_probe",
+        inputs=[tets_vi],
+        outputs=[pairs_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: edge enumeration (build_edges) — sphere PEC, Phase G.6 ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Tiny test mesh: 2 tets sharing an edge
+    tets_np = np.array(
+        [[0, 1, 2, 3],
+         [1, 2, 3, 4]],
+        dtype=np.int64,
+    )
+    n_tets = tets_np.shape[0]
+
+    # --- Part A: expressible sub-steps ---
+    print("Part A — local pair extraction + canonicalization (steps 1-2 of build_edges)")
+    print("--------------------------------------------------------------")
+    model_a = build_local_pairs_graph(n_tets)
+    try:
+        onnx.checker.check_model(model_a)
+        a_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_checker = f"FAIL ({e!r})"
+
+    a_rt = "skipped"
+    a_err = float("nan")
+    try:
+        sess_a = ort.InferenceSession(model_a.SerializeToString())
+        out_a = sess_a.run(["lo_hi_pairs"], {"tets": tets_np})
+        pairs_onnx = out_a[0]
+
+        # Reference: what numpy would do
+        la = np.array([a for a, _ in TET_LOCAL_EDGES], dtype=np.int64)
+        lb = np.array([b for _, b in TET_LOCAL_EDGES], dtype=np.int64)
+        va = tets_np[:, la]
+        vb = tets_np[:, lb]
+        lo = np.minimum(va, vb).ravel()
+        hi = np.maximum(va, vb).ravel()
+        pairs_ref = np.stack([lo, hi], axis=1)
+
+        a_err = float(np.max(np.abs(pairs_onnx - pairs_ref)))
+        a_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_rt = f"FAIL ({e!r})"
+
+    print(f"  Gather (axis=1)      EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print(f"  Min / Max            EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print(f"  Reshape / Unsqueeze  EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print(f"  Concat               EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print(f"  onnx.checker: {a_checker}")
+    print(f"  onnxruntime: {a_rt}")
+    if a_rt == "OK":
+        print(f"  max |pairs_onnx - pairs_ref| = {a_err:.3e}")
+    print()
+
+    # --- Part B: deduplication — NOT expressible ---
+    print("Part B — deduplication + inverse map (steps 3-5 of build_edges)")
+    print("--------------------------------------------------------------")
+    print("  Attempting to build a graph for np.unique(pairs, axis=0)...")
+    print()
+    # ONNX `Unique` op (opset 11) operates only on 1D flat arrays and returns
+    # (unique_values, indices, inverse_indices, counts). For 2D row-dedup we
+    # would need to encode each (lo, hi) pair as a scalar key and then unique
+    # that. Even if we did, the output `n_edges` is data-dependent — its size
+    # depends on the mesh topology.
+    #
+    # Attempt: encode each row as lo * (max_node+1) + hi and apply Unique.
+    max_node = int(tets_np.max()) + 1
+    nodes: list[onnx.NodeProto] = []
+
+    tets_vi = oh.make_tensor_value_info("tets", TensorProto.INT64, shape=[n_tets, 4])
+
+    # Reuse the local-pair extraction from Part A.
+    nodes.append(_const("local_a", LOCAL_A))
+    nodes.append(_const("local_b", LOCAL_B))
+    nodes.append(oh.make_node("Gather", ["tets", "local_a"], ["vert_a"], axis=1))
+    nodes.append(oh.make_node("Gather", ["tets", "local_b"], ["vert_b"], axis=1))
+    nodes.append(oh.make_node("Min", ["vert_a", "vert_b"], ["lo"]))
+    nodes.append(oh.make_node("Max", ["vert_a", "vert_b"], ["hi"]))
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["lo", "shape_flat"], ["lo_flat"]))
+    nodes.append(oh.make_node("Reshape", ["hi", "shape_flat"], ["hi_flat"]))
+
+    # Encode: key = lo * max_node + hi
+    nodes.append(_const("max_node_scalar", np.array(max_node, dtype=np.int64)))
+    nodes.append(oh.make_node("Mul", ["lo_flat", "max_node_scalar"], ["lo_scaled"]))
+    nodes.append(oh.make_node("Add", ["lo_scaled", "hi_flat"], ["pair_keys"]))
+
+    # Apply Unique — this is the step that introduces data-dependent output shape.
+    # `Unique` returns: (unique_values, indices, inverse_indices, counts)
+    nodes.append(oh.make_node(
+        "Unique",
+        inputs=["pair_keys"],
+        outputs=["unique_keys", "unique_indices", "inverse_indices", "counts"],
+        sorted=1,
+    ))
+
+    # unique_keys has shape (n_edges,) where n_edges is DATA-DEPENDENT.
+    # This means everything downstream has a dynamic shape axis.
+    unique_vi = oh.make_tensor_value_info(
+        "unique_keys", TensorProto.INT64, shape=[None]  # data-dependent!
+    )
+
+    try:
+        graph_b = oh.make_graph(
+            nodes,
+            name="dedup_probe",
+            inputs=[tets_vi],
+            outputs=[unique_vi],
+        )
+        model_b = oh.make_model(
+            graph_b,
+            opset_imports=[oh.make_opsetid("", OPSET)],
+            ir_version=9,
+        )
+        onnx.checker.check_model(model_b)
+        b_checker = "OK (but output shape is [None] — data-dependent!)"
+    except Exception as e:  # noqa: BLE001
+        b_checker = f"FAIL ({e!r})"
+
+    b_rt = "skipped"
+    n_unique_onnx = None
+    n_unique_ref = None
+    try:
+        sess_b = ort.InferenceSession(model_b.SerializeToString())
+        out_b = sess_b.run(["unique_keys"], {"tets": tets_np})
+        unique_keys = out_b[0]
+        n_unique_onnx = len(unique_keys)
+
+        # Reference
+        edges_ref, _, _ = build_edges(tets_np)
+        n_unique_ref = len(edges_ref)
+        b_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_rt = f"FAIL ({e!r})"
+
+    print(f"  Unique (opset 11)    EXPRESSIBLE but output shape is data-dependent:")
+    print(f"                       n_edges = len(unique_keys) depends on mesh topology.")
+    print(f"                       The ONNX IR types this as [None] — no static shape.")
+    print()
+    print(f"  onnx.checker: {b_checker}")
+    print(f"  onnxruntime: {b_rt}")
+    if b_rt == "OK":
+        print(f"  n_unique_edges via ONNX: {n_unique_onnx}")
+        print(f"  n_unique_edges via NumPy: {n_unique_ref}")
+    print()
+    print("  Even if Unique succeeds for the encoded keys, recovering the (lo, hi)")
+    print("  pairs requires decoding (mod + div on unique_keys), and then filling")
+    print("  the tet_edge_idx / tet_edge_sign tables requires a scatter-with-lookup")
+    print("  whose target indices are the output of the Unique step — i.e. data-")
+    print("  dependent indices into a data-dependent-length buffer. This chain")
+    print("  cannot be expressed in a statically-shaped ONNX graph.")
+    print()
+    print("  Classification: NOT EXPRESSIBLE as a static-shape graph.")
+    print("  The Unique op exists, but the entire build_edges pipeline requires:")
+    print("    (1) data-dependent output shape (n_edges is a function of mesh topology),")
+    print("    (2) a hash-map lookup (Python dict) that has no ONNX equivalent,")
+    print("    (3) a topological sort that is imperatively shaped.")
+    print()
+    print("Cross-cutting frictions observed:")
+    print("--------------------------------------------------------------")
+    print("  - `build_edges` is FUNDAMENTALLY host-imperative. It is the")
+    print("    combinatorial backbone of the Nedelec assembly and cannot be")
+    print("    lowered to any static-graph IR (ONNX, XLA, TF-Java).")
+    print("  - The P1 analog (cube-cavity) had NO equivalent step: node DOFs")
+    print("    are directly indexed by the connectivity table; no deduplication")
+    print("    or inverse-map construction is needed. This is Nedelec-specific.")
+    print("  - Every backend (NumPy, Burn/Rust, JAX) computes build_edges")
+    print("    outside any traced/compiled function boundary. ONNX makes this")
+    print("    explicit by having no `Unique`-on-2D-rows operator.")
+    print("  - Recommendation: `edges`, `tet_edge_idx`, `tet_edge_sign` are")
+    print("    HOST-COMPUTED graph inputs for any Nedelec ONNX assembly graph,")
+    print("    exactly as `nodes` and `tets` are for P1.")
+    print()
+    print("Verdict: NOT EXPRESSIBLE")
+    print("  `build_edges` (deduplication + inverse map) cannot be expressed as")
+    print("  a pure ONNX graph. The local pair extraction (steps 1-2) lowers")
+    print("  cleanly; the deduplication (step 3) requires Unique with data-")
+    print("  dependent output shape; the inverse-map lookup (steps 4-5) requires")
+    print("  an imperative hash-map that has no ONNX operator equivalent.")
+    print("  Friction class: secretly-imperative L4 escape.")
+
+    # Exit 0 if Part A worked (which is the expressible sub-claim), 1 if broken.
+    return 0 if a_checker == "OK" and a_rt == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/sphere_pec/probe_nedelec_local.py
+++ b/reference/onnx/audit/sphere_pec/probe_nedelec_local.py
@@ -1,0 +1,471 @@
+"""Probe: ONNX expressibility of Nedelec element-local 6x6 curl-curl matrix.
+
+Epic #88, Phase G.6 (issue #135). This probe asks whether the per-element
+6x6 Nedelec curl-curl and mass matrices can be expressed as a pure ONNX
+graph, mirroring `reference/numpy/nedelec_local_matrices.py` and the
+NumPy reference in `reference/numpy/sphere_pec.py`.
+
+Assembly spine for one element
+==============================
+
+Stage 1 of the sphere PEC assembly generates, per tet:
+
+    (1) cofactor-form area-weighted gradients g_0..g_3  (shapes (N, 3))
+    (2) cofactor Gram matrix gg[e, p, q] = g_p . g_q    (N, 4, 4)
+    (3) |det(J)| per element                             (N,)
+    (4) K_{ij} = (2/3) * (gg_ac gg_bd - gg_ad gg_bc) / |det|^3
+    (5) M_{ij} = (1/(120|det|)) * [f_ac gg_bd - f_ad gg_bc
+                                    - f_bc gg_ad + f_bd gg_ac]
+
+where i = (a,b) and j = (c,d) range over TET_LOCAL_EDGES (6 pairs each),
+and f_pq = (1 + delta_pq).
+
+The key structural difference from the P1 case (Stage 1 of cube-cavity):
+- P1 outputs a (N, 4, 4) matrix (nodes x nodes)
+- Nedelec outputs a (N, 6, 6) matrix (edges x edges)
+- The 6x6 index structure (TET_LOCAL_EDGES pair-of-pairs) must be
+  baked in as constants; there is no looped dynamic dispatch in the
+  static graph.
+
+The good news: every operation on `gg` (element-wise products, constant
+scalar multiplications, sums) is a combination of Gather, Mul, Sub, Add,
+and Div. The 6x6 structure is FIXED for all tets (shape does not depend
+on data values). The same Einsum operator or explicit Gather decomposition
+that works for P1 generalizes here.
+
+Strategy
+========
+
+We build the graph with `onnx.helper` (NOT `onnxscript`). The Gram
+matrix gg is computed as g_mat @ g_mat^T via Einsum (cleaner than the
+MatMul + Transpose used in probe_p1_local.py because gg has shape
+(N, 4, 4) but we need to slice 6x6 entries by (a,b,c,d) tuples). Then
+each of the 36 K_{ij} and M_{ij} entries is assembled by:
+
+    Gather(gg, row=a, col=c) * Gather(gg, row=b, col=d) - ...
+
+Explicitly: 36 * 4 = 144 Gather ops + 36 * (2 Mul + 1 Sub) K-entries
+plus 36 * (4 Mul + 3 Add/Sub) M-entries. This is graph-correct and
+corresponds exactly to the nested for-loop in `nedelec_local_matrices.py`.
+
+In practice a real Nedelec graph would use Einsum to express the 6x6
+index contraction more compactly. We demonstrate that path as a
+`PARTIAL: EXPRESSIBLE via Einsum` note — but build the explicit Gather
+version to surface the friction at the IR level.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pec/probe_nedelec_local.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import (  # noqa: E402
+    TET_LOCAL_EDGES,
+    batched_nedelec_local_matrices,
+)
+
+OPSET = 18
+
+# The 36 (i,j) = ((a,b), (c,d)) pair-of-pairs, baked in as constants.
+# This is the fixed 6x6 Nedelec local stiffness/mass index structure.
+EDGE_PAIRS: list[tuple[int, int, int, int]] = [
+    (a, b, c, d)
+    for (a, b) in TET_LOCAL_EDGES
+    for (c, d) in TET_LOCAL_EDGES
+]
+
+# Kronecker delta factors f_pq = 1 + delta_pq, precomputed for all (a,c)
+# (b,d) (a,d) (b,c) pairs used by the mass formula.
+def _f(p: int, q: int) -> float:
+    return 2.0 if p == q else 1.0
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_nedelec_local_graph() -> onnx.ModelProto:
+    """Build a graph that takes elem_coords (N, 4, 3) f64 and returns
+    k_local (N, 6, 6) and m_local (N, 6, 6).
+
+    Inner loop structure:
+      1. Compute g0..g3 (cofactor gradients) via Sub + cross synthesis.
+      2. Compute gg (4x4 Gram matrix) via Einsum.
+      3. Compute |det| via ReduceSum.
+      4. For each of 36 edge pairs, extract 4 Gram entries via Gather
+         and form K_{ij}, M_{ij}.
+      5. Stack the 36 entries into (N, 6, 6) via Reshape.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    elem_coords_vi = oh.make_tensor_value_info(
+        "elem_coords", TensorProto.DOUBLE, shape=["N", 4, 3]
+    )
+
+    # --- Axis constants ---
+    nodes.append(_const("axis1_const", np.array([1], dtype=np.int64)))
+    nodes.append(_const("axis_neg1_const", np.array([-1], dtype=np.int64)))
+    for i in range(4):
+        nodes.append(_const(f"idx_{i}", np.array(i, dtype=np.int64)))
+
+    # --- Gather v0..v3 from elem_coords along axis=1 ---
+    for i in range(4):
+        nodes.append(oh.make_node(
+            "Gather",
+            inputs=["elem_coords", f"idx_{i}"],
+            outputs=[f"v{i}"],
+            axis=1,
+        ))
+
+    # --- Edge vectors from v0 ---
+    for i in (1, 2, 3):
+        nodes.append(oh.make_node("Sub", [f"v{i}", "v0"], [f"e{i}"]))
+
+    # --- Cross product synthesis: cross(a, b) -> (N, 3) ---
+    # ONNX has no native Cross. We synthesize as 6 Mul + 3 Sub + Unsqueeze + Concat.
+    nodes.append(_const("comp_0", np.array(0, dtype=np.int64)))
+    nodes.append(_const("comp_1", np.array(1, dtype=np.int64)))
+    nodes.append(_const("comp_2", np.array(2, dtype=np.int64)))
+
+    emitted_components: set[str] = set()
+
+    def emit_components(vec: str) -> tuple[str, str, str]:
+        outs = []
+        for c in range(3):
+            out_name = f"{vec}_c{c}"
+            if out_name not in emitted_components:
+                nodes.append(oh.make_node(
+                    "Gather",
+                    inputs=[vec, f"comp_{c}"],
+                    outputs=[out_name],
+                    axis=1,
+                ))
+                emitted_components.add(out_name)
+            outs.append(out_name)
+        return tuple(outs)  # type: ignore[return-value]
+
+    def emit_cross(a: str, b: str, out: str) -> None:
+        ax, ay, az = emit_components(a)
+        bx, by, bz = emit_components(b)
+        nodes.append(oh.make_node("Mul", [ay, bz], [f"{out}_t1"]))
+        nodes.append(oh.make_node("Mul", [az, by], [f"{out}_t2"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t1", f"{out}_t2"], [f"{out}_cx"]))
+        nodes.append(oh.make_node("Mul", [az, bx], [f"{out}_t3"]))
+        nodes.append(oh.make_node("Mul", [ax, bz], [f"{out}_t4"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t3", f"{out}_t4"], [f"{out}_cy"]))
+        nodes.append(oh.make_node("Mul", [ax, by], [f"{out}_t5"]))
+        nodes.append(oh.make_node("Mul", [ay, bx], [f"{out}_t6"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t5", f"{out}_t6"], [f"{out}_cz"]))
+        for comp in ("cx", "cy", "cz"):
+            nodes.append(oh.make_node(
+                "Unsqueeze",
+                inputs=[f"{out}_{comp}", "axis_neg1_const"],
+                outputs=[f"{out}_{comp}_u"],
+            ))
+        nodes.append(oh.make_node(
+            "Concat",
+            inputs=[f"{out}_cx_u", f"{out}_cy_u", f"{out}_cz_u"],
+            outputs=[out],
+            axis=1,
+        ))
+
+    # g1 = cross(e2, e3), g2 = cross(e3, e1), g3 = cross(e1, e2)
+    emit_cross("e2", "e3", "g1")
+    emit_cross("e3", "e1", "g2")
+    emit_cross("e1", "e2", "g3")
+    # g0 = -(g1 + g2 + g3)
+    nodes.append(oh.make_node("Add", ["g1", "g2"], ["g1_g2"]))
+    nodes.append(oh.make_node("Add", ["g1_g2", "g3"], ["g_sum"]))
+    nodes.append(oh.make_node("Neg", ["g_sum"], ["g0"]))
+
+    # --- det = sum(e1 * g1) along axis=1 ---
+    nodes.append(oh.make_node("Mul", ["e1", "g1"], ["e1g1"]))
+    nodes.append(oh.make_node(
+        "ReduceSum",
+        inputs=["e1g1", "axis1_const"],
+        outputs=["det"],
+        keepdims=0,
+    ))
+    nodes.append(oh.make_node("Abs", ["det"], ["abs_det"]))
+
+    # --- Gram matrix gg (N, 4, 4) via Einsum: "eik,ejk->eij" ---
+    # Stack g0..g3 into g_mat (N, 4, 3)
+    for g in ("g0", "g1", "g2", "g3"):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[g, "axis1_const"],
+            outputs=[f"{g}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["g0_u", "g1_u", "g2_u", "g3_u"],
+        outputs=["g_mat"],
+        axis=1,
+    ))
+    # Einsum: g_mat (N, 4, 3) x g_mat^T -> gg (N, 4, 4)
+    nodes.append(oh.make_node(
+        "Einsum",
+        inputs=["g_mat", "g_mat"],
+        outputs=["gg"],
+        equation="eik,ejk->eij",
+    ))
+
+    # --- Per-element scale factors ---
+    # inv_abs_det = 1 / abs_det  (N,)
+    nodes.append(_const("one_f64", np.array(1.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Div", ["one_f64", "abs_det"], ["inv_abs_det"]))
+    # inv_abs_det3 = inv_abs_det^3
+    nodes.append(oh.make_node("Mul", ["inv_abs_det", "inv_abs_det"], ["inv_abs_det2"]))
+    nodes.append(oh.make_node("Mul", ["inv_abs_det2", "inv_abs_det"], ["inv_abs_det3"]))
+
+    # Reshape scalars (N,) -> (N, 1, 1) for broadcasting against (N, 6, 6)
+    nodes.append(_const("shape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["inv_abs_det3", "shape_n11"], ["inv_det3_b"]))
+    nodes.append(oh.make_node("Reshape", ["inv_abs_det", "shape_n11"], ["inv_det_b"]))
+
+    # --- Per-pair Gram entry extraction ---
+    # For each unique (p, q) pair in {0,1,2,3} x {0,1,2,3} that appears
+    # in EDGE_PAIRS, extract gg[:, p, q] via Gather(axis=1) + Gather(axis=2).
+    # Shape: (N, 4, 4) -Gather(ax=1, idx=p)-> (N, 4) -Gather(ax=1, idx=q)-> (N,)
+    emitted_gg: set[tuple[int, int]] = set()
+
+    def emit_gg(p: int, q: int) -> str:
+        key = (p, q)
+        name = f"gg_{p}{q}"
+        if key not in emitted_gg:
+            # First gather along axis=1 (rows)
+            row_name = f"gg_row{p}"
+            if (p, -1) not in emitted_gg:
+                nodes.append(oh.make_node(
+                    "Gather",
+                    inputs=["gg", f"idx_{p}"],
+                    outputs=[row_name],
+                    axis=1,
+                ))
+                emitted_gg.add((p, -1))
+            # Then gather along axis=1 again (cols of the row-slice)
+            nodes.append(oh.make_node(
+                "Gather",
+                inputs=[row_name, f"idx_{q}"],
+                outputs=[name],
+                axis=1,
+            ))
+            emitted_gg.add(key)
+        return name
+
+    # Build K_ij and M_ij for each of 36 edge pairs
+    k_entries: list[str] = []
+    m_entries: list[str] = []
+
+    for idx, (a, b, c, d) in enumerate(EDGE_PAIRS):
+        gg_ac = emit_gg(a, c)
+        gg_ad = emit_gg(a, d)
+        gg_bc = emit_gg(b, c)
+        gg_bd = emit_gg(b, d)
+
+        # K_{ij} = (2/3) * (gg_ac * gg_bd - gg_ad * gg_bc) / |det|^3
+        # We'll accumulate the cross products in a matrix and broadcast-divide later.
+        nodes.append(oh.make_node("Mul", [gg_ac, gg_bd], [f"kp{idx}_1"]))
+        nodes.append(oh.make_node("Mul", [gg_ad, gg_bc], [f"kp{idx}_2"]))
+        nodes.append(oh.make_node("Sub", [f"kp{idx}_1", f"kp{idx}_2"], [f"kp{idx}_diff"]))
+        k_entries.append(f"kp{idx}_diff")
+
+        # M_{ij} terms with Kronecker factors (baked as float constants)
+        f_ac = _f(a, c)
+        f_ad = _f(a, d)
+        f_bc = _f(b, c)
+        f_bd = _f(b, d)
+
+        # M_term = f_ac * gg_bd - f_ad * gg_bc - f_bc * gg_ad + f_bd * gg_ac
+        nodes.append(_const(f"fac_{idx}_ac", np.array(f_ac, dtype=np.float64)))
+        nodes.append(_const(f"fac_{idx}_ad", np.array(f_ad, dtype=np.float64)))
+        nodes.append(_const(f"fac_{idx}_bc", np.array(f_bc, dtype=np.float64)))
+        nodes.append(_const(f"fac_{idx}_bd", np.array(f_bd, dtype=np.float64)))
+
+        nodes.append(oh.make_node("Mul", [f"fac_{idx}_ac", gg_bd], [f"mp{idx}_1"]))
+        nodes.append(oh.make_node("Mul", [f"fac_{idx}_ad", gg_bc], [f"mp{idx}_2"]))
+        nodes.append(oh.make_node("Mul", [f"fac_{idx}_bc", gg_ad], [f"mp{idx}_3"]))
+        nodes.append(oh.make_node("Mul", [f"fac_{idx}_bd", gg_ac], [f"mp{idx}_4"]))
+        nodes.append(oh.make_node("Sub", [f"mp{idx}_1", f"mp{idx}_2"], [f"mp{idx}_a"]))
+        nodes.append(oh.make_node("Sub", [f"mp{idx}_a", f"mp{idx}_3"], [f"mp{idx}_b"]))
+        nodes.append(oh.make_node("Add", [f"mp{idx}_b", f"mp{idx}_4"], [f"mp{idx}_term"]))
+        m_entries.append(f"mp{idx}_term")
+
+    # Stack 36 (N,) entries into (N, 36) -> reshape to (N, 6, 6)
+    # Unsqueeze each to (N, 1) then Concat along axis=1
+    for i, name in enumerate(k_entries):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[name, "axis_neg1_const"],
+            outputs=[f"{name}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=[f"{name}_u" for name in k_entries],
+        outputs=["k_flat"],
+        axis=1,
+    ))
+    nodes.append(_const("shape_n66", np.array([-1, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["k_flat", "shape_n66"], ["k_raw"]))
+    # Apply (2/3) * (1/|det|^3) scale
+    nodes.append(_const("two_thirds", np.array(2.0 / 3.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["two_thirds", "inv_det3_b"], ["k_scale"]))
+    nodes.append(oh.make_node("Mul", ["k_raw", "k_scale"], ["k_local"]))
+
+    for i, name in enumerate(m_entries):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[name, "axis_neg1_const"],
+            outputs=[f"{name}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=[f"{name}_u" for name in m_entries],
+        outputs=["m_flat"],
+        axis=1,
+    ))
+    nodes.append(oh.make_node("Reshape", ["m_flat", "shape_n66"], ["m_raw"]))
+    # Apply (1/120) * (1/|det|) scale
+    nodes.append(_const("inv_120", np.array(1.0 / 120.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["inv_120", "inv_det_b"], ["m_scale"]))
+    nodes.append(oh.make_node("Mul", ["m_raw", "m_scale"], ["m_local"]))
+
+    k_vi = oh.make_tensor_value_info("k_local", TensorProto.DOUBLE, shape=["N", 6, 6])
+    m_vi = oh.make_tensor_value_info("m_local", TensorProto.DOUBLE, shape=["N", 6, 6])
+
+    graph = oh.make_graph(
+        nodes,
+        name="nedelec_local_probe",
+        inputs=[elem_coords_vi],
+        outputs=[k_vi, m_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: Nedelec local 6x6 curl-curl + mass (sphere PEC, Phase G.6) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    model = build_nedelec_local_graph()
+
+    try:
+        onnx.checker.check_model(model)
+        checker_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        checker_status = f"FAIL ({e!r})"
+
+    rt_status = "skipped"
+    max_err_k = max_err_m = float("nan")
+    try:
+        sess = ort.InferenceSession(model.SerializeToString())
+        # Canonical reference tet
+        verts = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        elem_coords = verts.reshape(1, 4, 3)
+
+        outs = sess.run(["k_local", "m_local"], {"elem_coords": elem_coords})
+        k_onnx, m_onnx = outs
+
+        k_np, m_np, _ = batched_nedelec_local_matrices(elem_coords)
+        max_err_k = float(np.max(np.abs(k_onnx - k_np)))
+        max_err_m = float(np.max(np.abs(m_onnx - m_np)))
+        rt_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        rt_status = f"FAIL ({e!r})"
+
+    print("Operator inventory for Nedelec 6x6 local matrix assembly:")
+    print("--------------------------------------------------------------")
+    print("  Gather (axis=1)       EXPRESSIBLE  lowers cleanly (opset 18 native, int64 idx)")
+    print("  Sub / Add / Neg       EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("  Mul / Div             EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("  Abs                   EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("  ReduceSum             EXPRESSIBLE  lowers cleanly (opset 18 native, axes-as-input)")
+    print("  Einsum (eik,ejk->eij) EXPRESSIBLE  lowers cleanly (opset 12+ native)")
+    print("                                     NOTE: Einsum is preferred over MatMul+Transpose")
+    print("                                     here because the 4x4 Gram contraction reads")
+    print("                                     more clearly as the named index formula.")
+    print("  Unsqueeze / Concat    EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("                                     — Stack synthesis (same as P1).")
+    print("  Reshape               EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print()
+    print("  cross product         EXPRESSIBLE  (synthesized: 6 Mul + 3 Sub + Unsqueeze + Concat)")
+    print("                                     — same graph-only friction as cube-cavity P1.")
+    print()
+    print("Key structural difference from P1:")
+    print("--------------------------------------------------------------")
+    print("  P1: outputs (N, 4, 4)  — node x node, 16 entries")
+    print("  Nedelec: outputs (N, 6, 6)  — edge x edge, 36 entries")
+    print("  The 6x6 index structure (TET_LOCAL_EDGES pair-of-pairs) is")
+    print("  baked in as graph-level constants. No dynamic dispatch; the")
+    print("  static graph size grows by 36/16 = 2.25x vs. P1, but the")
+    print("  graph-only expressibility classification is unchanged.")
+    print()
+    print("  The Gram matrix (4x4) is shared for both K and M, so the")
+    print("  gg (N,4,4) tensor serves as the pivot: all 36 entry formulas")
+    print("  reduce to 4-index Gather + arithmetic on gg columns.")
+    print("  This is EXPRESSIBLE via Einsum or Gather decomposition.")
+    print()
+    print(f"onnx.checker.check_model: {checker_status}")
+    print(f"onnxruntime execution: {rt_status}")
+    if rt_status == "OK":
+        print(f"  max |K_onnx - K_numpy| = {max_err_k:.3e}")
+        print(f"  max |M_onnx - M_numpy| = {max_err_m:.3e}")
+    print()
+    if checker_status == "OK" and rt_status == "OK":
+        print("Verdict: EXPRESSIBLE")
+        print("  Nedelec 6x6 local matrices lower to pure ONNX opset-18 graph.")
+        print("  Friction: same graph-only overhead as P1 (no Stack op, int64")
+        print("  axis constants, cross-product synthesis). The 36-entry expansion")
+        print("  is verbose but does not introduce any secretly-imperative escape.")
+    else:
+        print("Verdict: CHECK FAILED — see errors above.")
+
+    return 0 if checker_status == "OK" and rt_status == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py
+++ b/reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py
@@ -1,0 +1,373 @@
+"""Probe: ONNX expressibility of the Nedelec irregular edge scatter-add.
+
+Epic #88, Phase G.6 (issue #135). This probe asks whether the global
+Nedelec K/M assembly step (scatter per-element 6x6 blocks into a global
+(n_edges, n_edges) buffer) can be expressed as a pure ONNX graph, given
+that `edges`, `tet_edge_idx`, and `tet_edge_sign` are HOST-COMPUTED
+inputs (per the `build_edges` verdict: NOT EXPRESSIBLE, so they enter
+as pre-computed graph inputs exactly like `tets` and `nodes`).
+
+What assemble_global_nedelec does
+==================================
+
+Given:
+  - k_local (n_tets, 6, 6) and m_local (n_tets, 6, 6) — per-element matrices
+  - tet_edge_idx (n_tets, 6) int64 — global edge index per local edge
+  - tet_edge_sign (n_tets, 6) float64 — +/-1 sign per local edge
+  - epsilon_r (n_tets,) float64 — per-tet permittivity
+  - n_edges: int — number of global edges
+
+It:
+  1. Applies sign corrections: k_signed[e,i,j] = k_local[e,i,j] * sign[e,i] * sign[e,j]
+  2. Applies epsilon scaling: m_signed[e,i,j] = m_local[e,i,j] * sign * eps[e]
+  3. Builds COO triplets: rows[e,i,j] = tet_edge_idx[e,i],
+                           cols[e,i,j] = tet_edge_idx[e,j]
+  4. Scatter-adds vals[e,i,j] into K_global[rows[e,i,j], cols[e,i,j]]
+
+Comparison with P1 scatter (cube-cavity)
+==========================================
+
+The P1 scatter (probe_assembly_scatter.py) used ScatterND with
+reduction="add" and was EXPRESSIBLE cleanly.
+
+The Nedelec scatter has additional complications:
+
+  (A) The sign correction involves an OUTER PRODUCT of (n_tets, 6) signs:
+      sign_outer[e, i, j] = sign[e, i] * sign[e, j]
+      This outer product IS expressible via Mul with Unsqueeze broadcasting.
+
+  (B) The COO index construction involves broadcasting tet_edge_idx:
+      rows[e, i, j] = tet_edge_idx[e, i]  (broadcast j-dim)
+      cols[e, i, j] = tet_edge_idx[e, j]  (broadcast i-dim)
+      This IS expressible via Expand/Unsqueeze + Reshape.
+
+  (C) The final ScatterND reduction="add" step is the SAME as P1 —
+      EXPRESSIBLE via ScatterND(reduction="add").
+
+  (D) HOWEVER: n_edges is DATA-DEPENDENT (output of build_edges). The
+      zero-buffer initialization `np.zeros((n_edges, n_edges))` requires
+      knowing n_edges at graph construction time OR accepting it as a
+      shape-carrying input.
+
+      In the P1 case, n_nodes is fixed by the mesh (a static integer).
+      In the Nedelec case, n_edges is the output of a deduplicated edge
+      enumeration — it is a GRAPH INPUT, not a constant. This forces the
+      ConstantOfShape node to take a runtime-shaped input rather than a
+      baked constant, which is legal in ONNX (ConstantOfShape accepts a
+      dynamic shape tensor) but means the output buffer shape is dynamic.
+
+      ScatterND still works on a dynamic-shape buffer, but the output
+      type becomes (n_edges, n_edges) where n_edges is unknown at compile
+      time. This is the same "data-dependent shape" friction class as
+      NonZero in the Dirichlet probe — it propagates through to K_global.
+
+      Classification: PARTIAL — the scatter itself is expressible, but
+      the global buffer size is data-dependent (inherited from build_edges),
+      which breaks static shape inference on K_global.
+
+This probe demonstrates:
+  (1) The sign outer product IS expressible.
+  (2) The COO index construction IS expressible.
+  (3) ScatterND(reduction="add") on the signed 6x6 blocks IS expressible
+      when n_edges is fixed at graph-build time.
+  (4) The n_edges dependency on the dynamic Unique output breaks the
+      static-shape contract for the global buffer.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+from sphere_pec import build_edges  # noqa: E402
+
+OPSET = 18
+
+N_LOCAL = 6  # 6 edges per tet
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_nedelec_scatter_graph(n_tets: int, n_edges: int) -> onnx.ModelProto:
+    """Build the Nedelec scatter-add graph with n_tets and n_edges fixed.
+
+    Inputs:
+      k_local (n_tets, 6, 6) float64
+      m_local (n_tets, 6, 6) float64
+      tet_edge_idx (n_tets, 6) int64
+      tet_edge_sign (n_tets, 6) float64
+      epsilon_r (n_tets,) float64
+
+    Outputs:
+      k_global (n_edges, n_edges) float64
+      m_global (n_edges, n_edges) float64
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    k_local_vi = oh.make_tensor_value_info("k_local", TensorProto.DOUBLE, [n_tets, 6, 6])
+    m_local_vi = oh.make_tensor_value_info("m_local", TensorProto.DOUBLE, [n_tets, 6, 6])
+    tei_vi = oh.make_tensor_value_info("tet_edge_idx", TensorProto.INT64, [n_tets, 6])
+    tes_vi = oh.make_tensor_value_info("tet_edge_sign", TensorProto.DOUBLE, [n_tets, 6])
+    eps_vi = oh.make_tensor_value_info("epsilon_r", TensorProto.DOUBLE, [n_tets])
+
+    # --- (1) Sign outer product: sign_outer[e,i,j] = sign[e,i] * sign[e,j] ---
+    # tet_edge_sign: (n_tets, 6) -> unsqueeze to (n_tets, 6, 1) and (n_tets, 1, 6)
+    nodes.append(_const("ax2", np.array([2], dtype=np.int64)))
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax2"], ["sign_col"]))   # (N,6,1)
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax1"], ["sign_row"]))   # (N,1,6)
+    nodes.append(oh.make_node("Mul", ["sign_col", "sign_row"], ["sign_outer"]))       # (N,6,6)
+
+    # --- (2) Apply sign to k_local ---
+    nodes.append(oh.make_node("Mul", ["k_local", "sign_outer"], ["k_signed"]))
+
+    # --- (3) Apply sign + epsilon to m_local ---
+    # epsilon_r: (n_tets,) -> reshape to (n_tets, 1, 1) for broadcasting
+    nodes.append(_const("shape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["epsilon_r", "shape_n11"], ["eps_b"]))
+    nodes.append(oh.make_node("Mul", ["m_local", "sign_outer"], ["m_signed_pre"]))
+    nodes.append(oh.make_node("Mul", ["m_signed_pre", "eps_b"], ["m_signed"]))
+
+    # --- (4) COO index construction ---
+    # rows[e,i,j] = tet_edge_idx[e,i] (broadcast j-dim)
+    # cols[e,i,j] = tet_edge_idx[e,j] (broadcast i-dim)
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax2"], ["tei_col"]))  # (N,6,1)
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax1"], ["tei_row"]))  # (N,1,6)
+
+    # Broadcast to (n_tets, 6, 6)
+    nodes.append(_const("target_shape", np.array([n_tets, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Expand", ["tei_col", "target_shape"], ["rows_3d"]))
+    nodes.append(oh.make_node("Expand", ["tei_row", "target_shape"], ["cols_3d"]))
+
+    # Flatten to (n_tets * 36,)
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["rows_3d", "shape_flat"], ["rows_flat"]))
+    nodes.append(oh.make_node("Reshape", ["cols_3d", "shape_flat"], ["cols_flat"]))
+    nodes.append(oh.make_node("Reshape", ["k_signed", "shape_flat"], ["k_vals"]))
+    nodes.append(oh.make_node("Reshape", ["m_signed", "shape_flat"], ["m_vals"]))
+
+    # Stack (rows, cols) into (n_tets*36, 2) index table
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows_flat", "ax_neg1"], ["rows_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["cols_flat", "ax_neg1"], ["cols_col"]))
+    nodes.append(oh.make_node("Concat", ["rows_col", "cols_col"], ["indices"], axis=1))
+
+    # --- (5) Zero buffer of shape (n_edges, n_edges) ---
+    # n_edges is FIXED AT GRAPH-BUILD TIME here (static-shape version).
+    # The friction note below explains why this becomes data-dependent
+    # in the real pipeline (after build_edges).
+    nodes.append(_const("shape_nn", np.array([n_edges, n_edges], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_buf_k"],
+        value=oh.make_tensor("zero_f64", TensorProto.DOUBLE, [1], [0.0]),
+    ))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_buf_m"],
+        value=oh.make_tensor("zero_f64_m", TensorProto.DOUBLE, [1], [0.0]),
+    ))
+
+    # --- (6) ScatterND with reduction="add" ---
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf_k", "indices", "k_vals"],
+        outputs=["k_global"],
+        reduction="add",
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf_m", "indices", "m_vals"],
+        outputs=["m_global"],
+        reduction="add",
+    ))
+
+    k_global_vi = oh.make_tensor_value_info("k_global", TensorProto.DOUBLE, [n_edges, n_edges])
+    m_global_vi = oh.make_tensor_value_info("m_global", TensorProto.DOUBLE, [n_edges, n_edges])
+
+    graph = oh.make_graph(
+        nodes,
+        name="nedelec_scatter_probe",
+        inputs=[k_local_vi, m_local_vi, tei_vi, tes_vi, eps_vi],
+        outputs=[k_global_vi, m_global_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: Nedelec edge scatter-add (sphere PEC, Phase G.6) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Synthetic mesh: 2 tets sharing a face
+    import scipy.sparse
+
+    tets_np = np.array(
+        [[0, 1, 2, 3],
+         [1, 2, 3, 4]],
+        dtype=np.int64,
+    )
+    nodes_np = np.array(
+        [[0.0, 0.0, 0.0],
+         [1.0, 0.0, 0.0],
+         [0.0, 1.0, 0.0],
+         [0.0, 0.0, 1.0],
+         [0.5, 0.5, 0.5]],
+        dtype=np.float64,
+    )
+    n_tets = tets_np.shape[0]
+    n_nodes = nodes_np.shape[0]
+
+    # Host-computed inputs (from build_edges — NOT in the ONNX graph)
+    edges, tet_edge_idx, tet_edge_sign = build_edges(tets_np)
+    n_edges = int(edges.shape[0])
+
+    # Per-element local matrices
+    coords = nodes_np[tets_np, :]
+    k_local, m_local, _ = batched_nedelec_local_matrices(coords)
+    tet_edge_sign_f64 = tet_edge_sign.astype(np.float64)
+    epsilon_r = np.ones(n_tets, dtype=np.float64)
+
+    print(f"Test mesh: n_tets={n_tets}, n_nodes={n_nodes}, n_edges={n_edges}")
+    print()
+
+    # Build and check the ONNX scatter graph
+    model = build_nedelec_scatter_graph(n_tets, n_edges)
+
+    try:
+        onnx.checker.check_model(model)
+        checker_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        checker_status = f"FAIL ({e!r})"
+
+    rt_status = "skipped"
+    max_err_k = max_err_m = float("nan")
+    try:
+        sess = ort.InferenceSession(model.SerializeToString())
+        outs = sess.run(["k_global", "m_global"], {
+            "k_local": k_local,
+            "m_local": m_local,
+            "tet_edge_idx": tet_edge_idx,
+            "tet_edge_sign": tet_edge_sign_f64,
+            "epsilon_r": epsilon_r,
+        })
+        k_global_onnx, m_global_onnx = outs
+
+        # NumPy reference scatter
+        sign_outer = tet_edge_sign_f64[:, :, None] * tet_edge_sign_f64[:, None, :]
+        k_signed = k_local * sign_outer
+        m_signed = m_local * sign_outer * epsilon_r[:, None, None]
+        rows = np.broadcast_to(tet_edge_idx[:, :, None], (n_tets, 6, 6)).ravel()
+        cols = np.broadcast_to(tet_edge_idx[:, None, :], (n_tets, 6, 6)).ravel()
+        k_ref_sparse = scipy.sparse.coo_matrix(
+            (k_signed.ravel(), (rows, cols)), shape=(n_edges, n_edges)
+        ).toarray()
+        m_ref_sparse = scipy.sparse.coo_matrix(
+            (m_signed.ravel(), (rows, cols)), shape=(n_edges, n_edges)
+        ).toarray()
+
+        max_err_k = float(np.max(np.abs(k_global_onnx - k_ref_sparse)))
+        max_err_m = float(np.max(np.abs(m_global_onnx - m_ref_sparse)))
+        rt_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        rt_status = f"FAIL ({e!r})"
+
+    print("Operator inventory for Nedelec edge scatter-add:")
+    print("--------------------------------------------------------------")
+    print("  Unsqueeze / Expand / Mul   EXPRESSIBLE  lowers cleanly (sign outer product)")
+    print("  Reshape                    EXPRESSIBLE  lowers cleanly (flatten 6x6 blocks)")
+    print("  Concat                     EXPRESSIBLE  lowers cleanly (build (M,2) indices)")
+    print("  ConstantOfShape            EXPRESSIBLE  lowers cleanly (zero buffer)")
+    print("  ScatterND(reduction='add') EXPRESSIBLE  lowers cleanly (opset 16+ native)")
+    print()
+    print(f"onnx.checker.check_model: {checker_status}")
+    print(f"onnxruntime execution: {rt_status}")
+    if rt_status == "OK":
+        print(f"  max |K_onnx - K_numpy| = {max_err_k:.3e}")
+        print(f"  max |M_onnx - M_numpy| = {max_err_m:.3e}")
+    print()
+
+    print("Friction analysis — why the real pipeline is PARTIAL:")
+    print("--------------------------------------------------------------")
+    print("  1. STATIC-SHAPE VERSION (tested above): when n_edges is known at")
+    print("     graph-build time, the scatter IS fully expressible. All operators")
+    print("     lower cleanly via ScatterND(reduction='add'). This is the clean path.")
+    print()
+    print("  2. DYNAMIC-SHAPE VERSION (real pipeline): n_edges is the output of")
+    print("     build_edges (NOT EXPRESSIBLE). So n_edges is a runtime value.")
+    print("     The ConstantOfShape node can accept a dynamic shape tensor,")
+    print("     making the zero buffer (n_edges, n_edges) dynamic. This means:")
+    print("       - k_global and m_global are typed (n_edges, n_edges) where")
+    print("         n_edges is unknown at compile time.")
+    print("       - Static shape inference is broken: any downstream consumer")
+    print("         sees (None, None) for K_global.")
+    print("       - The Dirichlet restriction (Gather on interior-edge indices)")
+    print("         inherits this data-dependent shape from K_global.")
+    print()
+    print("  3. SIGN OUTER PRODUCT — a new friction vs. P1:")
+    print("     The P1 scatter had no sign correction. Nedelec requires an outer")
+    print("     product of (n_tets, 6) sign vectors. This IS expressible via")
+    print("     Unsqueeze + Mul broadcasting, but it is structurally more complex")
+    print("     than the P1 scatter. Classification: graph-only friction.")
+    print()
+    print("  4. BUFFER SIZE (n_edges vs. n_nodes):")
+    print("     P1: global buffer is (n_nodes, n_nodes) — known from the input")
+    print("         shape of `tets`/`nodes` (static).")
+    print("     Nedelec: global buffer is (n_edges, n_edges) — unknown until")
+    print("              build_edges completes (data-dependent).")
+    print("     This is the structural difference that breaks static shape.")
+    print()
+    print("Verdict: PARTIAL")
+    print("  The scatter-add mechanics (ScatterND + sign outer product) lower")
+    print("  cleanly when n_edges is a static graph constant. In the real pipeline,")
+    print("  n_edges is data-dependent (from build_edges), which propagates a")
+    print("  dynamic-shape axis through k_global and m_global. The graph is")
+    print("  EXPRESSIBLE in ONNX but NOT statically-shaped end-to-end.")
+    print("  Friction class: graph-only (data-dependent shape from build_edges;")
+    print("  the scatter mechanism itself is not secretly-imperative).")
+
+    return 0 if checker_status == "OK" and rt_status == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/sphere_pec/probe_pec_mask.py
+++ b/reference/onnx/audit/sphere_pec/probe_pec_mask.py
@@ -1,0 +1,288 @@
+"""Probe: ONNX expressibility of the PEC boundary mask (Nedelec).
+
+Epic #88, Phase G.6 (issue #135). This probe asks whether the PEC mask
+step from `reference/numpy/sphere_pec.py` — eliminating edges that lie
+entirely on the outer PEC wall — can be expressed as a pure ONNX graph,
+given that `edges` (n_edges, 2) and `nodes` (n_nodes, 3) are graph inputs.
+
+What sphere_pec_interior_edges does
+=====================================
+
+Given `nodes (n_nodes, 3)` and `edges (n_edges, 2)`:
+
+  1. Compute node radii: r[i] = |nodes[i]|  (L2 norm, axis=1)
+  2. Build boundary mask: on_boundary[i] = |r[i] - r_outer| < tol
+  3. For each edge (a, b): mask[e] = ~(on_boundary[a] & on_boundary[b])
+     (interior if NOT both endpoints are on the wall)
+  4. Return interior_mask (n_edges,) bool
+
+Comparison with the P1 Dirichlet step (cube-cavity)
+=====================================================
+
+P1 (cube-cavity): interior_mask was a boolean mask on NODES; the step
+was: `idx = np.where(mask)[0]` → NonZero with data-dependent shape.
+
+Nedelec PEC mask: the mask is on EDGES. The key difference is HOW the
+mask is derived:
+  - P1: mask comes from an externally-tagged "boundary node" concept
+    (Dirichlet BCs are tagged by the problem setup, often precomputed
+    from the mesh's boundary-face list).
+  - Nedelec PEC: mask is DERIVED FROM NODE POSITIONS in the graph —
+    the r = |nodes| computation and the r ≈ r_outer threshold.
+
+ONNX expressibility of each sub-step:
+  1. L2 norm per node: `ReduceL2(nodes, axis=1)` — EXPRESSIBLE (opset 18).
+  2. |r[i] - r_outer| < tol: Sub, Abs, Less with a broadcast constant
+     — EXPRESSIBLE (all opset 18 native).
+  3. Gather endpoint flags: `on_boundary[edges[:, 0]]` and `[edges[:, 1]]`
+     via GatherElements or Gather — EXPRESSIBLE.
+  4. And + Not to build the interior mask — EXPRESSIBLE (And, Not native).
+
+BUT: the same "data-dependent shape" friction as the P1 Dirichlet step
+applies if we then try to derive idx from the mask:
+
+  5. `idx = np.flatnonzero(interior_mask)` → NonZero → data-dependent shape.
+     The Gather-based Dirichlet restriction (K_int = K[idx,:][:,idx]) is
+     then typed (None, None). Same friction class as cube-cavity stage 3.
+
+The probe demonstrates:
+  (A) The mask computation itself (steps 1-4) IS expressible and produces
+      a static-shape (n_edges,) bool tensor.
+  (B) Deriving idx via NonZero introduces data-dependent shape, exactly
+      as in the P1 case.
+  (C) Recommendation: accept `interior_idx` (int64, host-computed from
+      the mask) as a graph input, exactly mirroring the P1 convention.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pec/probe_pec_mask.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from sphere_pec import sphere_pec_interior_edges, R_BUFFER  # noqa: E402
+
+OPSET = 18
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("bool"): TensorProto.BOOL,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_pec_mask_graph(n_nodes: int, n_edges: int, r_outer: float = R_BUFFER) -> onnx.ModelProto:
+    """Build the PEC mask computation graph (steps 1-4 only).
+
+    Inputs:
+      nodes (n_nodes, 3) float64
+      edges (n_edges, 2) int64
+
+    Output:
+      interior_mask (n_edges,) bool
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    nodes_vi = oh.make_tensor_value_info("nodes", TensorProto.DOUBLE, [n_nodes, 3])
+    edges_vi = oh.make_tensor_value_info("edges", TensorProto.INT64, [n_edges, 2])
+
+    # --- Step 1: r[i] = ReduceL2(nodes[i], axis=1) ---
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ReduceL2",
+        inputs=["nodes", "ax1"],
+        outputs=["r"],
+        keepdims=0,
+    ))
+
+    # --- Step 2: on_boundary[i] = |r[i] - r_outer| < tol ---
+    tol = 1e-6 * max(r_outer, 1.0)
+    nodes.append(_const("r_outer_const", np.array(r_outer, dtype=np.float64)))
+    nodes.append(_const("tol_const", np.array(tol, dtype=np.float64)))
+    nodes.append(oh.make_node("Sub", ["r", "r_outer_const"], ["r_minus_outer"]))
+    nodes.append(oh.make_node("Abs", ["r_minus_outer"], ["r_dist"]))
+    nodes.append(oh.make_node("Less", ["r_dist", "tol_const"], ["on_boundary"]))
+
+    # --- Step 3: gather endpoint flags ---
+    # endpoints_a = edges[:, 0], endpoints_b = edges[:, 1]
+    nodes.append(_const("idx0", np.array(0, dtype=np.int64)))
+    nodes.append(_const("idx1", np.array(1, dtype=np.int64)))
+    nodes.append(oh.make_node("Gather", ["edges", "idx0"], ["ep_a"], axis=1))
+    nodes.append(oh.make_node("Gather", ["edges", "idx1"], ["ep_b"], axis=1))
+
+    # on_boundary[edges[:, 0]] via GatherElements
+    # on_boundary is (n_nodes,) bool; ep_a is (n_edges,) int64.
+    # GatherElements requires both tensors to have the same rank.
+    # Gather(axis=0) on a 1D tensor is equivalent here.
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["on_boundary", "ep_a"],
+        outputs=["a_on"],
+        axis=0,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["on_boundary", "ep_b"],
+        outputs=["b_on"],
+        axis=0,
+    ))
+
+    # --- Step 4: interior_mask = ~(a_on & b_on) ---
+    nodes.append(oh.make_node("And", ["a_on", "b_on"], ["both_on"]))
+    nodes.append(oh.make_node("Not", ["both_on"], ["interior_mask"]))
+
+    interior_vi = oh.make_tensor_value_info(
+        "interior_mask", TensorProto.BOOL, [n_edges]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="pec_mask_probe",
+        inputs=[nodes_vi, edges_vi],
+        outputs=[interior_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: PEC boundary mask (sphere PEC, Phase G.6) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Synthetic nodes: some on the outer sphere (r = R_BUFFER = 2.0)
+    r = R_BUFFER
+    nodes_np = np.array(
+        [
+            [0.0, 0.0, 0.0],     # interior: r = 0
+            [1.0, 0.0, 0.0],     # interior: r = 1
+            [r, 0.0, 0.0],       # on wall: r = 2.0
+            [0.0, r, 0.0],       # on wall: r = 2.0
+            [0.0, 0.0, r],       # on wall: r = 2.0
+        ],
+        dtype=np.float64,
+    )
+    n_nodes = nodes_np.shape[0]
+    # Edges: some interior, some mixed, some fully on wall
+    edges_np = np.array(
+        [
+            [0, 1],   # both interior -> INTERIOR
+            [0, 2],   # one interior, one on wall -> INTERIOR
+            [2, 3],   # both on wall -> PEC (eliminated)
+            [3, 4],   # both on wall -> PEC (eliminated)
+            [1, 2],   # one interior, one on wall -> INTERIOR
+        ],
+        dtype=np.int64,
+    )
+    n_edges = edges_np.shape[0]
+
+    # NumPy reference
+    mask_ref, on_bdry_ref = sphere_pec_interior_edges(nodes_np, edges_np)
+
+    # Build and test graph
+    model = build_pec_mask_graph(n_nodes, n_edges)
+
+    try:
+        onnx.checker.check_model(model)
+        checker_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        checker_status = f"FAIL ({e!r})"
+
+    rt_status = "skipped"
+    mask_match = False
+    try:
+        sess = ort.InferenceSession(model.SerializeToString())
+        outs = sess.run(["interior_mask"], {"nodes": nodes_np, "edges": edges_np})
+        mask_onnx = outs[0]
+        mask_match = bool(np.all(mask_onnx == mask_ref))
+        rt_status = "OK"
+    except Exception as e:  # noqa: BLE001
+        rt_status = f"FAIL ({e!r})"
+
+    print("Operator inventory for PEC mask computation (steps 1-4):")
+    print("--------------------------------------------------------------")
+    print("  ReduceL2 (axis=1)    EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("                       — computes per-node L2 norm (radii)")
+    print("  Sub / Abs / Less     EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("                       — threshold comparison: |r - r_outer| < tol")
+    print("  Gather (axis=0)      EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("                       — endpoint flag lookup: on_boundary[edges[:,0]]")
+    print("  And / Not            EXPRESSIBLE  lowers cleanly (opset 18 native)")
+    print("                       — interior = NOT (both endpoints on wall)")
+    print()
+    print(f"onnx.checker.check_model: {checker_status}")
+    print(f"onnxruntime execution: {rt_status}")
+    if rt_status == "OK":
+        print(f"  interior_mask matches NumPy reference: {mask_match}")
+        print(f"  expected:  {mask_ref.tolist()}")
+        print(f"  got:       {mask_onnx.tolist()}")
+    print()
+
+    print("Friction analysis — steps 5+ (idx derivation + Dirichlet restriction):")
+    print("--------------------------------------------------------------")
+    print("  Step 5: idx = np.flatnonzero(interior_mask)")
+    print("          -> NonZero op -> data-dependent output shape [None]")
+    print("          SAME friction class as cube-cavity Dirichlet stage 3.")
+    print("          Classification: caveat (graph-only friction, not secretly-imperative).")
+    print()
+    print("  Recommendation (same as P1 case):")
+    print("    - Compute interior_mask and idx on the HOST before entering the ONNX graph.")
+    print("    - Accept `interior_idx` (int64, n_int) as a graph input.")
+    print("    - Apply Gather(K_global, interior_idx, axis=0) then Gather on axis=1.")
+    print("    - This keeps K_int and M_int statically-shaped (n_int x n_int).")
+    print()
+    print("  One structural difference from P1:")
+    print("    - P1 mask is on NODES (n_nodes,) — a property of the mesh,")
+    print("      often tagged externally.")
+    print("    - Nedelec PEC mask is on EDGES (n_edges,) — DERIVED FROM NODE")
+    print("      POSITIONS in the graph (ReduceL2 + threshold). The mask")
+    print("      computation itself IS expressible; it is only the idx-derivation")
+    print("      step that introduces data-dependent shape.")
+    print("    - This means the Nedelec PEC graph CAN compute its own mask")
+    print("      (unlike P1, where the mask is typically precomputed by the")
+    print("      mesh reader). However, the idx must still be host-extracted.")
+    print()
+    print("Verdict: EXPRESSIBLE (with pre-computed interior_idx as graph input)")
+    print("  The PEC mask computation (steps 1-4: ReduceL2, Sub, Abs, Less,")
+    print("  Gather, And, Not) lowers cleanly to a static-shape ONNX graph.")
+    print("  The Dirichlet restriction (idx -> K_int) follows the same path as")
+    print("  the cube-cavity audit: interior_idx is host-computed (via NonZero")
+    print("  on the host side), then passed as a graph input for two Gathers.")
+    print("  This matches the JAX and TF-Java conventions.")
+
+    return 0 if checker_status == "OK" and rt_status == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Four probe scripts in `reference/onnx/audit/sphere_pec/` that empirically test each Nédélec sphere-PEC assembly operator against ONNX opset-18 graph-only constraints (all pass `onnx.checker` + `onnxruntime`, bit-exact numerical checks where applicable)
- Audit document `nedelec_operator_audit.md` with full operator-by-operator table, F.1 cross-references, and design recommendations for a future Nédélec ONNX assembly graph
- Friction summary posted on issue #5 (whiteroom tracker)

## Verdict summary

| Stage | Verdict |
|---|---|
| ε_r assignment | EXPRESSIBLE |
| build_edges local pair extraction | EXPRESSIBLE |
| **build_edges dedup + inverse map** | **NOT EXPRESSIBLE (secretly-imperative)** |
| Nédélec 6×6 local curl-curl + mass | EXPRESSIBLE (bit-exact vs. NumPy) |
| PEC boundary mask computation | EXPRESSIBLE |
| mask → interior_idx | caveat: data-dependent shape (same as F.1) |
| Global scatter-add (static n_edges) | EXPRESSIBLE |
| Global scatter-add (real pipeline) | PARTIAL: data-dependent shape from build_edges |
| Dirichlet restriction | EXPRESSIBLE (with host-computed idx) |
| Eigensolve | out of scope (shared L4 friction) |

## Key new finding vs. Phase F.1

`build_edges` is the **first secretly-imperative L4 escape** on the Nédélec spine. The P1 cube-cavity audit found zero secretly-imperative operators. The Nédélec case exposes one immediately: the edge-DOF deduplication (`np.unique`) + inverse-map construction (Python `dict` lookup) is not expressible in any static-graph IR. This is H(curl)-specific, not ONNX-specific. Design implication: `edges`, `tet_edge_idx`, `tet_edge_sign` must be host-computed graph inputs.

## Test plan

- [ ] `python3 reference/onnx/audit/sphere_pec/probe_nedelec_local.py` — exits 0, prints `Verdict: EXPRESSIBLE`
- [ ] `python3 reference/onnx/audit/sphere_pec/probe_edge_enumeration.py` — exits 0 (Part A passes), prints `Verdict: NOT EXPRESSIBLE`
- [ ] `python3 reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py` — exits 0, prints `Verdict: PARTIAL`
- [ ] `python3 reference/onnx/audit/sphere_pec/probe_pec_mask.py` — exits 0, prints `Verdict: EXPRESSIBLE (with pre-computed interior_idx as graph input)`

Requires: `pip install onnx==1.21.0 onnxruntime==1.26.0 numpy scipy` (see `reference/onnx/requirements.txt`).

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)