### PR TITLE
feat: Phase I.3 — ONNX de Rham expressibility audit (Epic #88, #169)

### DIFF
--- a/reference/onnx/audit/derham/derham_operator_audit.md
+++ b/reference/onnx/audit/derham/derham_operator_audit.md
@@ -1,0 +1,326 @@
+# Discrete de Rham ONNX expressibility audit (Phase I.3)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase I.3
+deliverable. Tracking issue:
+[#169](https://github.com/rjwalters/geode-fem/issues/169).
+
+## Scope
+
+This audit catalogs the operators of the **discrete de Rham chain**
+(d⁰ gradient, d¹ curl, d² divergence) — as defined by the NumPy
+reference in [`reference/numpy/derham.py`](../../../numpy/derham.py)
+and the Burn implementation in `crates/geode-core/src/derham.rs` —
+and records whether each lowers to a graph-only ONNX opset-18 form.
+
+Unlike the previous audits (F.1 cube-cavity, G.6 sphere-PEC, H.5
+sphere-PML), which walked a single assembly *pipeline*, this audit
+deliberately splits each operator into two distinct questions:
+
+1. **Construction** — edge/face enumeration, row deduplication,
+   inverse-index maps, orientation signs. Expected verdict:
+   host-side, confirming that the "topology belongs at the L4-input
+   boundary" rule ([#5](https://github.com/rjwalters/geode-fem/issues/5),
+   2026-06-05 comment; G.6 `build_edges` finding) generalizes from a
+   Nédélec-assembly one-off to the full d-chain.
+2. **Application** — `d⁰·φ`, `d¹·v`, `d²·w` as sparse matvecs over
+   host-pre-assembled index tables. Question: is *application*
+   graph-pure under opset 18 even though construction is not?
+
+**Headline finding**: yes — the split is clean. Every construction
+stage is **blocked** (host-side) by exactly the G.6 friction class
+(data-dependent dedup shapes + hash-map inverse lookups), and every
+application stage is **emittable** with zero friction: the de Rham
+matrices are integer `{-1, 0, +1}` incidence matrices, so the c128
+frictions that dominated H.5 never arise, and the int64 type path
+through `Gather` / `Sub` / `Add` / `Mul` / `ConstantOfShape` /
+`ScatterND(reduction="add")` is fully supported by opset 18 and
+onnxruntime. The composed exactness identity `d¹ ∘ d⁰ ≡ 0` holds
+**in-graph, bit-exactly**, on the full bundled sphere fixture.
+
+## Pinned versions used for this audit
+
+Same as Phase F.1 / G.6 / H.5:
+
+| Package | Version |
+|---|---|
+| `onnx` | `1.21.0` |
+| `onnxruntime` | `1.26.0` |
+| Target opset | `18` |
+
+See [`reference/onnx/requirements.txt`](../../requirements.txt) for the
+pinned `pip` line. The exactness probe additionally needs `scipy` and
+`meshio` from [`reference/numpy/requirements.txt`](../../../numpy/requirements.txt)
+(it loads the bundled `.msh` fixture through `derham.py`).
+
+## Classification convention
+
+Same as H.5 (issue #157 convention):
+
+| Marker | Meaning |
+|---|---|
+| **emittable** | Op lowers directly to opset 18 with no special handling. |
+| **fallback** | Op cannot lower as-typed; a documented alternative lowering exists. |
+| **blocked** | Op has no lowering — must be host-computed and passed as a graph input or executed in an out-of-graph sidecar. |
+
+## Construction stages
+
+No new probes were written for construction: every stage below is an
+instance of the friction class already demonstrated empirically by
+[`probe_edge_enumeration.py`](../sphere_pec/probe_edge_enumeration.py)
+(G.6), which showed that `np.unique(..., axis=0)` has a data-dependent
+output shape (ONNX `Unique` types it `[None]`) and that the
+sorted-unique-**inverse** map (the Python dict) has no ONNX operator
+equivalent. The de Rham constructors are structurally identical:
+
+### Stage C1 — `build_edges` (d⁰ row space)
+
+Inherited verbatim from G.6. Pair canonicalization (`Gather` + `Min` +
+`Max`) is emittable; `np.unique(pairs, axis=0)` and the
+`edge_to_idx` dict are not.
+
+**Stage C1 verdict: BLOCKED (host-side).** Unchanged from G.6 /
+PR [#142](https://github.com/rjwalters/geode-fem/pull/142).
+
+### Stage C2 — `build_faces` (d¹ row space, d² column space)
+
+| Operator (NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `tets[:, local_face]` per slot | `Gather(axis=1)` | **emittable** | Same as the G.6 pair extraction. |
+| `np.sort(tri, axis=1)` (3-wide ascending) | `TopK`/`Sort`-free: `Min`/`Max`/median composition | **emittable** | Verbose but static-shape; graph-only friction. |
+| `np.unique(triples, axis=0)` | **none** | **blocked** | Same data-dependent-shape friction as `build_edges`: `n_faces` is a topological property of the mesh. The 1-D `Unique` workaround (encode each triple as a scalar key) still yields a `[None]`-shaped output. |
+
+**Stage C2 verdict: BLOCKED (host-side).** Same friction class as C1;
+the dedup key is a vertex *triple* instead of a pair, which changes
+nothing.
+
+### Stage C3 — `curl_map` column indices (`edge_to_idx` lookup)
+
+The d¹ COO column indices are `edge_to_idx[(a,b)]`,
+`edge_to_idx[(b,c)]`, `edge_to_idx[(a,c)]` per face — a hash-map
+inverse of the deduplicated edge table.
+
+**Stage C3 verdict: BLOCKED (host-side).** Identical to the G.6
+step-4/5 finding (no sorted-unique-with-inverse operator). The data
+values of d¹ (`+1, +1, -1` per row) are a fixed pattern and would be
+trivially emittable — but they are useless without the blocked column
+indices, so the whole constructor is host-side.
+
+### Stage C4 — `build_tet_faces` / `divergence_map` (face lookup + parity signs)
+
+| Operator (NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `face_to_idx[sorted(local)]` | **none** | **blocked** | Hash-map inverse of `build_faces`, same as C3. |
+| `_triple_permutation_sign` (3-element parity) | comparison ladder (`Less`/`Where`) | **emittable** | A fixed-depth comparator network; graph-only friction. |
+| `(-1)^k` alternation | baked `Constant` | **emittable** | Static per-slot constant. |
+
+**Stage C4 verdict: BLOCKED (host-side)** — the parity arithmetic is
+emittable, but it is downstream of the blocked `face_to_idx` lookup.
+
+### Construction summary
+
+All four constructors fail on the **same two ops** that blocked
+`build_edges` in G.6: row-deduplication with data-dependent output
+shape, and hash-map inverse lookup. Nothing about the d-chain adds a
+*new* construction friction, and nothing about it removes one. The
+"topology belongs at the L4-input boundary" rule is therefore **not**
+a Nédélec-assembly one-off — it is the general disposition for every
+combinatorial-topology constructor in the codebase.
+
+## Application stages
+
+Probes:
+[`probe_d0_apply.py`](probe_d0_apply.py),
+[`probe_d1_apply.py`](probe_d1_apply.py),
+[`probe_exactness_in_graph.py`](probe_exactness_in_graph.py).
+
+Each operator is probed in two graph forms:
+
+- **Structured incidence form** — exploits the fixed per-row nnz
+  pattern (2 for d⁰, 3 for d¹, 4 for d²): pure `Gather` + `Add`/`Sub`
+  on the host-provided index table, no scatter at all.
+- **Generic COO matvec** — `y = ScatterND_add(zeros(n_rows),
+  rows[:, None], vals · Gather(x, cols))`, consuming the COO triplets
+  of the host-assembled matrix as plain graph inputs. This is the
+  form that generalizes to *any* pre-assembled sparse operator.
+
+### Stage A1 — d⁰ application (`g = d⁰ · φ`)
+
+Probe: [`probe_d0_apply.py`](probe_d0_apply.py).
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `edges[:, 0]` / `edges[:, 1]` column split | `Gather(axis=1)` with scalar index | **emittable** | Scalar index drops the axis — no `Squeeze` needed. |
+| `φ[heads]`, `φ[tails]` | `Gather(axis=0)` | **emittable** | int64 and f64. |
+| `φ[b] - φ[a]` | `Sub` | **emittable** | int64 and f64. Bit-exact (`0.000e+00`) vs. NumPy in both dtypes. |
+| `vals * φ[cols]` (COO form) | `Mul` | **emittable** | int64 and f64. |
+| Zero buffer `(n_edges,)` | `ConstantOfShape` | **emittable** | **int64 fill is supported** (unlike the c128 fill blocked in H.5 Stage 5). |
+| Accumulate | `ScatterND(reduction="add")` | **emittable** | **int64 reduction works in onnxruntime 1.26** — bit-exact vs. scipy. |
+
+**Stage A1 verdict: EMITTABLE (graph-pure)**, both forms, both dtypes.
+
+### Stage A2 — d¹ application (`c = d¹ · v`)
+
+Probe: [`probe_d1_apply.py`](probe_d1_apply.py).
+
+Host-side input: `face_edge_idx (n_faces, 3) int64` with columns
+`[edge(a,b), edge(b,c), edge(a,c)]` (the C3 dict lookup output), or
+equivalently the `curl_map` COO triplets.
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Three column splits of `face_edge_idx` | `Gather(axis=1)` scalar index | **emittable** | |
+| `v[e_ab] + v[e_bc] - v[e_ac]` | `Gather` × 3 + `Add` + `Sub` | **emittable** | The `+1, +1, -1` sign pattern is baked into the op choice — no sign tensor needed in the structured form. Bit-exact in int64 and f64. |
+| Generic COO matvec on d¹ | `Gather` + `Mul` + `ConstantOfShape` + `ScatterND(add)` | **emittable** | Bit-exact vs. scipy in both dtypes. |
+
+**Stage A2 verdict: EMITTABLE (graph-pure)**, both forms, both dtypes.
+
+### Stage A3 — d² application (`s = d² · w`)
+
+Probed in [`probe_d1_apply.py`](probe_d1_apply.py) Part (C): the
+**identical** generic COO matvec builder runs on the `divergence_map`
+triplets with zero modification (4 nnz per row, signs
+`(-1)^k · sign_k` live in the host-provided `vals` tensor). Bit-exact
+vs. scipy in int64 and f64.
+
+**Stage A3 verdict: EMITTABLE (graph-pure).** Application
+expressibility is a property of the COO input contract, not of any
+particular d-operator.
+
+### Stage A4 — composed in-graph exactness `d¹ · (d⁰ · φ) ≡ 0`
+
+Probe: [`probe_exactness_in_graph.py`](probe_exactness_in_graph.py),
+executed against the bundled sphere fixture
+([`reference/fixtures/sphere_pec/sphere.msh`](../../../fixtures/sphere_pec/sphere.msh):
+774 nodes, 4512 edges, 7074 faces, 3335 tets) after cross-checking the
+cell counts against the [#149](https://github.com/rjwalters/geode-fem/issues/149)
+baseline ([`reference/fixtures/derham/baseline.json`](../../../fixtures/derham/baseline.json),
+fixture_id `derham/sphere_n774_d0_d1_d2`).
+
+The assertion is a **graph node**, not a host-side comparison:
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `d⁰·φ` then `d¹·g` chained | (Stages A1 + A2 composed) | **emittable** | Both the structured form and the two-`ScatterND` COO form compose with no friction. |
+| `max abs(residual)` | `Abs` + `ReduceMax(keepdims=0)` | **emittable** | int64 supported. |
+| `== 0` assert | `Equal` against an int64 `Constant` | **emittable** | Emits a scalar `BOOL` graph output. |
+
+Measured results (onnxruntime 1.26.0, full sphere fixture, random
+int64 nodal field in `[-10⁶, 10⁶)`):
+
+| Graph | `max abs d¹·(d⁰·φ)` | in-graph `exact` bool |
+|---|---|---|
+| Structured chain, int64 | `0` | `True` |
+| Composed COO matvec chain (`ScatterND` × 2), int64 | `0` | `True` |
+| Structured chain, **f64 control** | `8.882e-16` | `False` |
+
+The f64 control row is a finding, not a failure: `g = fl(φ_b − φ_a)`
+is already rounded, so the telescoping cancellation in the d¹ row only
+holds to roundoff — in *any* backend, not just ONNX. The bit-exact
+in-graph assert therefore **must** run on the integer channel, which
+is exactly the dtype contract #149 fixed for the de Rham baselines
+("bit-exact integer cross-check, no floating-point tolerance
+question"). Opset 18's full int64 support for `Gather` / `Sub` /
+`Add` / `Mul` / `ScatterND(add)` / `Abs` / `ReduceMax` / `Equal` is
+what makes this possible.
+
+**Stage A4 verdict: EMITTABLE (graph-pure).** The exactness identity
+of the discrete de Rham complex survives lowering to a pure opset-18
+graph.
+
+## Per-stage verdicts (one-line summary)
+
+| Stage | Verdict |
+|---|---|
+| C1. `build_edges` | **blocked** — host-side (inherited G.6; dedup + inverse map) |
+| C2. `build_faces` | **blocked** — host-side (same friction, triple keys) |
+| C3. `curl_map` column indices (`edge_to_idx`) | **blocked** — host-side (hash-map inverse) |
+| C4. `build_tet_faces` / `divergence_map` indices | **blocked** — host-side (hash-map inverse; parity signs alone would be emittable) |
+| A1. d⁰ application | **emittable** — `Gather` + `Sub`, or generic COO matvec; bit-exact int64 + f64 |
+| A2. d¹ application | **emittable** — `Gather` × 3 + `Add` + `Sub`, or COO matvec; bit-exact |
+| A3. d² application | **emittable** — same COO matvec builder, unmodified |
+| A4. in-graph `d¹∘d⁰ ≡ 0` | **emittable** — holds bit-exactly under onnxruntime on the full sphere fixture (int64 channel) |
+
+## Spec implications (L4 input boundary)
+
+1. **The input-boundary rule generalizes.** Every de Rham constructor
+   is blocked by the *same two ops* as `build_edges` (data-dependent
+   dedup + hash-map inverse). "Topology belongs at the L4-input
+   boundary" is the uniform disposition for the whole d-chain, not a
+   Nédélec special case. An L4 spec can state it once, as a rule
+   about *combinatorial topology constructors*, rather than
+   enumerating per-operator exceptions.
+2. **The d-operators can live in the traced L4 surface.** Application
+   is graph-pure provided the operator arrives as a pre-assembled
+   host artifact. Two equivalent input contracts work, and both are
+   shapes the spec has already paid for:
+   - *structured index tables* (`edges (n_edges, 2)`,
+     `face_edge_idx (n_faces, 3)`, `tet_face_idx (n_tets, 4)` +
+     sign tensor) — the same shape as the Phase G.7
+     `tet_edge_idx` / `tet_edge_sign` contract;
+   - *generic COO triplets* (`rows`, `cols`, `vals`) — one
+     operator-agnostic matvec subgraph serves d⁰, d¹, d², and any
+     future pre-assembled sparse operator.
+3. **The integer channel is load-bearing.** The #149 "bit-exact
+   integer cross-check" contract transfers into the graph unchanged
+   because opset 18 supports int64 end-to-end, including
+   `ScatterND(reduction="add")` and `ConstantOfShape` with int64
+   fill. This is the mirror image of the H.5 finding: where c128 is
+   a vestigial type with no kernel support, **int64 is a first-class
+   citizen** — the de Rham chain dodges every H.5 friction by being
+   integer-valued.
+4. **f64 exactness is roundoff-bounded everywhere.** The f64 control
+   (residual `8.9e-16` on unit-scale fields) documents that an
+   in-graph exactness *assert* must use the integer dtype; an f64
+   d-chain embedded in a physics graph should treat `d¹∘d⁰` as zero
+   only to tolerance. This is backend-independent arithmetic, not an
+   ONNX limitation, but it belongs in the spec's conformance-test
+   wording.
+
+## Cross-cutting frictions: G.6/H.5 vs. I.3 comparison
+
+| Friction | G.6 / H.5 status | I.3 (de Rham) status | Change |
+|---|---|---|---|
+| Dedup with data-dependent shape (`np.unique` axis=0) | blocked (`build_edges`) | blocked (`build_edges`, `build_faces`) | **Unchanged** — now known to cover the full d-chain |
+| Hash-map inverse lookup | blocked (`edge_to_idx`) | blocked (`edge_to_idx`, `face_to_idx`) | **Unchanged** |
+| `ScatterND(reduction="add")` f64 | emittable | emittable | **Unchanged** |
+| `ScatterND(reduction="add")` **int64** | untested | **emittable** (probed, bit-exact) | **NEW in I.3** |
+| `ConstantOfShape` int64 fill | untested | **emittable** | **NEW in I.3** |
+| int64 `Abs`/`ReduceMax`/`Equal` (in-graph assert) | untested | **emittable** | **NEW in I.3** |
+| c128 type path | blocked (H.5 headline) | not applicable — d-chain is integer-valued | — |
+
+## Re-running this audit
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt -r ../numpy/requirements.txt
+python3 audit/derham/probe_d0_apply.py
+python3 audit/derham/probe_d1_apply.py
+python3 audit/derham/probe_exactness_in_graph.py
+```
+
+Each probe prints a one-screen verdict that should match the
+corresponding row(s) in this table and exits nonzero if any bit-exact
+check fails. If a probe's verdict disagrees with the table after a
+version bump, the table is stale — re-audit. The construction
+verdicts (C1–C4) are inherited from the G.6 probe; re-run
+`audit/sphere_pec/probe_edge_enumeration.py` to refresh them.
+
+## Acknowledgements / cross-references
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — overall
+  framing; Phase I.3 scope.
+- Issue [#149](https://github.com/rjwalters/geode-fem/issues/149) — the
+  NumPy de Rham reference and integer baseline this audit consumes
+  ([`reference/numpy/derham.py`](../../../numpy/derham.py),
+  [`reference/fixtures/derham/baseline.json`](../../../fixtures/derham/baseline.json)).
+- Issue [#5](https://github.com/rjwalters/geode-fem/issues/5) — the
+  L4-input-boundary rule this audit confirms and generalizes.
+- Phase G.6: [`nedelec_operator_audit.md`](../sphere_pec/nedelec_operator_audit.md)
+  — origin of the `build_edges` "secretly imperative" finding and the
+  construction friction class inherited here.
+- Phase H.5: [`nedelec_pml_operator_audit.md`](../sphere_pml/nedelec_pml_operator_audit.md)
+  — the c128 headline this audit's int64 finding mirrors.
+- Burn-side source of truth: `crates/geode-core/src/derham.rs`
+  (`gradient_map`, `curl_map`, `divergence_map`) and
+  `crates/geode-core/src/mesh/mod.rs` (`TET_LOCAL_EDGES`,
+  `TET_LOCAL_FACES`).

--- a/reference/onnx/audit/derham/probe_d0_apply.py
+++ b/reference/onnx/audit/derham/probe_d0_apply.py
@@ -1,0 +1,315 @@
+"""Probe: ONNX expressibility of d⁰ *application* (discrete gradient matvec).
+
+Epic #88, Phase I.3 (issue #169). This probe asks whether **applying**
+the discrete gradient ``d⁰`` to a nodal field — ``g = d⁰ · φ`` — can be
+expressed as a pure ONNX opset-18 graph, given that the **construction**
+of ``d⁰`` (edge enumeration, dedup, orientation signs) is host-side per
+the Phase G.6 ``build_edges`` finding
+(``reference/onnx/audit/sphere_pec/probe_edge_enumeration.py``).
+
+The construction/application split
+==================================
+
+``d⁰`` is an ``(n_edges, n_nodes)`` signed ``{-1, +1}`` incidence
+matrix (``reference/numpy/derham.py::gradient_map``). Constructing it
+requires ``np.unique(pairs, axis=0)`` — data-dependent output shape,
+no ONNX lowering (G.6 verdict: secretly imperative, host-side).
+
+But once the host hands the graph the **edge table** ``edges
+(n_edges, 2) int64`` (or equivalently the COO triplets of ``d⁰``),
+application is pure gather/scatter arithmetic with static shapes:
+
+  - Row ``[a, b]`` of ``d⁰`` has exactly ``-1`` at column ``a`` and
+    ``+1`` at column ``b``, so ``(d⁰·φ)[edge] = φ[b] - φ[a]``.
+
+Strategy: two graph forms
+=========================
+
+(A) **Structured incidence form** — exploit the fixed 2-nnz-per-row
+    structure: ``Gather(φ, edges[:, 1]) - Gather(φ, edges[:, 0])``.
+    Two Gathers + one Sub. Runs in both int64 (bit-exact, the #149
+    contract dtype) and float64.
+
+(B) **Generic COO sparse matvec** — the form that generalizes to any
+    pre-assembled host sparse matrix (d¹, d² included):
+    ``y = ScatterND_add(zeros(n_rows), rows[:, None],
+    data * Gather(x, cols))``. This is the load-bearing form for the
+    L4 spec question: it consumes (rows, cols, data) as plain graph
+    inputs, exactly the input-contract shape already established for
+    ``tet_edge_idx`` / ``tet_edge_sign`` in Phase G.7.
+
+Both forms are expected EMITTABLE: Gather, Sub, Mul, ConstantOfShape,
+and ScatterND(reduction="add") are all native opset-18 over int64 and
+float64 (the c128 frictions of Phase H.5 do not arise — the de Rham
+chain is integer-valued).
+
+Run
+===
+
+    python3 reference/onnx/audit/derham/probe_d0_apply.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from derham import build_edges, gradient_map  # noqa: E402
+
+OPSET = 18
+
+DTYPE_MAP = {
+    np.dtype("float64"): TensorProto.DOUBLE,
+    np.dtype("int64"): TensorProto.INT64,
+    np.dtype("int32"): TensorProto.INT32,
+}
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=DTYPE_MAP[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_structured_d0_graph(
+    n_nodes: int, n_edges: int, elem_type: int
+) -> onnx.ModelProto:
+    """Graph (A) — structured incidence form of ``g = d⁰ · φ``.
+
+    Inputs:  phi (n_nodes,) elem_type, edges (n_edges, 2) int64
+    Output:  g (n_edges,) elem_type — per-edge ``φ[b] - φ[a]``.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    phi_vi = oh.make_tensor_value_info("phi", elem_type, [n_nodes])
+    edges_vi = oh.make_tensor_value_info("edges", TensorProto.INT64, [n_edges, 2])
+
+    # Scalar column indices — Gather with a scalar index drops the axis,
+    # yielding (n_edges,) directly (no Squeeze needed).
+    nodes.append(_const("col0", np.array(0, dtype=np.int64)))
+    nodes.append(_const("col1", np.array(1, dtype=np.int64)))
+    nodes.append(oh.make_node("Gather", ["edges", "col0"], ["tail_idx"], axis=1))
+    nodes.append(oh.make_node("Gather", ["edges", "col1"], ["head_idx"], axis=1))
+
+    # φ at heads / tails, then the signed difference.
+    nodes.append(oh.make_node("Gather", ["phi", "head_idx"], ["phi_head"], axis=0))
+    nodes.append(oh.make_node("Gather", ["phi", "tail_idx"], ["phi_tail"], axis=0))
+    nodes.append(oh.make_node("Sub", ["phi_head", "phi_tail"], ["g"]))
+
+    g_vi = oh.make_tensor_value_info("g", elem_type, [n_edges])
+    graph = oh.make_graph(
+        nodes,
+        name="d0_apply_structured",
+        inputs=[phi_vi, edges_vi],
+        outputs=[g_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def build_coo_matvec_graph(
+    n_rows: int, n_cols: int, nnz: int, elem_type: int
+) -> onnx.ModelProto:
+    """Graph (B) — generic COO sparse matvec ``y = A · x``.
+
+    Inputs:  x (n_cols,) elem_type,
+             rows (nnz,) int64, cols (nnz,) int64, vals (nnz,) elem_type
+    Output:  y (n_rows,) elem_type
+
+    Operator-agnostic: works for any host-pre-assembled sparse matrix
+    handed over as COO triplets (d⁰, d¹, d², Nédélec blocks, ...).
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    x_vi = oh.make_tensor_value_info("x", elem_type, [n_cols])
+    rows_vi = oh.make_tensor_value_info("rows", TensorProto.INT64, [nnz])
+    cols_vi = oh.make_tensor_value_info("cols", TensorProto.INT64, [nnz])
+    vals_vi = oh.make_tensor_value_info("vals", elem_type, [nnz])
+
+    # Per-nnz products: vals * x[cols]
+    nodes.append(oh.make_node("Gather", ["x", "cols"], ["x_at_cols"], axis=0))
+    nodes.append(oh.make_node("Mul", ["vals", "x_at_cols"], ["updates"]))
+
+    # Indices for ScatterND: (nnz, 1)
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows", "ax_neg1"], ["indices"]))
+
+    # Zero output buffer (n_rows,) of the working dtype.
+    zero_fill = (
+        oh.make_tensor("z", TensorProto.INT64, [1], [0])
+        if elem_type == TensorProto.INT64
+        else oh.make_tensor("z", TensorProto.DOUBLE, [1], [0.0])
+    )
+    nodes.append(_const("shape_rows", np.array([n_rows], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_rows"],
+        outputs=["zero_buf"],
+        value=zero_fill,
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf", "indices", "updates"],
+        outputs=["y"],
+        reduction="add",
+    ))
+
+    y_vi = oh.make_tensor_value_info("y", elem_type, [n_rows])
+    graph = oh.make_graph(
+        nodes,
+        name="coo_matvec",
+        inputs=[x_vi, rows_vi, cols_vi, vals_vi],
+        outputs=[y_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def _check_and_run(model, output_names, feeds):
+    onnx.checker.check_model(model)
+    sess = ort.InferenceSession(model.SerializeToString())
+    return sess.run(output_names, feeds)
+
+
+def main() -> int:
+    print("== Probe: d⁰ application (discrete gradient matvec) — Phase I.3 ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Tiny test mesh: 2 tets sharing a face — same as the G.6/H.5 probes.
+    tets_np = np.array(
+        [[0, 1, 2, 3],
+         [1, 2, 3, 4]],
+        dtype=np.int64,
+    )
+    n_nodes = 5
+
+    # HOST-SIDE construction (the G.6 "secretly imperative" boundary):
+    # edge dedup + ordering happens here, in NumPy, never in the graph.
+    edges = build_edges(tets_np)
+    n_edges = int(edges.shape[0])
+    d0 = gradient_map(n_nodes, edges)  # scipy CSR, int64 {-1, +1}
+    d0_coo = d0.tocoo()
+    print(f"Test mesh: n_tets={tets_np.shape[0]}, n_nodes={n_nodes}, "
+          f"n_edges={n_edges}, d0 nnz={d0.nnz}")
+    print()
+
+    rng = np.random.default_rng(42)
+    phi_i64 = rng.integers(-1000, 1000, size=n_nodes).astype(np.int64)
+    phi_f64 = rng.standard_normal(n_nodes).astype(np.float64)
+
+    g_ref_i64 = np.asarray(d0 @ phi_i64, dtype=np.int64)
+    g_ref_f64 = phi_f64[edges[:, 1]] - phi_f64[edges[:, 0]]
+
+    overall_ok = True
+
+    # ------------------------------------------------------------- #
+    # Graph (A) — structured incidence form, int64 and f64
+    # ------------------------------------------------------------- #
+    print("--- Graph (A): structured form  g = Gather(φ, head) - Gather(φ, tail) ---")
+    for label, etype, phi, g_ref in [
+        ("int64", TensorProto.INT64, phi_i64, g_ref_i64),
+        ("float64", TensorProto.DOUBLE, phi_f64, g_ref_f64),
+    ]:
+        try:
+            model = build_structured_d0_graph(n_nodes, n_edges, etype)
+            (g_onnx,) = _check_and_run(model, ["g"], {"phi": phi, "edges": edges})
+            err = int(np.max(np.abs(g_onnx - g_ref))) if label == "int64" \
+                else float(np.max(np.abs(g_onnx - g_ref)))
+            status = "OK"
+        except Exception as e:  # noqa: BLE001
+            status, err = f"FAIL ({e!r})", float("nan")
+            overall_ok = False
+        print(f"  [{label:7s}] checker+runtime: {status}   "
+              f"max |g_onnx - g_ref| = {err:.3e}" if status == "OK"
+              else f"  [{label:7s}] {status}")
+        if status == "OK" and err != 0:
+            overall_ok = False
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (B) — generic COO matvec, int64 and f64
+    # ------------------------------------------------------------- #
+    print("--- Graph (B): generic COO matvec  y = ScatterND_add(0, rows, vals·x[cols]) ---")
+    rows = d0_coo.row.astype(np.int64)
+    cols = d0_coo.col.astype(np.int64)
+    for label, etype, x, vals, y_ref in [
+        ("int64", TensorProto.INT64, phi_i64,
+         d0_coo.data.astype(np.int64), g_ref_i64),
+        ("float64", TensorProto.DOUBLE, phi_f64,
+         d0_coo.data.astype(np.float64),
+         np.asarray(d0.astype(np.float64) @ phi_f64)),
+    ]:
+        try:
+            model = build_coo_matvec_graph(n_edges, n_nodes, int(d0.nnz), etype)
+            (y_onnx,) = _check_and_run(
+                model, ["y"], {"x": x, "rows": rows, "cols": cols, "vals": vals}
+            )
+            err = int(np.max(np.abs(y_onnx - y_ref))) if label == "int64" \
+                else float(np.max(np.abs(y_onnx - y_ref)))
+            status = "OK"
+        except Exception as e:  # noqa: BLE001
+            status, err = f"FAIL ({e!r})", float("nan")
+            overall_ok = False
+        print(f"  [{label:7s}] checker+runtime: {status}   "
+              f"max |y_onnx - y_ref| = {err:.3e}" if status == "OK"
+              else f"  [{label:7s}] {status}")
+        if status == "OK" and err != 0:
+            overall_ok = False
+    print()
+
+    # ------------------------------------------------------------- #
+    # Operator inventory + verdict
+    # ------------------------------------------------------------- #
+    print("Operator inventory for d⁰ application:")
+    print("--------------------------------------------------------------")
+    print("  Gather (axis=0/1, int64+f64)      EMITTABLE  native opset 18")
+    print("  Sub (int64, f64)                  EMITTABLE  native opset 18")
+    print("  Mul (int64, f64)                  EMITTABLE  native opset 18")
+    print("  Unsqueeze / Constant              EMITTABLE  native opset 18")
+    print("  ConstantOfShape (int64/f64 fill)  EMITTABLE  native opset 18")
+    print("  ScatterND reduction='add' (int64) EMITTABLE  native opset 18")
+    print()
+    print("Construction boundary (NOT probed here — inherited from G.6):")
+    print("  build_edges (dedup + inverse map) BLOCKED    host-side; see")
+    print("    reference/onnx/audit/sphere_pec/probe_edge_enumeration.py")
+    print()
+    if overall_ok:
+        print("Verdict: d⁰ APPLICATION is GRAPH-PURE (emittable).")
+        print("  Both the structured two-Gather form and the generic COO matvec")
+        print("  lower to opset 18 and reproduce the NumPy/scipy reference")
+        print("  bit-exactly in int64 (the #149 contract dtype) and f64.")
+        print("  Construction stays host-side; the edge table (or COO triplets)")
+        print("  crosses the L4-input boundary as plain int64 tensors.")
+    else:
+        print("Verdict: FAILED — see errors above; audit table is stale.")
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/derham/probe_d1_apply.py
+++ b/reference/onnx/audit/derham/probe_d1_apply.py
@@ -1,0 +1,367 @@
+"""Probe: ONNX expressibility of d¹ *application* (discrete curl matvec).
+
+Epic #88, Phase I.3 (issue #169). Companion to ``probe_d0_apply.py``:
+asks whether **applying** the discrete curl ``d¹`` to an edge field —
+``c = d¹ · v`` — is graph-pure under opset 18, given that the
+**construction** of ``d¹`` (face dedup via ``np.unique(..., axis=0)``
+plus the ``edge_to_idx`` dict lookup in
+``reference/numpy/derham.py::curl_map``) is host-side, by the same
+friction class as the G.6 ``build_edges`` finding.
+
+The construction/application split
+==================================
+
+``d¹`` is an ``(n_faces, n_edges)`` signed ``{-1, +1}`` incidence
+matrix with exactly three nonzeros per row (face ``[a, b, c]``,
+``a < b < c``, boundary cycle ``a → b → c → a``):
+
+    d¹[face, edge(a, b)] = +1
+    d¹[face, edge(b, c)] = +1
+    d¹[face, edge(a, c)] = -1
+
+Constructing the column indices needs ``build_faces`` (row dedup —
+data-dependent shape) and the ``edge_to_idx`` hash map (no ONNX
+equivalent). Both are host-side. But once the host hands the graph a
+``face_edge_idx (n_faces, 3) int64`` table (columns ordered
+``[edge(a,b), edge(b,c), edge(a,c)]``) — or the raw COO triplets —
+application is three Gathers and two adds:
+
+    c = v[face_edge_idx[:, 0]] + v[face_edge_idx[:, 1]]
+        - v[face_edge_idx[:, 2]]
+
+Strategy: three sub-probes
+==========================
+
+(A) **Structured incidence form** — three scalar-index Gathers on the
+    host-provided ``face_edge_idx`` table, Add + Sub. int64 + f64.
+
+(B) **Generic COO sparse matvec** — same builder shape as the d⁰
+    probe: ``ScatterND_add(zeros(n_faces), rows, data · v[cols])``
+    consuming the COO triplets of ``curl_map`` as graph inputs.
+
+(C) **d² via the same generic builder** — the COO matvec is operator-
+    agnostic, so the divergence ``d² · w`` (4 nnz per row, signs
+    ``(-1)^k · sign_k`` from host-side ``build_tet_faces``) runs
+    through the *identical* graph builder with different inputs. This
+    extends the application verdict to the full d-chain without a
+    third probe file.
+
+Run
+===
+
+    python3 reference/onnx/audit/derham/probe_d1_apply.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from derham import (  # noqa: E402
+    build_edges,
+    build_faces,
+    curl_map,
+    divergence_map,
+)
+
+OPSET = 18
+
+DTYPE_MAP = {
+    np.dtype("float64"): TensorProto.DOUBLE,
+    np.dtype("int64"): TensorProto.INT64,
+    np.dtype("int32"): TensorProto.INT32,
+}
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=DTYPE_MAP[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def host_face_edge_idx(edges: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    """HOST-SIDE: per-face edge-index table, columns [e_ab, e_bc, e_ac].
+
+    This is the dict-lookup step from ``curl_map`` — the part of d¹
+    construction that has no ONNX lowering (hash-map inverse of the
+    deduplicated edge table). It runs in NumPy/Python and its output
+    crosses the L4-input boundary as a plain int64 tensor.
+    """
+    edge_to_idx = {
+        (int(edges[i, 0]), int(edges[i, 1])): i for i in range(edges.shape[0])
+    }
+    n_faces = faces.shape[0]
+    fei = np.empty((n_faces, 3), dtype=np.int64)
+    for f in range(n_faces):
+        a, b, c = int(faces[f, 0]), int(faces[f, 1]), int(faces[f, 2])
+        fei[f, 0] = edge_to_idx[(a, b)]
+        fei[f, 1] = edge_to_idx[(b, c)]
+        fei[f, 2] = edge_to_idx[(a, c)]
+    return fei
+
+
+def build_structured_d1_graph(
+    n_edges: int, n_faces: int, elem_type: int
+) -> onnx.ModelProto:
+    """Graph (A) — structured incidence form of ``c = d¹ · v``.
+
+    Inputs:  v (n_edges,) elem_type, face_edge_idx (n_faces, 3) int64
+    Output:  c (n_faces,) elem_type — per-face ``v[e_ab] + v[e_bc] - v[e_ac]``.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    v_vi = oh.make_tensor_value_info("v", elem_type, [n_edges])
+    fei_vi = oh.make_tensor_value_info(
+        "face_edge_idx", TensorProto.INT64, [n_faces, 3]
+    )
+
+    for k, name in [(0, "idx_ab"), (1, "idx_bc"), (2, "idx_ac")]:
+        nodes.append(_const(f"col{k}", np.array(k, dtype=np.int64)))
+        nodes.append(oh.make_node(
+            "Gather", ["face_edge_idx", f"col{k}"], [name], axis=1
+        ))
+    nodes.append(oh.make_node("Gather", ["v", "idx_ab"], ["v_ab"], axis=0))
+    nodes.append(oh.make_node("Gather", ["v", "idx_bc"], ["v_bc"], axis=0))
+    nodes.append(oh.make_node("Gather", ["v", "idx_ac"], ["v_ac"], axis=0))
+
+    nodes.append(oh.make_node("Add", ["v_ab", "v_bc"], ["v_sum"]))
+    nodes.append(oh.make_node("Sub", ["v_sum", "v_ac"], ["c"]))
+
+    c_vi = oh.make_tensor_value_info("c", elem_type, [n_faces])
+    graph = oh.make_graph(
+        nodes,
+        name="d1_apply_structured",
+        inputs=[v_vi, fei_vi],
+        outputs=[c_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def build_coo_matvec_graph(
+    n_rows: int, n_cols: int, nnz: int, elem_type: int
+) -> onnx.ModelProto:
+    """Graph (B)/(C) — generic COO sparse matvec ``y = A · x``.
+
+    Identical builder to ``probe_d0_apply.py``; duplicated so each
+    probe stays self-contained (existing audit convention).
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    x_vi = oh.make_tensor_value_info("x", elem_type, [n_cols])
+    rows_vi = oh.make_tensor_value_info("rows", TensorProto.INT64, [nnz])
+    cols_vi = oh.make_tensor_value_info("cols", TensorProto.INT64, [nnz])
+    vals_vi = oh.make_tensor_value_info("vals", elem_type, [nnz])
+
+    nodes.append(oh.make_node("Gather", ["x", "cols"], ["x_at_cols"], axis=0))
+    nodes.append(oh.make_node("Mul", ["vals", "x_at_cols"], ["updates"]))
+
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows", "ax_neg1"], ["indices"]))
+
+    zero_fill = (
+        oh.make_tensor("z", TensorProto.INT64, [1], [0])
+        if elem_type == TensorProto.INT64
+        else oh.make_tensor("z", TensorProto.DOUBLE, [1], [0.0])
+    )
+    nodes.append(_const("shape_rows", np.array([n_rows], dtype=np.int64)))
+    nodes.append(oh.make_node(
+        "ConstantOfShape",
+        inputs=["shape_rows"],
+        outputs=["zero_buf"],
+        value=zero_fill,
+    ))
+    nodes.append(oh.make_node(
+        "ScatterND",
+        inputs=["zero_buf", "indices", "updates"],
+        outputs=["y"],
+        reduction="add",
+    ))
+
+    y_vi = oh.make_tensor_value_info("y", elem_type, [n_rows])
+    graph = oh.make_graph(
+        nodes,
+        name="coo_matvec",
+        inputs=[x_vi, rows_vi, cols_vi, vals_vi],
+        outputs=[y_vi],
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def _check_and_run(model, output_names, feeds):
+    onnx.checker.check_model(model)
+    sess = ort.InferenceSession(model.SerializeToString())
+    return sess.run(output_names, feeds)
+
+
+def _run_coo_cases(title, sp_mat, x_i64, x_f64):
+    """Run the generic COO matvec graph (int64 + f64) for a scipy CSR."""
+    coo = sp_mat.tocoo()
+    rows = coo.row.astype(np.int64)
+    cols = coo.col.astype(np.int64)
+    n_rows, n_cols = sp_mat.shape
+    nnz = int(sp_mat.nnz)
+    ok = True
+    print(title)
+    for label, etype, x, vals, y_ref in [
+        ("int64", TensorProto.INT64, x_i64,
+         coo.data.astype(np.int64), np.asarray(sp_mat @ x_i64, dtype=np.int64)),
+        ("float64", TensorProto.DOUBLE, x_f64,
+         coo.data.astype(np.float64),
+         np.asarray(sp_mat.astype(np.float64) @ x_f64)),
+    ]:
+        try:
+            model = build_coo_matvec_graph(n_rows, n_cols, nnz, etype)
+            (y_onnx,) = _check_and_run(
+                model, ["y"], {"x": x, "rows": rows, "cols": cols, "vals": vals}
+            )
+            err = float(np.max(np.abs(y_onnx - y_ref)))
+            status = "OK"
+        except Exception as e:  # noqa: BLE001
+            status, err = f"FAIL ({e!r})", float("nan")
+            ok = False
+        print(f"  [{label:7s}] checker+runtime: {status}   "
+              f"max |y_onnx - y_ref| = {err:.3e}" if status == "OK"
+              else f"  [{label:7s}] {status}")
+        if status == "OK" and err != 0:
+            ok = False
+    print()
+    return ok
+
+
+def main() -> int:
+    print("== Probe: d¹ application (discrete curl matvec) — Phase I.3 ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # Tiny test mesh: 2 tets sharing a face — same as the G.6/H.5 probes.
+    tets_np = np.array(
+        [[0, 1, 2, 3],
+         [1, 2, 3, 4]],
+        dtype=np.int64,
+    )
+
+    # HOST-SIDE construction: edge/face dedup + dict inverse maps.
+    edges = build_edges(tets_np)
+    faces = build_faces(tets_np)
+    n_edges = int(edges.shape[0])
+    n_faces = int(faces.shape[0])
+    d1 = curl_map(edges, faces)            # (n_faces, n_edges), int64
+    d2 = divergence_map(tets_np, faces)    # (n_tets, n_faces), int64
+    face_edge_idx = host_face_edge_idx(edges, faces)
+    print(f"Test mesh: n_tets={tets_np.shape[0]}, n_edges={n_edges}, "
+          f"n_faces={n_faces}, d1 nnz={d1.nnz}, d2 nnz={d2.nnz}")
+    print()
+
+    rng = np.random.default_rng(42)
+    v_i64 = rng.integers(-1000, 1000, size=n_edges).astype(np.int64)
+    v_f64 = rng.standard_normal(n_edges).astype(np.float64)
+    w_i64 = rng.integers(-1000, 1000, size=n_faces).astype(np.int64)
+    w_f64 = rng.standard_normal(n_faces).astype(np.float64)
+
+    overall_ok = True
+
+    # ------------------------------------------------------------- #
+    # Graph (A) — structured incidence form, int64 and f64
+    # ------------------------------------------------------------- #
+    print("--- Graph (A): structured form  c = v[e_ab] + v[e_bc] - v[e_ac] ---")
+    c_ref_i64 = np.asarray(d1 @ v_i64, dtype=np.int64)
+    c_ref_f64 = (
+        v_f64[face_edge_idx[:, 0]]
+        + v_f64[face_edge_idx[:, 1]]
+        - v_f64[face_edge_idx[:, 2]]
+    )
+    for label, etype, v, c_ref in [
+        ("int64", TensorProto.INT64, v_i64, c_ref_i64),
+        ("float64", TensorProto.DOUBLE, v_f64, c_ref_f64),
+    ]:
+        try:
+            model = build_structured_d1_graph(n_edges, n_faces, etype)
+            (c_onnx,) = _check_and_run(
+                model, ["c"], {"v": v, "face_edge_idx": face_edge_idx}
+            )
+            err = float(np.max(np.abs(c_onnx - c_ref)))
+            status = "OK"
+        except Exception as e:  # noqa: BLE001
+            status, err = f"FAIL ({e!r})", float("nan")
+            overall_ok = False
+        print(f"  [{label:7s}] checker+runtime: {status}   "
+              f"max |c_onnx - c_ref| = {err:.3e}" if status == "OK"
+              else f"  [{label:7s}] {status}")
+        if status == "OK" and err != 0:
+            overall_ok = False
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (B) — generic COO matvec on d¹
+    # ------------------------------------------------------------- #
+    overall_ok &= _run_coo_cases(
+        "--- Graph (B): generic COO matvec on d¹ (curl) ---",
+        d1, v_i64, v_f64,
+    )
+
+    # ------------------------------------------------------------- #
+    # Graph (C) — the SAME generic builder applied to d² (divergence)
+    # ------------------------------------------------------------- #
+    overall_ok &= _run_coo_cases(
+        "--- Graph (C): identical COO matvec builder on d² (divergence) ---",
+        d2, w_i64, w_f64,
+    )
+
+    # ------------------------------------------------------------- #
+    # Operator inventory + verdict
+    # ------------------------------------------------------------- #
+    print("Operator inventory for d¹ / d² application:")
+    print("--------------------------------------------------------------")
+    print("  Gather (axis=0/1, int64+f64)      EMITTABLE  native opset 18")
+    print("  Add / Sub / Mul (int64, f64)      EMITTABLE  native opset 18")
+    print("  ConstantOfShape (int64/f64 fill)  EMITTABLE  native opset 18")
+    print("  ScatterND reduction='add' (int64) EMITTABLE  native opset 18")
+    print()
+    print("Construction boundary (NOT probed here — host-side by the G.6")
+    print("friction class):")
+    print("  build_faces (np.unique axis=0)    BLOCKED    data-dependent n_faces")
+    print("  edge_to_idx / face_to_idx dicts   BLOCKED    no hash-map / sorted-")
+    print("                                               unique-inverse op")
+    print("  build_tet_faces parity signs      BLOCKED    consumes the dict above")
+    print()
+    if overall_ok:
+        print("Verdict: d¹ (and d²) APPLICATION is GRAPH-PURE (emittable).")
+        print("  The structured three-Gather form and the operator-agnostic COO")
+        print("  matvec both lower to opset 18 and match scipy bit-exactly in")
+        print("  int64 and f64. The same builder served d¹ and d² unchanged —")
+        print("  application expressibility is a property of the COO input")
+        print("  contract, not of any particular d-operator.")
+    else:
+        print("Verdict: FAILED — see errors above; audit table is stale.")
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/derham/probe_exactness_in_graph.py
+++ b/reference/onnx/audit/derham/probe_exactness_in_graph.py
@@ -1,0 +1,405 @@
+"""Probe: in-graph de Rham exactness ``d¹ · (d⁰ · φ) ≡ 0`` (sphere fixture).
+
+Epic #88, Phase I.3 (issue #169), Deliverable 3. Builds a **single**
+ONNX opset-18 graph that applies d⁰ then d¹ to a nodal field and
+asserts the exactness identity ``d¹ ∘ d⁰ ≡ 0`` *inside the graph*,
+then executes it under onnxruntime against the bundled sphere fixture
+(``reference/fixtures/sphere_pec/sphere.msh``) — the same mesh behind
+the #149 baseline (``reference/fixtures/derham/baseline.json``,
+fixture_id ``derham/sphere_n774_d0_d1_d2``).
+
+Graph design
+============
+
+Host-side (the L4-input boundary, never in the graph):
+  - ``build_edges`` / ``build_faces`` — dedup + ordering (G.6 verdict)
+  - ``face_edge_idx (n_faces, 3) int64`` — the edge_to_idx dict lookup
+
+In-graph (all native opset 18, int64):
+
+    g        = Gather(φ, edges[:, 1]) - Gather(φ, edges[:, 0])   # d⁰·φ
+    r        = g[fei[:, 0]] + g[fei[:, 1]] - g[fei[:, 2]]        # d¹·g
+    max_abs  = ReduceMax(Abs(r))                                  # scalar
+    exact    = Equal(max_abs, 0)                                  # BOOL
+
+The graph *outputs* the boolean ``exact`` — the assertion itself is a
+graph node, not a host-side comparison. The host merely reads it.
+
+A second composed graph runs the same chain through the **generic COO
+matvec** form (two ScatterND(reduction="add") stages consuming the
+COO triplets of ``gradient_map`` / ``curl_map`` as graph inputs),
+confirming the operator-agnostic input contract composes.
+
+dtype note (why int64, not f64)
+===============================
+
+The d-operators are integer ``{-1, 0, +1}`` matrices and the #149
+exactness contract is **bit-exact at the integer level**. In int64
+the in-graph identity holds exactly (integer adds are associative).
+In f64, ``g = fl(φ_b − φ_a)`` is already rounded, so the telescoping
+sum ``g_ab + g_bc − g_ac`` is only zero to roundoff — this probe also
+runs the f64 variant and reports the measured residual to document
+that the *in-graph assert* must use an integer dtype.
+
+Run
+===
+
+    python3 reference/onnx/audit/derham/probe_exactness_in_graph.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from derham import (  # noqa: E402
+    _read_msh_tets,
+    build_edges,
+    build_faces,
+    curl_map,
+    gradient_map,
+)
+
+OPSET = 18
+MESH_PATH = REFERENCE_ROOT / "fixtures" / "sphere_pec" / "sphere.msh"
+BASELINE_PATH = REFERENCE_ROOT / "fixtures" / "derham" / "baseline.json"
+
+DTYPE_MAP = {
+    np.dtype("float64"): TensorProto.DOUBLE,
+    np.dtype("int64"): TensorProto.INT64,
+    np.dtype("int32"): TensorProto.INT32,
+}
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=DTYPE_MAP[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def build_structured_exactness_graph(
+    n_nodes: int, n_edges: int, n_faces: int, elem_type: int
+) -> onnx.ModelProto:
+    """Composed structured graph: φ → d⁰·φ → d¹·(d⁰·φ) → in-graph zero check.
+
+    Inputs:  phi (n_nodes,) elem_type,
+             edges (n_edges, 2) int64,
+             face_edge_idx (n_faces, 3) int64
+    Outputs: residual (n_faces,) elem_type,
+             max_abs () elem_type,
+             exact () BOOL — the in-graph assertion d¹∘d⁰ ≡ 0.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    phi_vi = oh.make_tensor_value_info("phi", elem_type, [n_nodes])
+    edges_vi = oh.make_tensor_value_info("edges", TensorProto.INT64, [n_edges, 2])
+    fei_vi = oh.make_tensor_value_info(
+        "face_edge_idx", TensorProto.INT64, [n_faces, 3]
+    )
+
+    # --- d⁰ · φ (structured: two Gathers + Sub) ---
+    nodes.append(_const("e_col0", np.array(0, dtype=np.int64)))
+    nodes.append(_const("e_col1", np.array(1, dtype=np.int64)))
+    nodes.append(oh.make_node("Gather", ["edges", "e_col0"], ["tail_idx"], axis=1))
+    nodes.append(oh.make_node("Gather", ["edges", "e_col1"], ["head_idx"], axis=1))
+    nodes.append(oh.make_node("Gather", ["phi", "head_idx"], ["phi_head"], axis=0))
+    nodes.append(oh.make_node("Gather", ["phi", "tail_idx"], ["phi_tail"], axis=0))
+    nodes.append(oh.make_node("Sub", ["phi_head", "phi_tail"], ["g"]))
+
+    # --- d¹ · g (structured: three Gathers + Add + Sub) ---
+    for k, name in [(0, "idx_ab"), (1, "idx_bc"), (2, "idx_ac")]:
+        nodes.append(_const(f"f_col{k}", np.array(k, dtype=np.int64)))
+        nodes.append(oh.make_node(
+            "Gather", ["face_edge_idx", f"f_col{k}"], [name], axis=1
+        ))
+    nodes.append(oh.make_node("Gather", ["g", "idx_ab"], ["g_ab"], axis=0))
+    nodes.append(oh.make_node("Gather", ["g", "idx_bc"], ["g_bc"], axis=0))
+    nodes.append(oh.make_node("Gather", ["g", "idx_ac"], ["g_ac"], axis=0))
+    nodes.append(oh.make_node("Add", ["g_ab", "g_bc"], ["g_sum"]))
+    nodes.append(oh.make_node("Sub", ["g_sum", "g_ac"], ["residual"]))
+
+    # --- In-graph zero assertion ---
+    nodes.append(oh.make_node("Abs", ["residual"], ["abs_residual"]))
+    nodes.append(oh.make_node(
+        "ReduceMax", ["abs_residual"], ["max_abs"], keepdims=0
+    ))
+    zero = (
+        np.array(0, dtype=np.int64)
+        if elem_type == TensorProto.INT64
+        else np.array(0.0, dtype=np.float64)
+    )
+    nodes.append(_const("zero_scalar", zero))
+    nodes.append(oh.make_node("Equal", ["max_abs", "zero_scalar"], ["exact"]))
+
+    outputs = [
+        oh.make_tensor_value_info("residual", elem_type, [n_faces]),
+        oh.make_tensor_value_info("max_abs", elem_type, []),
+        oh.make_tensor_value_info("exact", TensorProto.BOOL, []),
+    ]
+    graph = oh.make_graph(
+        nodes,
+        name="derham_exactness_structured",
+        inputs=[phi_vi, edges_vi, fei_vi],
+        outputs=outputs,
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def build_coo_exactness_graph(
+    n_nodes: int, n_edges: int, n_faces: int,
+    nnz_d0: int, nnz_d1: int,
+) -> onnx.ModelProto:
+    """Composed COO-matvec graph (int64): two chained sparse matvecs.
+
+    Inputs:  phi (n_nodes,) int64,
+             d0_rows/d0_cols (nnz_d0,) int64, d0_vals (nnz_d0,) int64,
+             d1_rows/d1_cols (nnz_d1,) int64, d1_vals (nnz_d1,) int64
+    Outputs: max_abs () int64, exact () BOOL.
+
+    This is the operator-agnostic form: the d-matrices arrive as
+    pre-assembled host COO triplets, the same input-contract shape as
+    the Phase G.7 edge tables.
+    """
+    nodes: list[onnx.NodeProto] = []
+    et = TensorProto.INT64
+
+    inputs = [
+        oh.make_tensor_value_info("phi", et, [n_nodes]),
+        oh.make_tensor_value_info("d0_rows", et, [nnz_d0]),
+        oh.make_tensor_value_info("d0_cols", et, [nnz_d0]),
+        oh.make_tensor_value_info("d0_vals", et, [nnz_d0]),
+        oh.make_tensor_value_info("d1_rows", et, [nnz_d1]),
+        oh.make_tensor_value_info("d1_cols", et, [nnz_d1]),
+        oh.make_tensor_value_info("d1_vals", et, [nnz_d1]),
+    ]
+
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    zero_fill = oh.make_tensor("z", TensorProto.INT64, [1], [0])
+
+    def coo_matvec(tag: str, x: str, n_rows: int, y: str) -> None:
+        nodes.append(oh.make_node(
+            "Gather", [x, f"{tag}_cols"], [f"{tag}_x_at_cols"], axis=0
+        ))
+        nodes.append(oh.make_node(
+            "Mul", [f"{tag}_vals", f"{tag}_x_at_cols"], [f"{tag}_updates"]
+        ))
+        nodes.append(oh.make_node(
+            "Unsqueeze", [f"{tag}_rows", "ax_neg1"], [f"{tag}_indices"]
+        ))
+        nodes.append(_const(
+            f"{tag}_shape", np.array([n_rows], dtype=np.int64)
+        ))
+        nodes.append(oh.make_node(
+            "ConstantOfShape",
+            inputs=[f"{tag}_shape"],
+            outputs=[f"{tag}_zero"],
+            value=zero_fill,
+        ))
+        nodes.append(oh.make_node(
+            "ScatterND",
+            inputs=[f"{tag}_zero", f"{tag}_indices", f"{tag}_updates"],
+            outputs=[y],
+            reduction="add",
+        ))
+
+    coo_matvec("d0", "phi", n_edges, "g")      # g = d⁰ · φ
+    coo_matvec("d1", "g", n_faces, "residual")  # r = d¹ · g
+
+    nodes.append(oh.make_node("Abs", ["residual"], ["abs_residual"]))
+    nodes.append(oh.make_node(
+        "ReduceMax", ["abs_residual"], ["max_abs"], keepdims=0
+    ))
+    nodes.append(_const("zero_scalar", np.array(0, dtype=np.int64)))
+    nodes.append(oh.make_node("Equal", ["max_abs", "zero_scalar"], ["exact"]))
+
+    outputs = [
+        oh.make_tensor_value_info("max_abs", et, []),
+        oh.make_tensor_value_info("exact", TensorProto.BOOL, []),
+    ]
+    graph = oh.make_graph(
+        nodes,
+        name="derham_exactness_coo",
+        inputs=inputs,
+        outputs=outputs,
+    )
+    return oh.make_model(
+        graph,
+        opset_imports=[oh.make_opsetid("", OPSET)],
+        ir_version=9,
+    )
+
+
+def host_face_edge_idx(edges: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    """HOST-SIDE dict lookup — see probe_d1_apply.py for the rationale."""
+    edge_to_idx = {
+        (int(edges[i, 0]), int(edges[i, 1])): i for i in range(edges.shape[0])
+    }
+    n_faces = faces.shape[0]
+    fei = np.empty((n_faces, 3), dtype=np.int64)
+    for f in range(n_faces):
+        a, b, c = int(faces[f, 0]), int(faces[f, 1]), int(faces[f, 2])
+        fei[f, 0] = edge_to_idx[(a, b)]
+        fei[f, 1] = edge_to_idx[(b, c)]
+        fei[f, 2] = edge_to_idx[(a, c)]
+    return fei
+
+
+def _baseline_scalar(baseline: dict, key: str) -> int:
+    return int(round(baseline["outputs"][key]["data"][0]))
+
+
+def main() -> int:
+    print("== Probe: in-graph exactness d¹·(d⁰·φ) ≡ 0 on the sphere fixture ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Host-side: load fixture, build topology, cross-check vs #149
+    # ------------------------------------------------------------- #
+    nodes_xyz, tets = _read_msh_tets(MESH_PATH)
+    n_nodes = int(nodes_xyz.shape[0])
+    n_tets = int(tets.shape[0])
+    edges = build_edges(tets)
+    faces = build_faces(tets)
+    n_edges = int(edges.shape[0])
+    n_faces = int(faces.shape[0])
+    face_edge_idx = host_face_edge_idx(edges, faces)
+    d0 = gradient_map(n_nodes, edges)
+    d1 = curl_map(edges, faces)
+
+    print(f"fixture: {MESH_PATH.relative_to(REFERENCE_ROOT.parent)}")
+    print(f"  n_nodes={n_nodes}, n_edges={n_edges}, n_faces={n_faces}, "
+          f"n_tets={n_tets}")
+
+    with BASELINE_PATH.open() as fh:
+        baseline = json.load(fh)
+    baseline_ok = (
+        baseline["fixture_id"] == "derham/sphere_n774_d0_d1_d2"
+        and _baseline_scalar(baseline, "n_nodes") == n_nodes
+        and _baseline_scalar(baseline, "n_edges") == n_edges
+        and _baseline_scalar(baseline, "n_faces") == n_faces
+        and _baseline_scalar(baseline, "n_tets") == n_tets
+    )
+    print(f"  #149 baseline cross-check ({baseline['fixture_id']}): "
+          f"{'MATCH' if baseline_ok else 'MISMATCH'}")
+    print()
+
+    rng = np.random.default_rng(2026)
+    phi_i64 = rng.integers(-10**6, 10**6, size=n_nodes).astype(np.int64)
+    phi_f64 = rng.standard_normal(n_nodes).astype(np.float64)
+
+    overall_ok = baseline_ok
+
+    # ------------------------------------------------------------- #
+    # Graph 1 — structured composed chain, int64 (the in-graph assert)
+    # ------------------------------------------------------------- #
+    print("--- Graph 1: structured d¹∘d⁰ chain, int64, in-graph Equal-zero ---")
+    model = build_structured_exactness_graph(
+        n_nodes, n_edges, n_faces, TensorProto.INT64
+    )
+    onnx.checker.check_model(model)
+    sess = ort.InferenceSession(model.SerializeToString())
+    residual, max_abs, exact = sess.run(
+        ["residual", "max_abs", "exact"],
+        {"phi": phi_i64, "edges": edges, "face_edge_idx": face_edge_idx},
+    )
+    print(f"  in-graph max|d¹·(d⁰·φ)| = {int(max_abs)}")
+    print(f"  in-graph exactness bool  = {bool(exact)}")
+    # Host-side scipy cross-check of the same residual.
+    r_scipy = np.asarray((d1 @ (d0 @ phi_i64)), dtype=np.int64)
+    scipy_match = bool(np.array_equal(residual, r_scipy))
+    print(f"  residual vs scipy d1@(d0@φ): {'bit-exact' if scipy_match else 'MISMATCH'}")
+    if not (bool(exact) and int(max_abs) == 0 and scipy_match):
+        overall_ok = False
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph 2 — composed COO-matvec chain, int64 (operator-agnostic)
+    # ------------------------------------------------------------- #
+    print("--- Graph 2: composed COO matvec chain (ScatterND × 2), int64 ---")
+    d0_coo, d1_coo = d0.tocoo(), d1.tocoo()
+    model2 = build_coo_exactness_graph(
+        n_nodes, n_edges, n_faces, int(d0.nnz), int(d1.nnz)
+    )
+    onnx.checker.check_model(model2)
+    sess2 = ort.InferenceSession(model2.SerializeToString())
+    max_abs2, exact2 = sess2.run(
+        ["max_abs", "exact"],
+        {
+            "phi": phi_i64,
+            "d0_rows": d0_coo.row.astype(np.int64),
+            "d0_cols": d0_coo.col.astype(np.int64),
+            "d0_vals": d0_coo.data.astype(np.int64),
+            "d1_rows": d1_coo.row.astype(np.int64),
+            "d1_cols": d1_coo.col.astype(np.int64),
+            "d1_vals": d1_coo.data.astype(np.int64),
+        },
+    )
+    print(f"  in-graph max|d¹·(d⁰·φ)| = {int(max_abs2)}")
+    print(f"  in-graph exactness bool  = {bool(exact2)}")
+    if not (bool(exact2) and int(max_abs2) == 0):
+        overall_ok = False
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph 3 — f64 control: why the in-graph assert is int64
+    # ------------------------------------------------------------- #
+    print("--- Graph 3 (control): structured chain in float64 ---")
+    model3 = build_structured_exactness_graph(
+        n_nodes, n_edges, n_faces, TensorProto.DOUBLE
+    )
+    onnx.checker.check_model(model3)
+    sess3 = ort.InferenceSession(model3.SerializeToString())
+    _, max_abs3, exact3 = sess3.run(
+        ["residual", "max_abs", "exact"],
+        {"phi": phi_f64, "edges": edges, "face_edge_idx": face_edge_idx},
+    )
+    print(f"  f64 max|d¹·(d⁰·φ)| = {float(max_abs3):.3e}   "
+          f"(roundoff in g = fl(φ_b − φ_a); not an ONNX defect)")
+    print(f"  f64 Equal-zero bool = {bool(exact3)}")
+    print("  → the bit-exact in-graph assert requires the int64 channel;")
+    print("    f64 exactness only holds to roundoff, as in any backend.")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Verdict
+    # ------------------------------------------------------------- #
+    if overall_ok:
+        print("Verdict: d¹∘d⁰ ≡ 0 holds IN-GRAPH under onnxruntime, bit-exactly,")
+        print("  on the full bundled sphere fixture (774 nodes / 4512 edges /")
+        print("  7074 faces), in both the structured-incidence form and the")
+        print("  operator-agnostic COO-matvec form. The exactness identity of")
+        print("  the discrete de Rham complex survives the lowering to a pure")
+        print("  opset-18 graph — only the topology tables cross the host")
+        print("  boundary.")
+    else:
+        print("Verdict: FAILED — see above; audit table is stale.")
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #169

## Summary

ONNX opset-18 expressibility audit for the discrete de Rham chain (d⁰/d¹/d²), splitting **construction** from **application** per the issue scope. Mirrors the F.1 / G.6 / H.5 audit pattern; pinned versions unchanged (`onnx==1.21.0`, `onnxruntime==1.26.0`, opset 18).

**Verdicts**

- **Construction — BLOCKED (host-side), all four stages.** `build_edges`, `build_faces`, the `edge_to_idx`/`face_to_idx` inverse maps, and `build_tet_faces` all fail on the *same two ops* as the G.6 `build_edges` finding: row-dedup with data-dependent output shape and hash-map inverse lookup. The "topology belongs at the L4-input boundary" rule generalizes to the full d-chain — it is not a Nédélec one-off.
- **Application — EMITTABLE (graph-pure), all stages.** Both the structured incidence form (Gather + Add/Sub on host index tables) and an operator-agnostic COO matvec (Gather + Mul + ConstantOfShape + ScatterND(add)) lower cleanly and match scipy **bit-exactly** in int64 and f64. The identical COO builder serves d⁰, d¹, and d² unmodified.
- **In-graph exactness — d¹·(d⁰·φ) ≡ 0 holds in-graph** under onnxruntime on the full bundled sphere fixture (774 nodes / 4512 edges / 7074 faces, cross-checked against the #149 baseline), with the zero-assert emitted as a graph node (`Abs` → `ReduceMax` → `Equal`) in both the structured and the composed ScatterND×2 forms.

**Notable findings**

- int64 is a first-class opset-18 citizen end-to-end (including `ScatterND(reduction="add")` and int64 `ConstantOfShape` fill) — the mirror image of the H.5 c128 vestigial-type finding. The #149 bit-exact integer contract transfers into the graph unchanged.
- f64 control: the composed residual is `8.9e-16`, not zero — `fl(φ_b − φ_a)` rounding breaks the telescoping cancellation in any backend. The in-graph exactness assert must use the integer channel; documented as a spec-implication for conformance-test wording.

## Deliverables

- `reference/onnx/audit/derham/derham_operator_audit.md` — per-stage verdicts, pinned-versions table (H.5 format), spec-implication section
- `reference/onnx/audit/derham/probe_d0_apply.py` — d⁰ apply, structured + COO forms, int64 + f64
- `reference/onnx/audit/derham/probe_d1_apply.py` — d¹ apply, plus d² through the identical COO builder
- `reference/onnx/audit/derham/probe_exactness_in_graph.py` — composed in-graph d¹∘d⁰ ≡ 0 on the sphere fixture vs. the #149 baseline

## Test plan

- [x] All three probes run green (exit 0) under `onnx==1.21.0` / `onnxruntime==1.26.0` / opset 18
- [x] All application checks bit-exact (`0.000e+00`) vs. scipy in int64 and f64
- [x] In-graph `exact` bool is `True` on the full sphere fixture; #149 baseline cell counts MATCH
- [x] No Rust changes (audit-only; nothing outside `reference/onnx/audit/derham/` touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)