### PR TITLE
feat: add fe_assemble L4 operator surface to geode-core (Epic #88, #136)

### DIFF
--- a/crates/geode-core/src/fe_assemble.rs
+++ b/crates/geode-core/src/fe_assemble.rs
@@ -1,0 +1,149 @@
+//! The GEODE-FEM realization of the whiteroom L4 `fe_assemble` operator.
+//!
+//! This module exposes a public [`fe_assemble`] function that matches the
+//! whiteroom L4 operator shape: a pure function from
+//! (element, mesh, fields, BCs) → (K_int, M_int).
+//!
+//! The L4 operator name and shape are formally defined in the whiteroom
+//! design documentation and tracked by Epic #88. This module closes the
+//! naming gap between GEODE-FEM's assembly internals and that contract.
+//!
+//! # Element Types
+//!
+//! [`ElementType::P1`] — nodal Lagrange tetrahedra (scalar Helmholtz).
+//!
+//! Nédélec and other element families will be added here as subsequent
+//! Epic #88 phases land.
+//!
+//! # Boundary Conditions
+//!
+//! [`DirichletBc`] carries a boolean interior mask (one entry per global
+//! DOF; `true` = free). Homogeneous Dirichlet elimination is applied
+//! inside `fe_assemble` via [`apply_dirichlet_bc`], so callers receive
+//! already-reduced matrices ready for the eigensolver.
+//!
+//! # Backend Agnosticism
+//!
+//! The Burn tensors (`K`, `M`) are assembled on whatever backend `B` is
+//! active. The reduction step and output (`K_int`, `M_int`) use
+//! `faer::Mat<f64>` — backend-agnostic CPU double precision — matching
+//! the existing eigen-solver layer.
+
+use burn::tensor::backend::Backend;
+use faer::Mat;
+
+use crate::assembly::{assemble_global_p1, upload_mesh};
+use crate::eigen::{apply_dirichlet_bc, burn_matrix_to_faer, EigenError};
+use crate::TetMesh;
+
+/// Selector for the finite element type passed to [`fe_assemble`].
+///
+/// Only [`P1`](ElementType::P1) (linear nodal Lagrange on tetrahedra) is
+/// implemented in this release. The enum is non-exhaustive so callers
+/// cannot match on it exhaustively and break when new variants arrive.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementType {
+    /// Linear P1 nodal element on tetrahedral meshes (scalar fields).
+    P1,
+}
+
+/// Homogeneous Dirichlet boundary condition descriptor.
+///
+/// `interior_mask[i] == true` marks DOF `i` as a free interior DOF that
+/// survives elimination. Boundary DOFs (`false`) are eliminated from the
+/// assembled system, and the returned `(K_int, M_int)` contain only the
+/// free-DOF block.
+#[derive(Debug, Clone)]
+pub struct DirichletBc {
+    /// One entry per global DOF. `true` → free interior; `false` → Dirichlet.
+    pub interior_mask: Vec<bool>,
+}
+
+/// Result returned by [`fe_assemble`].
+///
+/// Both matrices are in double-precision CPU form (`faer::Mat<f64>`) so
+/// they can be passed directly to the eigensolver layer without an extra
+/// conversion step.
+#[derive(Debug)]
+pub struct FeAssembleResult {
+    /// Interior stiffness matrix after Dirichlet elimination.
+    pub k_int: Mat<f64>,
+    /// Interior consistent mass matrix after Dirichlet elimination.
+    pub m_int: Mat<f64>,
+}
+
+/// The GEODE-FEM realization of the whiteroom L4 `fe_assemble` operator.
+/// See Epic #88.
+///
+/// Assembles the global stiffness and mass matrices for the supplied mesh
+/// using the chosen finite element type, then applies the Dirichlet
+/// boundary conditions and returns the interior sub-matrices.
+///
+/// # Arguments
+///
+/// * `element` — Finite element family to use (see [`ElementType`]).
+/// * `mesh`    — CPU-side tetrahedral mesh (`TetMesh`).
+/// * `bc`      — Dirichlet BC descriptor: a boolean interior-DOF mask.
+/// * `device`  — Target Burn device for intermediate tensor assembly.
+///
+/// # Returns
+///
+/// [`FeAssembleResult`] with `k_int` and `m_int` reduced to the free-DOF
+/// block, in `faer::Mat<f64>` form.
+///
+/// # Errors
+///
+/// Returns [`EigenError::MaskDimMismatch`] if the length of
+/// `bc.interior_mask` does not equal the number of mesh nodes, or any
+/// other [`EigenError`] variant from the Dirichlet elimination step.
+///
+/// # Example (P1 on a 3×3×3 cube)
+///
+/// ```rust,no_run
+/// use geode_core::{cube_tet_mesh, cube_interior_mask, DefaultBackend};
+/// use geode_core::fe_assemble::{fe_assemble, DirichletBc, ElementType};
+/// use burn::tensor::backend::BackendTypes;
+///
+/// let mesh = cube_tet_mesh(3, 1.0);
+/// let mask = cube_interior_mask(&mesh.nodes, 1.0);
+/// let bc   = DirichletBc { interior_mask: mask };
+/// let dev  = <DefaultBackend as BackendTypes>::Device::default();
+///
+/// let result = fe_assemble::<DefaultBackend>(ElementType::P1, &mesh, &bc, &dev)
+///     .expect("assembly failed");
+///
+/// assert!(result.k_int.nrows() > 0, "interior system must be non-empty");
+/// ```
+pub fn fe_assemble<B: Backend>(
+    element: ElementType,
+    mesh: &TetMesh,
+    bc: &DirichletBc,
+    device: &B::Device,
+) -> Result<FeAssembleResult, EigenError> {
+    match element {
+        ElementType::P1 => fe_assemble_p1::<B>(mesh, bc, device),
+    }
+}
+
+/// P1 specialization: compose `assemble_global_p1` + `apply_dirichlet_bc`.
+fn fe_assemble_p1<B: Backend>(
+    mesh: &TetMesh,
+    bc: &DirichletBc,
+    device: &B::Device,
+) -> Result<FeAssembleResult, EigenError> {
+    let n_dof = mesh.n_nodes();
+
+    // Upload mesh to device and assemble.
+    let (nodes, tets) = upload_mesh::<B>(mesh, device);
+    let sys = assemble_global_p1(nodes, tets, n_dof);
+
+    // Convert dense Burn tensors to faer for Dirichlet elimination.
+    let k_faer = burn_matrix_to_faer(sys.k);
+    let m_faer = burn_matrix_to_faer(sys.m);
+
+    // Apply Dirichlet BCs to extract interior sub-matrices.
+    let (k_int, m_int) = apply_dirichlet_bc(k_faer.as_ref(), m_faer.as_ref(), &bc.interior_mask)?;
+
+    Ok(FeAssembleResult { k_int, m_int })
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod complex_eigen;
 pub mod complex_lanczos;
 pub mod derham;
 pub mod eigen;
+pub mod fe_assemble;
 pub mod lanczos;
 pub mod mesh;
 pub mod mie;
@@ -34,6 +35,7 @@ pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
     FaerDenseEigensolver,
 };
+pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
 pub use lanczos::{SparseEigenSolver, SparseShiftInvertLanczos};
 #[allow(deprecated)]
 pub use mesh::PHYS_VACUUM_BUFFER;

--- a/crates/geode-core/tests/fe_assemble.rs
+++ b/crates/geode-core/tests/fe_assemble.rs
@@ -1,0 +1,155 @@
+//! Integration tests for the L4 `fe_assemble` operator (Epic #88, issue #136).
+//!
+//! Validates that `fe_assemble(P1, mesh, bc, device)` produces K_int / M_int
+//! matrices that are byte-for-byte identical (within f64 round-off) to the
+//! existing two-step path: `assemble_global_p1` → `apply_dirichlet_bc`.
+
+use burn::tensor::backend::BackendTypes;
+
+use geode_core::{
+    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask,
+    cube_tet_mesh, upload_mesh, DefaultBackend, DirichletBc, ElementType,
+};
+use geode_core::fe_assemble::fe_assemble;
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// Maximum acceptable entry-wise difference between fe_assemble and the
+/// manual two-step path. Set to a safe multiple of f64 machine epsilon —
+/// both paths do the same arithmetic in the same order so the discrepancy
+/// should be exactly zero on any deterministic backend, but we allow a
+/// small tolerance for backend-specific floating-point scheduling.
+const TOL: f64 = 1e-12;
+
+/// Helper: flatten a faer Mat<f64> to a row-major Vec<f64>.
+fn mat_to_vec(m: &faer::Mat<f64>) -> Vec<f64> {
+    (0..m.nrows())
+        .flat_map(|i| (0..m.ncols()).map(move |j| m[(i, j)]))
+        .collect()
+}
+
+/// Verify that `fe_assemble(P1, ...)` matches the manual two-step path on
+/// a small cube mesh with homogeneous Dirichlet BCs on all boundary nodes.
+#[test]
+fn fe_assemble_p1_matches_manual_two_step_path() {
+    let mesh = cube_tet_mesh(4, 1.0);
+    let interior_mask = cube_interior_mask(&mesh.nodes, 1.0);
+    let bc = DirichletBc {
+        interior_mask: interior_mask.clone(),
+    };
+
+    // --- New L4 path ---
+    let result = fe_assemble::<B>(ElementType::P1, &mesh, &bc, &device())
+        .expect("fe_assemble should succeed on a valid mesh");
+
+    // --- Reference two-step path ---
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &device());
+    let sys = assemble_global_p1(nodes, tets, mesh.n_nodes());
+    let k_faer = burn_matrix_to_faer(sys.k);
+    let m_faer = burn_matrix_to_faer(sys.m);
+    let (k_int_ref, m_int_ref) =
+        apply_dirichlet_bc(k_faer.as_ref(), m_faer.as_ref(), &interior_mask)
+            .expect("manual Dirichlet BC should succeed");
+
+    // --- Compare dimensions ---
+    assert_eq!(
+        result.k_int.nrows(),
+        k_int_ref.nrows(),
+        "K_int row count mismatch"
+    );
+    assert_eq!(
+        result.k_int.ncols(),
+        k_int_ref.ncols(),
+        "K_int col count mismatch"
+    );
+    assert_eq!(
+        result.m_int.nrows(),
+        m_int_ref.nrows(),
+        "M_int row count mismatch"
+    );
+    assert_eq!(
+        result.m_int.ncols(),
+        m_int_ref.ncols(),
+        "M_int col count mismatch"
+    );
+
+    // --- Compare values ---
+    let k_new = mat_to_vec(&result.k_int);
+    let k_ref = mat_to_vec(&k_int_ref);
+    let m_new = mat_to_vec(&result.m_int);
+    let m_ref = mat_to_vec(&m_int_ref);
+
+    let max_k_err = k_new
+        .iter()
+        .zip(k_ref.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    let max_m_err = m_new
+        .iter()
+        .zip(m_ref.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+
+    assert!(
+        max_k_err <= TOL,
+        "K_int max entry error {max_k_err} exceeds tolerance {TOL}"
+    );
+    assert!(
+        max_m_err <= TOL,
+        "M_int max entry error {max_m_err} exceeds tolerance {TOL}"
+    );
+}
+
+/// Verify that the interior DOF count is strictly smaller than the total
+/// DOF count (some nodes must be on the boundary of a side > 1 cube mesh).
+#[test]
+fn fe_assemble_p1_interior_dof_count_is_smaller_than_total() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let interior_mask = cube_interior_mask(&mesh.nodes, 1.0);
+    let n_interior = interior_mask.iter().filter(|&&b| b).count();
+    let bc = DirichletBc {
+        interior_mask: interior_mask.clone(),
+    };
+
+    let result = fe_assemble::<B>(ElementType::P1, &mesh, &bc, &device())
+        .expect("fe_assemble should succeed");
+
+    assert_eq!(
+        result.k_int.nrows(),
+        n_interior,
+        "K_int size should equal number of interior DOFs"
+    );
+    assert!(
+        n_interior < mesh.n_nodes(),
+        "interior DOF count {n_interior} must be < total {}", mesh.n_nodes()
+    );
+}
+
+/// Verify that `fe_assemble` returns `EigenError::MaskDimMismatch` when the
+/// interior mask has the wrong length.
+#[test]
+fn fe_assemble_p1_wrong_mask_length_returns_error() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    // Deliberately one entry short.
+    let bad_mask = vec![true; mesh.n_nodes() - 1];
+    let bc = DirichletBc {
+        interior_mask: bad_mask,
+    };
+
+    let result = fe_assemble::<B>(ElementType::P1, &mesh, &bc, &device());
+    assert!(
+        result.is_err(),
+        "fe_assemble with wrong-length mask should return Err"
+    );
+    match result.unwrap_err() {
+        geode_core::EigenError::MaskDimMismatch { got, want } => {
+            assert_eq!(got, mesh.n_nodes() - 1);
+            assert_eq!(want, mesh.n_nodes());
+        }
+        other => panic!("expected MaskDimMismatch, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `geode_core::fe_assemble` — the GEODE-FEM realization of the whiteroom L4 `fe_assemble` operator (Epic #88).
- New `src/fe_assemble.rs` module: `ElementType` enum, `DirichletBc` descriptor, `FeAssembleResult` struct, and the public `fe_assemble<B: Backend>` generic function.
- P1 specialization composes `assemble_global_p1` + `apply_dirichlet_bc` — a pure function from (element, mesh, BCs, device) → (K_int, M_int).
- Exports all four public items from `geode_core::lib.rs`.
- Three integration tests in `tests/fe_assemble.rs` covering: parity with the manual two-step path, interior-DOF count correctness, and `MaskDimMismatch` error handling.

## Test plan

- [x] `cargo test -p geode-core --features ndarray --test fe_assemble` — 3/3 pass
- [x] `cargo test -p geode-core --features ndarray --test assembly` — 5/5 pass (no regressions)
- [x] `cargo test -p geode-core --features ndarray --test eigensolver` — passes (4 ignored as documented)
- [x] `cargo test -p geode-core --features ndarray --test p1_local_matrices` — 6/6 pass
- [ ] `cargo test -p geode-validation` — to be confirmed in CI

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)