### PR TITLE
fix(driver): sphere-PEC per-backend fixture schema cleanup (#161)

### DIFF
--- a/.github/workflows/onnx-cube-cavity.yml
+++ b/.github/workflows/onnx-cube-cavity.yml
@@ -324,6 +324,7 @@ jobs:
         run: |
           python3 reference/driver/eigensolve_sphere_pec_sidecar.py \
               target/out/reduced_kM_sphere_pec_onnx.json \
+              --backend onnx \
               --baseline reference/fixtures/sphere_pec/baseline.json \
               --rtol "${SPHERE_RTOL}" \
               --k 5 \

--- a/reference/driver/eigensolve_from_sidecar.py
+++ b/reference/driver/eigensolve_from_sidecar.py
@@ -98,6 +98,48 @@ BACKENDS: dict[str, dict] = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# Per-backend metadata (sphere-PEC path)
+# ---------------------------------------------------------------------------
+#
+# Sphere-PEC mirrors the cube-cavity per-backend convention so that the
+# emitted eigenresult fixture_id varies by assembly backend (instead of
+# the legacy hardcoded `tfjava_eigenresult` literal, which incorrectly
+# labelled ONNX-computed eigenvalues with TF-Java provenance — see
+# issue #161). Suffixes follow the sphere-PEC schema rather than the
+# cube-cavity `_eigensolve` suffix because the sphere-PEC pipeline emits
+# a richer artifact (physical_eigenvalues + best_gap + eigenvalues_lowest)
+# rather than a plain dense eigensolve.
+
+SPHERE_PEC_BACKENDS: dict[str, dict] = {
+    "tfjava": {
+        "fixture_id_suffix": "tfjava_eigenresult",
+        "comparison_header": "TF-Java",
+        "description": (
+            "Physical eigenvalues from the TF-Java sphere-PEC Nédélec assembly + "
+            "SciPy shift-and-invert eigensolve (Epic #88 / #134). "
+            "Cross-checked against reference/fixtures/sphere_pec/baseline.json."
+        ),
+        "provenance_source": (
+            "reference/tf_java/sphere_pec (assembly) → "
+            "reference/driver/eigensolve_from_sidecar.py (SciPy eigensolve seam)"
+        ),
+    },
+    "onnx": {
+        "fixture_id_suffix": "onnx_eigenresult",
+        "comparison_header": "ONNX",
+        "description": (
+            "Physical eigenvalues from the ONNX sphere-PEC Nédélec assembly + "
+            "SciPy shift-and-invert eigensolve (Epic #88 / #134 / #140). "
+            "Cross-checked against reference/fixtures/sphere_pec/baseline.json."
+        ),
+        "provenance_source": (
+            "reference/onnx/sphere_pec (assembly) → "
+            "reference/driver/eigensolve_from_sidecar.py (SciPy eigensolve seam)"
+        ),
+    },
+}
+
 PROBLEMS = ("cube-cavity", "sphere-pec")
 
 # Per-fixture spurious-dim fallback when no baseline.json is supplied.
@@ -242,6 +284,19 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
     import scipy.sparse as sp
     import scipy.sparse.linalg as spla
 
+    if args.backend not in SPHERE_PEC_BACKENDS:
+        # Defensive guard for future backends added to BACKENDS but not yet
+        # to SPHERE_PEC_BACKENDS — keeps the schema-hygiene contract honest
+        # (no silent fallback to TF-Java labelling for non-TF-Java runs).
+        print(
+            f"[sphere-pec-driver] ERROR: backend '{args.backend}' has no "
+            f"sphere-PEC metadata. Add an entry to SPHERE_PEC_BACKENDS in "
+            f"{Path(__file__).name} mirroring the cube-cavity convention.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sphere_meta = SPHERE_PEC_BACKENDS[args.backend]
+
     # --- Load K_int, M_int ---
     k_int_flat = _load_field(sidecar, "outputs", "k_int")
     m_int_flat = _load_field(sidecar, "outputs", "m_int")
@@ -343,7 +398,7 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
         ref_physical = np.array(bl["outputs"]["physical_eigenvalues"]["data"])
         n_compare = min(len(physical), len(ref_physical))
         print("\n[sphere-pec-driver] Cross-backend comparison vs NumPy baseline:")
-        print(f"  {'i':>3}  {'TF-Java':>14}  {'NumPy':>14}  {'rel':>10}")
+        print(f"  {'i':>3}  {sphere_meta['comparison_header']:>14}  {'NumPy':>14}  {'rel':>10}")
         all_ok = True
         for i in range(n_compare):
             got  = physical[i]
@@ -367,12 +422,8 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
 
     result_fixture = {
         "schema_version": "1",
-        "fixture_id": "sphere_pec/n774_pec_eigenmode_tfjava_eigenresult",
-        "description": (
-            "Physical eigenvalues from the TF-Java sphere-PEC Nédélec assembly + "
-            "SciPy shift-and-invert eigensolve (Epic #88 / #134). "
-            "Cross-checked against reference/fixtures/sphere_pec/baseline.json."
-        ),
+        "fixture_id": f"sphere_pec/n774_pec_eigenmode_{sphere_meta['fixture_id_suffix']}",
+        "description": sphere_meta["description"],
         "units": "lambda = k^2 (inverse-length squared); dimensionless mesh coordinates",
         "inputs": {
             "n_index": {
@@ -427,10 +478,7 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
             },
         },
         "provenance": {
-            "source": (
-                "reference/tf_java/sphere_pec (assembly) → "
-                "reference/driver/eigensolve_sphere_pec_sidecar.py (SciPy eigensolve seam)"
-            ),
+            "source": sphere_meta["provenance_source"],
             "verified_against": "reference/fixtures/sphere_pec/baseline.json",
             "issue": "#134",
         },


### PR DESCRIPTION
## Summary

- `_run_sphere_pec` in `reference/driver/eigensolve_from_sidecar.py` now consults `args.backend` for `fixture_id`, `description`, `provenance.source`, and the cross-backend comparison column header (previously all hardcoded to TF-Java). New per-backend map mirrors the cube-cavity convention: `tfjava` → `tfjava_eigenresult`, `onnx` → `onnx_eigenresult`, extendable for future backends.
- `.github/workflows/onnx-cube-cavity.yml` passes `--backend onnx` explicitly to the sphere-PEC shim (default was `tfjava`, so prior ONNX CI artifacts were silently mislabelled).
- Defensive guard fires with a clear error if a future backend appears in `BACKENDS` but not yet in `SPHERE_PEC_BACKENDS`.

This is pure schema hygiene — no numerical change. PR #150's Judge spotted and deferred the bug; this PR closes the loop.

## What was validated locally

- Synthetic round-trip through `_run_sphere_pec`: emitted JSON now has `fixture_id: "sphere_pec/n774_pec_eigenmode_tfjava_eigenresult"` with `--backend tfjava` and `"sphere_pec/n774_pec_eigenmode_onnx_eigenresult"` with `--backend onnx`; description and provenance.source vary accordingly.
- Synthetic cube-cavity round-trip unchanged (`cube_cavity/n4_tfjava_eigensolve` / `cube_cavity/n4_onnx_eigensolve`).
- `cargo test -p geode-validation` — all sphere-PEC integration tests pass (TF-Java, ONNX, JAX, NumPy, Julia); cube-cavity tests pass; full suite green (release-only spectrum-agrees tests remain ignored under debug-assertions, as expected — unrelated to this change).
- `python3 reference/driver/eigensolve_from_sidecar.py --help` parses cleanly.

## Downstream consumers updated

- None required. A repo-wide search for the literal `tfjava_eigenresult` / `onnx_eigenresult` / `sphere_pec/n774_pec_eigenmode_tfjava_eigenresult` strings outside the driver itself returned no hits. The eigenresult JSON is currently only a CI artifact (no Rust test asserts on its `fixture_id`); the sphere-PEC sidecar fixtures use the `_<backend>` suffix (no `_eigenresult`) and are unchanged.
- The Rust sphere-PEC reference tests (`crates/geode-validation/tests/sphere_pec_{onnx,tfjava}_reference.rs`) assert on sidecar `fixture_id`, not the eigenresult — no migration needed.

## Test plan

- [x] Synthetic sphere-PEC round-trip per backend confirms the new per-backend fixture_id / description / provenance
- [x] Synthetic cube-cavity round-trip confirms no regression
- [x] `cargo test -p geode-validation` all green
- [ ] CI re-runs the ONNX sphere-PEC workflow with the new `--backend onnx` argument and produces an artifact with `fixture_id: ...onnx_eigenresult`

## Notes

`/sweep` flagged PR #163 (TF-Java sphere-PML driver) as recently touching the same file; reviewed and confirmed no overlap — that change targets a future `_run_sphere_pml` path, while this PR is scoped to `_run_sphere_pec`.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)