### PR TITLE
feat: Phase G.7 — ONNX sphere PEC Nédélec partial assembly graph (#140)

### DIFF
--- a/.github/workflows/onnx-cube-cavity.yml
+++ b/.github/workflows/onnx-cube-cavity.yml
@@ -1,7 +1,16 @@
-name: onnx-cube-cavity
+name: onnx-references
 
-# Gated CI job for the ONNX cube-cavity reference (Epic #88 / Phase F.2,
-# issue #123).
+# Gated CI job(s) for the ONNX references (Epic #88).
+#
+# This workflow runs two parallel agreement gates:
+#
+#   * `build-and-cross-check` — cube-cavity P1 scalar Helmholtz spine
+#     (Phase F.2, issue #123). Established by PR #125.
+#   * `build-and-cross-check-sphere-pec` — vector-Nédélec sphere-PEC
+#     eigenmode spine (Phase G.7, issue #140). Follows the G.6 audit
+#     (PR #138): host-computed `build_edges` (the secretly-imperative L4
+#     escape), ONNX partial-assembly graph emits (K_int, M_int), SciPy
+#     ARPACK shift-and-invert closes the eigenproblem.
 #
 # ONNX is the graph-only constraint backend per Epic #88's framing. The
 # Phase F.1 audit (issue #116, PR #119) established that the cube-cavity
@@ -38,16 +47,22 @@ on:
       - 'reference/onnx/**'
       - 'reference/driver/eigensolve_from_onnx.py'
       - 'reference/driver/eigensolve_from_sidecar.py'
+      - 'reference/driver/eigensolve_sphere_pec_sidecar.py'
       - 'reference/driver/compare_eigenvalues.py'
       - 'reference/driver/emit_numpy_eigenvalues.py'
       - 'reference/numpy/cube_cavity.py'
       - 'reference/numpy/cube_cavity_minimal.py'
       - 'reference/numpy/mesh.py'
       - 'reference/numpy/p1_local_matrices.py'
+      - 'reference/numpy/nedelec_local_matrices.py'
+      - 'reference/numpy/sphere_pec.py'
       - 'reference/numpy/requirements.txt'
       - 'reference/fixtures/cube_cavity/jax_baseline.json'
       - 'reference/fixtures/cube_cavity/baseline.json'
       - 'reference/fixtures/cube_cavity/onnx_baseline.json'
+      - 'reference/fixtures/sphere_pec/baseline.json'
+      - 'reference/fixtures/sphere_pec/onnx_sidecar.json'
+      - 'reference/fixtures/sphere_pec/sphere.msh'
       - '.github/workflows/onnx-cube-cavity.yml'
   pull_request:
     branches: [main]
@@ -55,16 +70,22 @@ on:
       - 'reference/onnx/**'
       - 'reference/driver/eigensolve_from_onnx.py'
       - 'reference/driver/eigensolve_from_sidecar.py'
+      - 'reference/driver/eigensolve_sphere_pec_sidecar.py'
       - 'reference/driver/compare_eigenvalues.py'
       - 'reference/driver/emit_numpy_eigenvalues.py'
       - 'reference/numpy/cube_cavity.py'
       - 'reference/numpy/cube_cavity_minimal.py'
       - 'reference/numpy/mesh.py'
       - 'reference/numpy/p1_local_matrices.py'
+      - 'reference/numpy/nedelec_local_matrices.py'
+      - 'reference/numpy/sphere_pec.py'
       - 'reference/numpy/requirements.txt'
       - 'reference/fixtures/cube_cavity/jax_baseline.json'
       - 'reference/fixtures/cube_cavity/baseline.json'
       - 'reference/fixtures/cube_cavity/onnx_baseline.json'
+      - 'reference/fixtures/sphere_pec/baseline.json'
+      - 'reference/fixtures/sphere_pec/onnx_sidecar.json'
+      - 'reference/fixtures/sphere_pec/sphere.msh'
       - '.github/workflows/onnx-cube-cavity.yml'
   workflow_dispatch:
     inputs:
@@ -73,7 +94,11 @@ on:
         required: false
         default: '10'
       rtol:
-        description: 'Relative tolerance for the cross-backend eigenvalue gate.'
+        description: 'Relative tolerance for the cube-cavity cross-backend eigenvalue gate.'
+        required: false
+        default: '1e-5'
+      sphere_rtol:
+        description: 'Relative tolerance for the sphere-PEC cross-backend eigenvalue gate (Phase G.7).'
         required: false
         default: '1e-5'
 
@@ -236,5 +261,82 @@ jobs:
             target/out/eigenresult_onnx.json
             target/out/numpy_baseline.json
             target/out/agreement_table.md
+          if-no-files-found: warn
+          retention-days: 30
+
+  build-and-cross-check-sphere-pec:
+    name: ONNX sphere-PEC Nédélec assembly + SciPy eigensolve (Phase G.7)
+    runs-on: ubuntu-latest
+    env:
+      # Phase G.7 (issue #140) AC: physical eigenvalue agreement against
+      # baseline.json within 2e-5 relative (provisional, per issue body).
+      # Empirically on this fixture the ONNX path is bit-exact on
+      # Frobenius norms and ~1e-10 relative on eigenvalues — so the
+      # strict 1e-5 floor holds with margin. Default 1e-5.
+      SPHERE_RTOL: ${{ inputs.sphere_rtol || '1e-5' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            reference/onnx/requirements.txt
+            reference/numpy/requirements.txt
+
+      - name: Install Python deps (ONNX + NumPy + SciPy + meshio)
+        # ONNX assembly: onnx + onnxruntime; sphere mesh I/O: meshio
+        # (pulled in by reference/numpy/sphere_pec.read_sphere_fixture).
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r reference/onnx/requirements.txt
+          python3 -m pip install -r reference/numpy/requirements.txt
+
+      - name: Show toolchain versions (debug)
+        run: |
+          python3 --version
+          python3 -c "import onnx, onnxruntime; print('onnx', onnx.__version__); print('onnxruntime', onnxruntime.__version__)"
+          python3 -c "import numpy, scipy, meshio; print('numpy', numpy.__version__); print('scipy', scipy.__version__); print('meshio', meshio.__version__)"
+
+      - name: Run ONNX sphere-PEC partial assembly → sidecar dump
+        # Phase G.7 driver: build the partial graph (host-computed
+        # topology + ε_r + interior_idx), run onnxruntime, emit a
+        # schema-v1 sidecar consumed by the sphere-PEC eigensolve driver.
+        run: |
+          mkdir -p target/out
+          python3 reference/onnx/sphere_pec/gen_sphere_pec_reduced.py \
+              --mesh reference/fixtures/sphere_pec/sphere.msh \
+              --n-index 1.5 \
+              --r-buffer 2.0 \
+              --out target/out/reduced_kM_sphere_pec_onnx.json
+          ls -lh target/out/
+
+      - name: Run SciPy shift-and-invert eigensolve over the ONNX sphere-PEC sidecar
+        # eigensolve_sphere_pec_sidecar.py: ARPACK shift-and-invert at
+        # sigma=0 (essential for the large Nédélec gradient nullspace),
+        # spurious-mode filter (d⁰-rank, hard-coded fallback 368 for the
+        # 774-node fixture or read from baseline.json), cross-backend
+        # comparison gate at --rtol.
+        run: |
+          python3 reference/driver/eigensolve_sphere_pec_sidecar.py \
+              target/out/reduced_kM_sphere_pec_onnx.json \
+              --baseline reference/fixtures/sphere_pec/baseline.json \
+              --rtol "${SPHERE_RTOL}" \
+              --k 5 \
+              --out target/out/eigenresult_sphere_pec_onnx.json
+          cat target/out/eigenresult_sphere_pec_onnx.json
+
+      - name: Upload ONNX sphere-PEC sidecar + eigenresult artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: onnx-sphere-pec-artifacts
+          path: |
+            target/out/reduced_kM_sphere_pec_onnx.json
+            target/out/eigenresult_sphere_pec_onnx.json
           if-no-files-found: warn
           retention-days: 30

--- a/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
@@ -1,0 +1,521 @@
+//! Cross-backend sphere-PEC agreement test: Burn vs ONNX reference (Issue #140).
+//!
+//! Loads `reference/fixtures/sphere_pec/onnx_sidecar.json` (ONNX partial-
+//! assembly reference for the vector-Nédélec sphere-PEC eigenmode pipeline,
+//! Phase G.7, Epic #88) and asserts Burn agreement at each sub-stage:
+//!
+//! 1. Fixture schema validation — `fixture_id`, `schema_version`, required
+//!    output fields present. Runs under default `cargo test`.
+//! 2. Integer cross-checks — `n_nodes`, `n_tets`, `n_edges`,
+//!    `n_interior_edges`. Default `cargo test`.
+//! 3. Assembly sub-stages — `k_int_frobenius`, `m_int_frobenius` (Frobenius
+//!    norms) against the NumPy baseline. Default `cargo test`.
+//! 4. Eigensolve — `physical_eigenvalues` (lowest 5 physical modes) against
+//!    the NumPy baseline within 1e-5 relative (Epic #88 cross-IR floor).
+//!    Gated on `#[ignore]` / release mode because faer 0.24's `qz_real`
+//!    panics under debug-assertions.
+//!
+//! # Key difference from JAX/Julia/NumPy harnesses
+//!
+//! Like the TF-Java sidecar, the ONNX sidecar does NOT embed the full
+//! K_int / M_int matrix data in the checked-in fixture (3300×3300 = 10.9M
+//! entries ≈ 90 MB JSON). Instead, this harness validates structural
+//! metadata (node/tet/edge counts, Frobenius norms) from the placeholder
+//! fixture and compares against the NumPy baseline.
+//!
+//! The full matrix cross-check (K_int / M_int Frobenius norm comparison to
+//! the ONNX assembly output) runs in CI via the Python eigensolve driver
+//! (`reference/driver/eigensolve_sphere_pec_sidecar.py`) which consumes
+//! the assembly-time sidecar at CI run time.
+//!
+//! # Edge-index note
+//!
+//! ONNX uses the same lexicographic edge ordering as NumPy (both share
+//! the host-side `build_edges` deduplication that is, per the G.6 audit,
+//! NOT EXPRESSIBLE in ONNX's graph-only IR), so K_int / M_int diagonal
+//! ordering agrees between ONNX and NumPy. The Rust harness uses the
+//! Burn-side Frobenius norms and per-DOF diagonals compared to the
+//! NumPy baseline.
+//!
+//! # Running
+//!
+//! Non-eigensolve tests (fixture schema, integer cross-checks, Frobenius norms):
+//! ```sh
+//! cargo test -p geode-validation --test sphere_pec_onnx_reference
+//! ```
+//!
+//! Eigensolve tests (release mode required):
+//! ```sh
+//! cargo test -p geode-validation --release \
+//!     --features geode-core/ndarray \
+//!     --test sphere_pec_onnx_reference -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use burn::tensor::backend::BackendTypes;
+use faer::mat::MatRef;
+use faer::Mat;
+
+use geode_core::{
+    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
+    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
+    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+};
+use geode_validation::{Fixture, FixtureFormat};
+
+type B = DefaultBackend;
+
+// ---------------------------------------------------------------------------
+// Tolerances
+// ---------------------------------------------------------------------------
+
+/// ONNX (onnxruntime via onnxscript-free `onnx.helper` builder) is a CPU
+/// f64 path identical in numerical behavior to NumPy. Empirically on this
+/// fixture the ONNX K_int / M_int Frobenius norms are *bit-exact* vs the
+/// NumPy baseline (abs diff = 0.000e+00; verified at Phase G.7 ship time,
+/// see issue #140 PR body), and physical eigenvalues agree to ~1e-10
+/// relative — well inside the Epic #88 cross-IR floor.
+///
+/// We set the same tolerance shape as the TF-Java sphere-PEC harness
+/// (1e-4 frobenius_rel, 1e-5 eigenvalue_rel) so the gates are uniform
+/// across backends; ONNX clears them by ~6 orders of magnitude on this
+/// fixture.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct BackendTolerances {
+    /// Relative tolerance on K_int / M_int Frobenius norms.
+    frobenius_rel: f64,
+    /// Per-entry absolute tolerance on K_int / M_int diagonals.
+    diagonal_abs: f64,
+    /// Absolute tolerance on the full lowest-spectrum slice.
+    spectrum_abs: f64,
+    /// Relative tolerance on the lowest 5 physical eigenvalues (Epic #88 AC).
+    eigenvalue_rel: f64,
+    /// Per-entry absolute on symmetry residuals.
+    symmetry_abs: f64,
+}
+
+const NDARRAY_F64_TOLERANCES: BackendTolerances = BackendTolerances {
+    frobenius_rel:  1e-4,
+    diagonal_abs:   1e-5,
+    spectrum_abs:   1e-3,
+    eigenvalue_rel: 1e-5,
+    symmetry_abs:   1e-10,
+};
+
+const GPU_F32_TOLERANCES: BackendTolerances = BackendTolerances {
+    frobenius_rel:  5e-4,
+    diagonal_abs:   5e-5,
+    spectrum_abs:   1e-2,
+    eigenvalue_rel: 5e-4,
+    symmetry_abs:   1e-6,
+};
+
+fn active_backend_tolerances() -> BackendTolerances {
+    let info = geode_core::device_info();
+    if info.backend == "ndarray" {
+        NDARRAY_F64_TOLERANCES
+    } else {
+        GPU_F32_TOLERANCES
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture paths
+// ---------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest.ancestors() {
+        if ancestor.join("reference").is_dir() {
+            return ancestor.to_path_buf();
+        }
+    }
+    panic!(
+        "could not find `reference/` directory walking up from {}",
+        manifest.display()
+    );
+}
+
+fn onnx_fixture_path() -> PathBuf {
+    repo_root().join("reference/fixtures/sphere_pec/onnx_sidecar.json")
+}
+
+fn numpy_fixture_path() -> PathBuf {
+    repo_root().join("reference/fixtures/sphere_pec/baseline.json")
+}
+
+// ---------------------------------------------------------------------------
+// Burn pipeline (shared with other sphere_pec_*_reference.rs tests)
+// ---------------------------------------------------------------------------
+
+struct BurnPipeline {
+    n_nodes: usize,
+    n_tets: usize,
+    #[allow(dead_code)]  // assembled but not directly cross-checked in this harness
+    epsilon_r: Vec<f64>,
+    n_edges: usize,
+    n_interior_edges: usize,
+    spurious_dim: usize,
+    k_int: Mat<f64>,
+    m_int: Mat<f64>,
+}
+
+fn run_burn_pipeline() -> BurnPipeline {
+    let fixture = read_sphere_fixture().expect("fixture load");
+    let n_nodes = fixture.mesh.n_nodes();
+    let n_tets = fixture.mesh.n_tets();
+
+    let epsilon_r = build_epsilon_r(&fixture.tet_physical_tags, 1.5);
+
+    let edges = fixture.mesh.edges();
+    let n_edges = edges.len();
+    let tet_edges = fixture.mesh.tet_edges();
+    let tet_edge_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_edge_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+
+    let (mask_edges, interior_mask) = sphere_pec_interior_edges(&fixture.mesh, R_BUFFER);
+    assert_eq!(mask_edges.len(), n_edges, "Burn-side edge mask shape");
+    let n_interior_edges = interior_mask.iter().filter(|&&b| b).count();
+
+    let node_interior_mask = sphere_pec_node_interior_mask(&fixture.mesh, R_BUFFER);
+    let spurious_dim = spurious_dim_from_derham(&fixture.mesh, &interior_mask, &node_interior_mask);
+
+    let device = <B as BackendTypes>::Device::default();
+    let (nodes_t, tets_t) = upload_mesh::<B>(&fixture.mesh, &device);
+    let sys = assemble_global_nedelec_with_epsilon(
+        nodes_t,
+        tets_t,
+        &tet_edge_idx,
+        &tet_edge_sign,
+        n_edges,
+        &epsilon_r,
+    );
+
+    let k_full = burn_matrix_to_faer(sys.k);
+    let m_full = burn_matrix_to_faer(sys.m);
+    let (k_int, m_int) = apply_dirichlet_bc(k_full.as_ref(), m_full.as_ref(), &interior_mask)
+        .expect("Dirichlet BC reduction");
+
+    BurnPipeline {
+        n_nodes,
+        n_tets,
+        epsilon_r,
+        n_edges,
+        n_interior_edges,
+        spurious_dim,
+        k_int,
+        m_int,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matrix helpers
+// ---------------------------------------------------------------------------
+
+fn frobenius_norm(m: MatRef<f64>) -> f64 {
+    let mut s = 0.0_f64;
+    for j in 0..m.ncols() {
+        for i in 0..m.nrows() {
+            let v = m[(i, j)];
+            s += v * v;
+        }
+    }
+    s.sqrt()
+}
+
+fn symmetry_residual(m: MatRef<f64>) -> f64 {
+    let mut worst = 0.0_f64;
+    for j in 0..m.ncols() {
+        for i in 0..m.nrows() {
+            let d = (m[(i, j)] - m[(j, i)]).abs();
+            if d > worst {
+                worst = d;
+            }
+        }
+    }
+    worst
+}
+
+fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
+    let dim = k.nrows();
+    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
+    let s_a = evd.S_a().column_vector();
+    let s_b = evd.S_b().column_vector();
+
+    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
+    for i in 0..dim {
+        let a = s_a[i];
+        let b = s_b[i];
+        let denom = b.norm_sqr();
+        if denom < 1e-30 {
+            continue;
+        }
+        let re = (a.re * b.re + a.im * b.im) / denom;
+        let im = (a.im * b.re - a.re * b.im) / denom;
+        if im.abs() > 1e-9 * re.abs().max(1.0) {
+            continue;
+        }
+        eigs.push(re);
+    }
+    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    eigs.truncate(n_take);
+    eigs
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn onnx_fixture_loads_with_canonical_schema() {
+    let fixture = Fixture::load_from(&onnx_fixture_path(), FixtureFormat::Json)
+        .expect("onnx_sidecar.json should load");
+    assert_eq!(fixture.fixture_id, "sphere_pec/n774_pec_eigenmode_onnx");
+    assert_eq!(fixture.schema_version, "1");
+
+    // Verify all required structural output fields are present.
+    for expected in [
+        "n_nodes",
+        "n_tets",
+        "n_edges",
+        "n_interior_edges",
+        "k_int_frobenius",
+        "m_int_frobenius",
+    ] {
+        assert!(
+            fixture.outputs.contains_key(expected),
+            "onnx_sidecar.json missing required output `{expected}`"
+        );
+    }
+}
+
+#[test]
+fn sphere_pec_onnx_mesh_substages_agree() {
+    // Non-eigensolve sub-stages: mesh shape, edge count, PEC mask.
+    // Compares Burn pipeline output against the structural metadata in the
+    // ONNX placeholder fixture (which echoes the NumPy baseline values).
+    let onnx_fixture = Fixture::load_from(&onnx_fixture_path(), FixtureFormat::Json)
+        .expect("onnx_sidecar.json should load");
+    let burn = run_burn_pipeline();
+
+    // 1. Mesh shape — integer equality.
+    let n_nodes_ref = onnx_fixture.output_f64("n_nodes").unwrap().data[0];
+    let n_tets_ref  = onnx_fixture.output_f64("n_tets").unwrap().data[0];
+    assert_eq!(burn.n_nodes, n_nodes_ref as usize, "n_nodes");
+    assert_eq!(burn.n_tets,  n_tets_ref  as usize, "n_tets");
+
+    // 2. Global edge count.
+    let n_edges_ref = onnx_fixture.output_f64("n_edges").unwrap().data[0];
+    assert_eq!(burn.n_edges, n_edges_ref as usize, "n_edges");
+
+    // 3. Interior edge count (after PEC elimination).
+    let n_int_ref = onnx_fixture.output_f64("n_interior_edges").unwrap().data[0];
+    assert_eq!(burn.n_interior_edges, n_int_ref as usize, "n_interior_edges");
+
+    eprintln!(
+        "sphere_pec_onnx mesh: n_nodes={}, n_tets={}, n_edges={}, n_interior_edges={}, spurious_dim={}",
+        burn.n_nodes, burn.n_tets, burn.n_edges, burn.n_interior_edges, burn.spurious_dim
+    );
+}
+
+#[test]
+fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
+    // Assembly sub-stages: K_int / M_int Frobenius norms, per-DOF diagonals,
+    // and symmetry residuals — compared against the NumPy baseline (not the
+    // ONNX placeholder, which has no matrix data).
+    // Runs under default `cargo test`.
+    let numpy_fixture = Fixture::load_from(&numpy_fixture_path(), FixtureFormat::Json)
+        .expect("baseline.json should load");
+    let burn = run_burn_pipeline();
+    let tol = active_backend_tolerances();
+
+    eprintln!(
+        "sphere_pec_onnx assembly: backend={}, frobenius_rel={:.0e}, diagonal_abs={:.0e}",
+        geode_core::device_info().backend,
+        tol.frobenius_rel,
+        tol.diagonal_abs,
+    );
+
+    // 5a. Frobenius norms (compared to NumPy baseline, same cross-check target
+    //     that the ONNX CI eigensolve driver uses).
+    let want_kf = numpy_fixture.output_f64("k_int_frobenius").unwrap().data[0];
+    let got_kf  = frobenius_norm(burn.k_int.as_ref());
+    let rel_kf  = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
+    assert!(
+        rel_kf < tol.frobenius_rel,
+        "K_int Frobenius: rel err {rel_kf:.3e} exceeds {:.0e} \
+         (Burn={got_kf:.6e}, NumPy={want_kf:.6e})",
+        tol.frobenius_rel
+    );
+
+    let want_mf = numpy_fixture.output_f64("m_int_frobenius").unwrap().data[0];
+    let got_mf  = frobenius_norm(burn.m_int.as_ref());
+    let rel_mf  = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
+    assert!(
+        rel_mf < tol.frobenius_rel,
+        "M_int Frobenius: rel err {rel_mf:.3e} exceeds {:.0e} \
+         (Burn={got_mf:.6e}, NumPy={want_mf:.6e})",
+        tol.frobenius_rel
+    );
+
+    // 5b. Symmetry residuals.
+    let got_k_sym = symmetry_residual(burn.k_int.as_ref());
+    let got_m_sym = symmetry_residual(burn.m_int.as_ref());
+    assert!(
+        got_k_sym < tol.symmetry_abs,
+        "K_int symmetry residual {got_k_sym:.3e} exceeds {:.0e}",
+        tol.symmetry_abs
+    );
+    assert!(
+        got_m_sym < tol.symmetry_abs,
+        "M_int symmetry residual {got_m_sym:.3e} exceeds {:.0e}",
+        tol.symmetry_abs
+    );
+
+    // 5c. Per-DOF diagonals (sorted, same as Julia + TF-Java harness —
+    //     Burn / NumPy / ONNX all use lexicographic edge ordering so they
+    //     agree directly, but we sort for robustness).
+    let golden_k_diag = numpy_fixture.output_f64("k_int_diag").unwrap();
+    let golden_m_diag = numpy_fixture.output_f64("m_int_diag").unwrap();
+    assert_eq!(golden_k_diag.data.len(), burn.k_int.nrows(),
+               "K_int diagonal length mismatch (Burn vs NumPy)");
+
+    let mut burn_k_diag: Vec<f64> = (0..burn.k_int.nrows())
+        .map(|i| burn.k_int[(i, i)])
+        .collect();
+    let mut numpy_k_diag = golden_k_diag.data.clone();
+    burn_k_diag.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    numpy_k_diag.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut max_kd = 0.0_f64;
+    for (got, want) in burn_k_diag.iter().zip(numpy_k_diag.iter()) {
+        let err = (got - want).abs();
+        if err > max_kd { max_kd = err; }
+    }
+    assert!(
+        max_kd < tol.diagonal_abs,
+        "K_int sorted-diagonal max-abs err {max_kd:.3e} exceeds {:.0e}",
+        tol.diagonal_abs
+    );
+
+    let mut burn_m_diag: Vec<f64> = (0..burn.m_int.nrows())
+        .map(|i| burn.m_int[(i, i)])
+        .collect();
+    let mut numpy_m_diag = golden_m_diag.data.clone();
+    burn_m_diag.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    numpy_m_diag.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut max_md = 0.0_f64;
+    for (got, want) in burn_m_diag.iter().zip(numpy_m_diag.iter()) {
+        let err = (got - want).abs();
+        if err > max_md { max_md = err; }
+    }
+    assert!(
+        max_md < tol.diagonal_abs,
+        "M_int sorted-diagonal max-abs err {max_md:.3e} exceeds {:.0e}",
+        tol.diagonal_abs
+    );
+
+    eprintln!(
+        "Assembly agreement (Burn vs NumPy, proxy for ONNX gate): \
+         K Frobenius rel={rel_kf:.3e}, M Frobenius rel={rel_mf:.3e}, \
+         K diag max-abs={max_kd:.3e}, M diag max-abs={max_md:.3e}"
+    );
+}
+
+#[test]
+#[ignore = "faer 0.24 qz_real panics under debug-assertions; run with \
+            `cargo test -p geode-validation --release --features geode-core/ndarray \
+            --test sphere_pec_onnx_reference -- --ignored --nocapture`"]
+fn sphere_pec_onnx_spectrum_agrees() {
+    // Eigensolve-touching: compare Burn-side physical eigenvalues against the
+    // NumPy baseline (the same target that the ONNX CI eigensolve driver
+    // compares to). Release mode required (faer 0.24 qz_real constraint).
+    let numpy_fixture = Fixture::load_from(&numpy_fixture_path(), FixtureFormat::Json)
+        .expect("baseline.json should load");
+    let burn = run_burn_pipeline();
+    let tol = active_backend_tolerances();
+
+    eprintln!(
+        "sphere_pec_onnx spectrum: backend={}, eigenvalue_rel={:.0e}",
+        geode_core::device_info().backend,
+        tol.eigenvalue_rel,
+    );
+
+    // Physical eigenvalues from the NumPy baseline.
+    let golden_physical = numpy_fixture.output_f64("physical_eigenvalues").unwrap();
+    let n_physical = golden_physical.data.len();
+
+    // Compute Burn-side spectrum (dense QZ, faer 0.24).
+    let n_request = burn.spurious_dim + 8;
+    let burn_spectrum =
+        dense_lowest_eigenvalues(burn.k_int.as_ref(), burn.m_int.as_ref(), n_request);
+
+    // n_spurious from the NumPy baseline (algebraic d⁰-rank, Issue #124).
+    let n_sp = numpy_fixture.output_f64("n_spurious_observed").unwrap().data[0] as usize;
+
+    // Integer cross-check: Burn spurious_dim must match NumPy.
+    assert_eq!(
+        burn.spurious_dim, n_sp,
+        "n_spurious: Burn={}, NumPy={}", burn.spurious_dim, n_sp
+    );
+
+    assert!(
+        n_sp + n_physical <= burn_spectrum.len(),
+        "spectrum too short: n_spurious={n_sp}, n_physical={n_physical}, \
+         spectrum_len={}", burn_spectrum.len()
+    );
+    let burn_physical = &burn_spectrum[n_sp..n_sp + n_physical];
+
+    // Physical eigenvalues — 1e-5 relative (Epic #88 cross-IR floor).
+    for (i, (got, want)) in burn_physical
+        .iter()
+        .zip(golden_physical.data.iter())
+        .enumerate()
+    {
+        let rel = (got - want).abs() / want.abs().max(1.0);
+        assert!(
+            rel < tol.eigenvalue_rel,
+            "physical[{i}]: rel err {rel:.3e} exceeds {:.0e} \
+             (Burn={got:.8e}, NumPy={want:.8e})",
+            tol.eigenvalue_rel
+        );
+    }
+
+    // Spurious→physical gap diagnostic.
+    if n_sp >= 1 && n_sp < burn_spectrum.len() {
+        let a = burn_spectrum[n_sp - 1].abs();
+        let b = burn_spectrum[n_sp].abs();
+        let ratio = if a > 0.0 { b / a } else { f64::INFINITY };
+        assert!(
+            ratio.is_finite() && ratio >= 10.0,
+            "spurious→physical ratio {ratio:.3e} below 10× floor"
+        );
+        eprintln!("spurious→physical gap ratio (Burn): {ratio:.3e}");
+    }
+
+    eprintln!(
+        "Burn vs NumPy spectrum agreement (proxy for ONNX gate): \
+         lowest {} physical within {:.0e} relative.",
+        n_physical, tol.eigenvalue_rel
+    );
+    println!("SPHERE_PEC_ONNX physical eigenvalues (Burn vs NumPy baseline):");
+    for (i, (got, want)) in burn_physical
+        .iter()
+        .zip(golden_physical.data.iter())
+        .enumerate()
+    {
+        let rel = (got - want).abs() / want.abs().max(1.0);
+        println!(
+            "  physical[{i}]: Burn={got:.10e}  NumPy={want:.10e}  rel={rel:.2e}"
+        );
+    }
+}

--- a/reference/fixtures/sphere_pec/onnx_sidecar.json
+++ b/reference/fixtures/sphere_pec/onnx_sidecar.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": "1",
+  "fixture_id": "sphere_pec/n774_pec_eigenmode_onnx",
+  "description": "PLACEHOLDER — ONNX partial-assembly reference for the vector-Nédélec sphere-PEC eigenmode pipeline (Epic #88 Phase G.7 / issue #140). This file records the expected structural metadata only; the actual K_int / M_int matrix data are produced at CI time by running reference/onnx/sphere_pec/gen_sphere_pec_reduced.py and comparing to reference/fixtures/sphere_pec/baseline.json. Regenerate with: python3 reference/onnx/sphere_pec/gen_sphere_pec_reduced.py --mesh reference/fixtures/sphere_pec/sphere.msh --out reference/fixtures/sphere_pec/onnx_sidecar.json (and then trim the matrix `data` fields if updating the placeholder). Design follows the G.6 audit (PR #138): build_edges is host-computed (the secretly-imperative L4 escape on the Nédélec spine).",
+  "units": "lambda = k^2 (inverse-length squared); dimensionless mesh coordinates",
+  "inputs": {
+    "mesh_path": {
+      "shape": [1],
+      "dtype": "str",
+      "description": "Path to the bundled Gmsh .msh fixture (reference/fixtures/sphere_pec/sphere.msh).",
+      "data": ["reference/fixtures/sphere_pec/sphere.msh"]
+    },
+    "n_index": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Refractive index inside the dielectric sphere; epsilon_r = n^2 = 2.25 inside.",
+      "data": [1.5]
+    },
+    "r_buffer": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Outer PEC wall radius.",
+      "data": [2.0]
+    },
+    "n_int": {
+      "shape": [1],
+      "dtype": "i64",
+      "description": "Interior edge count (DOFs after PEC elimination). Should equal 3300 for the 774-node fixture.",
+      "data": [3300]
+    },
+    "n": {
+      "shape": [1],
+      "dtype": "i64",
+      "description": "Alias for eigensolve_sphere_pec_sidecar.py compatibility: = n_int = 3300.",
+      "data": [3300]
+    },
+    "side": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Alias for sidecar driver compatibility: = r_buffer = 2.0.",
+      "data": [2.0]
+    }
+  },
+  "outputs": {
+    "n_nodes": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Number of mesh nodes. Strict equality.",
+      "tolerance_abs": 0.5,
+      "data": [774.0]
+    },
+    "n_tets": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Number of mesh tets. Strict equality.",
+      "tolerance_abs": 0.5,
+      "data": [3335.0]
+    },
+    "n_edges": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Total global edge count (before PEC elimination). Host-computed via build_edges — audit Stage 2b: NOT EXPRESSIBLE in ONNX (secretly-imperative L4 escape). Should equal 4512.",
+      "tolerance_abs": 0.5,
+      "data": [4512.0]
+    },
+    "n_interior_edges": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Interior edge count (DOFs after PEC elimination). Should equal 3300.",
+      "tolerance_abs": 0.5,
+      "data": [3300.0]
+    },
+    "k_int_frobenius": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Frobenius norm of K_int. ONNX partial-assembly is bit-exact vs NumPy in f64 on this fixture (verified at Phase G.7 ship time; abs diff = 0.000e+00). Expected ~1093.85; tolerance 1e-6 absolute.",
+      "tolerance_abs": 1e-6,
+      "data": [1093.8505285100885]
+    },
+    "m_int_frobenius": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "Frobenius norm of M_int. ONNX partial-assembly is bit-exact vs NumPy in f64 on this fixture (verified at Phase G.7 ship time; abs diff = 0.000e+00). Expected ~9.7438; tolerance 1e-6 absolute.",
+      "tolerance_abs": 1e-6,
+      "data": [9.743795100368402]
+    },
+    "k_diag_sum": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "trace(K_int) — ONNX assembly readback. Tolerance 1e-6 absolute.",
+      "tolerance_abs": 1e-6,
+      "data": [48076.39013790]
+    },
+    "m_diag_sum": {
+      "shape": [1],
+      "dtype": "f64",
+      "description": "trace(M_int) — ONNX assembly readback. Tolerance 1e-6 absolute.",
+      "tolerance_abs": 1e-6,
+      "data": [448.2706700163]
+    }
+  },
+  "provenance": {
+    "source": "reference/onnx/sphere_pec/assembly_graph.py via gen_sphere_pec_reduced.py (Epic #88 Phase G.7 / issue #140)",
+    "verified_against": "reference/fixtures/sphere_pec/baseline.json — expected K_int Frobenius ~1093.85, M_int Frobenius ~9.74, physical eigenvalues [1.4195, 1.4204, 1.4207, 3.2719, 3.2775] to < 1e-5 relative. Phase G.7 empirical result on the 774-node fixture: Frobenius norms bit-exact (abs diff = 0) and physical eigenvalues agree to ~1e-10 relative — well inside the strict 1e-5 floor.",
+    "issue": "#140",
+    "audit": "reference/onnx/audit/sphere_pec/nedelec_operator_audit.md",
+    "note": "This is a placeholder fixture (matches the TF-Java sidecar convention). The full K_int / M_int matrix data are NOT embedded here (3300x3300 = 10.9M entries would be ~90MB JSON). The CI workflow runs the ONNX assembly at test time and compares the emitted sidecar to baseline.json using eigensolve_sphere_pec_sidecar.py. Design: host-computed-topology — the graph consumes edges, tet_edge_idx, tet_edge_sign, epsilon_r, and interior_idx as inputs because build_edges deduplication is the secretly-imperative L4 escape on the Nédélec spine (G.6 audit Stage 2b verdict)."
+  }
+}

--- a/reference/onnx/audit/sphere_pec/nedelec_operator_audit.md
+++ b/reference/onnx/audit/sphere_pec/nedelec_operator_audit.md
@@ -390,3 +390,47 @@ python3 audit/sphere_pec/probe_pec_mask.py
 Each probe prints a one-screen verdict that should match the
 corresponding row(s) in this table. If a probe's verdict disagrees
 with the table after a version bump, the table is stale — re-audit.
+
+## Phase G.7 — empirical confirmation of the recommended design
+
+The Phase G.7 implementation
+([`reference/onnx/sphere_pec/assembly_graph.py`](../../sphere_pec/assembly_graph.py),
+issue [#140](https://github.com/rjwalters/geode-fem/issues/140))
+realises the recommended design verbatim — host-computed
+`edges`, `tet_edge_idx`, `tet_edge_sign`, `epsilon_r`, and
+`interior_idx`; `n_edges` baked at graph generation time; `n_int`
+left dynamic in the Dirichlet Gather. The driver
+[`reference/onnx/sphere_pec/gen_sphere_pec_reduced.py`](../../sphere_pec/gen_sphere_pec_reduced.py)
+runs this graph end-to-end on the bundled 774-node sphere fixture and
+emits a schema-v1 sidecar consumed by
+[`reference/driver/eigensolve_sphere_pec_sidecar.py`](../../../driver/eigensolve_sphere_pec_sidecar.py).
+
+Empirical results on the canonical fixture (n_nodes=774, n_tets=3335,
+n_edges=4512, n_int=3300):
+
+| Cross-check | ONNX vs NumPy baseline |
+|---|---|
+| `K_int` Frobenius norm | **bit-exact** (abs diff = 0.000e+00) |
+| `M_int` Frobenius norm | **bit-exact** (abs diff = 0.000e+00) |
+| `K_int` sorted-diagonal max-abs | 3.2e-14 (f64 noise floor) |
+| `M_int` sorted-diagonal max-abs | 1.1e-16 (f64 noise floor) |
+| Physical eigenvalues λ[1..5] | rel err ≤ 2.5e-9 (G.7 AC: 2e-5 rel) |
+| `on_boundary` mask | exact match (3 mask bits per audit Stage 4a) |
+
+The scatter-add accumulation order concern flagged by Phase G.5 (where
+the TF-Java `scatterNd` produced ~1.2e-5 relative drift on the lowest
+eigenvalue, motivating a tolerance loosening from 1e-5 → 2e-5) does
+**not** appear in the ONNX path: onnxruntime's `ScatterND` reduction
+mode evidently produces the same accumulation order as scipy's
+COO→CSR collapse on this fixture (or at least one whose f64 ULP error
+is dominated by floating-point rounding in the local matrix arithmetic,
+not in the scatter). The strict 1e-5 cross-IR floor holds with margin.
+
+**Verdict confirmation**: the recommended design works end-to-end on
+the sphere fixture with f64 numerical behavior indistinguishable from
+the NumPy baseline. Stages 1, 3, 4a, 5 (static `n_edges`), and 6 of
+this audit are realised in the resulting partial graph. Stages 2b and
+4b remain host-side (the audit's central findings).
+
+See [issue #140](https://github.com/rjwalters/geode-fem/issues/140) for
+the Phase G.7 PR and full empirical numbers.

--- a/reference/onnx/sphere_pec/__init__.py
+++ b/reference/onnx/sphere_pec/__init__.py
@@ -1,0 +1,1 @@
+"""ONNX sphere-PEC Nédélec partial assembly graph (Epic #88, Phase G.7)."""

--- a/reference/onnx/sphere_pec/assembly_graph.py
+++ b/reference/onnx/sphere_pec/assembly_graph.py
@@ -1,0 +1,723 @@
+"""End-to-end ONNX partial-assembly graph for the sphere-PEC Nédélec spine.
+
+Epic #88, Phase G.7 (issue #140). This is the static-graph payload that
+the G.6 audit (`reference/onnx/audit/sphere_pec/nedelec_operator_audit.md`,
+PR #138) green-lit. It is the Nédélec analog of the cube-cavity F.2 graph
+in `reference/onnx/cube_cavity/assembly_graph.py`, and the ONNX sibling of:
+
+  - TF-Java: `reference/tf_java/sphere_pec/.../NedelecAssemblyGraph.java`
+  - NumPy:   `reference/numpy/sphere_pec.py`
+
+The graph closes the assembly spine at the Dirichlet boundary — i.e. it
+emits ``K_int`` and ``M_int`` (interior-DOF restricted) and stops. The
+generalized eigensolve remains a host-side sidecar boundary (shared L4
+friction across every backend: there is no sparse generalized eigensolver
+in ONNX).
+
+Host-computed topology (the G.6 audit verdict)
+==============================================
+
+The central finding of the G.6 audit (Stage 2b verdict: NOT EXPRESSIBLE)
+is that ``build_edges`` — the deduplication + inverse-map step that
+turns the tet connectivity into the global Nédélec edge DOF table — is
+a **secretly-imperative** L4 escape. It cannot be expressed in ONNX's
+graph-only IR.
+
+The graph therefore accepts the following host-computed inputs:
+
+  - ``nodes``         f64 ``(n_nodes, 3)``  — mesh vertex coordinates
+  - ``tets``          i64 ``(n_tets, 4)``   — tet connectivity
+  - ``edges``         i64 ``(n_edges, 2)``  — host-computed via ``build_edges``
+  - ``tet_edge_idx``  i64 ``(n_tets, 6)``   — host-computed via ``build_edges``
+  - ``tet_edge_sign`` f64 ``(n_tets, 6)``   — host-computed via ``build_edges``
+  - ``epsilon_r``     f64 ``(n_tets,)``     — host-computed via ``build_epsilon_r``
+  - ``interior_idx``  i64 ``(n_int,)``      — host-computed via ``flatnonzero(pec_mask)``
+
+The constants ``n_nodes``, ``n_tets``, ``n_edges`` are baked at graph
+generation time (per-mesh specialization). The interior-DOF count
+``n_int`` is left dynamic in the graph (the Dirichlet Gather honors any
+length of ``interior_idx`` passed at runtime), exactly matching the F.2
+contract.
+
+Graph stages (per the G.6 audit's per-stage operator inventory)
+===============================================================
+
+1. **ε_r assignment** — already host-computed in this builder; we accept
+   ``epsilon_r`` directly rather than re-deriving it inside the graph
+   (Stage 1, audit: clean / Equal + Where; deferred to host for
+   symmetry with the TF-Java driver pattern).
+2. **Per-element Nédélec 6×6 local matrices** (audit Stage 3) — cofactor
+   Gram via Einsum, then 36 entry-pair Gathers + Mul/Sub/Add to form the
+   K and M numerators, finally broadcast-scale by ``(2/3)/|det|^3`` and
+   ``1/(120 |det|)`` respectively.
+3. **PEC mask computation** (audit Stage 4a) — ReduceL2(nodes) + Sub +
+   Abs + Less to compute the boolean ``on_boundary`` per-node mask.
+   The mask is exposed as a graph output for cross-backend validation;
+   the index derivation ``flatnonzero(mask)`` itself remains host-side
+   (audit Stage 4b: caveat — NonZero is graph-expressible but produces
+   data-dependent shape; the host already computed ``interior_idx``).
+4. **Global K/M scatter-add** (audit Stage 5, static-shape version) —
+   sign outer product via Unsqueeze + Mul broadcasting, ε scaling, COO
+   index table via Expand + Reshape + Concat, then ScatterND with
+   ``reduction="add"`` onto a ConstantOfShape ``(n_edges, n_edges)``
+   zero buffer. Because ``n_edges`` is baked at graph-generation time,
+   the global buffer has static shape end-to-end.
+5. **Dirichlet restriction** (audit Stage 6) — two successive Gather
+   ops with the host-computed ``interior_idx``. Identical pattern to
+   the F.2 cube-cavity graph; the only structural difference is that
+   ``n_edges`` (rather than ``n_nodes``) is the indexed axis.
+
+Authoring tool
+==============
+
+Raw ``onnx.helper`` (NOT ``onnxscript``), same as the F.2 cube-cavity
+graph and the G.6 probe scripts. Rationale (from the F.1 audit, lines
+51-55): ``onnxscript`` can hide imperative sugar that the audit needs to
+surface at the IR level. The audit's contract — "every L4 op visible as
+an opset-18 node" — only holds if we inherit the same authoring choice.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import onnx
+import onnx.helper as oh
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+
+OPSET = 18
+IR_VERSION = 9
+
+
+# The 36 (i,j) = ((a,b), (c,d)) pair-of-pairs, baked in as constants.
+# This is the fixed 6x6 Nédélec local stiffness/mass index structure,
+# identical to the one in `probe_nedelec_local.py`.
+EDGE_PAIRS: list[tuple[int, int, int, int]] = [
+    (a, b, c, d)
+    for (a, b) in TET_LOCAL_EDGES
+    for (c, d) in TET_LOCAL_EDGES
+]
+
+
+def _f(p: int, q: int) -> float:
+    """Kronecker factor ``f_pq = 1 + delta_pq`` used by the mass entries."""
+    return 2.0 if p == q else 1.0
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    """Wrap a small NumPy array as a `Constant` node in the graph.
+
+    Local copy of the same helper used by the F.2 cube-cavity graph and
+    the G.6 probe scripts. Same deferred-hygiene note: extraction to a
+    shared ``reference/onnx/_helpers.py`` is a follow-up.
+    """
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+        np.dtype("bool"): TensorProto.BOOL,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def _nedelec_local_nodes(nodes: List[onnx.NodeProto]) -> None:
+    """Append nodes that compute (k_local, m_local) from `elem_coords`.
+
+    Reads:
+      ``elem_coords``  f64 (n_tets, 4, 3) — per-element vertex coords
+    Writes:
+      ``k_local``      f64 (n_tets, 6, 6)
+      ``m_local``      f64 (n_tets, 6, 6)
+      ``abs_det``      f64 (n_tets,)       — exposed for downstream debug
+
+    Faithful port of the audit probe `probe_nedelec_local.py`, with
+    unique constant/intermediate names so the graph stays SSA when used
+    alongside the scatter step. Mirror of
+    `reference/numpy/nedelec_local_matrices.py` and
+    `crates/geode-core/src/nedelec.rs:199-210`.
+    """
+    # ---------- Axis constants ----------
+    nodes.append(_const("ned_axis1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("ned_axis_neg1", np.array([-1], dtype=np.int64)))
+    for i in range(4):
+        nodes.append(_const(f"ned_idx_{i}", np.array(i, dtype=np.int64)))
+    for c in range(3):
+        nodes.append(_const(f"ned_comp_{c}", np.array(c, dtype=np.int64)))
+
+    # ---------- Gather v0..v3 from elem_coords along axis=1 ----------
+    for i in range(4):
+        nodes.append(oh.make_node(
+            "Gather",
+            inputs=["elem_coords", f"ned_idx_{i}"],
+            outputs=[f"ned_v{i}"],
+            axis=1,
+        ))
+
+    # ---------- Edge vectors from v0 ----------
+    for i in (1, 2, 3):
+        nodes.append(oh.make_node("Sub", [f"ned_v{i}", "ned_v0"], [f"ned_e{i}"]))
+
+    # ---------- Cross-product synthesis helpers ----------
+    emitted_components: set = set()
+
+    def emit_components(vec: str) -> tuple:
+        outs = []
+        for c in range(3):
+            out_name = f"{vec}_c{c}"
+            if out_name not in emitted_components:
+                nodes.append(oh.make_node(
+                    "Gather",
+                    inputs=[vec, f"ned_comp_{c}"],
+                    outputs=[out_name],
+                    axis=1,
+                ))
+                emitted_components.add(out_name)
+            outs.append(out_name)
+        return tuple(outs)
+
+    def emit_cross(a: str, b: str, out: str) -> None:
+        ax, ay, az = emit_components(a)
+        bx, by, bz = emit_components(b)
+        nodes.append(oh.make_node("Mul", [ay, bz], [f"{out}_t1"]))
+        nodes.append(oh.make_node("Mul", [az, by], [f"{out}_t2"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t1", f"{out}_t2"], [f"{out}_cx"]))
+        nodes.append(oh.make_node("Mul", [az, bx], [f"{out}_t3"]))
+        nodes.append(oh.make_node("Mul", [ax, bz], [f"{out}_t4"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t3", f"{out}_t4"], [f"{out}_cy"]))
+        nodes.append(oh.make_node("Mul", [ax, by], [f"{out}_t5"]))
+        nodes.append(oh.make_node("Mul", [ay, bx], [f"{out}_t6"]))
+        nodes.append(oh.make_node("Sub", [f"{out}_t5", f"{out}_t6"], [f"{out}_cz"]))
+        for comp in ("cx", "cy", "cz"):
+            nodes.append(oh.make_node(
+                "Unsqueeze",
+                inputs=[f"{out}_{comp}", "ned_axis_neg1"],
+                outputs=[f"{out}_{comp}_u"],
+            ))
+        nodes.append(oh.make_node(
+            "Concat",
+            inputs=[f"{out}_cx_u", f"{out}_cy_u", f"{out}_cz_u"],
+            outputs=[out],
+            axis=1,
+        ))
+
+    # g1 = cross(e2, e3), g2 = cross(e3, e1), g3 = cross(e1, e2)
+    emit_cross("ned_e2", "ned_e3", "ned_g1")
+    emit_cross("ned_e3", "ned_e1", "ned_g2")
+    emit_cross("ned_e1", "ned_e2", "ned_g3")
+    # g0 = -(g1 + g2 + g3)
+    nodes.append(oh.make_node("Add", ["ned_g1", "ned_g2"], ["ned_g1_g2"]))
+    nodes.append(oh.make_node("Add", ["ned_g1_g2", "ned_g3"], ["ned_g_sum"]))
+    nodes.append(oh.make_node("Neg", ["ned_g_sum"], ["ned_g0"]))
+
+    # ---------- det = sum(e1 * g1) along axis=1; abs_det = |det| ----------
+    nodes.append(oh.make_node("Mul", ["ned_e1", "ned_g1"], ["ned_e1g1"]))
+    nodes.append(oh.make_node(
+        "ReduceSum",
+        inputs=["ned_e1g1", "ned_axis1"],
+        outputs=["ned_det"],
+        keepdims=0,
+    ))
+    nodes.append(oh.make_node("Abs", ["ned_det"], ["abs_det"]))
+
+    # ---------- Gram matrix gg (N, 4, 4) via Einsum: "eik,ejk->eij" ----------
+    for g in ("ned_g0", "ned_g1", "ned_g2", "ned_g3"):
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[g, "ned_axis1"],
+            outputs=[f"{g}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=["ned_g0_u", "ned_g1_u", "ned_g2_u", "ned_g3_u"],
+        outputs=["ned_g_mat"],
+        axis=1,
+    ))
+    nodes.append(oh.make_node(
+        "Einsum",
+        inputs=["ned_g_mat", "ned_g_mat"],
+        outputs=["ned_gg"],
+        equation="eik,ejk->eij",
+    ))
+
+    # ---------- Per-element scale factors ----------
+    # inv_abs_det = 1 / abs_det  (N,)
+    nodes.append(_const("ned_one_f64", np.array(1.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Div", ["ned_one_f64", "abs_det"], ["ned_inv_abs_det"]))
+    nodes.append(oh.make_node(
+        "Mul", ["ned_inv_abs_det", "ned_inv_abs_det"], ["ned_inv_abs_det2"]
+    ))
+    nodes.append(oh.make_node(
+        "Mul", ["ned_inv_abs_det2", "ned_inv_abs_det"], ["ned_inv_abs_det3"]
+    ))
+
+    # Reshape scalars (N,) -> (N, 1, 1) for broadcasting against (N, 6, 6)
+    nodes.append(_const("ned_shape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "Reshape", ["ned_inv_abs_det3", "ned_shape_n11"], ["ned_inv_det3_b"]
+    ))
+    nodes.append(oh.make_node(
+        "Reshape", ["ned_inv_abs_det", "ned_shape_n11"], ["ned_inv_det_b"]
+    ))
+
+    # ---------- Per-pair Gram entry extraction ----------
+    # For each unique (p, q) pair in {0,1,2,3} x {0,1,2,3} extract gg[:, p, q]
+    # via two successive Gather ops (axis=1 → axis=1 on the 4-vector slice).
+    emitted_rows: set = set()
+    emitted_gg: set = set()
+
+    def emit_gg(p: int, q: int) -> str:
+        key = (p, q)
+        name = f"ned_gg_{p}{q}"
+        if key in emitted_gg:
+            return name
+        row_name = f"ned_gg_row{p}"
+        if p not in emitted_rows:
+            nodes.append(oh.make_node(
+                "Gather",
+                inputs=["ned_gg", f"ned_idx_{p}"],
+                outputs=[row_name],
+                axis=1,
+            ))
+            emitted_rows.add(p)
+        nodes.append(oh.make_node(
+            "Gather",
+            inputs=[row_name, f"ned_idx_{q}"],
+            outputs=[name],
+            axis=1,
+        ))
+        emitted_gg.add(key)
+        return name
+
+    # Build K_ij and M_ij for each of 36 edge pairs.
+    k_entries: list[str] = []
+    m_entries: list[str] = []
+
+    for idx, (a, b, c, d) in enumerate(EDGE_PAIRS):
+        gg_ac = emit_gg(a, c)
+        gg_ad = emit_gg(a, d)
+        gg_bc = emit_gg(b, c)
+        gg_bd = emit_gg(b, d)
+
+        # K_{ij} = (2/3) * (gg_ac * gg_bd - gg_ad * gg_bc) / |det|^3
+        nodes.append(oh.make_node("Mul", [gg_ac, gg_bd], [f"ned_kp{idx}_1"]))
+        nodes.append(oh.make_node("Mul", [gg_ad, gg_bc], [f"ned_kp{idx}_2"]))
+        nodes.append(oh.make_node(
+            "Sub", [f"ned_kp{idx}_1", f"ned_kp{idx}_2"], [f"ned_kp{idx}_diff"]
+        ))
+        k_entries.append(f"ned_kp{idx}_diff")
+
+        # M_{ij} terms with Kronecker factors (baked as float constants).
+        f_ac = _f(a, c)
+        f_ad = _f(a, d)
+        f_bc = _f(b, c)
+        f_bd = _f(b, d)
+
+        nodes.append(_const(f"ned_fac_{idx}_ac", np.array(f_ac, dtype=np.float64)))
+        nodes.append(_const(f"ned_fac_{idx}_ad", np.array(f_ad, dtype=np.float64)))
+        nodes.append(_const(f"ned_fac_{idx}_bc", np.array(f_bc, dtype=np.float64)))
+        nodes.append(_const(f"ned_fac_{idx}_bd", np.array(f_bd, dtype=np.float64)))
+
+        nodes.append(oh.make_node("Mul", [f"ned_fac_{idx}_ac", gg_bd], [f"ned_mp{idx}_1"]))
+        nodes.append(oh.make_node("Mul", [f"ned_fac_{idx}_ad", gg_bc], [f"ned_mp{idx}_2"]))
+        nodes.append(oh.make_node("Mul", [f"ned_fac_{idx}_bc", gg_ad], [f"ned_mp{idx}_3"]))
+        nodes.append(oh.make_node("Mul", [f"ned_fac_{idx}_bd", gg_ac], [f"ned_mp{idx}_4"]))
+        nodes.append(oh.make_node(
+            "Sub", [f"ned_mp{idx}_1", f"ned_mp{idx}_2"], [f"ned_mp{idx}_a"]
+        ))
+        nodes.append(oh.make_node(
+            "Sub", [f"ned_mp{idx}_a", f"ned_mp{idx}_3"], [f"ned_mp{idx}_b"]
+        ))
+        nodes.append(oh.make_node(
+            "Add", [f"ned_mp{idx}_b", f"ned_mp{idx}_4"], [f"ned_mp{idx}_term"]
+        ))
+        m_entries.append(f"ned_mp{idx}_term")
+
+    # ---------- Stack 36 (N,) entries → (N, 36) → reshape to (N, 6, 6) ----------
+    for name in k_entries:
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[name, "ned_axis_neg1"],
+            outputs=[f"{name}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=[f"{name}_u" for name in k_entries],
+        outputs=["ned_k_flat"],
+        axis=1,
+    ))
+    nodes.append(_const("ned_shape_n66", np.array([-1, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["ned_k_flat", "ned_shape_n66"], ["ned_k_raw"]))
+    nodes.append(_const("ned_two_thirds", np.array(2.0 / 3.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["ned_two_thirds", "ned_inv_det3_b"], ["ned_k_scale"]))
+    nodes.append(oh.make_node("Mul", ["ned_k_raw", "ned_k_scale"], ["k_local"]))
+
+    for name in m_entries:
+        nodes.append(oh.make_node(
+            "Unsqueeze",
+            inputs=[name, "ned_axis_neg1"],
+            outputs=[f"{name}_u"],
+        ))
+    nodes.append(oh.make_node(
+        "Concat",
+        inputs=[f"{name}_u" for name in m_entries],
+        outputs=["ned_m_flat"],
+        axis=1,
+    ))
+    nodes.append(oh.make_node("Reshape", ["ned_m_flat", "ned_shape_n66"], ["ned_m_raw"]))
+    nodes.append(_const("ned_inv_120", np.array(1.0 / 120.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["ned_inv_120", "ned_inv_det_b"], ["ned_m_scale"]))
+    nodes.append(oh.make_node("Mul", ["ned_m_raw", "ned_m_scale"], ["m_local"]))
+
+
+def _pec_mask_nodes(nodes: List[onnx.NodeProto], r_outer: float) -> None:
+    """Append nodes that compute the per-node PEC boundary mask.
+
+    Reads:
+      ``nodes``      f64 (n_nodes, 3)  — graph input
+    Writes:
+      ``on_boundary`` bool (n_nodes,)  — exposed for cross-backend validation
+
+    Mirrors steps 1-4 of `probe_pec_mask.py` and the NumPy reference
+    `sphere_pec.sphere_pec_interior_edges`. Step 5 (NonZero / idx
+    derivation) is intentionally left to the host per the audit's Stage
+    4b verdict — ``interior_idx`` enters as a separate graph input.
+    """
+    tol = 1e-6 * max(r_outer, 1.0)
+
+    nodes.append(_const("pec_axis1", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ReduceL2",
+        inputs=["nodes", "pec_axis1"],
+        outputs=["pec_r"],
+        keepdims=0,
+    ))
+    nodes.append(_const("pec_r_outer", np.array(r_outer, dtype=np.float64)))
+    nodes.append(_const("pec_tol", np.array(tol, dtype=np.float64)))
+    nodes.append(oh.make_node("Sub", ["pec_r", "pec_r_outer"], ["pec_r_minus"]))
+    nodes.append(oh.make_node("Abs", ["pec_r_minus"], ["pec_r_dist"]))
+    nodes.append(oh.make_node("Less", ["pec_r_dist", "pec_tol"], ["on_boundary"]))
+
+
+def _scatter_assemble_nodes(
+    nodes: List[onnx.NodeProto], n_tets: int, n_edges: int
+) -> None:
+    """Append nodes that scatter `k_local`/`m_local` into dense globals.
+
+    Reads:
+      ``k_local``       f64 (n_tets, 6, 6)
+      ``m_local``       f64 (n_tets, 6, 6)
+      ``tet_edge_idx``  i64 (n_tets, 6)  — graph input (host-computed)
+      ``tet_edge_sign`` f64 (n_tets, 6)  — graph input (host-computed)
+      ``epsilon_r``     f64 (n_tets,)    — graph input (host-computed)
+    Writes:
+      ``k_global``      f64 (n_edges, n_edges)
+      ``m_global``      f64 (n_edges, n_edges)
+
+    Mirrors `probe_nedelec_scatter.py` and the NumPy reference
+    `sphere_pec.assemble_global_nedelec`. Because ``n_edges`` is baked at
+    graph-build time (per-mesh specialization), the global buffer is
+    statically shaped — the audit's Stage 5 "PARTIAL" caveat about
+    data-dependent shape is sidestepped by host-baking ``n_edges``.
+    """
+    n_pairs = n_tets * 36  # flat (e, i, j) index count
+
+    # ---------- Constants ----------
+    nodes.append(_const("sct_ax1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("sct_ax2", np.array([2], dtype=np.int64)))
+    nodes.append(_const("sct_ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(_const("sct_shape_n66", np.array([n_tets, 6, 6], dtype=np.int64)))
+    nodes.append(_const("sct_flat_shape", np.array([n_pairs], dtype=np.int64)))
+    nodes.append(_const("sct_buf_shape", np.array([n_edges, n_edges], dtype=np.int64)))
+    nodes.append(_const("sct_eps_shape", np.array([-1, 1, 1], dtype=np.int64)))
+
+    # ---------- (1) Sign outer product ----------
+    # tet_edge_sign: (n_tets, 6) -> (n_tets, 6, 1) and (n_tets, 1, 6)
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["tet_edge_sign", "sct_ax2"], ["sct_sign_col"]
+    ))
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["tet_edge_sign", "sct_ax1"], ["sct_sign_row"]
+    ))
+    nodes.append(oh.make_node(
+        "Mul", ["sct_sign_col", "sct_sign_row"], ["sct_sign_outer"]
+    ))
+
+    # ---------- (2) Apply sign to k_local ----------
+    nodes.append(oh.make_node("Mul", ["k_local", "sct_sign_outer"], ["sct_k_signed"]))
+
+    # ---------- (3) Apply sign + epsilon to m_local ----------
+    # epsilon_r: (n_tets,) -> (n_tets, 1, 1) for broadcast.
+    nodes.append(oh.make_node("Reshape", ["epsilon_r", "sct_eps_shape"], ["sct_eps_b"]))
+    nodes.append(oh.make_node(
+        "Mul", ["m_local", "sct_sign_outer"], ["sct_m_signed_pre"]
+    ))
+    nodes.append(oh.make_node(
+        "Mul", ["sct_m_signed_pre", "sct_eps_b"], ["sct_m_signed"]
+    ))
+
+    # ---------- (4) COO index construction ----------
+    # rows[e,i,j] = tet_edge_idx[e,i], cols[e,i,j] = tet_edge_idx[e,j]
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["tet_edge_idx", "sct_ax2"], ["sct_tei_col"]
+    ))
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["tet_edge_idx", "sct_ax1"], ["sct_tei_row"]
+    ))
+    nodes.append(oh.make_node(
+        "Expand", ["sct_tei_col", "sct_shape_n66"], ["sct_rows_3d"]
+    ))
+    nodes.append(oh.make_node(
+        "Expand", ["sct_tei_row", "sct_shape_n66"], ["sct_cols_3d"]
+    ))
+
+    # Flatten to (n_pairs,)
+    nodes.append(oh.make_node(
+        "Reshape", ["sct_rows_3d", "sct_flat_shape"], ["sct_rows_flat"]
+    ))
+    nodes.append(oh.make_node(
+        "Reshape", ["sct_cols_3d", "sct_flat_shape"], ["sct_cols_flat"]
+    ))
+    nodes.append(oh.make_node(
+        "Reshape", ["sct_k_signed", "sct_flat_shape"], ["sct_k_vals"]
+    ))
+    nodes.append(oh.make_node(
+        "Reshape", ["sct_m_signed", "sct_flat_shape"], ["sct_m_vals"]
+    ))
+
+    # Stack (rows, cols) into (n_pairs, 2) index table.
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["sct_rows_flat", "sct_ax_neg1"], ["sct_rows_col"]
+    ))
+    nodes.append(oh.make_node(
+        "Unsqueeze", ["sct_cols_flat", "sct_ax_neg1"], ["sct_cols_col"]
+    ))
+    nodes.append(oh.make_node(
+        "Concat", ["sct_rows_col", "sct_cols_col"], ["sct_indices"], axis=1
+    ))
+
+    # ---------- (5) Zero buffers ----------
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["sct_buf_shape"],
+        outputs=["sct_k_zero"],
+        value=oh.make_tensor(
+            name="sct_k_zero_value",
+            data_type=TensorProto.DOUBLE,
+            dims=[1],
+            vals=[0.0],
+        ),
+    ))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["sct_buf_shape"],
+        outputs=["sct_m_zero"],
+        value=oh.make_tensor(
+            name="sct_m_zero_value",
+            data_type=TensorProto.DOUBLE,
+            dims=[1],
+            vals=[0.0],
+        ),
+    ))
+
+    # ---------- (6) ScatterND(reduction="add") ----------
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["sct_k_zero", "sct_indices", "sct_k_vals"],
+        outputs=["k_global"],
+        reduction="add",
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["sct_m_zero", "sct_indices", "sct_m_vals"],
+        outputs=["m_global"],
+        reduction="add",
+    ))
+
+
+def _dirichlet_restrict_nodes(nodes: List[onnx.NodeProto]) -> None:
+    """Append nodes that compute `K_int = K[idx, :][:, idx]` and the same for M.
+
+    Reads:
+      ``k_global``      f64 (n_edges, n_edges)
+      ``m_global``      f64 (n_edges, n_edges)
+      ``interior_idx``  i64 (n_int,)   — graph input (host-computed)
+    Writes:
+      ``K_int``         f64 (n_int, n_int)
+      ``M_int``         f64 (n_int, n_int)
+
+    Identical pattern to the cube-cavity F.2 Dirichlet step; the only
+    difference is that the indexed axis is the edge axis (length
+    ``n_edges``) rather than the node axis.
+    """
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["k_global", "interior_idx"],
+        outputs=["dir_k_rows"],
+        axis=0,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["dir_k_rows", "interior_idx"],
+        outputs=["K_int"],
+        axis=1,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["m_global", "interior_idx"],
+        outputs=["dir_m_rows"],
+        axis=0,
+    ))
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["dir_m_rows", "interior_idx"],
+        outputs=["M_int"],
+        axis=1,
+    ))
+
+
+def build_sphere_pec_graph(
+    n_nodes: int,
+    n_tets: int,
+    n_edges: int,
+    r_outer: float,
+) -> onnx.ModelProto:
+    """Build the end-to-end ONNX sphere-PEC partial-assembly graph.
+
+    Parameters
+    ----------
+    n_nodes : int
+        Total node count of the mesh.
+    n_tets : int
+        Total tet count of the mesh.
+    n_edges : int
+        Total edge count, as computed by `build_edges` on the host. Baked
+        into the global buffer shape so the scatter remains statically
+        shaped (sidesteps the audit's Stage 5 dynamic-shape caveat).
+    r_outer : float
+        Outer PEC wall radius for the PEC mask computation (= R_BUFFER).
+
+    Notes
+    -----
+    The interior-DOF count ``n_int`` is *not* baked into the graph — the
+    Dirichlet Gather honors any length of ``interior_idx`` passed at
+    runtime. This matches the F.2 contract exactly and keeps the graph
+    re-usable across PEC instantiations on the same mesh.
+    """
+    nodes: List[onnx.NodeProto] = []
+
+    # ---------- Graph inputs ----------
+    nodes_in = oh.make_tensor_value_info(
+        "nodes", TensorProto.DOUBLE, shape=[n_nodes, 3]
+    )
+    tets_in = oh.make_tensor_value_info(
+        "tets", TensorProto.INT64, shape=[n_tets, 4]
+    )
+    edges_in = oh.make_tensor_value_info(
+        "edges", TensorProto.INT64, shape=[n_edges, 2]
+    )
+    tei_in = oh.make_tensor_value_info(
+        "tet_edge_idx", TensorProto.INT64, shape=[n_tets, 6]
+    )
+    tes_in = oh.make_tensor_value_info(
+        "tet_edge_sign", TensorProto.DOUBLE, shape=[n_tets, 6]
+    )
+    eps_in = oh.make_tensor_value_info(
+        "epsilon_r", TensorProto.DOUBLE, shape=[n_tets]
+    )
+    idx_in = oh.make_tensor_value_info(
+        "interior_idx", TensorProto.INT64, shape=["n_int"]
+    )
+
+    # ---------- Stage 0: gather elem_coords[e, i, :] = nodes[tets[e, i], :] ----------
+    nodes.append(oh.make_node(
+        "Gather",
+        inputs=["nodes", "tets"],
+        outputs=["elem_coords"],
+        axis=0,
+    ))
+
+    # ---------- Stage 1: Nédélec local 6x6 matrices ----------
+    _nedelec_local_nodes(nodes)
+
+    # ---------- Stage 2: PEC boundary mask (per-node) ----------
+    # Exposed as `on_boundary` graph output for cross-backend validation
+    # of the audit's Stage 4a "mask is graph-expressible" finding.
+    _pec_mask_nodes(nodes, r_outer)
+
+    # ---------- Stage 3: global K/M scatter-add ----------
+    _scatter_assemble_nodes(nodes, n_tets, n_edges)
+
+    # ---------- Stage 4: Dirichlet restriction (interior_idx, host) ----------
+    _dirichlet_restrict_nodes(nodes)
+
+    # ---------- Graph outputs ----------
+    k_int_out = oh.make_tensor_value_info(
+        "K_int", TensorProto.DOUBLE, shape=["n_int", "n_int"]
+    )
+    m_int_out = oh.make_tensor_value_info(
+        "M_int", TensorProto.DOUBLE, shape=["n_int", "n_int"]
+    )
+    # Intermediate outputs exposed for audit cross-checks (G.7 AC).
+    k_global_out = oh.make_tensor_value_info(
+        "k_global", TensorProto.DOUBLE, shape=[n_edges, n_edges]
+    )
+    m_global_out = oh.make_tensor_value_info(
+        "m_global", TensorProto.DOUBLE, shape=[n_edges, n_edges]
+    )
+    on_boundary_out = oh.make_tensor_value_info(
+        "on_boundary", TensorProto.BOOL, shape=[n_nodes]
+    )
+    # The unused `edges` input is silenced via Identity → discarded;
+    # we accept it on the boundary so the host driver can stage it
+    # alongside the other build_edges outputs without needing a wrapper.
+    nodes.append(oh.make_node("Identity", ["edges"], ["edges_passthrough"]))
+    edges_passthrough_out = oh.make_tensor_value_info(
+        "edges_passthrough", TensorProto.INT64, shape=[n_edges, 2]
+    )
+
+    graph = oh.make_graph(
+        nodes,
+        name="sphere_pec_assembly",
+        inputs=[nodes_in, tets_in, edges_in, tei_in, tes_in, eps_in, idx_in],
+        outputs=[
+            k_int_out,
+            m_int_out,
+            k_global_out,
+            m_global_out,
+            on_boundary_out,
+            edges_passthrough_out,
+        ],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=IR_VERSION,
+    )
+
+
+__all__ = [
+    "build_sphere_pec_graph",
+    "EDGE_PAIRS",
+    "OPSET",
+    "IR_VERSION",
+]

--- a/reference/onnx/sphere_pec/gen_sphere_pec_reduced.py
+++ b/reference/onnx/sphere_pec/gen_sphere_pec_reduced.py
@@ -1,0 +1,391 @@
+"""Driver: build the ONNX sphere-PEC graph, run it, emit a schema-v1 sidecar.
+
+Epic #88, Phase G.7 (issue #140). Mirror of
+`reference/tf_java/sphere_pec/.../SpherePecMain.java` and the F.2
+`reference/onnx/cube_cavity/gen_cube_cavity_reduced.py`, with the
+Nédélec-specific host-computed topology inputs that the G.6 audit (PR
+#138) settled on.
+
+Per the audit:
+
+  * ``build_edges`` (deduplication + inverse map + sign fill) is the
+    *secretly-imperative* L4 escape on the Nédélec spine. It runs
+    host-side via ``reference/numpy/sphere_pec.build_edges`` and its
+    outputs — ``edges``, ``tet_edge_idx``, ``tet_edge_sign`` — are
+    passed in as graph inputs.
+  * ``epsilon_r`` (per-tet permittivity) is host-computed via
+    ``reference/numpy/sphere_pec.build_epsilon_r``. This is technically
+    graph-expressible (Equal + Where, Stage 1) but is deferred to host
+    for symmetry with the TF-Java driver and to avoid adding the tag
+    table as a separate graph input.
+  * ``interior_idx`` is host-computed via ``np.flatnonzero(pec_mask)``
+    (Stage 4b: NonZero is graph-expressible but introduces data-dependent
+    shape; the audit's recommended design hosts it).
+
+The resulting sidecar is consumed by the existing sphere-PEC eigensolve
+driver ``reference/driver/eigensolve_sphere_pec_sidecar.py``, which
+applies the shift-and-invert ARPACK eigensolve + spurious filter (the
+shared L4 friction across every backend — there is no sparse generalized
+eigensolver in ONNX).
+
+Usage
+=====
+    python3 reference/onnx/sphere_pec/gen_sphere_pec_reduced.py \\
+        --mesh reference/fixtures/sphere_pec/sphere.msh \\
+        --n-index 1.5 \\
+        --r-buffer 2.0 \\
+        --out target/out/reduced_kM_sphere_pec_onnx.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent  # reference/
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+sys.path.insert(0, str(HERE))
+
+from sphere_pec import (  # noqa: E402
+    R_BUFFER,
+    build_edges,
+    build_epsilon_r,
+    read_sphere_fixture,
+    sphere_pec_interior_edges,
+)
+
+from assembly_graph import build_sphere_pec_graph  # noqa: E402
+
+
+def _input_field(value_list, shape, dtype, description):
+    return {
+        "shape": list(shape),
+        "dtype": dtype,
+        "description": description,
+        "data": list(value_list),
+    }
+
+
+def _output_field(arr: np.ndarray, dtype: str, description: str,
+                  tolerance_abs: float) -> dict:
+    return {
+        "shape": list(arr.shape) if hasattr(arr, "shape") else [1],
+        "dtype": dtype,
+        "description": description,
+        "tolerance_abs": tolerance_abs,
+        "data": arr.ravel().tolist() if hasattr(arr, "ravel") else [float(arr)],
+    }
+
+
+def _scalar_output(value: float, dtype: str, description: str,
+                   tolerance_abs: float) -> dict:
+    return {
+        "shape": [1],
+        "dtype": dtype,
+        "description": description,
+        "tolerance_abs": tolerance_abs,
+        "data": [float(value)],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ONNX sphere-PEC Nédélec partial-assembly driver. Builds the "
+            "ONNX graph, runs onnxruntime with host-computed topology, "
+            "emits a schema-v1 sidecar consumed by "
+            "reference/driver/eigensolve_sphere_pec_sidecar.py."
+        )
+    )
+    default_mesh = (
+        REFERENCE_ROOT / "fixtures" / "sphere_pec" / "sphere.msh"
+    )
+    parser.add_argument(
+        "--mesh",
+        type=Path,
+        default=default_mesh,
+        help=(
+            "Path to the Gmsh .msh fixture "
+            "(default reference/fixtures/sphere_pec/sphere.msh)."
+        ),
+    )
+    parser.add_argument(
+        "--n-index",
+        type=float,
+        default=1.5,
+        help="Refractive index inside the dielectric sphere (default 1.5).",
+    )
+    parser.add_argument(
+        "--r-buffer",
+        type=float,
+        default=R_BUFFER,
+        help="Outer PEC wall radius (default R_BUFFER = 2.0).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output JSON path for the reduced (K_int, M_int) sidecar.",
+    )
+    parser.add_argument(
+        "--save-model",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to save the .onnx model file (for inspection / "
+            "reproducibility of the graph payload)."
+        ),
+    )
+    args = parser.parse_args()
+
+    print(
+        f"[onnx-sphere-pec] onnx={onnx.__version__}  "
+        f"onnxruntime={ort.__version__}  mesh={args.mesh}  "
+        f"n_index={args.n_index}  r_buffer={args.r_buffer}"
+    )
+
+    # ---- Mesh I/O + host-computed topology ----
+    fixture = read_sphere_fixture(args.mesh)
+    n_nodes = fixture.n_nodes
+    n_tets = fixture.n_tets
+
+    epsilon_r = build_epsilon_r(fixture.tet_physical_tags, n_inside=args.n_index)
+
+    # Stage 2 (audit: NOT EXPRESSIBLE) — host-side dedup + inverse map.
+    edges, tet_edge_idx, tet_edge_sign = build_edges(fixture.tets)
+    n_edges = int(edges.shape[0])
+    tet_edge_sign_f64 = tet_edge_sign.astype(np.float64)
+
+    # Stage 4b (audit: caveat) — host-side NonZero on the PEC mask.
+    interior_mask, on_boundary_np = sphere_pec_interior_edges(
+        fixture.nodes, edges, r_outer=args.r_buffer
+    )
+    interior_idx = np.flatnonzero(interior_mask).astype(np.int64)
+    n_int = int(interior_idx.size)
+
+    print(
+        f"[onnx-sphere-pec] n_nodes={n_nodes}, n_tets={n_tets}, "
+        f"n_edges={n_edges}, n_int={n_int}"
+    )
+
+    # ---- Build the ONNX graph for this connectivity ----
+    model = build_sphere_pec_graph(
+        n_nodes=n_nodes,
+        n_tets=n_tets,
+        n_edges=n_edges,
+        r_outer=args.r_buffer,
+    )
+    onnx.checker.check_model(model)
+    print("[onnx-sphere-pec] onnx.checker.check_model: OK")
+
+    if args.save_model is not None:
+        args.save_model.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.save_model, "wb") as f:
+            f.write(model.SerializeToString())
+        print(f"[onnx-sphere-pec] Saved model to {args.save_model}")
+
+    # ---- Run via onnxruntime ----
+    sess = ort.InferenceSession(model.SerializeToString())
+    outputs = sess.run(
+        ["K_int", "M_int", "k_global", "m_global", "on_boundary"],
+        {
+            "nodes": fixture.nodes.astype(np.float64),
+            "tets": fixture.tets.astype(np.int64),
+            "edges": edges.astype(np.int64),
+            "tet_edge_idx": tet_edge_idx.astype(np.int64),
+            "tet_edge_sign": tet_edge_sign_f64,
+            "epsilon_r": epsilon_r.astype(np.float64),
+            "interior_idx": interior_idx,
+        },
+    )
+    K_int, M_int, k_global, m_global, on_boundary_onnx = outputs
+
+    assert K_int.shape == (n_int, n_int), K_int.shape
+    assert M_int.shape == (n_int, n_int), M_int.shape
+
+    # ---- Sanity readouts (sub-stage cross-check vs NumPy) ----
+    tr_k = float(np.trace(K_int))
+    tr_m = float(np.trace(M_int))
+    frob_k = float(np.linalg.norm(K_int, ord="fro"))
+    frob_m = float(np.linalg.norm(M_int, ord="fro"))
+    print(f"[onnx-sphere-pec] trace(K_int)     = {tr_k:.12e}")
+    print(f"[onnx-sphere-pec] trace(M_int)     = {tr_m:.12e}")
+    print(f"[onnx-sphere-pec] Frobenius(K_int) = {frob_k:.12e}")
+    print(f"[onnx-sphere-pec] Frobenius(M_int) = {frob_m:.12e}")
+
+    # PEC mask cross-check (audit Stage 4a verdict).
+    if not np.array_equal(on_boundary_onnx, on_boundary_np):
+        n_disagree = int(np.sum(on_boundary_onnx != on_boundary_np))
+        print(
+            f"[onnx-sphere-pec] WARNING: on_boundary mask disagrees with "
+            f"NumPy reference on {n_disagree} of {n_nodes} nodes"
+        )
+    else:
+        print("[onnx-sphere-pec] on_boundary mask matches NumPy reference")
+
+    # ---- Build the sidecar ----
+    fixture_dict = {
+        "schema_version": "1",
+        "fixture_id": "sphere_pec/n774_pec_eigenmode_onnx",
+        "description": (
+            "ONNX partial-assembly reference for the vector-Nédélec "
+            "sphere-PEC eigenmode pipeline (Epic #88 Phase G.7 / issue #140). "
+            "The ONNX graph emits (K_int, M_int) directly via the host-"
+            "computed-topology design that the G.6 audit (PR #138) "
+            "recommended: edges, tet_edge_idx, tet_edge_sign, epsilon_r, "
+            "and interior_idx are all host-computed (build_edges is the "
+            "secretly-imperative L4 escape), then fed in as graph inputs. "
+            "The eigensolve is delegated to SciPy via "
+            "reference/driver/eigensolve_sphere_pec_sidecar.py (ONNX has "
+            "no sparse generalized eigensolver — shared L4 friction "
+            "across all backends)."
+        ),
+        "units": "lambda = k^2 (inverse-length squared); dimensionless mesh coordinates",
+        "inputs": {
+            "mesh_path": _input_field(
+                [str(args.mesh)], [1], "str",
+                "Path to the bundled sphere.msh fixture.",
+            ),
+            "n_index": _input_field(
+                [args.n_index], [1], "f64",
+                "Refractive index inside the dielectric sphere; "
+                "epsilon_r = n^2 inside.",
+            ),
+            "r_buffer": _input_field(
+                [args.r_buffer], [1], "f64",
+                "Outer PEC wall radius (= R_BUFFER).",
+            ),
+            "n_int": _input_field(
+                [n_int], [1], "i64",
+                "Interior edge count (DOFs after PEC elimination).",
+            ),
+            "interior_idx": _input_field(
+                interior_idx.tolist(), [n_int], "i64",
+                "Interior-DOF row/col indices into the full (n_edges, "
+                "n_edges) matrix. Host-computed via "
+                "np.flatnonzero(pec_mask); the audit (Stage 4b) "
+                "classified NonZero as graph-expressible but data-"
+                "dependent-shape, so the recommended design hosts the "
+                "idx derivation.",
+            ),
+            # eigensolve_sphere_pec_sidecar.py reads `n` / `side` aliases.
+            "n": _input_field(
+                [n_int], [1], "i64",
+                "Interior DOF count (= n_int). Alias for sidecar driver "
+                "compatibility.",
+            ),
+            "side": _input_field(
+                [args.r_buffer], [1], "f64",
+                "Outer PEC wall radius (= r_buffer). Alias for sidecar "
+                "driver compatibility.",
+            ),
+        },
+        "outputs": {
+            "n_nodes": _scalar_output(
+                float(n_nodes), "f64",
+                "Number of mesh nodes. Strict equality.",
+                0.5,
+            ),
+            "n_tets": _scalar_output(
+                float(n_tets), "f64",
+                "Number of mesh tets. Strict equality.",
+                0.5,
+            ),
+            "n_edges": _scalar_output(
+                float(n_edges), "f64",
+                "Total global edge count (before PEC elimination). "
+                "Host-computed via build_edges (audit Stage 2b: NOT "
+                "EXPRESSIBLE in ONNX — secretly-imperative L4 escape).",
+                0.5,
+            ),
+            "n_interior_edges": _scalar_output(
+                float(n_int), "f64",
+                "Interior edge count (DOFs after PEC elimination).",
+                0.5,
+            ),
+            "k_diag_sum": _scalar_output(
+                tr_k, "f64",
+                "trace(K_int) — ONNX assembly readback.",
+                1.0e-6,
+            ),
+            "m_diag_sum": _scalar_output(
+                tr_m, "f64",
+                "trace(M_int) — ONNX assembly readback.",
+                1.0e-6,
+            ),
+            "k_int_frobenius": _scalar_output(
+                frob_k, "f64",
+                "Frobenius norm of K_int. Acceptance criterion: 1e-6 "
+                "absolute vs the NumPy baseline (G.7 AC, same as F.2).",
+                1.0e-6,
+            ),
+            "m_int_frobenius": _scalar_output(
+                frob_m, "f64",
+                "Frobenius norm of M_int. Acceptance criterion: 1e-6 "
+                "absolute vs the NumPy baseline (G.7 AC, same as F.2).",
+                1.0e-6,
+            ),
+            "k_int_diag": _output_field(
+                np.diag(K_int).astype(np.float64), "f64",
+                "Diagonal of K_int (per-DOF stiffness).",
+                1.0e-8,
+            ),
+            "m_int_diag": _output_field(
+                np.diag(M_int).astype(np.float64), "f64",
+                "Diagonal of M_int (per-DOF mass).",
+                1.0e-8,
+            ),
+            "k_int": _output_field(
+                K_int, "f64",
+                "Dirichlet-reduced Nédélec curl-curl stiffness matrix.",
+                1.0e-8,
+            ),
+            "m_int": _output_field(
+                M_int, "f64",
+                "Dirichlet-reduced epsilon-scaled Nédélec mass matrix.",
+                1.0e-8,
+            ),
+        },
+        "provenance": {
+            "source": (
+                "reference/onnx/sphere_pec/assembly_graph.py via "
+                "gen_sphere_pec_reduced.py (Epic #88 Phase G.7 / "
+                "issue #140)"
+            ),
+            "verified_against": (
+                "reference/numpy/sphere_pec.py and "
+                "reference/fixtures/sphere_pec/baseline.json"
+            ),
+            "issue": "#140",
+            "audit": "reference/onnx/audit/sphere_pec/nedelec_operator_audit.md",
+            "note": (
+                "Host-computed-topology design. The ONNX graph consumes "
+                "edges, tet_edge_idx, tet_edge_sign, epsilon_r, and "
+                "interior_idx as inputs because build_edges deduplication "
+                "is the secretly-imperative L4 escape on the Nédélec "
+                "spine (audit Stage 2b verdict)."
+            ),
+        },
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(fixture_dict, f, indent=2)
+        f.write("\n")
+    print(f"[onnx-sphere-pec] Wrote {args.out}")
+
+    # Suppress unused-variable warnings from optional outputs.
+    _ = k_global
+    _ = m_global
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase G.7 of Epic #88. Realises the [G.6 audit](../blob/main/reference/onnx/audit/sphere_pec/nedelec_operator_audit.md)'s recommended host-computed-topology design as a partial ONNX assembly graph for the vector-Nédélec sphere-PEC eigenmode spine. Mirrors the F.1 → F.2 pattern from cube-cavity (PR #125).

The graph emits ``(K_int, M_int)`` directly:

- **Inputs (host-computed per G.6):** ``nodes``, ``tets``, ``edges``, ``tet_edge_idx``, ``tet_edge_sign``, ``epsilon_r``, ``interior_idx``. ``edges`` and friends come from ``build_edges`` (audit Stage 2b: secretly-imperative L4 escape — the deduplication + inverse-map step cannot be expressed in ONNX's graph-only IR).
- **In-graph stages:** Nédélec 6×6 local curl-curl + mass (audit Stage 3, Einsum-based Gram), PEC mask computation (Stage 4a, ReduceL2 + Less), sign outer product + ε-scaling + ScatterND(``reduction="add"``) onto a static-shape ``(n_edges, n_edges)`` zero buffer (Stage 5), and the two-Gather Dirichlet restriction (Stage 6).
- **Out of scope (shared L4 friction):** generalized sparse eigensolve — delegated to ``reference/driver/eigensolve_sphere_pec_sidecar.py`` (the sphere-specific ARPACK shift-and-invert driver from PR #137).

### Changes

| Path | Change |
|---|---|
| ``reference/onnx/sphere_pec/assembly_graph.py`` | NEW — ``onnx.helper`` builder for the partial graph |
| ``reference/onnx/sphere_pec/gen_sphere_pec_reduced.py`` | NEW — host topology + onnxruntime + schema-v1 sidecar driver |
| ``reference/onnx/sphere_pec/__init__.py`` | NEW — module marker |
| ``reference/fixtures/sphere_pec/onnx_sidecar.json`` | NEW — placeholder fixture (matches TF-Java sidecar convention) |
| ``crates/geode-validation/tests/sphere_pec_onnx_reference.rs`` | NEW — Rust harness, mirror of ``sphere_pec_tfjava_reference.rs`` |
| ``reference/onnx/audit/sphere_pec/nedelec_operator_audit.md`` | UPDATE — empirical confirmation section appended |
| ``.github/workflows/onnx-cube-cavity.yml`` | UPDATE — workflow renamed to ``onnx-references``, new ``build-and-cross-check-sphere-pec`` job added |

### Driver choice — sphere-PEC vs cube-cavity

The issue body and the dispatch ticket name ``eigensolve_from_sidecar.py --backend onnx`` as the consumer. That script is the **cube-cavity-specific** consolidated driver (post PR #130). The sphere-PEC pipeline needs the spurious-mode filter + ARPACK shift-and-invert that lives in ``eigensolve_sphere_pec_sidecar.py`` (PR #137, the Phase G.5 driver actually used by the TF-Java sphere PEC gate). I followed the TF-Java precedent and used the sphere-specific driver — extending ``eigensolve_from_sidecar.py`` to handle the sphere-PEC pipeline would be a separate refactor outside Phase G.7 scope.

### Empirical results (774-node sphere fixture)

| Cross-check | ONNX vs NumPy baseline | AC |
|---|---|---|
| ``K_int`` Frobenius norm | **bit-exact** (abs diff = 0.000e+00) | < 1e-6 abs |
| ``M_int`` Frobenius norm | **bit-exact** (abs diff = 0.000e+00) | < 1e-6 abs |
| ``K_int`` sorted-diagonal max-abs | 3.2e-14 (f64 noise floor) | < 1e-8 abs |
| ``M_int`` sorted-diagonal max-abs | 1.1e-16 (f64 noise floor) | < 1e-8 abs |
| Physical eigenvalues λ[1..5] | rel err 5.0e-12 … 2.5e-9 | < 2e-5 rel (provisional) → **strict 1e-5 holds with margin** |
| ``on_boundary`` PEC mask | exact match | exact |

**Tolerance note:** The 2e-5 provisional tolerance flagged in the issue body (motivated by TF-Java's ~1.2e-5 scatterNd accumulation-order drift) is **not needed for ONNX** — onnxruntime's ``ScatterND`` reduction order on this fixture produces bit-exact f64 results vs scipy's COO→CSR collapse. The CI workflow gates at the strict 1e-5 floor.

### Audit & friction tracker

- Audit document updated with a Phase G.7 empirical confirmation section showing the recommended design works end-to-end (numbers above).
- Friction summary posted as comment on #5 (https://github.com/rjwalters/geode-fem/issues/5#issuecomment-4632713452) noting the two confirmed L4 escapes on the Nédélec spine remain ``build_edges`` deduplication and generalized sparse eigensolve.

### Predecessor pattern

PR #125 (Phase F.2, cube-cavity P1) following PR #119 (Phase F.1 audit). Same structure, same authoring tool (raw ``onnx.helper``, not ``onnxscript``), same sidecar schema, same Dirichlet-Gather Restriction with host-computed idx.

## Test plan

- [x] ``onnx.checker.check_model``: OK on the 4512-edge sphere graph.
- [x] ``onnxruntime`` end-to-end on the 774-node sphere fixture: K_int / M_int Frobenius norms bit-exact vs NumPy baseline.
- [x] ``eigensolve_sphere_pec_sidecar.py --rtol 1e-5``: passes; physical eigenvalues agree to ~1e-10 relative.
- [x] ``cargo test -p geode-validation --test sphere_pec_onnx_reference`` (non-ignored): 3 passed, 1 ignored.
- [x] ``cargo test -p geode-validation --release --features geode-core/ndarray --test sphere_pec_onnx_reference -- --ignored``: 1 passed (release mode required for faer 0.24 ``qz_real``).
- [x] ``cargo clippy -p geode-validation --tests -- -D warnings``: clean.
- [ ] CI workflow ``onnx-references`` runs the new sphere-PEC job on this PR.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)