### PR TITLE
feat: Phase H.5 — ONNX sphere-PML expressibility audit (Epic #88)

### DIFF
--- a/reference/onnx/audit/sphere_pml/nedelec_pml_operator_audit.md
+++ b/reference/onnx/audit/sphere_pml/nedelec_pml_operator_audit.md
@@ -1,0 +1,375 @@
+# Nédélec sphere-PML ONNX expressibility audit (Phase H.5)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase H.5
+deliverable. Tracking issue:
+[#157](https://github.com/rjwalters/geode-fem/issues/157).
+
+## Scope
+
+This audit catalogs the operators added by the **sphere-PML** assembly
+spine on top of the sphere-PEC spine audited in Phase G.6
+([`nedelec_operator_audit.md`](../sphere_pec/nedelec_operator_audit.md))
+and records whether each lowers to a graph-only ONNX opset-18 form.
+
+The sphere-PML pipeline — as defined by the NumPy reference in
+[`reference/numpy/sphere_pml.py`](../../../numpy/sphere_pml.py) and the
+Burn implementation in `crates/geode-core/src/nedelec_assembly.rs`
+(`assemble_global_nedelec_with_complex_epsilon`) and
+`crates/geode-core/src/pml.rs` (`build_complex_epsilon_r_pml`,
+`tet_centroid_radii`) — differs from PEC in exactly **one**
+constitutive piece: the per-tet permittivity becomes **complex** and
+the mass scatter accumulates a complex-symmetric (not Hermitian)
+matrix. Everything else (mesh I/O, edge enumeration, PEC outer mask,
+Dirichlet restriction, d⁰ rank classifier) is imported verbatim from
+the PEC pipeline; those stages inherit their PEC verdicts.
+
+The new stages audited here are:
+
+1. **`tet_centroid_radii`** — real, identical structure to ε_r
+   assignment. No new ONNX friction.
+2. **`build_complex_epsilon_r_pml`** — per-tet complex relative
+   permittivity from physical-group tag + centroid radius. **Real
+   ramp arithmetic, complex output.**
+3. **Complex local Nédélec stiffness scatter** — per-element K block
+   is real-valued, but lives inside a complex (K, M) pencil so the
+   sidecar boundary types it as complex128.
+4. **Complex local Nédélec mass scatter** — `m_local * sign_outer *
+   epsilon_r_complex` is a c128 outer product on the per-element 6×6.
+5. **Complex global assembly** — scatter c128 values into a c128
+   (n_edges, n_edges) buffer via ScatterND.
+6. **Complex generalized eigensolve** — LAPACK ZGGEV on the host.
+   Out-of-graph by definition, same disposition as the PEC sidecar
+   (and the cube-cavity F.2 eigensolve).
+
+**Headline finding**: opset 18 has no first-class `complex128` (or
+`complex64`) typed value path. The TypeProto enum lists `COMPLEX64=14`
+and `COMPLEX128=15`, and `onnx.checker.check_model` schema-accepts
+c128 in `Constant`/`Identity`/`Reshape`/`Gather`/`Scatter*`/`Where`
+output positions — but **every** arithmetic op (`Add`, `Sub`, `Mul`,
+`Div`, `Pow`, `MatMul`, `Einsum`, `ReduceSum`, …) and the
+`ConstantOfShape` fill type and `Cast` exclude c128 from their type
+constraints, and `onnxruntime` rejects c128 inputs even to the ops
+whose schema accepts them. This is the broader graph-only finding
+flagged in Comment 4 of Epic [#88](https://github.com/rjwalters/geode-fem/issues/88):
+the ONNX IR's c128 type is a vestigial datum that no kernel honors.
+
+## Pinned versions used for this audit
+
+Same as Phase F.1 / G.6:
+
+| Package | Version |
+|---|---|
+| `onnx` | `1.21.0` |
+| `onnxruntime` | `1.26.0` |
+| Target opset | `18` |
+
+See [`reference/onnx/requirements.txt`](../../requirements.txt) for the
+pinned `pip` line.
+
+## Classification convention
+
+Per-operator status follows the issue #157 convention:
+
+| Marker | Meaning |
+|---|---|
+| **emittable** | Op lowers directly to opset 18 with no special handling. |
+| **fallback** | Op cannot lower as-typed (e.g. c128 forbidden); a paired-real or alternative lowering exists and is documented. |
+| **blocked** | Op has no lowering — must be host-computed and passed as a graph input or executed in an out-of-graph sidecar. |
+
+This is a slight reframing of the Phase F.1 / G.6 markers
+(`clean` / `synth` / `caveat` / `secretly imperative`) to match the
+issue's request, with the following mapping:
+
+- `clean` / `synth` (real-valued ops working in opset 18) → **emittable**
+- "graph-only friction" (real, just verbose) → **emittable**
+- "complex op not supported, but paired-real lowering exists" → **fallback**
+- "secretly imperative" + "no lowering, host-only" → **blocked**
+
+## Operator table
+
+### Stage 1 — Per-tet centroid radius (`tet_centroid_radii`)
+
+No probe required; this is `mean(nodes[tets], axis=1)` followed by
+`ReduceL2(axis=1)`. Identical structure to the PEC mask Stage 4a
+(node radii) but on the per-tet centroid instead of per-node.
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `nodes[tets, :]` gather | `Gather(axis=0)` on `nodes` with `tets` flattened | **emittable** | Native opset-18. Same as the per-tet coord gather in Stage 3 of G.6. |
+| `mean(..., axis=1)` over 4-vertex group | `ReduceMean(axes=[1])` | **emittable** | Native. |
+| `np.linalg.norm(centroids, axis=1)` | `ReduceL2(axes=[1])` | **emittable** | Native opset 18, same as PEC Stage 4a. |
+
+**Stage 1 verdict: EMITTABLE.** Real-valued; no friction beyond the
+PEC pattern already audited in G.6.
+
+### Stage 2 — Complex ε ramp (`build_complex_epsilon_r_pml`)
+
+Probe: [`probe_complex_eps_ramp.py`](probe_complex_eps_ramp.py).
+
+The PML profile is a tag-keyed Where ladder plus a quadratic ramp on
+the radii. The arithmetic is **all real** until the final
+`(re, im) → c128` step. That last step has no opset-18 lowering.
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `tags == PHYS_SPHERE_INTERIOR`, `tags == PHYS_PML_SHELL` | `Equal` | **emittable** | Native, int32. |
+| `where(is_int, n², 1.0)` (real part) | `Where` | **emittable** | Native, f64. |
+| `(radii − R_PML_INNER) / Δ` | `Sub` + `Mul` | **emittable** | Native f64. |
+| `clip(u, 0, 1)` | `Clip` | **emittable** | Native f64. |
+| `u * u` | `Mul` | **emittable** | Native. |
+| `−σ₀ · u²` | `Mul` | **emittable** | Native. |
+| `where(is_pml, im_ramp, 0)` (imag part) | `Where` | **emittable** | Native f64. |
+| **`re + 1j * im → complex128`** | **none** | **blocked** | **No `Complex(re, im)` op in opset 18.** `Cast` excludes c128 as a target. The only ways to introduce a c128 tensor are (a) a c128 graph input, or (b) a c128 `Constant` — neither constructs c128 from two f64 tensors. |
+
+**Recommended lowering (fallback): paired-real outputs.** Emit two
+f64 outputs `eps_re (n_tets,)` and `eps_im (n_tets,)`. The downstream
+scatter consumes them as two parallel real channels. This mirrors the
+"complex as two reals" convention used by TF-Java (Phase H.4),
+JAX-on-TPU, and the SciML community.
+
+Probe result: paired-real graph passes `onnx.checker` and
+`onnxruntime`; bit-exact match (`0.000e+00`) vs. the NumPy reference
+on a 6-tet test case spanning all three regions (interior, vacuum,
+PML at three radii including the clamped `u = 1` overshoot).
+
+The native-c128 control graph (A) fails at session-load time with
+the precise error:
+
+```
+[ONNXRuntimeError] : 1 : FAIL : Exception during loading:
+MLDataType for: tensor(complex128) is not currently registered
+or supported
+```
+
+This is captured automatically when running the probe; the failure
+itself is the load-bearing evidence.
+
+**Stage 2 verdict: FALLBACK (paired-real lowering).** The op as
+specified (single c128 output) is BLOCKED; the paired-real
+alternative is EMITTABLE.
+
+### Stage 3 — Complex local Nédélec stiffness scatter
+
+**Structurally unchanged from G.6 Stage 3 + Stage 5.** The K curl-curl
+local block is real-valued in both PEC and PML; only the eigensolve
+boundary sees it as complex128 (where it has `Im(K) = 0` identically).
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Per-element 6×6 K_local computation | (see G.6 Stage 3 — full inventory of Gather/Mul/Sub/Add/Einsum) | **emittable** | Unchanged from G.6. Bit-exact in f64. |
+| Sign outer product `s_i s_j` | `Unsqueeze` × 2 + `Mul` | **emittable** | Unchanged from G.6 Stage 5. |
+| `k_local * sign_outer` | `Mul` (f64) | **emittable** | Unchanged from G.6 Stage 5. |
+| Real ScatterND into `(n_edges, n_edges)` f64 buffer | `ConstantOfShape` + `ScatterND(reduction="add")` | **emittable** | Unchanged from G.6 Stage 5. |
+| Eigensolve boundary types K as complex128 | (downstream) | **fallback** | The sidecar driver promotes K to c128 (with `Im(K) = 0`) before calling LAPACK ZGGEV. The promotion happens **on the host**, not in the graph. |
+
+**Stage 3 verdict: EMITTABLE** (real graph; eigensolve sidecar
+handles the c128 promotion on the host). No new ONNX friction over G.6.
+
+### Stage 4 — Complex local Nédélec mass scatter
+
+Probe: [`probe_complex_local_scatter.py`](probe_complex_local_scatter.py).
+
+The mass `M_local` is real, but it picks up a per-tet **complex**
+scaling: `m_signed_c128 = m_local * sign_outer * epsilon_r_complex[e]`.
+The Mul between an f64 tensor and a c128 tensor has no opset-18
+lowering.
+
+| Operator (L4 / NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Per-element 6×6 M_local computation | (see G.6 Stage 3) | **emittable** | Real. Unchanged from G.6. |
+| Sign outer product `s_i s_j` | `Unsqueeze` × 2 + `Mul` | **emittable** | Real. Unchanged from G.6 Stage 5. |
+| `m_local * sign_outer` | `Mul` (f64) | **emittable** | Real. |
+| **`m_signed_real * eps_complex[e]`** (f64 × c128) | `Mul` | **blocked** | `Mul`'s `T` type constraint in opset 18 excludes c128/c64. Runtime error: `Type 'tensor(complex128)' of input parameter (eps_b) of operator (Mul) in node () is invalid.` |
+| **`m_signed_c128 * m_signed_c128`** (c128 × c128) | `Mul` | **blocked** | Same type constraint exclusion. |
+| `Reshape` over c128 | `Reshape` | (schema-OK) **blocked at upstream** | Reshape schema accepts c128 as `T`, but no upstream op can produce the c128 tensor to feed it. |
+
+**Recommended lowering (fallback): paired-real Mul + paired-real
+ScatterND.** Emit `m_signed_re = m_local * sign_outer * eps_re[e]`
+and `m_signed_im = m_local * sign_outer * eps_im[e]`. The COO
+indices (int64) and sign outer product (f64) are shared between the
+two channels; only the final Mul-by-ε and the terminal ScatterND
+duplicate. The graph runtime cost is ~2× the PEC scatter (one extra
+Mul + one extra ScatterND per call), not 4× as a naïve "complex
+multiplication adds 4 real multiplies" estimate might suggest,
+because `m_local * sign_outer` is shared and `m_local` is real
+(so `Re(eps · M) = Re(eps) · M` and `Im(eps · M) = Im(eps) · M`).
+
+Probe result: paired-real graph passes `onnx.checker` and
+`onnxruntime`; bit-exact match (`0.000e+00`) for both `Re(M_global)`
+and `Im(M_global)` vs. the NumPy `scipy.sparse.coo_matrix` complex
+reference on a 2-tet (n_edges=9) test case with a non-trivial
+imaginary ε on one of the two tets.
+
+**Stage 4 verdict: FALLBACK (paired-real lowering).** The single-Mul
+c128 path is BLOCKED; the two-Mul paired-real alternative is
+EMITTABLE and is the recommended design.
+
+### Stage 5 — Complex global assembly (sparse scatter into c128 K, M)
+
+Same situation as Stage 4 at the global-buffer level. The c128
+ScatterND **schema-accepts** c128 in its `T` type constraint, but
+two upstream blockers prevent reaching it:
+
+1. **`ConstantOfShape` does not support c128 as a fill type.** Its
+   `T2` (value) type constraint excludes both c128 and c64. There is
+   no way to initialize a zero c128 buffer in-graph.
+2. **No c128 value tensor exists** to feed `ScatterND` as the
+   `updates` input, because Stage 4's Mul is blocked.
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Zero c128 buffer `(n_edges, n_edges)` | `ConstantOfShape` | **blocked** | `T2` excludes c128. Workaround: emit two f64 zero buffers via `ConstantOfShape` (which IS emittable) — see Stage 4 paired-real recommendation. |
+| `ScatterND(reduction="add")` on c128 buffer | `ScatterND` | schema-OK, **unreachable** | `T` accepts c128, but no upstream c128 producer exists in opset 18. |
+| Paired-real two-buffer ScatterND | `ConstantOfShape` × 2 + `ScatterND` × 2 | **emittable** | Recommended. Same int64 indices shared between Re and Im scatters. |
+| Host re-assembly `M = M_re + 1j * M_im` | (out-of-graph) | **blocked** | Done in the sidecar driver, not in the ONNX graph. Same convention as the eigensolve sidecar. |
+
+**Stage 5 verdict: FALLBACK (paired-real two-buffer scatter).**
+Single-buffer c128 ScatterND is BLOCKED; paired-real two-buffer
+alternative is EMITTABLE.
+
+### Stage 6 — Complex generalized eigensolve (LAPACK ZGGEV)
+
+**Out-of-graph by definition**, same disposition as the PEC
+eigensolve sidecar (G.6 Stage 7) and the cube-cavity F.2 eigensolve
+(F.1 Stage 4).
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `scipy.linalg.eig(K_int, M_int)` (LAPACK ZGGEV) | **none** | **blocked** | No `Eigh` op in ONNX; no `Eig` op for non-Hermitian pencils. The PML pencil is complex-symmetric (`M = Mᵀ`) but **not** Hermitian, so even a hypothetical `Eigh` would not apply. ARPACK `eigs` shift-and-invert at σ=0 fails for the curl-curl operator (large gradient kernel makes `(K − σM)⁻¹` near-singular at σ=0) — see [`sphere_pml.py:eigensolve_complex_dense`](../../../numpy/sphere_pml.py) for the dense-LAPACK rationale. The dense path is what the sidecar runs. |
+
+**Stage 6 verdict: BLOCKED (out-of-graph sidecar).** Same convention
+as Phase F.2 / G.7: the ONNX graph emits the c128 (K_int, M_int)
+pair (in paired-real form), the host driver re-assembles complex
+matrices, calls `scipy.linalg.eig`, and writes the result to the
+schema-v1 sidecar JSON.
+
+## Cross-cutting frictions: G.6 vs. H.5 comparison
+
+| Friction | G.6 (sphere-PEC Nédélec) | H.5 (sphere-PML Nédélec) | Change |
+|---|---|---|---|
+| `build_edges` secretly-imperative | yes (host-precomputed in [PR #142](https://github.com/rjwalters/geode-fem/pull/142)) | yes (inherited verbatim) | **Unchanged** |
+| Sign outer product (real) | emittable, graph-only friction | emittable, graph-only friction | **Unchanged** |
+| Global buffer size `(n_edges, n_edges)` | data-dependent (inherited from `build_edges`) | data-dependent (inherited) | **Unchanged** |
+| `NonZero` (mask→idx) data-dependent shape | caveat (recommendation: host-precompute) | caveat (inherited) | **Unchanged** |
+| ScatterND `reduction="add"` (f64) | emittable | emittable (for K and for paired Re/Im of M) | **Unchanged** |
+| **Complex permittivity construction** | N/A (no PML) | **blocked** (no `Complex(re, im)` op; `Cast` excludes c128) | **NEW in H.5** |
+| **f64 × c128 elementwise Mul** | N/A | **blocked** (`T` type constraint excludes c128) | **NEW in H.5** |
+| **`ConstantOfShape` with c128 fill** | N/A | **blocked** (`T2` excludes c128) | **NEW in H.5** |
+| **c128 ScatterND** | N/A | schema-OK, unreachable | **NEW in H.5** |
+| **Complex generalized eigensolve** | N/A (real `eigsh`) | **blocked** out-of-graph; same disposition as the real `eigsh` boundary in G.6/F.1 | **NEW in H.5; same sidecar pattern** |
+
+### Friction class summary
+
+All of the H.5 new findings collapse into one underlying friction:
+**ONNX opset 18 does not provide a usable c128 type path.** The type
+exists in the IR enum and is accepted as a schema-level value type
+by a handful of value-passing ops (Constant, Identity, Reshape,
+Gather, ScatterND, Where), but:
+
+- No op constructs c128 from real parts (`Complex` missing).
+- No arithmetic op accepts c128 (`Add`/`Sub`/`Mul`/`Div`/`MatMul`/`Einsum`/`ReduceSum`/etc. exclude c128 from `T`).
+- No reduction op accepts c128.
+- `ConstantOfShape` cannot initialize a c128 buffer.
+- `Cast` cannot promote real → c128 or c128 → real.
+- `onnxruntime` rejects c128 inputs even where the schema accepts them.
+
+The result is that **c128 values can move through the graph but
+cannot be produced or operated on inside it**. The only viable
+lowering is paired-real: split every c128 tensor into two f64
+tensors and let the host re-assemble at the sidecar boundary.
+
+This matches the broader graph-only finding from Comment 4 on Epic
+[#88](https://github.com/rjwalters/geode-fem/issues/88): the c128
+type is a vestigial signpost in the ONNX IR, not a working dtype.
+Any backend that wants complex arithmetic must lower it to
+paired-real before emitting ONNX.
+
+## Per-stage verdicts (one-line summary)
+
+| Stage | Verdict |
+|---|---|
+| 1. `tet_centroid_radii` | **emittable** — Gather + ReduceMean + ReduceL2 (real) |
+| 2. `build_complex_epsilon_r_pml` | **fallback** — real ramp is emittable; c128 output is **blocked** (no `Complex(re, im)` op). Emit two f64 outputs `eps_re`, `eps_im`. |
+| 3. Complex local stiffness scatter | **emittable** — K_local is real-valued; promotion to c128 happens at the eigensolve sidecar (out-of-graph) |
+| 4. Complex local mass scatter | **fallback** — `m_local * sign_outer * eps_complex` Mul is **blocked**; emit paired-real `m_signed_re`, `m_signed_im` |
+| 5. Complex global assembly | **fallback** — single-buffer c128 ScatterND is **blocked** (no c128 ConstantOfShape, no c128 upstream); use two paired-real ScatterND calls into `M_re_global`, `M_im_global` |
+| 6. Complex generalized eigensolve | **blocked** — out-of-graph LAPACK ZGGEV sidecar, same as PEC `eigsh` sidecar |
+
+## Recommended design for a future Nédélec sphere-PML ONNX assembly graph
+
+Building on the [Phase G.7 design](../sphere_pec/nedelec_operator_audit.md#phase-g7--empirical-confirmation-of-the-recommended-design)
+that proved out the recommended Nédélec PEC graph:
+
+Graph inputs:
+- `nodes (n_nodes, 3) float64` — mesh vertex coordinates
+- `tets (n_tets, 4) int64` — tet connectivity
+- `tag (n_tets,) int32` — per-tet physical-group tag (replaces `epsilon_r`)
+- `tet_edge_idx (n_tets, 6) int64` — host-computed (from `build_edges`)
+- `tet_edge_sign (n_tets, 6) float64` — host-computed (from `build_edges`)
+- `interior_idx (n_int,) int64` — host-computed (from `flatnonzero(pec_mask)`)
+- `n_inside: float`, `sigma_0: float` — scalar constants baked at graph generation
+
+Graph constants (baked at generation time):
+- `n_edges: int` — from `len(edges)` (output of `build_edges`)
+- `n_int: int` — from `len(interior_idx)`
+- `R_PML_INNER`, `R_BUFFER` — fixture geometry constants
+
+Graph outputs (paired-real):
+- `K_int (n_int, n_int) float64` — real curl-curl interior
+- `M_re_int (n_int, n_int) float64` — real part of complex ε-mass
+- `M_im_int (n_int, n_int) float64` — imag part of complex ε-mass
+
+Sidecar host steps (out-of-graph):
+1. Re-assemble `M_int_complex = M_re_int + 1j * M_im_int`.
+2. Promote K to c128 with `K_int_complex = K_int + 0j` for uniform
+   pencil dtype.
+3. Call `scipy.linalg.eig(K_int_complex, M_int_complex)` (dense
+   LAPACK ZGGEV — see [`sphere_pml.eigensolve_complex_dense`](../../../numpy/sphere_pml.py) for why ARPACK shift-and-invert is not usable).
+4. Filter infinite eigenvalues, sort by `|Re(λ)|`, split spurious
+   cluster off via the d⁰ rank (`spurious_dim_from_derham`, also
+   host-side per G.6 Stage 7).
+5. Emit schema-v1 sidecar (extends the Phase H schema with the
+   c128 mass channel).
+
+Total c128 surface area in the graph: **zero**. The host owns every
+c128 value.
+
+## Acknowledgements / cross-references
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — overall
+  framing and Phase H scope. See Comment 4 for the broader graph-only
+  finding that c128 is a vestigial type across ONNX/TF/XLA IRs.
+- Phase G.6 analog: [`nedelec_operator_audit.md`](../sphere_pec/nedelec_operator_audit.md)
+  — the baseline comparison for every "unchanged" row above. The
+  `build_edges` "secretly-imperative" finding from G.6 is inherited
+  verbatim; PR [#142](https://github.com/rjwalters/geode-fem/pull/142)
+  is where the host-precompute landed.
+- Phase F.1 baseline: [`cube_cavity_operator_audit.md`](../cube_cavity_operator_audit.md)
+  — the original real-valued audit that set the classification
+  convention.
+- NumPy sphere-PML reference: [`reference/numpy/sphere_pml.py`](../../../numpy/sphere_pml.py).
+- Burn-side kernels:
+  `crates/geode-core/src/pml.rs` (build_complex_epsilon_r_pml,
+  tet_centroid_radii) and
+  `crates/geode-core/src/nedelec_assembly.rs::assemble_global_nedelec_with_complex_epsilon`.
+- Phase G.7 PR [#140](https://github.com/rjwalters/geode-fem/issues/140)
+  — empirical confirmation of the PEC recommended design; the PML
+  graph should follow the same skeleton with paired-real M outputs.
+
+## Re-running this audit
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt
+python3 audit/sphere_pml/probe_complex_eps_ramp.py
+python3 audit/sphere_pml/probe_complex_local_scatter.py
+```
+
+Each probe prints a one-screen verdict that should match the
+corresponding row(s) in this table. If a probe's verdict disagrees
+with the table after a version bump, the table is stale — re-audit.
+In particular, if a future onnxruntime release registers a c128
+MLDataType for `Add`/`Mul`/`ScatterND`, the entire "fallback (paired-
+real)" column collapses to "emittable" and this audit is obsolete.
+The probes' explicit runtime-error capture is the load-bearing
+freshness signal.

--- a/reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py
+++ b/reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py
@@ -1,0 +1,361 @@
+"""Probe: ONNX expressibility of build_complex_epsilon_r_pml.
+
+Epic #88, Phase H.5 (issue #157). This probe asks whether the per-tet
+**complex** permittivity ramp from ``reference/numpy/sphere_pml.py``
+can be expressed as a pure ONNX opset-18 graph.
+
+What build_complex_epsilon_r_pml does
+=====================================
+
+Given:
+  - physical_tags (n_tets,) int32 — per-tet physical-group tag
+  - centroid_radii (n_tets,) float64 — per-tet centroid distance from origin
+  - n_inside: float — refractive index inside dielectric sphere
+  - sigma_0: float — PML absorption strength at r = R_BUFFER
+
+It produces a per-tet **complex128** relative permittivity:
+
+  - tag == PHYS_SPHERE_INTERIOR  →  ε = n²  + 0j   (real dielectric)
+  - tag == PHYS_PML_SHELL        →  ε = 1   - j σ₀ u²   (lossy ramp)
+                                    where u = clip((r - R_PML_INNER)/Δ, 0, 1)
+  - otherwise                    →  ε = 1   + 0j   (vacuum)
+
+The shape and the **real part** computation are straightforward (a
+small Where ladder over the tag). The novelty for ONNX is the
+**complex output type** — the result must be a complex128 tensor
+suitable for use as a per-tet scaling on the global Nédélec mass.
+
+Strategy: two graphs
+====================
+
+We build TWO ONNX models and check both against ``onnx.checker`` and
+``onnxruntime``:
+
+  (A) **Native complex128 output** — Declare the output as
+      ``TensorProto.COMPLEX128`` and assemble it from a real-part
+      tensor and an imaginary-part tensor. Since ONNX opset 18 has
+      no `Complex(real, imag)` op (PyTorch's `torch.complex` lives
+      at the framework level, not the ONNX IR), there is no path to
+      construct a c128 tensor from two f64 tensors **inside** the
+      graph. This graph is **NOT EXPRESSIBLE**.
+
+  (B) **Paired-real lowering** — Emit two f64 outputs `eps_re` and
+      `eps_im` of shape (n_tets,), one for the real part and one for
+      the imaginary part. This is the standard "split complex into
+      two real channels" workaround used in TF-Java, onnxruntime,
+      and Burn's complex64/complex128 backends. The mass scatter then
+      consumes the paired-real tensors as two independent ScatterND
+      calls into two real buffers (or into a paired-real (n, n, 2)
+      buffer). This IS expressible.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from sphere_pec import (  # noqa: E402
+    PHYS_PML_SHELL,
+    PHYS_SPHERE_INTERIOR,
+    R_BUFFER,
+    R_PML_INNER,
+)
+from sphere_pml import build_complex_epsilon_r_pml  # noqa: E402
+
+OPSET = 18
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("float32"): TensorProto.FLOAT,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+        np.dtype("bool"): TensorProto.BOOL,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_native_c128_graph(n_inside: float, sigma_0: float) -> onnx.ModelProto:
+    """Graph (A): emit a single COMPLEX128 output.
+
+    The graph has no native opset-18 op to construct a complex value
+    from a (real, imag) pair. The only way to introduce a c128 tensor
+    is via a graph input or a c128 Constant. There is no `Complex(re,
+    im)` op, and `Cast` does not accept COMPLEX128 / COMPLEX64.
+
+    We therefore cannot synthesize a per-tet c128 tensor from per-tet
+    real radii inside the graph. To even *try*, we emit a c128 graph
+    input ``eps_seed`` of length 1 with value (1+0j), broadcast it to
+    (n_tets,), and let the runtime show that the c128 broadcast is
+    rejected. This demonstrates the failure mode without requiring
+    any synthetic complex construction.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    # Inputs: tags (n_tets,) int32, radii (n_tets,) f64
+    tags_vi = oh.make_tensor_value_info("tags", TensorProto.INT32, ["N"])
+    radii_vi = oh.make_tensor_value_info("radii", TensorProto.DOUBLE, ["N"])
+    # c128 seed (length 1) — the only way to introduce a c128 value in
+    # opset 18 without `Complex(re, im)`.
+    seed_vi = oh.make_tensor_value_info("eps_seed", TensorProto.COMPLEX128, [1])
+
+    # Compute the (real) selector mask and (real) PML imaginary part
+    # so we can show the f64 side works, then "wish" the c128 broadcast
+    # were a no-op (it is rejected by onnxruntime as an invalid type).
+    nodes.append(_const("phys_interior", np.array(PHYS_SPHERE_INTERIOR, dtype=np.int32)))
+    nodes.append(_const("phys_pml", np.array(PHYS_PML_SHELL, dtype=np.int32)))
+    nodes.append(oh.make_node("Equal", ["tags", "phys_interior"], ["is_int"]))
+    nodes.append(oh.make_node("Equal", ["tags", "phys_pml"], ["is_pml"]))
+
+    # eps_real = where(is_int, n^2, where(is_pml, 1, 1))  — trivial real part
+    nodes.append(_const("n2", np.array(n_inside * n_inside, dtype=np.float64)))
+    nodes.append(_const("one_f64", np.array(1.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Where", ["is_int", "n2", "one_f64"], ["eps_re"]))
+
+    # Now broadcast the c128 seed to (n_tets,) — this is what would
+    # happen if a c128 constant existed; the runtime will reject the op.
+    # Use the radii shape as the broadcast target via Shape.
+    nodes.append(oh.make_node("Shape", ["radii"], ["radii_shape"]))
+    nodes.append(oh.make_node("Expand", ["eps_seed", "radii_shape"], ["eps_c128_out"]))
+
+    out_vi = oh.make_tensor_value_info("eps_c128_out", TensorProto.COMPLEX128, ["N"])
+
+    graph = oh.make_graph(
+        nodes,
+        name="complex_eps_native_probe",
+        inputs=[tags_vi, radii_vi, seed_vi],
+        outputs=[out_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def build_paired_real_graph(n_inside: float, sigma_0: float) -> onnx.ModelProto:
+    """Graph (B): emit two f64 outputs `eps_re` and `eps_im`.
+
+    Mirrors the canonical "complex as two reals" lowering used in
+    TF-Java and the SciML community. The real part is the tag-keyed
+    permittivity; the imaginary part is the PML ramp, masked to zero
+    outside the shell.
+
+    All ops are opset-18 native and the runtime accepts them.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    tags_vi = oh.make_tensor_value_info("tags", TensorProto.INT32, ["N"])
+    radii_vi = oh.make_tensor_value_info("radii", TensorProto.DOUBLE, ["N"])
+
+    # --- Selector masks ---
+    nodes.append(_const("phys_interior", np.array(PHYS_SPHERE_INTERIOR, dtype=np.int32)))
+    nodes.append(_const("phys_pml", np.array(PHYS_PML_SHELL, dtype=np.int32)))
+    nodes.append(oh.make_node("Equal", ["tags", "phys_interior"], ["is_int"]))
+    nodes.append(oh.make_node("Equal", ["tags", "phys_pml"], ["is_pml"]))
+
+    # --- Real part: where(is_int, n^2, 1.0) ---
+    nodes.append(_const("n2", np.array(n_inside * n_inside, dtype=np.float64)))
+    nodes.append(_const("one_f64", np.array(1.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Where", ["is_int", "n2", "one_f64"], ["eps_re"]))
+
+    # --- Imaginary part: where(is_pml, -sigma_0 * u^2, 0) with u=clip(...) ---
+    width = R_BUFFER - R_PML_INNER
+    nodes.append(_const("r_pml_inner", np.array(R_PML_INNER, dtype=np.float64)))
+    nodes.append(_const("inv_width", np.array(1.0 / width, dtype=np.float64)))
+    nodes.append(_const("zero_f64", np.array(0.0, dtype=np.float64)))
+    nodes.append(_const("neg_sigma0", np.array(-float(sigma_0), dtype=np.float64)))
+
+    nodes.append(oh.make_node("Sub", ["radii", "r_pml_inner"], ["r_shift"]))
+    nodes.append(oh.make_node("Mul", ["r_shift", "inv_width"], ["u_raw"]))
+    # Clip(u_raw, 0, 1)
+    nodes.append(oh.make_node("Clip", ["u_raw", "zero_f64", "one_f64"], ["u"]))
+    nodes.append(oh.make_node("Mul", ["u", "u"], ["u2"]))
+    nodes.append(oh.make_node("Mul", ["neg_sigma0", "u2"], ["im_ramp"]))
+    nodes.append(oh.make_node("Where", ["is_pml", "im_ramp", "zero_f64"], ["eps_im"]))
+
+    re_vi = oh.make_tensor_value_info("eps_re", TensorProto.DOUBLE, ["N"])
+    im_vi = oh.make_tensor_value_info("eps_im", TensorProto.DOUBLE, ["N"])
+
+    graph = oh.make_graph(
+        nodes,
+        name="complex_eps_paired_real_probe",
+        inputs=[tags_vi, radii_vi],
+        outputs=[re_vi, im_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: complex epsilon_r PML ramp (sphere PML, Phase H.5) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    n_inside = 1.5
+    sigma_0 = 5.0
+
+    # Build a small synthetic test: 6 tets straddling the three regions.
+    radii_np = np.array(
+        [0.20, 0.40, 0.60, 0.80, 0.95, 1.05], dtype=np.float64
+    )
+    tags_np = np.array(
+        [
+            PHYS_SPHERE_INTERIOR,  # interior
+            PHYS_SPHERE_INTERIOR,  # interior
+            999,                    # vacuum gap (any tag != interior, != pml)
+            PHYS_PML_SHELL,         # PML mid-ramp
+            PHYS_PML_SHELL,         # PML mid-ramp
+            PHYS_PML_SHELL,         # PML at r > R_BUFFER (clamped)
+        ],
+        dtype=np.int32,
+    )
+
+    eps_ref = build_complex_epsilon_r_pml(
+        tags_np, radii_np, n_inside=n_inside, sigma_0=sigma_0
+    )
+
+    # ------------------------------------------------------------- #
+    # Graph (A) — native c128 output
+    # ------------------------------------------------------------- #
+    print("--- Graph (A): native COMPLEX128 output ---")
+    model_a = build_native_c128_graph(n_inside, sigma_0)
+    try:
+        onnx.checker.check_model(model_a)
+        a_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_checker = f"FAIL ({e!r})"
+    print(f"onnx.checker (schema-level): {a_checker}")
+
+    a_rt = "skipped"
+    a_err = ""
+    try:
+        sess_a = ort.InferenceSession(model_a.SerializeToString())
+        # Try to run it with a (1,) c128 seed.
+        seed = np.array([1.0 + 0.0j], dtype=np.complex128)
+        sess_a.run(["eps_c128_out"], {
+            "tags": tags_np,
+            "radii": radii_np,
+            "eps_seed": seed,
+        })
+        a_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_rt = "FAIL"
+        a_err = repr(e)
+    print(f"onnxruntime execution: {a_rt}")
+    if a_err:
+        # Truncate to keep the output one screen
+        msg = a_err if len(a_err) < 400 else a_err[:380] + "...(truncated)"
+        print(f"  runtime error: {msg}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (B) — paired-real lowering
+    # ------------------------------------------------------------- #
+    print("--- Graph (B): paired-real (eps_re, eps_im) lowering ---")
+    model_b = build_paired_real_graph(n_inside, sigma_0)
+    try:
+        onnx.checker.check_model(model_b)
+        b_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_checker = f"FAIL ({e!r})"
+    print(f"onnx.checker: {b_checker}")
+
+    b_rt = "skipped"
+    max_re_err = max_im_err = float("nan")
+    try:
+        sess_b = ort.InferenceSession(model_b.SerializeToString())
+        outs = sess_b.run(["eps_re", "eps_im"], {"tags": tags_np, "radii": radii_np})
+        re_onnx, im_onnx = outs
+        max_re_err = float(np.max(np.abs(re_onnx - eps_ref.real)))
+        max_im_err = float(np.max(np.abs(im_onnx - eps_ref.imag)))
+        b_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_rt = f"FAIL ({e!r})"
+    print(f"onnxruntime execution: {b_rt}")
+    if b_rt == "OK":
+        print(f"  max |eps_re_onnx - Re(eps_ref)| = {max_re_err:.3e}")
+        print(f"  max |eps_im_onnx - Im(eps_ref)| = {max_im_err:.3e}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Operator inventory + verdict
+    # ------------------------------------------------------------- #
+    print("Operator inventory for build_complex_epsilon_r_pml:")
+    print("--------------------------------------------------------------")
+    print("  Equal / Where           EXPRESSIBLE (real)  tag selector ladder")
+    print("  Sub / Mul / Clip        EXPRESSIBLE (real)  ramp arithmetic on radii")
+    print()
+    print("Complex output construction:")
+    print("--------------------------------------------------------------")
+    print("  Complex(re, im) → c128  BLOCKED  no opset-18 op constructs c128")
+    print("                                   from two f64 tensors. PyTorch's")
+    print("                                   torch.complex is a framework-level")
+    print("                                   helper; it does not lower.")
+    print("  Cast f64 → c128         BLOCKED  Cast type constraints exclude c128.")
+    print("  c128 elementwise ops    BLOCKED  Add/Sub/Mul/Div type constraints")
+    print("                                   exclude c128 in opset 18. Schema")
+    print("                                   accepts c128 as a Constant value")
+    print("                                   type, but the runtime rejects c128")
+    print("                                   inputs to ALL arithmetic ops.")
+    print("  Reshape / Concat / Gather / NonZero / Identity / Constant / Where /")
+    print("    ScatterND on c128     ACCEPTED schema-wise but the values can only")
+    print("                                   move through the graph; they cannot")
+    print("                                   be PRODUCED in-graph or operated on.")
+    print()
+    print("Verdict for Graph (A) — native COMPLEX128 output:")
+    print(f"  schema check: {a_checker}")
+    print(f"  runtime:      {a_rt}{(' (' + a_err[:80] + '...)') if a_err else ''}")
+    print("  → BLOCKED at runtime (onnxruntime rejects c128 inputs to arithmetic).")
+    print()
+    print("Verdict for Graph (B) — paired-real lowering:")
+    print(f"  schema check: {b_checker}")
+    print(f"  runtime:      {b_rt}")
+    if b_rt == "OK":
+        print("  → EXPRESSIBLE (fallback). Numerically bit-exact vs. NumPy ref.")
+    print()
+    print("Overall verdict: FALLBACK (paired-real lowering).")
+    print("  build_complex_epsilon_r_pml cannot produce a c128 tensor in-graph")
+    print("  in opset 18. The standard mitigation is to emit two f64 outputs")
+    print("  `eps_re` and `eps_im` and consume them downstream via two ScatterND")
+    print("  calls (one into Re(M), one into Im(M)). This matches the convention")
+    print("  used by the TF-Java reference (Phase H.4) and the SciML community.")
+    print()
+
+    # Success if A's runtime failed (the expected behavior) AND B passed.
+    ok = (a_rt == "FAIL") and (b_checker == "OK") and (b_rt == "OK")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py
+++ b/reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py
@@ -1,0 +1,429 @@
+"""Probe: ONNX expressibility of complex Nédélec local + global scatter.
+
+Epic #88, Phase H.5 (issue #157). This probe asks whether the complex
+sphere-PML assembly variant of the Nédélec scatter (per
+``reference/numpy/sphere_pml.py::assemble_global_nedelec_complex``) can
+be expressed as a pure ONNX opset-18 graph.
+
+What the PML assembly does on top of PEC
+=========================================
+
+Compared to the PEC scatter audited in
+``reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py``, the only
+structural change is the **complex** ε scaling of the mass:
+
+  - K_local (n_tets, 6, 6) f64 — real curl-curl (unchanged)
+  - M_local (n_tets, 6, 6) f64 — real raw mass (unchanged)
+  - epsilon_r (n_tets,) **complex128** — new in PML
+
+  k_signed = k_local * sign_outer                         (real)
+  m_signed = m_local.astype(c128) * sign_outer * eps[e]   (complex)
+  K_global = scatter_add(real,    n_edges, n_edges)        (real)
+  M_global = scatter_add(complex, n_edges, n_edges)        (complex)
+
+Strategy: three sub-probes
+==========================
+
+(A) **Native c128 local scatter** — Construct the complex M_signed
+    inside the graph by emitting `m_local * sign_outer * eps[e]` with
+    `eps` typed COMPLEX128 (a graph input from a future host-computed
+    `build_complex_epsilon_r_pml`). The runtime will reject the Mul
+    over c128 — there is no opset-18 elementwise op that accepts c128.
+
+(B) **Paired-real local scatter** — Emit two parallel scaffolds:
+    `m_signed_re = m_local * sign_outer * eps_re[e]`
+    `m_signed_im = m_local * sign_outer * eps_im[e]`
+    Then two ScatterND calls into `M_re_global` and `M_im_global`.
+    K_global stays a single real scatter. This IS expressible.
+
+(C) **Native c128 ScatterND** — Schema-check only: ScatterND's type
+    constraint `T` does list complex128 in opset 18, so the *graph*
+    type-checks; but every upstream op that produces the c128 value
+    tensor (Mul, Reshape after a c128 Constant, etc.) rejects c128 at
+    runtime, so this is unreachable end-to-end.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+import scipy.sparse
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+from sphere_pec import build_edges  # noqa: E402
+
+OPSET = 18
+N_LOCAL = 6
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_native_c128_scatter_graph(n_tets: int, n_edges: int) -> onnx.ModelProto:
+    """Graph (A) — single complex M_global via c128 Mul + c128 ScatterND."""
+    nodes: list[onnx.NodeProto] = []
+
+    m_local_vi = oh.make_tensor_value_info("m_local", TensorProto.DOUBLE, [n_tets, 6, 6])
+    tei_vi = oh.make_tensor_value_info("tet_edge_idx", TensorProto.INT64, [n_tets, 6])
+    tes_vi = oh.make_tensor_value_info("tet_edge_sign", TensorProto.DOUBLE, [n_tets, 6])
+    eps_vi = oh.make_tensor_value_info("epsilon_r", TensorProto.COMPLEX128, [n_tets])
+
+    # Sign outer product (real)
+    nodes.append(_const("ax2", np.array([2], dtype=np.int64)))
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax2"], ["sign_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax1"], ["sign_row"]))
+    nodes.append(oh.make_node("Mul", ["sign_col", "sign_row"], ["sign_outer"]))
+
+    # Real m_signed before c128 scaling
+    nodes.append(oh.make_node("Mul", ["m_local", "sign_outer"], ["m_signed_real"]))
+
+    # Now reshape eps to (n_tets, 1, 1) — even Reshape on c128 schemati-
+    # cally OK, but the c128 type tag is what blows up at session load.
+    nodes.append(_const("shape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["epsilon_r", "shape_n11"], ["eps_b"]))
+
+    # The problematic op: Mul over (f64, c128). This is rejected by both
+    # the type system (no shared T) AND by the runtime kernel registry.
+    nodes.append(oh.make_node("Mul", ["m_signed_real", "eps_b"], ["m_signed_c128"]))
+
+    # Build the COO indices (real int64) — same as PEC
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax2"], ["tei_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax1"], ["tei_row"]))
+    nodes.append(_const("target_shape", np.array([n_tets, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Expand", ["tei_col", "target_shape"], ["rows_3d"]))
+    nodes.append(oh.make_node("Expand", ["tei_row", "target_shape"], ["cols_3d"]))
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["rows_3d", "shape_flat"], ["rows_flat"]))
+    nodes.append(oh.make_node("Reshape", ["cols_3d", "shape_flat"], ["cols_flat"]))
+    nodes.append(oh.make_node("Reshape", ["m_signed_c128", "shape_flat"], ["m_vals"]))
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows_flat", "ax_neg1"], ["rows_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["cols_flat", "ax_neg1"], ["cols_col"]))
+    nodes.append(oh.make_node("Concat", ["rows_col", "cols_col"], ["indices"], axis=1))
+
+    # Zero c128 buffer (n_edges, n_edges) — ConstantOfShape does NOT
+    # support c128 (T2 type constraint excludes c128/c64). We use a
+    # workaround: produce a real zero buffer and try to "cast" it. Even
+    # that fails because Cast doesn't accept c128 as a target.
+    nodes.append(_const("shape_nn", np.array([n_edges, n_edges], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_buf_f64"],
+        value=oh.make_tensor("z", TensorProto.DOUBLE, [1], [0.0]),
+    ))
+    # Best-effort: try the ScatterND with mismatched (f64 buf, c128 vals).
+    # This will be rejected by the runtime as a type mismatch.
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf_f64", "indices", "m_vals"],
+        outputs=["m_global"],
+        reduction="add",
+    ))
+
+    m_global_vi = oh.make_tensor_value_info(
+        "m_global", TensorProto.COMPLEX128, [n_edges, n_edges]
+    )
+
+    graph = oh.make_graph(
+        nodes,
+        name="complex_local_scatter_native",
+        inputs=[m_local_vi, tei_vi, tes_vi, eps_vi],
+        outputs=[m_global_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def build_paired_real_scatter_graph(n_tets: int, n_edges: int) -> onnx.ModelProto:
+    """Graph (B) — paired-real M_re_global, M_im_global via two scatters."""
+    nodes: list[onnx.NodeProto] = []
+
+    m_local_vi = oh.make_tensor_value_info("m_local", TensorProto.DOUBLE, [n_tets, 6, 6])
+    tei_vi = oh.make_tensor_value_info("tet_edge_idx", TensorProto.INT64, [n_tets, 6])
+    tes_vi = oh.make_tensor_value_info("tet_edge_sign", TensorProto.DOUBLE, [n_tets, 6])
+    eps_re_vi = oh.make_tensor_value_info("eps_re", TensorProto.DOUBLE, [n_tets])
+    eps_im_vi = oh.make_tensor_value_info("eps_im", TensorProto.DOUBLE, [n_tets])
+
+    # Sign outer product (real)
+    nodes.append(_const("ax2", np.array([2], dtype=np.int64)))
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax2"], ["sign_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax1"], ["sign_row"]))
+    nodes.append(oh.make_node("Mul", ["sign_col", "sign_row"], ["sign_outer"]))
+
+    # Apply sign to m_local once
+    nodes.append(oh.make_node("Mul", ["m_local", "sign_outer"], ["m_signed_pre"]))
+
+    # Two parallel scalings: real channel and imaginary channel
+    nodes.append(_const("shape_n11", np.array([-1, 1, 1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["eps_re", "shape_n11"], ["eps_re_b"]))
+    nodes.append(oh.make_node("Reshape", ["eps_im", "shape_n11"], ["eps_im_b"]))
+    nodes.append(oh.make_node("Mul", ["m_signed_pre", "eps_re_b"], ["m_signed_re"]))
+    nodes.append(oh.make_node("Mul", ["m_signed_pre", "eps_im_b"], ["m_signed_im"]))
+
+    # COO indices (shared across both scatters)
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax2"], ["tei_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax1"], ["tei_row"]))
+    nodes.append(_const("target_shape", np.array([n_tets, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Expand", ["tei_col", "target_shape"], ["rows_3d"]))
+    nodes.append(oh.make_node("Expand", ["tei_row", "target_shape"], ["cols_3d"]))
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["rows_3d", "shape_flat"], ["rows_flat"]))
+    nodes.append(oh.make_node("Reshape", ["cols_3d", "shape_flat"], ["cols_flat"]))
+    nodes.append(oh.make_node("Reshape", ["m_signed_re", "shape_flat"], ["m_re_vals"]))
+    nodes.append(oh.make_node("Reshape", ["m_signed_im", "shape_flat"], ["m_im_vals"]))
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows_flat", "ax_neg1"], ["rows_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["cols_flat", "ax_neg1"], ["cols_col"]))
+    nodes.append(oh.make_node("Concat", ["rows_col", "cols_col"], ["indices"], axis=1))
+
+    # Two zero buffers + two scatters
+    nodes.append(_const("shape_nn", np.array([n_edges, n_edges], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_re"],
+        value=oh.make_tensor("zr", TensorProto.DOUBLE, [1], [0.0]),
+    ))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_nn"],
+        outputs=["zero_im"],
+        value=oh.make_tensor("zi", TensorProto.DOUBLE, [1], [0.0]),
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_re", "indices", "m_re_vals"],
+        outputs=["m_re_global"],
+        reduction="add",
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_im", "indices", "m_im_vals"],
+        outputs=["m_im_global"],
+        reduction="add",
+    ))
+
+    re_vi = oh.make_tensor_value_info(
+        "m_re_global", TensorProto.DOUBLE, [n_edges, n_edges]
+    )
+    im_vi = oh.make_tensor_value_info(
+        "m_im_global", TensorProto.DOUBLE, [n_edges, n_edges]
+    )
+
+    graph = oh.make_graph(
+        nodes,
+        name="complex_local_scatter_paired_real",
+        inputs=[m_local_vi, tei_vi, tes_vi, eps_re_vi, eps_im_vi],
+        outputs=[re_vi, im_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def main() -> int:
+    print("== Probe: complex local + global scatter (sphere PML, Phase H.5) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Synthetic mesh: 2 tets sharing a face — same as the PEC probe
+    tets_np = np.array(
+        [[0, 1, 2, 3],
+         [1, 2, 3, 4]],
+        dtype=np.int64,
+    )
+    nodes_np = np.array(
+        [[0.0, 0.0, 0.0],
+         [1.0, 0.0, 0.0],
+         [0.0, 1.0, 0.0],
+         [0.0, 0.0, 1.0],
+         [0.5, 0.5, 0.5]],
+        dtype=np.float64,
+    )
+    n_tets = tets_np.shape[0]
+
+    edges, tet_edge_idx, tet_edge_sign = build_edges(tets_np)
+    n_edges = int(edges.shape[0])
+
+    coords = nodes_np[tets_np, :]
+    _, m_local, _ = batched_nedelec_local_matrices(coords)
+    tet_edge_sign_f64 = tet_edge_sign.astype(np.float64)
+    # Complex epsilon: per-tet (1 - 0.3j) for the second tet, real 2.25 for the first
+    eps_c128 = np.array([2.25 + 0.0j, 1.0 - 0.3j], dtype=np.complex128)
+    eps_re = eps_c128.real.astype(np.float64)
+    eps_im = eps_c128.imag.astype(np.float64)
+
+    print(f"Test mesh: n_tets={n_tets}, n_edges={n_edges}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (A) — native c128 scatter
+    # ------------------------------------------------------------- #
+    print("--- Graph (A): native c128 local scatter ---")
+    model_a = build_native_c128_scatter_graph(n_tets, n_edges)
+    try:
+        onnx.checker.check_model(model_a)
+        a_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_checker = "FAIL"
+        a_checker_err = repr(e)
+        print(f"  checker error: {a_checker_err[:300]}")
+    print(f"onnx.checker: {a_checker}")
+
+    a_rt = "skipped"
+    a_err = ""
+    if a_checker == "OK":
+        try:
+            sess_a = ort.InferenceSession(model_a.SerializeToString())
+            sess_a.run(["m_global"], {
+                "m_local": m_local,
+                "tet_edge_idx": tet_edge_idx,
+                "tet_edge_sign": tet_edge_sign_f64,
+                "epsilon_r": eps_c128,
+            })
+            a_rt = "OK"
+        except Exception as e:  # noqa: BLE001
+            a_rt = "FAIL"
+            a_err = repr(e)
+    print(f"onnxruntime execution: {a_rt}")
+    if a_err:
+        msg = a_err if len(a_err) < 400 else a_err[:380] + "...(truncated)"
+        print(f"  runtime error: {msg}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (B) — paired-real scatter
+    # ------------------------------------------------------------- #
+    print("--- Graph (B): paired-real (M_re_global, M_im_global) ---")
+    model_b = build_paired_real_scatter_graph(n_tets, n_edges)
+    try:
+        onnx.checker.check_model(model_b)
+        b_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_checker = f"FAIL ({e!r})"
+    print(f"onnx.checker: {b_checker}")
+
+    b_rt = "skipped"
+    max_re_err = max_im_err = float("nan")
+    try:
+        sess_b = ort.InferenceSession(model_b.SerializeToString())
+        outs = sess_b.run(["m_re_global", "m_im_global"], {
+            "m_local": m_local,
+            "tet_edge_idx": tet_edge_idx,
+            "tet_edge_sign": tet_edge_sign_f64,
+            "eps_re": eps_re,
+            "eps_im": eps_im,
+        })
+        m_re_onnx, m_im_onnx = outs
+
+        # NumPy complex reference
+        sign_outer = tet_edge_sign_f64[:, :, None] * tet_edge_sign_f64[:, None, :]
+        m_signed_c128 = (
+            m_local.astype(np.complex128) * sign_outer * eps_c128[:, None, None]
+        )
+        rows = np.broadcast_to(tet_edge_idx[:, :, None], (n_tets, 6, 6)).ravel()
+        cols = np.broadcast_to(tet_edge_idx[:, None, :], (n_tets, 6, 6)).ravel()
+        m_ref = scipy.sparse.coo_matrix(
+            (m_signed_c128.ravel(), (rows, cols)),
+            shape=(n_edges, n_edges),
+            dtype=np.complex128,
+        ).toarray()
+
+        max_re_err = float(np.max(np.abs(m_re_onnx - m_ref.real)))
+        max_im_err = float(np.max(np.abs(m_im_onnx - m_ref.imag)))
+        b_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_rt = f"FAIL ({e!r})"
+    print(f"onnxruntime execution: {b_rt}")
+    if b_rt == "OK":
+        print(f"  max |M_re_onnx - Re(M_ref)| = {max_re_err:.3e}")
+        print(f"  max |M_im_onnx - Im(M_ref)| = {max_im_err:.3e}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Operator inventory + verdict
+    # ------------------------------------------------------------- #
+    print("Operator inventory for complex local + scatter:")
+    print("--------------------------------------------------------------")
+    print("  Mul over (f64, c128)           BLOCKED  no shared T type constraint;")
+    print("                                          no runtime kernel registered.")
+    print("  Mul over (c128, c128)          BLOCKED  same as above.")
+    print("  ConstantOfShape with c128 fill BLOCKED  T2 type constraint excludes c128.")
+    print("  ScatterND with c128 T          ACCEPTED schema-wise (c128 IS in T),")
+    print("                                          but unreachable because no")
+    print("                                          upstream op can produce the")
+    print("                                          c128 value tensor.")
+    print()
+    print("  Two parallel f64 scatters       EXPRESSIBLE  one for Re(M), one for Im(M).")
+    print("                                               K_global stays a single")
+    print("                                               real scatter (K is real).")
+    print("  Identical int64 indices, shared EXPRESSIBLE  the COO index construction")
+    print("                                               is independent of dtype.")
+    print()
+    print("Verdict for Graph (A) — native c128 scatter:")
+    print(f"  schema check: {a_checker}")
+    print(f"  runtime:      {a_rt}")
+    if a_err:
+        print(f"  → BLOCKED. Runtime error: c128 unsupported MLDataType.")
+    print()
+    print("Verdict for Graph (B) — paired-real scatter:")
+    print(f"  schema check: {b_checker}")
+    print(f"  runtime:      {b_rt}")
+    if b_rt == "OK":
+        print("  → EXPRESSIBLE (fallback). Numerically bit-exact vs. NumPy ref.")
+    print()
+    print("Overall verdict: FALLBACK (paired-real lowering).")
+    print("  The complex mass scatter must be split into two real scatters")
+    print("  consuming `eps_re`, `eps_im` from the paired-real epsilon ramp.")
+    print("  Downstream consumers (the LAPACK ZGGEV sidecar) re-assemble the")
+    print("  c128 mass on the host: M_complex = M_re + 1j * M_im. This matches")
+    print("  the eigensolve-sidecar convention from Phase G.7 / F.2: the host")
+    print("  driver owns the complex generalized eigensolve boundary anyway.")
+    print()
+
+    ok = (a_rt in ("FAIL", "skipped")) and (b_checker == "OK") and (b_rt == "OK")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Documentation-only audit (no numerical validation required) mirroring the Phase G.6 PEC pattern from [PR #138](https://github.com/rjwalters/geode-fem/pull/138). Two probe scripts in `reference/onnx/audit/sphere_pml/` empirically capture the precise opset-18 blockers for the PML-specific operators, and a markdown audit catalogs each operator as **emittable / fallback / blocked** with rationale.

Closes #157

## Per-operator verdict summary

| Operator | Status | Rationale |
|---|---|---|
| `tet_centroid_radii` | **emittable** | Real Gather + ReduceMean + ReduceL2; no new friction over G.6 |
| `build_complex_epsilon_r_pml` | **fallback** | Real ramp is emittable; c128 output is blocked. Emit `eps_re`, `eps_im` (bit-exact vs. NumPy) |
| Complex local stiffness scatter | **emittable** | K_local is real; c128 promotion happens at the eigensolve sidecar (off-graph) |
| Complex local mass scatter | **fallback** | `f64 × c128` Mul is blocked; paired-real `m_signed_re`, `m_signed_im` is bit-exact |
| Complex global assembly | **fallback** | c128 ConstantOfShape + ScatterND chain is unreachable end-to-end; two paired-real f64 scatters are emittable |
| Complex eigensolve (LAPACK ZGGEV) | **blocked** | Out-of-graph sidecar, same disposition as PEC eigsh sidecar in G.6 / F.1 / F.2 |

## Headline finding

Opset 18 has no usable c128 type path. The IR enum lists COMPLEX64=14 / COMPLEX128=15 and onnx.checker schema-accepts c128 in a handful of value-passing ops (Constant, Identity, Reshape, Gather, ScatterND, Where), but every arithmetic op (Add/Sub/Mul/Div/MatMul/Einsum/ReduceSum/...) and ConstantOfShape and Cast exclude c128 from their type constraints, and onnxruntime rejects c128 inputs even where the schema accepts them. c128 values can move through the graph but cannot be produced or operated on inside it.

This confirms the broader graph-only finding from Comment 4 on Epic #88: the c128 type is a vestigial signpost in the ONNX IR, not a working dtype. Any backend that wants complex arithmetic must lower it to paired-real before emitting ONNX.

## Empirical blocker evidence

The probes capture the exact runtime errors:

- \`[ONNXRuntimeError] : 1 : FAIL : Exception during loading: MLDataType for: tensor(complex128) is not currently registered or supported\` (session load with c128 graph input)
- \`[ONNXRuntimeError] : 10 : INVALID_GRAPH : Type 'tensor(complex128)' of input parameter (eps_b) of operator (Mul) in node () is invalid\` (graph type check on f64 x c128 Mul)

## Cross-references

- [PR #138](https://github.com/rjwalters/geode-fem/pull/138) — Phase G.6 PEC audit, template mirrored verbatim
- [PR #142](https://github.com/rjwalters/geode-fem/pull/142) — build_edges host-precompute (G.6 "secretly imperative" finding inherited verbatim — no re-derivation)
- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Comment 4 — broader graph-only finding

## Recommended PML graph design (recap from audit)

Paired-real outputs at the sidecar boundary; total c128 surface area inside the graph is **zero**:

- Inputs: nodes, tets, tag (int32), tet_edge_idx, tet_edge_sign, interior_idx (all host-computed per G.6), plus baked scalars n_inside, sigma_0.
- Outputs: K_int (f64), M_re_int (f64), M_im_int (f64).
- Host sidecar re-assembles M_int_complex = M_re_int + 1j * M_im_int, promotes K to c128, calls scipy.linalg.eig (dense LAPACK ZGGEV — ARPACK shift-and-invert at sigma=0 is not usable because the curl-curl kernel makes (K - sigma*M)^-1 near-singular).

## Test plan

- [ ] \`python3 reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py\` — exits 0, prints \`Overall verdict: FALLBACK (paired-real lowering)\` and the c128 session-load error from Graph (A)
- [ ] \`python3 reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py\` — exits 0, prints \`Overall verdict: FALLBACK (paired-real lowering)\` and the \`Type 'tensor(complex128)' ... invalid\` error from Graph (A), and \`0.000e+00\` numerical errors on the paired-real Graph (B)

Requires: \`pip install onnx==1.21.0 onnxruntime==1.26.0 numpy scipy\` (see reference/onnx/requirements.txt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)