### PR TITLE
feat: Phase J.6 — ONNX Mie expressibility audit (Epic #88, #175)

### DIFF
--- a/reference/onnx/audit/sphere_mie/mie_operator_audit.md
+++ b/reference/onnx/audit/sphere_mie/mie_operator_audit.md
@@ -400,11 +400,15 @@ python3 audit/sphere_mie/probe_root_finding_loop.py
 ```
 
 Each probe prints a one-screen verdict block and exits nonzero if any
-check fails. The probes' captured runtime errors (the c128 `Mul`
-rejection; the f64 `Cos` `NOT_IMPLEMENTED`) are the load-bearing
-freshness signals: if a future onnxruntime registers those kernels,
-the corresponding fallback rows collapse to emittable and this audit
-is stale — re-audit.
+check fails. The probes' expected-failure controls are the load-bearing
+freshness signals: the tensor probe's graph (A) asserts the c128 `Mul`
+rejection, and the root-finding probe's native f64 `Cos` control
+asserts the `NOT_IMPLEMENTED` session-create failure behind the
+`Sin(x+π/2)` fallback. If a future onnxruntime registers either
+kernel, the corresponding probe exits nonzero, the fallback row
+collapses to emittable, and this audit is stale — re-audit. (f64
+`Tan`/`Atan` are likewise missing but unused by the pipeline, so they
+carry no control.)
 
 ## Acknowledgements / cross-references
 

--- a/reference/onnx/audit/sphere_mie/mie_operator_audit.md
+++ b/reference/onnx/audit/sphere_mie/mie_operator_audit.md
@@ -1,0 +1,431 @@
+# Mie sphere ONNX expressibility audit (Phase J.6)
+
+Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) Phase J.6
+deliverable. Tracking issue:
+[#175](https://github.com/rjwalters/geode-fem/issues/175).
+
+## Scope
+
+This audit covers the two operator families the Mie slice adds on top
+of the previously audited spines (F.1 cube-cavity, G.6 sphere-PEC,
+H.5 sphere-PML, I.3 de Rham), and records whether each lowers to a
+graph-only ONNX opset-18 form:
+
+1. **Anisotropic UPML tensor-ε construction + complex-symmetric
+   scatter** — as defined by the NumPy reference in
+   [`reference/numpy/sphere_mie.py`](../../../numpy/sphere_mie.py)
+   (`build_anisotropic_pml_tensor_diag`,
+   `batched_nedelec_local_mass_anisotropic_diag`,
+   `assemble_global_nedelec_anisotropic`; issue #171 / PR #179) and the
+   Burn implementation in `crates/geode-core/src/nedelec.rs` /
+   `pml.rs` (issue #54). Expected to inherit the H.5 c128 verdicts;
+   the J.6 question is whether the **paired-real lowering composes
+   cleanly with the diagonal-3×3-per-tet tensor structure** or forces
+   extra reshapes/transposes.
+2. **Analytic Mie root finding** — as defined by
+   [`reference/numpy/mie_roots.py`](../../../numpy/mie_roots.py)
+   (issue #170 / PR #177, mirror of `crates/geode-core/src/mie.rs`):
+   spherical-Bessel characteristic functions, 30 000-interval dense
+   grid scan on (0.1, 20.0], sign-change bracketing with 1e8 pole
+   rejection, 1e-5 consecutive dedup, and 60-step bisection
+   refinement. This is the epic's first **iteration-shaped** primitive
+   to hit the graph-only constraint, audited sub-stage by sub-stage
+   because it bears directly on the whiteroom L4 `iterate-while` /
+   `iterate-while-with-prev` surface.
+
+**Headline findings:**
+
+- The tensor-ε pair-lowering **composes cleanly**: because the UPML
+  stretch enters the mass linearly and the geometric factor is real,
+  the Re/Im channels factor through one shared real per-axis tensor.
+  Cost over the scalar H.5 lowering: two extra `Einsum` contractions
+  and one extra `ScatterND` — **zero** extra reshapes or transposes.
+  Bit-exact (`0.000e+00`) against the NumPy reference end-to-end.
+- The **entire Mie root finder runs as a single ONNX graph** under
+  onnxruntime — grid scan, bracket mask, 60-step bisection (probed
+  both unrolled and as an ONNX `Loop`), the sequential dedup scan
+  (a 30 000-trip `Loop`), and even the final compaction
+  (`NonZero` + `Gather`) — reproducing the J.1 catalogue roots to
+  ~5e-13 relative. But two of those stages only work because
+  onnxruntime tolerates what a static-shape consumer cannot: the
+  dedup is a *sequential* scan (expressible-but-tortured), and the
+  compaction has a **data-dependent output shape** (the G.6
+  `np.unique` friction class). The static-shape disposition is:
+  dense roots + keep-mask in-graph, compaction at the host boundary.
+- **ONNX `Loop` is a working `iterate-while-with-prev`** — see the
+  spec-implications section.
+- **New kernel-coverage finding:** onnxruntime 1.26.0 registers a
+  float64 CPU kernel for `Sin` but **not** for `Cos` (nor `Tan`,
+  `Atan`). An f64 `Cos` node fails at session-create with
+  `NOT_IMPLEMENTED`. Workaround used here: `cos(x) = Sin(x + π/2)`
+  (error ≲ ε·x, far inside the 1e-10 root contract; the alternative
+  f32 round-trip would destroy it).
+
+## Pinned versions used for this audit
+
+Same as Phase F.1 / G.6 / H.5 / I.3:
+
+| Package | Version |
+|---|---|
+| `onnx` | `1.21.0` |
+| `onnxruntime` | `1.26.0` |
+| Target opset | `18` |
+
+See [`reference/onnx/requirements.txt`](../../requirements.txt) for the
+pinned `pip` line. The probes additionally need `scipy` from
+[`reference/numpy/requirements.txt`](../../../numpy/requirements.txt)
+(the root-finding reference uses `scipy.special` + `brentq`).
+
+A throwaway venv reproduces the environment:
+
+```bash
+uv venv /tmp/onnx-audit-175
+uv pip install --python /tmp/onnx-audit-175/bin/python \
+    onnx==1.21.0 onnxruntime==1.26.0 onnxscript==0.7.0 "numpy>=1.26" scipy
+```
+
+## Classification convention
+
+Same as H.5 / I.3 (issue #157 convention):
+
+| Marker | Meaning |
+|---|---|
+| **emittable** | Op lowers directly to opset 18 with no special handling. |
+| **fallback** | Op cannot lower as-typed; a documented alternative lowering exists. |
+| **blocked** | Op has no lowering — must be host-computed and passed as a graph input or executed in an out-of-graph sidecar. |
+
+## Target 1 — anisotropic UPML tensor-ε + complex-symmetric scatter
+
+Probe: [`probe_tensor_eps_ramp.py`](probe_tensor_eps_ramp.py).
+
+### Stage T1 — per-tet centroids (`tet_centroids`)
+
+No probe required: `mean(nodes[tets], axis=1)` is `Gather` +
+`ReduceMean`, the vector form of the H.5 Stage 1 radius computation.
+
+**Stage T1 verdict: EMITTABLE.**
+
+### Stage T2 — tensor-ε ramp (`build_anisotropic_pml_tensor_diag`)
+
+The new arithmetic over the scalar H.5 ramp is the complex UPML
+stretch `s = 1 − jσ/ω` and its reciprocal, applied per Cartesian axis
+through the radial direction `r̂`:
+
+```text
+ε_α = bg · (s⁻¹ r̂_α² + s (1 − r̂_α²)),   bg = n² inside / 1 elsewhere.
+```
+
+| Operator (NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `‖centroids‖` (keepdims) | `Mul` + `ReduceSum(axes=[1], keepdims=1)` + `Sqrt` | **emittable** | The `(n,1)` shape broadcasts against every `(n,3)` tensor below. |
+| Tag selectors, shell gate `r_c > R_PML_INNER` | `Equal` + `Unsqueeze` + `Greater` + `And` | **emittable** | Bool `(n,1)`. |
+| Ramp `u = clip(...)`, `σ = σ₀u²` | `Sub`/`Mul`/`Clip` | **emittable** | Real f64, same as H.5 Stage 2. |
+| **Complex stretch `s`, `1/s`** | `Mul`/`Add`/`Reciprocal`/`Neg` | **emittable (as paired-real)** | `s_re ≡ 1`, `s_im = −σ/ω`; `1/s = conj(s)/\|s\|²` has a **real** denominator `1 + s_im²` — the complex reciprocal lowers to 4 real ops, no complex arithmetic ever needed. |
+| Radial direction `r̂`, guard `r > 1e-12` | `Reciprocal` + `Where` + `Mul` | **emittable** | Defensive branch of the Burn kernel lowers to one `Where`. |
+| Per-axis assembly `ε_α` | `Mul`/`Add` with `(n,1)`-vs-`(n,3)` broadcast; `Where` on the `(n,1)` shell mask | **emittable** | The tensor structure is **one broadcast axis** — multidirectional broadcasting in `Mul`/`Where` covers it. No `Reshape`/`Transpose` nodes appear anywhere in the graph. |
+| `(re, im) → complex128` output | none | **blocked** | Inherited H.5 Stage 2 verdict (no `Complex(re, im)` op; `Cast` excludes c128). Emit `eps_re`, `eps_im`, shape `(n,3)` each. |
+
+Probe result: paired-real graph passes `onnx.checker` and
+onnxruntime; **bit-exact (`0.000e+00`)** for both channels vs.
+`build_anisotropic_pml_tensor_diag` on an 8-tet fixture spanning
+interior, vacuum gap, the `r ≤ R_PML_INNER` shell guard, axis-aligned
+and oblique mid-ramp directions, and the clamped `u = 1` overshoot.
+(Bit-exactness includes the complex reciprocal: NumPy's `1/s` reduces
+to the same `conj/|s|²` real arithmetic when `s_re = 1`.)
+
+**Stage T2 verdict: FALLBACK (paired-real lowering), composing
+cleanly with the tensor structure.** Same c128 root cause as H.5; the
+diagonal tensor adds a broadcast axis, not a new friction.
+
+### Stage T3 — anisotropic local mass (`batched_nedelec_local_mass_anisotropic_diag`)
+
+The kernel splits the scalar cofactor gram per axis and contracts
+against `ε_diag`:
+
+```text
+gg_axis[e,α,p,q] = g_p[α] g_q[α]
+M[e,i,j] = Σ_α ε_α · (f_ac gg^α_bd − f_ad gg^α_bc − f_bc gg^α_ad + f_bd gg^α_ac) / (120 |det|)
+```
+
+| Operator (NumPy verb) | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Edge vectors, cross products, `det` | `Gather`/`Sub`/`Mul`/`Concat`/`ReduceSum` | **emittable** | Same component-wise cross-product lowering as the G.6 K_local inventory (ONNX has no `Cross` op; 9 Mul + 3 Sub per cross). |
+| Per-axis cofactor gram | `Einsum("epa,eqa->eapq")` | **emittable** | ONE Einsum. The per-axis split costs an output axis, not a transpose. |
+| Edge-pair Kronecker ladder | `Einsum("eapq,pqij->eaij")` against a baked `Constant` `(4,4,6,6)` coefficient tensor | **emittable** | The four-term `f_ac/f_ad/f_bc/f_bd` combination is a *structural linear map* from the 16 gram entries to the 36 edge pairs — it bakes into one constant tensor at graph-generation time. |
+| **ε-weighting, Re/Im channels** | `Einsum("eaij,ea->eij")` × 2 | **emittable (paired-real)** | The per-axis mass term is REAL and shared; `Re(ε·M) = M·Re(ε)`, `Im(ε·M) = M·Im(ε)`. One extra Einsum per channel — **not** a 4-multiply complex product, and **zero** reshapes/transposes. |
+| `1/(120 |det|)` scaling | `Abs`/`Mul`/`Reciprocal`/`Unsqueeze` | **emittable** | Shared by both channels. |
+
+Probe result: **bit-exact (`0.000e+00`)** for both 6×6 channel blocks
+vs. the NumPy reference on a 2-tet mesh with genuinely anisotropic
+data (three distinct complex diagonal entries from an oblique clamped
+shell centroid).
+
+**Stage T3 verdict: FALLBACK (paired-real), composing cleanly.**
+
+### Stage T4 — global complex-symmetric scatter
+
+Unchanged from H.5 Stage 5: shared int64 COO indices, two f64 zero
+buffers (`ConstantOfShape`), two `ScatterND(reduction="add")` calls.
+Probe result: bit-exact vs.
+`assemble_global_nedelec_anisotropic` (`scipy.sparse` complex
+reference), and the assembled buffers are exactly complex-symmetric
+(`max|M − Mᵀ| = 0` in both channels — the pencil is complex-symmetric,
+not Hermitian, as required).
+
+**Stage T4 verdict: FALLBACK (paired-real two-buffer scatter).**
+Inherited H.5; the tensor ε changes nothing at this stage.
+
+### Stage T5 — complex generalized eigensolve
+
+**Out-of-graph by definition** — LAPACK ZGGEV sidecar
+(`sphere_pml.eigensolve_complex_dense`), identical disposition to H.5
+Stage 6. λ→k and Q post-processing live in the same sidecar.
+
+**Stage T5 verdict: BLOCKED (out-of-graph sidecar).** Unchanged.
+
+### Target 1 answer to the J.6 question
+
+**The pair-lowering composes cleanly with the tensor structure.** No
+additional reshapes or transposes appear anywhere: the diagonal
+tensor is one extra (broadcast or Einsum) axis, the complex reciprocal
+has a real denominator, and the linearity of ε in the mass means the
+Re/Im channels share every real intermediate. Marginal cost over the
+scalar H.5 lowering: 2 Einsums + 1 ScatterND.
+
+## Target 2 — analytic Mie root finding
+
+Probe: [`probe_root_finding_loop.py`](probe_root_finding_loop.py).
+All numerical checks compare against
+[`reference/numpy/mie_roots.py`](../../../numpy/mie_roots.py)
+(scipy `spherical_jn`/`spherical_yn` + `brentq`), scipy directly, or
+the J.1 catalogue fixture
+([`reference/fixtures/mie_roots/baseline.json`](../../../fixtures/mie_roots/baseline.json))
+— never against the graph itself.
+
+### Stage R-a — characteristic function evaluation
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| `sin(x)` | `Sin` | **emittable** | f64 kernel registered. |
+| **`cos(x)`** | `Cos` | **fallback** | **f64 kernel NOT registered in onnxruntime 1.26.0** (`NOT_IMPLEMENTED: Could not find an implementation for Cos(7)`; `Tan`/`Atan` f64 likewise missing). Lowering: `Sin(x + π/2)`, error ≲ ε·x. |
+| Closed forms `j₀,j₁,y₀,y₁` | `Mul`/`Sub`/`Neg`/`Reciprocal` | **emittable** | |
+| Upward recurrence to `j_l, y_l` (`l ≤ x+1` regime) | unrolled `Mul`/`Sub`, `l−1` steps | **emittable** | `l` is a graph-build-time constant (catalogue: `l ≤ 4`) — the recurrence is a FIXED-count loop and unrolls. |
+| Miller downward recurrence (`l > x+1` regime) | unrolled `Mul`/`Sub`, `l+20` steps; rescale-at-1e100 via `Abs`/`Max`/`Greater`/`Reciprocal`/`Where` | **emittable** | The Rust kernel's conditional rescale is value-dependent but **control-static**: it lowers to an unconditional per-element `Where` factor each step. |
+| Regime select | `GreaterOrEqual(x, l−1)` + `Where` | **emittable** | Compute both branches, select per element — both branches are total over the catalogue window. |
+| Riccati-Bessel `ψ, ψ′, χ, χ′` and the TE/TM combination | `Mul`/`Add`/`Sub`/`Neg` | **emittable** | Direct transliteration. |
+
+Probe results (30 001-point catalogue grid):
+
+| Check | Max error | Criterion |
+|---|---|---|
+| `l=1` characteristic vs. reference | `3.5e-15` (scaled) | `< 1e-10` |
+| `l=4` `j₃,j₄,y₃,y₄` vs. scipy, x ∈ [0.1, 40] (both regimes) | `≤ 1.9e-14` (envelope-scaled rel) | `< 1e-9` |
+| `l=4` characteristic vs. reference | `5.4e-15` (term-scaled) | `< 1e-9` |
+
+**Stage R-a verdict: EMITTABLE** (with the `Sin(x+π/2)` cosine
+fallback). The "spherical Bessel via recurrence at fixed l" intuition
+from the issue holds: every loop is fixed-count and unrolls; no `Loop`
+op is needed for function evaluation.
+
+### Stage R-b — grid scan + sign-change detection
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Endpoint pairs `f[i], f[i+1]` | `Slice` × 4 (also for `k` endpoints) | **emittable** | Fixed shapes `(30000,)`. |
+| Finite check | `IsNaN`/`IsInf`/`Or`/`Not` | **emittable** | f64 kernels registered. |
+| Sign change `f_a f_b ≤ 0`, both-zero exclusion | `Mul`/`LessOrEqual`/`Equal`/`And` | **emittable** | |
+| Pole rejection `min(\|f_a\|,\|f_b\|) > 1e8` | `Abs`/`Min`/`Greater`/`Not` | **emittable** | |
+
+Probe result: the in-graph mask (15 brackets for TE l=1) matches the
+`find_roots` acceptance conditions exactly.
+
+**Stage R-b verdict: EMITTABLE.** The scan is data-INdependent in
+shape (fixed 30 000 intervals), so the bracket *mask* is graph-pure.
+
+### Stage R-c — bracket extraction + dedup + compaction
+
+This is where the data-dependent control flow lives, and the verdict
+splits by representation:
+
+| Operator | ONNX expression | Status | Notes |
+|---|---|---|---|
+| Dense bracket mask (from R-b) | — | **emittable** | The recommended in-graph representation. |
+| **Consecutive 1e-5 dedup** | `Loop` (30 000 trips) carrying the last-*retained* scalar, scan-output keep flag | **expressible-but-tortured** | The dedup decision depends on the previously retained root — an inherently SEQUENTIAL scan, not a parallel op. Probed: works under onnxruntime (sub-second), matches `_dedup_consecutive` semantics exactly, including a synthetic near-duplicate case. But it serializes 30 000 subgraph invocations to make ~15 decisions. |
+| **Compaction (masked roots → dense list)** | `NonZero` + `Squeeze` + `Gather` | **blocked for static shapes** | Runs under onnxruntime (dynamic shapes tolerated at runtime), but the output count is data-dependent — the same friction class as the G.6 `np.unique` finding. A static-shape consumer (the L4 contract) cannot type this output. |
+
+Probe result: the full in-graph chain (dedup `Loop` → `NonZero` →
+`Gather`) emits exactly the 15 reference roots at `4.6e-13` max
+relative error — so the *runtime* can do it; the *type system* of a
+static-shape backend cannot.
+
+**Stage R-c verdict: BLOCKED for static shapes (host-side
+compaction).** Recommended design: the graph outputs the dense
+`(30000,)` refined-root vector plus the boolean keep-mask; the host
+compacts and truncates to `n_max`. The dedup scan may live on either
+side of the boundary — in-graph it is correct but tortured; host-side
+it is three lines.
+
+### Stage R-d — bisection refinement
+
+The Rust refinement runs 60 bisection steps per bracket with two
+early exits (converged: `f_mid = 0` or width `< 1e-12·max(|mid|,1)`;
+aborted: `f_mid` non-finite). Probed in **two** graph forms,
+vectorized over all 30 000 candidate intervals (inactive lanes are
+masked, never branched):
+
+| Form | ONNX expression | Status | Notes |
+|---|---|---|---|
+| **Unrolled** | 60 inlined copies of the step body; per-lane `break` → `Where` masking on an `active` lane mask | **emittable** | 7 160 top-level nodes for the full pipeline. Pure data-flow; no control-flow op at all. |
+| **`Loop`** | `Loop(trip=60, cond)` with loop-carried `(lo, hi, f_lo, active)` and a scalar all-lanes-converged continue-condition (`Cast`/`ReduceMax`) | **emittable** | 134 top-level nodes. Loop-carried bool tensors work; the body reuses the identical step emission. |
+| Per-lane early exit | none | (lowered) | No per-lane `break` exists in either form — convergence freezes a lane via `Where`; the `Loop` cond can only stop ALL lanes. |
+
+Probe results:
+
+| Check | Result |
+|---|---|
+| Unrolled vs. `Loop` forms on bracketed lanes | **bit-identical** |
+| 15 in-graph roots vs. brentq reference roots | max rel err `4.6e-13` (`< 1e-10` contract) |
+| First 5 roots vs. J.1 `baseline.json` TE l=1 (tol 2e-9 abs) | max abs diff `1.2e-12` |
+
+**Stage R-d verdict: EMITTABLE (both unrolled and `Loop` forms).**
+
+## Per-stage verdicts (one-line summary)
+
+| Stage | Verdict |
+|---|---|
+| T1. `tet_centroids` | **emittable** — Gather + ReduceMean (real) |
+| T2. `build_anisotropic_pml_tensor_diag` | **fallback** — paired-real `(n,3)` outputs; complex stretch + reciprocal lower to real ops; tensor structure = one broadcast axis, zero reshapes |
+| T3. anisotropic local mass kernel | **fallback** — 3-Einsum chain (per-axis gram, constant pair-ladder, ε-contraction); Re/Im share the real per-axis tensor; bit-exact |
+| T4. global complex-symmetric scatter | **fallback** — paired-real two-buffer ScatterND (inherited H.5); bit-exact, exactly symmetric |
+| T5. complex generalized eigensolve | **blocked** — out-of-graph ZGGEV sidecar (inherited H.5) |
+| R-a. characteristic function evaluation | **emittable** — fixed-count unrolled Bessel recurrences; `Cos` f64 needs the `Sin(x+π/2)` fallback |
+| R-b. grid scan + sign-change mask | **emittable** — fixed-shape `(30000,)` bool mask |
+| R-c. bracket extraction + dedup + compaction | **blocked for static shapes** — dedup is a sequential 30 000-trip `Loop` (tortured); compaction is `NonZero` (data-dependent shape). Keep dense+mask in-graph, compact at host. |
+| R-d. bisection refinement | **emittable** — unrolled-60-with-`Where` AND `Loop(60, cond)`; the two forms are bit-identical and hit the J.1 catalogue to 1.2e-12 |
+
+## Spec implications (whiteroom L4 `iterate-while` surface)
+
+This is the first concrete data point on whether the proposed L4
+`iterate-while` / `iterate-while-with-prev` primitives survive a
+graph-only backend. They do — with sharp boundary conditions:
+
+1. **ONNX `Loop` IS `iterate-while-with-prev`.** It provides
+   loop-carried state (any tensor types, including bool masks), an
+   optional max trip count, a scalar boolean continue-condition
+   evaluated per iteration, and per-iteration scan outputs. The
+   bisection probe ran it end-to-end under onnxruntime with f64 + bool
+   carried state and an early-exit condition, bit-identical to the
+   unrolled form. An L4 `iterate-while` lowers directly.
+2. **…provided three contract restrictions hold:**
+   - *Loop-invariant state shapes.* Carried tensors must keep their
+     shape across iterations (ONNX requires it; so would any
+     static-shape IR).
+   - *Scalar continue-condition.* There is no per-lane early exit.
+     Per-element convergence must lower to `Where` masking inside the
+     carried state (the `active`-mask idiom probed here); the
+     condition may only be a reduction ("any lane still active").
+     An L4 spec that allows element-wise `break` semantics would NOT
+     lower; one phrased as "state update + scalar predicate" does.
+   - *No data-dependent output counts.* `iterate-while` may not be
+     used to grow a result list. Variable-count results (the bracket
+     list, the deduped catalogue) stay dense + mask inside the graph
+     and compact at the host boundary — the same rule as the G.6/I.3
+     `np.unique` disposition, now confirmed for iteration outputs.
+3. **Fixed-trip iteration should prefer unrolling when the body is
+   cheap and the trip count is a compile-time constant.** Both Bessel
+   recurrences (≤ 24 steps) and the 60-step bisection unroll into
+   pure data-flow with no semantic loss; `Loop` buys a 53× smaller
+   graph (134 vs. 7 160 nodes) at the cost of a control-flow op that
+   some inference stacks optimize poorly. The L4 surface can treat
+   "unroll vs. emit-loop" as a backend lowering choice, not a
+   semantic one — the probe demonstrates the two are bit-identical.
+4. **Sequential scans are the true "secretly imperative" residue.**
+   The 1e-5 dedup (carried last-*retained* value) is the only stage
+   that is *inherently* sequential — not because of shapes, but
+   because its recurrence is non-associative. It is expressible as a
+   degenerate 30 000-trip `Loop`, but that is a serialization, not a
+   lowering. The L4 spec should classify consecutive-dedup with the
+   topology constructors: host-side, at the input/output boundary.
+5. **Kernel coverage is part of the contract.** The missing f64
+   `Cos`/`Tan` kernels in onnxruntime 1.26.0 show that opset-18
+   *schema* support does not imply *runtime* support even for
+   real-valued, first-class ops (the mirror image of the H.5 c128
+   finding, where the schema accepted what no kernel honored). An L4
+   conformance statement must pin the runtime, not just the IR
+   version; trig-identity fallbacks (`Sin(x+π/2)`) preserve f64
+   accuracy where dtype round-trips would not.
+
+## Cross-cutting frictions: F.1/G.6/H.5/I.3 vs. J.6 comparison
+
+| Friction | Prior status | J.6 status | Change |
+|---|---|---|---|
+| c128 type path (construct / arithmetic / fill) | blocked (H.5 headline) | blocked — inherited; tensor-ε adds no new c128 surface | **Unchanged** |
+| Paired-real lowering of complex constitutive data | fallback (H.5, scalar ε) | fallback — composes cleanly with diagonal-tensor ε (2 extra Einsums + 1 ScatterND, zero reshapes) | **Extended** |
+| Data-dependent output shape (`np.unique` / `NonZero`) | blocked (G.6, I.3 constructors) | blocked — recurs for bracket extraction and dedup compaction | **Unchanged — now covers iteration outputs** |
+| `ScatterND(reduction="add")` f64 | emittable | emittable | **Unchanged** |
+| `Einsum` f64 | emittable (G.6) | emittable — including 4-D per-axis grams and constant-tensor contraction | **Unchanged** |
+| **ONNX `Loop` (carried state + cond + scan outputs)** | untested | **emittable** — fixed-trip, early-exit, bool carried state, outer-scope capture, sequential scan all work under onnxruntime 1.26 | **NEW in J.6** |
+| **f64 trig kernel coverage** | untested | **`Sin` registered; `Cos`/`Tan`/`Atan` f64 NOT registered** in onnxruntime 1.26.0 — `Sin(x+π/2)` fallback | **NEW in J.6** |
+| Fixed-count recurrence unrolling (value-dependent rescale) | untested | **emittable** — Miller's recurrence with `Where`-lowered conditional rescale | **NEW in J.6** |
+
+## Recommended design for a future Mie ONNX pipeline
+
+Graph A (assembly — extends the H.5/G.7 skeleton):
+
+- Inputs: `nodes`, `tets`, `tag`, host-precomputed `tet_edge_idx` /
+  `tet_edge_sign` / `interior_idx` (G.6 disposition).
+- In-graph: centroids → paired-real tensor ramp (`eps_re`, `eps_im`
+  `(n_tets, 3)`) → 3-Einsum anisotropic mass → shared-index two-buffer
+  scatter. Outputs `K_int`, `M_re_int`, `M_im_int`.
+- Host sidecar: re-assemble c128 pencil, ZGGEV, λ→k, Q, classification
+  against the catalogue.
+
+Graph B (root catalogue — per `(l, pol)`, generated with `l` baked):
+
+- Input: the `(30001,)` k-grid (or bake it as a Constant).
+- In-graph: characteristic evaluation (unrolled Bessel ladders,
+  `Sin(x+π/2)` cosine) → bracket mask → bisection (unrolled or
+  `Loop(60, cond)` — bit-identical) → outputs dense `roots (30000,)` +
+  `mask (30000,) bool`.
+- Host: compact, dedup (3 lines), truncate to `n_max`, merge channels,
+  sort — exactly the cheap sequential residue.
+
+## Re-running this audit
+
+```bash
+cd reference/onnx
+python3 -m pip install -r requirements.txt -r ../numpy/requirements.txt
+python3 audit/sphere_mie/probe_tensor_eps_ramp.py
+python3 audit/sphere_mie/probe_root_finding_loop.py
+```
+
+Each probe prints a one-screen verdict block and exits nonzero if any
+check fails. The probes' captured runtime errors (the c128 `Mul`
+rejection; the f64 `Cos` `NOT_IMPLEMENTED`) are the load-bearing
+freshness signals: if a future onnxruntime registers those kernels,
+the corresponding fallback rows collapse to emittable and this audit
+is stale — re-audit.
+
+## Acknowledgements / cross-references
+
+- Epic [#88](https://github.com/rjwalters/geode-fem/issues/88) — Phase
+  J scope; Comment 4 for the broader vestigial-c128 finding.
+- Issue [#5](https://github.com/rjwalters/geode-fem/issues/5) — the
+  L4-input-boundary rule; the iterate-while finding above is the
+  first iteration-shaped extension of it (cross-posted per the issue
+  #175 acceptance criteria).
+- Phase J.1 ([#170](https://github.com/rjwalters/geode-fem/issues/170),
+  PR #177): [`mie_roots.py`](../../../numpy/mie_roots.py) and the
+  [catalogue fixture](../../../fixtures/mie_roots/baseline.json) this
+  audit's roots are validated against.
+- Phase J.2 ([#171](https://github.com/rjwalters/geode-fem/issues/171),
+  PR #179): [`sphere_mie.py`](../../../numpy/sphere_mie.py) — the
+  tensor-ε reference algebra.
+- Phase H.5: [`nedelec_pml_operator_audit.md`](../sphere_pml/nedelec_pml_operator_audit.md)
+  — the c128/paired-real baseline every Target-1 verdict builds on.
+- Phase I.3: [`derham_operator_audit.md`](../derham/derham_operator_audit.md)
+  — format precedent and the int64-is-first-class mirror finding.
+- Burn-side source of truth: `crates/geode-core/src/mie.rs`
+  (`spherical_j_pair`, `find_roots`, `resonance_roots`) and
+  `crates/geode-core/src/nedelec.rs`
+  (`batched_nedelec_local_mass_anisotropic_diag`).

--- a/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
+++ b/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
@@ -1,0 +1,898 @@
+"""Probe: ONNX expressibility of the analytic Mie root finder.
+
+Epic #88, Phase J.6 (issue #175). The Mie root catalogue
+(``reference/numpy/mie_roots.py``, mirror of
+``crates/geode-core/src/mie.rs::find_roots``) is the epic's first
+**iteration-shaped** primitive to hit the graph-only constraint. This
+probe audits each sub-stage separately:
+
+  (a) **Characteristic function evaluation** — spherical Bessel
+      ladders (closed forms for l ≤ 1; upward recurrence for
+      l ≤ x+1; Miller's downward recurrence for l > x+1) feeding the
+      TE/TM characteristic functions. All loops are FIXED-count at
+      graph-build time (l is a compile-time constant), so they unroll.
+      Probed at l = 1 (the in-graph pipeline below) and at l = 4 (the
+      catalogue's hardest case: 3-step upward ladder + 24-step
+      unrolled Miller recurrence + per-element Where regime select).
+
+  (b) **Grid scan + sign-change detection** — the 30 000-interval
+      dense sampling produces a FIXED-shape (30000,) bracket mask:
+      Slice + Mul + LessOrEqual + Abs + Min + IsNaN/IsInf + And.
+
+  (c) **Bracket extraction / dedup / compaction** — the
+      data-dependent-output-count stage. The 1e-5 consecutive dedup is
+      a SEQUENTIAL scan (each decision depends on the previously
+      *retained* root) — expressible only as a 30 000-trip ONNX
+      ``Loop`` carrying the last-retained scalar (probed; works, but
+      "tortured"). The final compaction to a dense root list is
+      ``NonZero`` + ``Gather`` — runs under onnxruntime but with a
+      data-dependent output shape, the same friction class as the G.6
+      ``np.unique`` finding.
+
+  (d) **Bisection refinement** — the Rust side runs 60 bisection
+      steps per bracket with early exit. Probed in BOTH graph forms,
+      vectorized over all 30 000 candidate intervals:
+        - **unrolled**: 60 copies of the step body with Where-based
+          convergence/activity masking;
+        - **ONNX Loop**: trip-count 60 + a scalar all-lanes-converged
+          continue-condition — i.e. a real `iterate-while-with-prev`.
+      The two forms must agree BIT-EXACTLY (same op sequence), and
+      both are validated against the brentq-refined NumPy reference
+      roots and the Phase J.1 catalogue fixture
+      (``reference/fixtures/mie_roots/baseline.json``).
+
+The probe never self-compares: every numerical check is against
+``reference/numpy/mie_roots.py`` (scipy ``spherical_jn``/``spherical_yn``
++ ``brentq``), scipy directly, or the J.1 baseline fixture.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+from scipy.special import spherical_jn, spherical_yn
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+import mie_roots  # noqa: E402
+from mie_roots import (  # noqa: E402
+    DEDUP_TOL,
+    K_MAX,
+    K_MIN,
+    N_SAMPLES,
+    POLE_SCALE_REJECT,
+    TE,
+    _dedup_consecutive,
+    characteristic_te,
+    resonance_roots,
+)
+
+OPSET = 18
+N_INSIDE = 1.5
+R_S = 1.0
+R_B = 2.0
+BASELINE = REFERENCE_ROOT / "fixtures" / "mie_roots" / "baseline.json"
+
+# Bisection constants — mirror mie.rs::find_roots.
+BISECT_ITERS = 60
+BISECT_RTOL = 1e-12
+# Miller downward start offset — mirror mie.rs::spherical_j_pair.
+MILLER_OFFSET = 20
+MILLER_RESCALE = 1e100
+
+
+# --------------------------------------------------------------------------- #
+# Tiny emitter: appends nodes with auto-unique value names.
+# --------------------------------------------------------------------------- #
+
+
+class Emitter:
+    def __init__(self, prefix: str = "v"):
+        self.nodes: list[onnx.NodeProto] = []
+        self._n = 0
+        self._prefix = prefix
+        self._const_cache: dict[tuple, str] = {}
+
+    def name(self, tag: str) -> str:
+        self._n += 1
+        return f"{self._prefix}_{tag}_{self._n}"
+
+    def op(self, op_type: str, inputs: list[str], tag: str | None = None, **attrs) -> str:
+        out = self.name(tag or op_type.lower())
+        self.nodes.append(oh.make_node(op_type, inputs, [out], **attrs))
+        return out
+
+    def const(self, arr: np.ndarray, tag: str = "c") -> str:
+        arr = np.asarray(arr)
+        key = (arr.dtype.str, arr.shape, arr.tobytes())
+        if key in self._const_cache:
+            return self._const_cache[key]
+        dtype_map = {
+            np.dtype("float64"): TensorProto.DOUBLE,
+            np.dtype("int64"): TensorProto.INT64,
+            np.dtype("bool"): TensorProto.BOOL,
+        }
+        out = self.name(tag)
+        self.nodes.append(
+            oh.make_node(
+                "Constant",
+                [],
+                [out],
+                value=oh.make_tensor(
+                    out + "_value",
+                    dtype_map[arr.dtype],
+                    list(arr.shape),
+                    arr.flatten().tolist(),
+                ),
+            )
+        )
+        self._const_cache[key] = out
+        return out
+
+    def f64(self, val: float) -> str:
+        return self.const(np.array(float(val), dtype=np.float64), "f")
+
+
+# --------------------------------------------------------------------------- #
+# In-graph spherical Bessel / Riccati-Bessel ladders.
+# --------------------------------------------------------------------------- #
+
+
+def emit_cos_f64(g: Emitter, x: str) -> str:
+    """cos(x) for an f64 tensor — via ``Sin(x + π/2)``.
+
+    FINDING (onnxruntime 1.26.0): the ``Cos`` (and ``Tan``) CPU kernels
+    are registered for float32 only; ``Sin`` has a float64 kernel. A
+    native f64 ``Cos`` node fails at session-create with
+    ``NOT_IMPLEMENTED : Could not find an implementation for Cos(7)``.
+    The shift identity costs one rounded addition (|err| ≲ ε·x), far
+    inside this probe's tolerances; the alternative (Cast→f32→Cos→f64)
+    would destroy the 1e-10 root contract.
+    """
+    half_pi = g.f64(np.pi / 2.0)
+    shifted = g.op("Add", [x, half_pi], "xshift")
+    return g.op("Sin", [shifted], "cos")
+
+
+def emit_bessel_l01(g: Emitter, x: str) -> dict[str, str]:
+    """Closed forms j0, j1, y0, y1 (and 1/x) for an f64 tensor x > 0."""
+    s = g.op("Sin", [x], "sin")
+    c = emit_cos_f64(g, x)
+    inv_x = g.op("Reciprocal", [x], "invx")
+    j0 = g.op("Mul", [s, inv_x], "j0")
+    s_x2 = g.op("Mul", [j0, inv_x], "sx2")
+    c_x = g.op("Mul", [c, inv_x], "cx")
+    j1 = g.op("Sub", [s_x2, c_x], "j1")
+    y0 = g.op("Neg", [c_x], "y0")
+    c_x2 = g.op("Mul", [c_x, inv_x], "cx2")
+    neg_y1a = g.op("Add", [c_x2, j0], "ny1")  # c/x² + s/x
+    y1 = g.op("Neg", [neg_y1a], "y1")
+    return {"j0": j0, "j1": j1, "y0": y0, "y1": y1, "inv_x": inv_x}
+
+
+def emit_upward_ladder(g: Emitter, inv_x: str, f0: str, f1: str, l: int) -> tuple[str, str]:
+    """Unrolled upward recurrence f_k = (2k−1)/x · f_{k−1} − f_{k−2}.
+
+    Returns (f_{l−1}, f_l). Fixed trip count (l − 1 steps): l is a
+    graph-build-time constant, so this is pure unrolled arithmetic.
+    """
+    prev, curr = f0, f1
+    for k in range(2, l + 1):
+        coeff = g.f64(2 * k - 1)
+        t1 = g.op("Mul", [coeff, inv_x], f"up{k}a")
+        t2 = g.op("Mul", [t1, curr], f"up{k}b")
+        nxt = g.op("Sub", [t2, prev], f"up{k}")
+        prev, curr = curr, nxt
+    return prev, curr
+
+
+def emit_miller_j_pair(g: Emitter, x: str, inv_x: str, j0: str, l: int) -> tuple[str, str]:
+    """Unrolled Miller downward recurrence for (j_{l−1}, j_l).
+
+    Mirror of ``mie.rs::spherical_j_pair``'s downward branch:
+    l_start = l + 20, seed (j_{l_start+1}, j_{l_start}) = (0, 1),
+    recurse j_{k−1} = (2k+1)/x · j_k − j_{k+1}, normalise against the
+    closed form j0 = sin(x)/x. The conditional rescale-at-1e100 is
+    value-dependent but CONTROL-static: it lowers to an unconditional
+    per-element ``Where`` factor applied to all live state each step.
+    Total: (l + 20) unrolled steps — fixed at graph-build time.
+    """
+    l_start = l + MILLER_OFFSET
+    one = g.f64(1.0)
+    thresh = g.f64(MILLER_RESCALE)
+    zero_t = g.op("Mul", [x, g.f64(0.0)], "mz")  # 0-tensor shaped like x
+    one_t = g.op("Add", [zero_t, one], "mone")  # 1-tensor shaped like x
+    j_higher = zero_t
+    j_high = one_t
+    at_target = one_t if l == l_start else None
+    at_target_m1 = None
+    at_zero = None
+    for k in range(l_start, 0, -1):
+        coeff = g.f64(2 * k + 1)
+        t1 = g.op("Mul", [coeff, inv_x], f"mi{k}a")
+        t2 = g.op("Mul", [t1, j_high], f"mi{k}b")
+        j_low = g.op("Sub", [t2, j_higher], f"mi{k}")
+        j_higher, j_high = j_high, j_low
+        if k - 1 == l:
+            at_target = j_high
+        if k - 1 == l - 1:
+            at_target_m1 = j_high
+        if k - 1 == 0:
+            at_zero = j_high
+        # Conditional rescale → unconditional Where factor.
+        abs_hi = g.op("Abs", [j_high], f"mr{k}a")
+        abs_hr = g.op("Abs", [j_higher], f"mr{k}b")
+        scale = g.op("Max", [abs_hi, abs_hr], f"mr{k}c")
+        big = g.op("Greater", [scale, thresh], f"mr{k}d")
+        inv_scale = g.op("Reciprocal", [scale], f"mr{k}e")
+        factor = g.op("Where", [big, inv_scale, one_t], f"mr{k}f")
+        j_high = g.op("Mul", [j_high, factor], f"mr{k}g")
+        j_higher = g.op("Mul", [j_higher, factor], f"mr{k}h")
+        if at_target is not None:
+            at_target = g.op("Mul", [at_target, factor], f"mr{k}i")
+        if at_target_m1 is not None:
+            at_target_m1 = g.op("Mul", [at_target_m1, factor], f"mr{k}j")
+        if at_zero is not None:
+            at_zero = g.op("Mul", [at_zero, factor], f"mr{k}k")
+    norm = g.op("Div", [j0, at_zero], "mnorm")
+    j_l = g.op("Mul", [at_target, norm], "mjl")
+    j_lm1 = g.op("Mul", [at_target_m1, norm], "mjlm1")
+    return j_lm1, j_l
+
+
+def emit_bessel_pair(g: Emitter, x: str, l: int) -> dict[str, str]:
+    """(j_{l−1}, j_l, y_{l−1}, y_l, 1/x) for an f64 tensor x > 0.
+
+    l = 1: closed forms. l ≥ 2: y via upward ladder (always stable);
+    j via per-element ``Where`` select between the upward ladder
+    (stable for l ≤ x+1) and the unrolled Miller downward recurrence
+    (l > x+1) — mirror of ``mie.rs::spherical_j_pair``'s regime split.
+    """
+    base = emit_bessel_l01(g, x)
+    if l == 1:
+        return {
+            "j_lm1": base["j0"],
+            "j_l": base["j1"],
+            "y_lm1": base["y0"],
+            "y_l": base["y1"],
+            "inv_x": base["inv_x"],
+        }
+    inv_x = base["inv_x"]
+    j_lm1_up, j_l_up = emit_upward_ladder(g, inv_x, base["j0"], base["j1"], l)
+    y_lm1, y_l = emit_upward_ladder(g, inv_x, base["y0"], base["y1"], l)
+    j_lm1_mi, j_l_mi = emit_miller_j_pair(g, x, inv_x, base["j0"], l)
+    # Upward regime when l ≤ x + 1, i.e. x ≥ l − 1.
+    boundary = g.f64(float(l - 1))
+    use_up = g.op("GreaterOrEqual", [x, boundary], "useup")
+    j_lm1 = g.op("Where", [use_up, j_lm1_up, j_lm1_mi], "jlm1")
+    j_l = g.op("Where", [use_up, j_l_up, j_l_mi], "jl")
+    return {"j_lm1": j_lm1, "j_l": j_l, "y_lm1": y_lm1, "y_l": y_l, "inv_x": inv_x}
+
+
+def emit_riccati(g: Emitter, x: str, l: int) -> dict[str, str]:
+    """ψ_l, ψ_l′, χ_l, χ_l′ at an f64 tensor x > 0 (Bohren-Huffman).
+
+    ψ = x·j_l, ψ′ = j_l + x·j_l′ with j_l′ = j_{l−1} − (l+1)/x · j_l;
+    χ = −x·y_l, χ′ = −y_l − x·y_l′ with y_l′ = y_{l−1} − (l+1)/x · y_l.
+    """
+    b = emit_bessel_pair(g, x, l)
+    lp1 = g.f64(float(l + 1))
+    lp1_x = g.op("Mul", [lp1, b["inv_x"]], "lp1x")
+
+    psi = g.op("Mul", [x, b["j_l"]], "psi")
+    jp_a = g.op("Mul", [lp1_x, b["j_l"]], "jpa")
+    jp = g.op("Sub", [b["j_lm1"], jp_a], "jp")
+    xjp = g.op("Mul", [x, jp], "xjp")
+    psip = g.op("Add", [b["j_l"], xjp], "psip")
+
+    xyl = g.op("Mul", [x, b["y_l"]], "xyl")
+    chi = g.op("Neg", [xyl], "chi")
+    yp_a = g.op("Mul", [lp1_x, b["y_l"]], "ypa")
+    yp = g.op("Sub", [b["y_lm1"], yp_a], "yp")
+    xyp = g.op("Mul", [x, yp], "xyp")
+    neg_chip = g.op("Add", [b["y_l"], xyp], "nchip")
+    chip = g.op("Neg", [neg_chip], "chip")
+    return {"psi": psi, "psip": psip, "chi": chi, "chip": chip}
+
+
+def emit_characteristic_te(g: Emitter, k: str, l: int) -> str:
+    """TE characteristic function of mie_roots.characteristic_te, in-graph."""
+    x_in = g.op("Mul", [k, g.f64(N_INSIDE * R_S)], "xin")
+    x_s = g.op("Mul", [k, g.f64(R_S)], "xs")
+    x_b = g.op("Mul", [k, g.f64(R_B)], "xb")
+
+    rb = emit_riccati(g, x_b, l)
+    rs = emit_riccati(g, x_s, l)
+    ri = emit_riccati(g, x_in, l)
+
+    big_a, big_b = rb["chi"], rb["psi"]
+    t1 = g.op("Mul", [big_a, rs["psi"]], "bufa")
+    t2 = g.op("Mul", [big_b, rs["chi"]], "bufb")
+    buf = g.op("Sub", [t1, t2], "buf")
+    t3 = g.op("Mul", [big_a, rs["psip"]], "bufpa")
+    t4 = g.op("Mul", [big_b, rs["chip"]], "bufpb")
+    bufp = g.op("Sub", [t3, t4], "bufp")
+
+    lhs = g.op("Mul", [ri["psi"], bufp], "lhs")
+    psip_n = g.op("Mul", [ri["psip"], g.f64(1.0 / N_INSIDE)], "psipn")
+    rhs = g.op("Mul", [psip_n, buf], "rhs")
+    return g.op("Sub", [lhs, rhs], "char_te")
+
+
+# --------------------------------------------------------------------------- #
+# In-graph bracket mask + bisection step (shared by unrolled and Loop forms).
+# --------------------------------------------------------------------------- #
+
+
+def emit_finite(g: Emitter, t: str) -> str:
+    isnan = g.op("IsNaN", [t], "isnan")
+    isinf = g.op("IsInf", [t], "isinf")
+    bad = g.op("Or", [isnan, isinf], "bad")
+    return g.op("Not", [bad], "fin")
+
+
+def emit_bracket_mask(g: Emitter, fa: str, fb: str) -> str:
+    """Mirror of the bracket-acceptance conditions in find_roots."""
+    fin = g.op("And", [emit_finite(g, fa), emit_finite(g, fb)], "finab")
+    zero = g.f64(0.0)
+    eq_a = g.op("Equal", [fa, zero], "eqa")
+    eq_b = g.op("Equal", [fb, zero], "eqb")
+    both_zero = g.op("And", [eq_a, eq_b], "bz")
+    prod = g.op("Mul", [fa, fb], "fafb")
+    sign_ok = g.op("LessOrEqual", [prod, zero], "signok")
+    abs_a = g.op("Abs", [fa], "absa")
+    abs_b = g.op("Abs", [fb], "absb")
+    min_ab = g.op("Min", [abs_a, abs_b], "minab")
+    pole = g.op("Greater", [min_ab, g.f64(POLE_SCALE_REJECT)], "pole")
+    keep = g.op("And", [fin, sign_ok], "k1")
+    keep = g.op("And", [keep, g.op("Not", [both_zero], "nbz")], "k2")
+    return g.op("And", [keep, g.op("Not", [pole], "npole")], "mask")
+
+
+def emit_bisection_step(
+    g: Emitter, lo: str, hi: str, f_lo: str, active: str, l: int
+) -> tuple[str, str, str, str]:
+    """One masked bisection step — mirror of the mie.rs inner loop.
+
+    Rust control flow per bracket:
+        mid = (lo+hi)/2; f_mid = f(mid)
+        if !finite(f_mid): break
+        if f_mid == 0 or hi−lo < 1e-12·max(|mid|,1): lo = hi = mid; break
+        if f_lo·f_mid < 0: hi = mid else: lo = mid; f_lo = f_mid
+
+    `break` lowers to clearing the per-lane `active` mask; the two
+    update branches lower to Where selects gated on `active`.
+    """
+    half = g.f64(0.5)
+    s = g.op("Add", [lo, hi], "sum")
+    mid = g.op("Mul", [s, half], "mid")
+    f_mid = emit_characteristic_te(g, mid, l)
+
+    fin = emit_finite(g, f_mid)
+    zero = g.f64(0.0)
+    eq0 = g.op("Equal", [f_mid, zero], "eq0")
+    width = g.op("Sub", [hi, lo], "width")
+    abs_mid = g.op("Abs", [mid], "absmid")
+    floor1 = g.op("Max", [abs_mid, g.f64(1.0)], "floor")
+    tol = g.op("Mul", [floor1, g.f64(BISECT_RTOL)], "tol")
+    small = g.op("Less", [width, tol], "small")
+    conv = g.op("And", [fin, g.op("Or", [eq0, small], "convraw")], "conv")
+
+    prod = g.op("Mul", [f_lo, f_mid], "flofm")
+    sign_neg = g.op("Less", [prod, zero], "sneg")
+    step_ok = g.op("And", [fin, g.op("Not", [conv], "nconv")], "stepok")
+    gate = g.op("And", [active, step_ok], "gate")
+    upd_hi = g.op("And", [gate, sign_neg], "updhi")
+    upd_lo = g.op("And", [gate, g.op("Not", [sign_neg], "nsneg")], "updlo")
+    take_conv = g.op("And", [active, conv], "takeconv")
+
+    lo1 = g.op("Where", [upd_lo, mid, lo], "lo1")
+    lo2 = g.op("Where", [take_conv, mid, lo1], "lo2")
+    hi1 = g.op("Where", [upd_hi, mid, hi], "hi1")
+    hi2 = g.op("Where", [take_conv, mid, hi1], "hi2")
+    f_lo2 = g.op("Where", [upd_lo, f_mid, f_lo], "flo2")
+    active2 = g.op("And", [active, step_ok], "act2")
+    return lo2, hi2, f_lo2, active2
+
+
+# --------------------------------------------------------------------------- #
+# Graph builders.
+# --------------------------------------------------------------------------- #
+
+
+def make_model(g: Emitter, name: str, inputs, outputs) -> onnx.ModelProto:
+    graph = oh.make_graph(g.nodes, name, inputs, outputs)
+    return oh.make_model(
+        graph, opset_imports=[oh.make_opsetid("", OPSET)], ir_version=9
+    )
+
+
+def build_characteristic_graph(l: int) -> onnx.ModelProto:
+    g = Emitter()
+    f = emit_characteristic_te(g, "ks", l)
+    g.nodes.append(oh.make_node("Identity", [f], ["f_out"]))
+    return make_model(
+        g,
+        f"char_te_l{l}",
+        [oh.make_tensor_value_info("ks", TensorProto.DOUBLE, ["G"])],
+        [oh.make_tensor_value_info("f_out", TensorProto.DOUBLE, ["G"])],
+    )
+
+
+def build_bessel4_graph() -> onnx.ModelProto:
+    g = Emitter()
+    b = emit_bessel_pair(g, "xs", 4)
+    for src, out in ((b["j_l"], "j4"), (b["j_lm1"], "j3"), (b["y_l"], "y4"), (b["y_lm1"], "y3")):
+        g.nodes.append(oh.make_node("Identity", [src], [out]))
+    return make_model(
+        g,
+        "bessel_l4",
+        [oh.make_tensor_value_info("xs", TensorProto.DOUBLE, ["G"])],
+        [oh.make_tensor_value_info(n, TensorProto.DOUBLE, ["G"]) for n in ("j3", "j4", "y3", "y4")],
+    )
+
+
+def build_pipeline_unrolled_graph(l: int, n_samples: int) -> onnx.ModelProto:
+    """ks (n_samples+1,) → bracket mask (n,), refined roots (n,) — the
+    bisection unrolled 60× with Where masking (form d-1), plus the
+    sequential dedup Loop (stage c) and NonZero compaction."""
+    g = Emitter()
+    fs = emit_characteristic_te(g, "ks", l)
+
+    n = n_samples
+    starts0 = g.const(np.array([0], dtype=np.int64), "s0")
+    starts1 = g.const(np.array([1], dtype=np.int64), "s1")
+    ends_n = g.const(np.array([n], dtype=np.int64), "en")
+    ends_n1 = g.const(np.array([n + 1], dtype=np.int64), "en1")
+    ax0 = g.const(np.array([0], dtype=np.int64), "ax0")
+    fa = g.op("Slice", [fs, starts0, ends_n, ax0], "fa")
+    fb = g.op("Slice", [fs, starts1, ends_n1, ax0], "fb")
+    ka = g.op("Slice", ["ks", starts0, ends_n, ax0], "ka")
+    kb = g.op("Slice", ["ks", starts1, ends_n1, ax0], "kb")
+
+    mask = emit_bracket_mask(g, fa, fb)
+
+    lo, hi, f_lo, active = ka, kb, fa, mask
+    for _ in range(BISECT_ITERS):
+        lo, hi, f_lo, active = emit_bisection_step(g, lo, hi, f_lo, active, l)
+    s = g.op("Add", [lo, hi], "rsum")
+    roots = g.op("Mul", [s, g.f64(0.5)], "roots")
+
+    # ---- Stage (c): sequential dedup scan as a 30 000-trip Loop ---- #
+    # Carried state: last retained root (scalar). Scan output: keep_i.
+    # The body reads root[i] / mask[i] from the OUTER scope via Gather
+    # on the iteration counter — an implicit-capture subgraph.
+    body = Emitter("dd")
+    it_vi = oh.make_tensor_value_info("dd_iter", TensorProto.INT64, [])
+    cond_vi = oh.make_tensor_value_info("dd_cond_in", TensorProto.BOOL, [])
+    last_vi = oh.make_tensor_value_info("dd_last_in", TensorProto.DOUBLE, [])
+    r_i = body.op("Gather", [roots, "dd_iter"], "ri", axis=0)
+    m_i = body.op("Gather", [mask, "dd_iter"], "mi", axis=0)
+    diff = body.op("Sub", [r_i, "dd_last_in"], "diff")
+    adiff = body.op("Abs", [diff], "adiff")
+    far = body.op("GreaterOrEqual", [adiff, body.f64(DEDUP_TOL)], "far")
+    keep = body.op("And", [m_i, far], "keep")
+    last_out = body.op("Where", [keep, r_i, "dd_last_in"], "lastout")
+    body.nodes.append(oh.make_node("Identity", ["dd_cond_in"], ["dd_cond_out"]))
+    body_graph = oh.make_graph(
+        body.nodes,
+        "dedup_body",
+        [it_vi, cond_vi, last_vi],
+        [
+            oh.make_tensor_value_info("dd_cond_out", TensorProto.BOOL, []),
+            oh.make_tensor_value_info(last_out, TensorProto.DOUBLE, []),
+            oh.make_tensor_value_info(keep, TensorProto.BOOL, []),
+        ],
+    )
+    trip = g.const(np.array(n, dtype=np.int64), "trip")
+    cond_true = g.const(np.array(True, dtype=bool), "ct")
+    last_init = g.f64(-1e300)
+    loop_node = oh.make_node(
+        "Loop",
+        [trip, cond_true, last_init],
+        ["dedup_last_final", "keep_mask"],
+        body=body_graph,
+    )
+    g.nodes.append(loop_node)
+
+    # ---- Compaction: NonZero + Gather (data-dependent shape) ---- #
+    nz = g.op("NonZero", ["keep_mask"], "nz")  # (1, nnz) int64
+    idx = g.op("Squeeze", [nz, ax0], "idx")  # (nnz,)
+    g.nodes.append(oh.make_node("Gather", [roots, idx], ["roots_dedup"], axis=0))
+
+    for src, out in ((mask, "mask_out"), (roots, "roots_out"), ("keep_mask", "keep_out")):
+        g.nodes.append(oh.make_node("Identity", [src], [out]))
+
+    return make_model(
+        g,
+        f"find_roots_te_l{l}_unrolled",
+        [oh.make_tensor_value_info("ks", TensorProto.DOUBLE, [n + 1])],
+        [
+            oh.make_tensor_value_info("mask_out", TensorProto.BOOL, [n]),
+            oh.make_tensor_value_info("roots_out", TensorProto.DOUBLE, [n]),
+            oh.make_tensor_value_info("keep_out", TensorProto.BOOL, [n]),
+            oh.make_tensor_value_info("roots_dedup", TensorProto.DOUBLE, ["NNZ"]),
+        ],
+    )
+
+
+def build_pipeline_loop_graph(l: int, n_samples: int) -> onnx.ModelProto:
+    """Same pipeline through the bracket mask, but the 60-step bisection
+    is an ONNX ``Loop`` (form d-2): trip-count 60, loop-carried
+    (lo, hi, f_lo, active), and a scalar continue-condition
+    `any lane still active` — i.e. iterate-while-with-prev."""
+    g = Emitter("o")
+    fs = emit_characteristic_te(g, "ks", l)
+
+    n = n_samples
+    starts0 = g.const(np.array([0], dtype=np.int64), "s0")
+    starts1 = g.const(np.array([1], dtype=np.int64), "s1")
+    ends_n = g.const(np.array([n], dtype=np.int64), "en")
+    ends_n1 = g.const(np.array([n + 1], dtype=np.int64), "en1")
+    ax0 = g.const(np.array([0], dtype=np.int64), "ax0")
+    fa = g.op("Slice", [fs, starts0, ends_n, ax0], "fa")
+    fb = g.op("Slice", [fs, starts1, ends_n1, ax0], "fb")
+    ka = g.op("Slice", ["ks", starts0, ends_n, ax0], "ka")
+    kb = g.op("Slice", ["ks", starts1, ends_n1, ax0], "kb")
+    mask = emit_bracket_mask(g, fa, fb)
+
+    # Loop body: one bisection step + all-lanes-converged condition.
+    body = Emitter("bi")
+    it_vi = oh.make_tensor_value_info("bi_iter", TensorProto.INT64, [])
+    cond_vi = oh.make_tensor_value_info("bi_cond_in", TensorProto.BOOL, [])
+    lo_vi = oh.make_tensor_value_info("bi_lo_in", TensorProto.DOUBLE, [n])
+    hi_vi = oh.make_tensor_value_info("bi_hi_in", TensorProto.DOUBLE, [n])
+    flo_vi = oh.make_tensor_value_info("bi_flo_in", TensorProto.DOUBLE, [n])
+    act_vi = oh.make_tensor_value_info("bi_act_in", TensorProto.BOOL, [n])
+    lo2, hi2, flo2, act2 = emit_bisection_step(
+        body, "bi_lo_in", "bi_hi_in", "bi_flo_in", "bi_act_in", l
+    )
+    # Continue while any lane is still active (early exit when all
+    # lanes have converged) — the iterate-while condition is a SCALAR.
+    act_i32 = body.op("Cast", [act2], "acti", to=TensorProto.INT32)
+    any_active_i = body.op("ReduceMax", [act_i32], "anyi", keepdims=0)
+    cond_out = body.op("Cast", [any_active_i], "condout", to=TensorProto.BOOL)
+    body_graph = oh.make_graph(
+        body.nodes,
+        "bisect_body",
+        [it_vi, cond_vi, lo_vi, hi_vi, flo_vi, act_vi],
+        [
+            oh.make_tensor_value_info(cond_out, TensorProto.BOOL, []),
+            oh.make_tensor_value_info(lo2, TensorProto.DOUBLE, [n]),
+            oh.make_tensor_value_info(hi2, TensorProto.DOUBLE, [n]),
+            oh.make_tensor_value_info(flo2, TensorProto.DOUBLE, [n]),
+            oh.make_tensor_value_info(act2, TensorProto.BOOL, [n]),
+        ],
+    )
+    trip = g.const(np.array(BISECT_ITERS, dtype=np.int64), "trip")
+    cond_true = g.const(np.array(True, dtype=bool), "ct")
+    g.nodes.append(
+        oh.make_node(
+            "Loop",
+            [trip, cond_true, ka, kb, fa, mask],
+            ["lo_fin", "hi_fin", "flo_fin", "act_fin"],
+            body=body_graph,
+        )
+    )
+    s = g.op("Add", ["lo_fin", "hi_fin"], "rsum")
+    roots = g.op("Mul", [s, g.f64(0.5)], "roots")
+    g.nodes.append(oh.make_node("Identity", [mask], ["mask_out"]))
+    g.nodes.append(oh.make_node("Identity", [roots], ["roots_out"]))
+
+    return make_model(
+        g,
+        f"find_roots_te_l{l}_loop",
+        [oh.make_tensor_value_info("ks", TensorProto.DOUBLE, [n + 1])],
+        [
+            oh.make_tensor_value_info("mask_out", TensorProto.BOOL, [n]),
+            oh.make_tensor_value_info("roots_out", TensorProto.DOUBLE, [n]),
+        ],
+    )
+
+
+def build_dedup_only_graph() -> onnx.ModelProto:
+    """Standalone dedup Loop over caller-provided (vals, mask) — used
+    for the synthetic near-duplicate check against _dedup_consecutive."""
+    g = Emitter("sd")
+    shape = g.op("Shape", ["vals"], "shape")
+    trip0 = g.op("Gather", [shape, g.const(np.array(0, dtype=np.int64), "i0")], "n")
+    body = Emitter("sdb")
+    it_vi = oh.make_tensor_value_info("sdb_iter", TensorProto.INT64, [])
+    cond_vi = oh.make_tensor_value_info("sdb_cond_in", TensorProto.BOOL, [])
+    last_vi = oh.make_tensor_value_info("sdb_last_in", TensorProto.DOUBLE, [])
+    r_i = body.op("Gather", ["vals", "sdb_iter"], "ri", axis=0)
+    m_i = body.op("Gather", ["mask", "sdb_iter"], "mi", axis=0)
+    diff = body.op("Sub", [r_i, "sdb_last_in"], "diff")
+    adiff = body.op("Abs", [diff], "adiff")
+    far = body.op("GreaterOrEqual", [adiff, body.f64(DEDUP_TOL)], "far")
+    keep = body.op("And", [m_i, far], "keep")
+    last_out = body.op("Where", [keep, r_i, "sdb_last_in"], "lastout")
+    body.nodes.append(oh.make_node("Identity", ["sdb_cond_in"], ["sdb_cond_out"]))
+    body_graph = oh.make_graph(
+        body.nodes,
+        "dedup_only_body",
+        [it_vi, cond_vi, last_vi],
+        [
+            oh.make_tensor_value_info("sdb_cond_out", TensorProto.BOOL, []),
+            oh.make_tensor_value_info(last_out, TensorProto.DOUBLE, []),
+            oh.make_tensor_value_info(keep, TensorProto.BOOL, []),
+        ],
+    )
+    cond_true = g.const(np.array(True, dtype=bool), "ct")
+    g.nodes.append(
+        oh.make_node(
+            "Loop",
+            [trip0, cond_true, g.f64(-1e300)],
+            ["sd_last_final", "keep_mask_out"],
+            body=body_graph,
+        )
+    )
+    return make_model(
+        g,
+        "dedup_scan",
+        [
+            oh.make_tensor_value_info("vals", TensorProto.DOUBLE, ["N"]),
+            oh.make_tensor_value_info("mask", TensorProto.BOOL, ["N"]),
+        ],
+        [oh.make_tensor_value_info("keep_mask_out", TensorProto.BOOL, ["N"])],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reference helpers (NumPy/scipy side — never the graph).
+# --------------------------------------------------------------------------- #
+
+
+def reference_bracket_mask(fs: np.ndarray) -> np.ndarray:
+    """Transliteration of the acceptance conditions in
+    mie_roots.find_roots (the loop body's `continue` ladder)."""
+    fa, fb = fs[:-1], fs[1:]
+    finite = np.isfinite(fa) & np.isfinite(fb)
+    both_zero = (fa == 0.0) & (fb == 0.0)
+    sign_ok = fa * fb <= 0.0
+    pole = np.minimum(np.abs(fa), np.abs(fb)) > POLE_SCALE_REJECT
+    return finite & sign_ok & ~both_zero & ~pole
+
+
+def run(model: onnx.ModelProto, outputs: list[str], feeds: dict):
+    onnx.checker.check_model(model)
+    sess = ort.InferenceSession(model.SerializeToString())
+    return sess.run(outputs, feeds)
+
+
+# --------------------------------------------------------------------------- #
+# Driver
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:  # noqa: PLR0915
+    print("== Probe: Mie root finding in-graph (Phase J.6, TE l=1 pipeline) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+    ok = True
+
+    dk = (K_MAX - K_MIN) / N_SAMPLES
+    ks = (K_MIN + dk * np.arange(N_SAMPLES + 1)).astype(np.float64)
+
+    # ------------------------------------------------------------- #
+    # (a) characteristic function evaluation
+    # ------------------------------------------------------------- #
+    print("--- Stage (a): characteristic function evaluation in-graph ---")
+    f_ref_l1 = characteristic_te(N_INSIDE, 1, R_S, R_B, ks)
+    (f_onnx_l1,) = run(build_characteristic_graph(1), ["f_out"], {"ks": ks})
+    scale_l1 = np.maximum(np.abs(f_ref_l1), 1.0)
+    err_l1 = float(np.max(np.abs(f_onnx_l1 - f_ref_l1) / scale_l1))
+    a1_ok = err_l1 < 1e-10
+    ok &= a1_ok
+    print(f"  l=1 closed forms vs mie_roots.characteristic_te over {len(ks)} pts:")
+    print(f"    max scaled error = {err_l1:.3e}  ({'PASS' if a1_ok else 'FAIL'} < 1e-10)")
+
+    # l=4 Bessel ladder (upward + unrolled 24-step Miller + Where select)
+    # across BOTH regimes (x < 3 → Miller; x ≥ 3 → upward); x range
+    # covers all three argument streams (x_b = 2k reaches 40).
+    xs = np.concatenate(
+        [np.linspace(0.1, 5.0, 2001), np.linspace(5.0, 40.0, 2001)]
+    ).astype(np.float64)
+    j3o, j4o, y3o, y4o = run(build_bessel4_graph(), ["j3", "j4", "y3", "y4"], {"xs": xs})
+
+    def dfact(n: int) -> float:  # (2l+1)!! etc.
+        out = 1.0
+        while n > 1:
+            out *= n
+            n -= 2
+        return out
+
+    def env_j(l: int, x: np.ndarray) -> np.ndarray:
+        # Amplitude envelope: x^l/(2l+1)!! near 0, 1/x in the
+        # oscillatory regime. A relative error against max(|ref|, 0.1·env)
+        # is a genuine relative test where the function is small-but-
+        # well-conditioned (Miller regime) and avoids the meaningless
+        # blow-up exactly AT the large-x crossing zeros.
+        return np.minimum(x**l / dfact(2 * l + 1), 1.0 / x)
+
+    def env_y(l: int, x: np.ndarray) -> np.ndarray:
+        return np.maximum(dfact(2 * l - 1) / x ** (l + 1), 1.0 / x)
+
+    checks = [
+        ("j3", j3o, spherical_jn(3, xs), env_j(3, xs)),
+        ("j4", j4o, spherical_jn(4, xs), env_j(4, xs)),
+        ("y3", y3o, spherical_yn(3, xs), env_y(3, xs)),
+        ("y4", y4o, spherical_yn(4, xs), env_y(4, xs)),
+    ]
+    a2_ok = True
+    for label, got, ref, env in checks:
+        scale = np.maximum(np.abs(ref), 0.1 * env)
+        err = float(np.max(np.abs(got - ref) / scale))
+        passed = err < 1e-9
+        a2_ok &= passed
+        print(f"  l=4 {label} vs scipy over x∈[0.1,40] ({len(xs)} pts): "
+              f"max envelope-scaled rel err = {err:.3e}  ({'PASS' if passed else 'FAIL'} < 1e-9)")
+    ok &= a2_ok
+
+    # l=4 characteristic function end-to-end. Scaled by the magnitude
+    # of the two cancelling terms (cancellation at roots makes a plain
+    # relative error meaningless there).
+    f_ref_l4 = characteristic_te(N_INSIDE, 4, R_S, R_B, ks)
+    (f_onnx_l4,) = run(build_characteristic_graph(4), ["f_out"], {"ks": ks})
+    psi_in = mie_roots.psi(4, N_INSIDE * ks)
+    psip_in = mie_roots.psi_prime(4, N_INSIDE * ks)
+    big_a, big_b = mie_roots.chi(4, R_B * ks), mie_roots.psi(4, R_B * ks)
+    buf = big_a * mie_roots.psi(4, ks) - big_b * mie_roots.chi(4, ks)
+    bufp = big_a * mie_roots.psi_prime(4, ks) - big_b * mie_roots.chi_prime(4, ks)
+    term_scale = np.maximum(np.abs(psi_in * bufp) + np.abs(psip_in / N_INSIDE * buf), 1.0)
+    err_l4 = float(np.max(np.abs(f_onnx_l4 - f_ref_l4) / term_scale))
+    a3_ok = err_l4 < 1e-9
+    ok &= a3_ok
+    print(f"  l=4 characteristic_te vs reference over the 30001-pt grid:")
+    print(f"    max term-scaled error = {err_l4:.3e}  ({'PASS' if a3_ok else 'FAIL'} < 1e-9)")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Full pipeline graphs (stages b, c, d) — TE l=1.
+    # ------------------------------------------------------------- #
+    print("--- Stages (b)+(c)+(d): full find_roots pipeline in-graph (TE l=1) ---")
+    model_unrolled = build_pipeline_unrolled_graph(1, N_SAMPLES)
+    n_nodes_unrolled = len(model_unrolled.graph.node)
+    print(f"  unrolled-form graph: {n_nodes_unrolled} top-level nodes "
+          f"(60 bisection steps inlined)")
+    mask_u, roots_u, keep_u, dedup_u = run(
+        model_unrolled,
+        ["mask_out", "roots_out", "keep_out", "roots_dedup"],
+        {"ks": ks},
+    )
+
+    model_loop = build_pipeline_loop_graph(1, N_SAMPLES)
+    n_nodes_loop = len(model_loop.graph.node)
+    print(f"  Loop-form graph: {n_nodes_loop} top-level nodes "
+          f"(bisection = ONNX Loop, trip-count 60 + all-converged early exit)")
+    mask_l, roots_l = run(model_loop, ["mask_out", "roots_out"], {"ks": ks})
+
+    # (b) bracket mask vs the find_roots acceptance conditions.
+    fs_ref = characteristic_te(N_INSIDE, 1, R_S, R_B, ks)
+    mask_ref = reference_bracket_mask(np.asarray(fs_ref))
+    b_ok = bool(np.array_equal(mask_u, mask_ref)) and bool(np.array_equal(mask_l, mask_ref))
+    ok &= b_ok
+    print(f"  (b) bracket mask: {int(mask_u.sum())} brackets; "
+          f"matches reference conditions exactly: {b_ok}")
+
+    # (d) the two bisection forms must agree bit-exactly on bracketed lanes.
+    bit_same = bool(np.array_equal(roots_u[mask_ref], roots_l[mask_ref]))
+    ok &= bit_same
+    print(f"  (d) unrolled vs Loop forms bit-identical on bracketed lanes: {bit_same}")
+
+    # (d) refined roots vs the brentq-refined NumPy reference.
+    ref_roots = np.array(
+        [r.k for r in resonance_roots(TE, N_INSIDE, 1, R_S, R_B, n_max=10**9)]
+    )
+    graph_roots = roots_u[mask_u]
+    graph_roots_dedup = _dedup_consecutive(list(graph_roots), DEDUP_TOL)
+    d_ok = len(graph_roots_dedup) == len(ref_roots)
+    rel = float(np.max(np.abs(np.array(graph_roots_dedup) - ref_roots) / ref_roots)) if d_ok else float("nan")
+    d_ok = d_ok and rel < 1e-10
+    ok &= d_ok
+    print(f"  (d) {len(graph_roots_dedup)} in-graph roots vs {len(ref_roots)} brentq "
+          f"reference roots: max rel err = {rel:.3e}  ({'PASS' if d_ok else 'FAIL'} < 1e-10)")
+
+    # (d) vs the J.1 catalogue fixture (first 5 TE l=1 roots).
+    with open(BASELINE) as fh:
+        base = json.load(fh)
+    outs = base["outputs"]
+    sel = [
+        i
+        for i in range(len(outs["root_k"]["data"]))
+        if outs["root_pol"]["data"][i] == 0 and outs["root_l"]["data"][i] == 1
+    ]
+    base_k = np.array([outs["root_k"]["data"][i] for i in sel])
+    tol_abs = float(outs["root_k"]["tolerance_abs"])
+    diffs = np.abs(np.array(graph_roots_dedup[: len(base_k)]) - base_k)
+    base_ok = bool(np.all(diffs <= tol_abs))
+    ok &= base_ok
+    print(f"  (d) first {len(base_k)} roots vs J.1 baseline.json (tol_abs {tol_abs:g}): "
+          f"max abs diff = {float(np.max(diffs)):.3e}  ({'PASS' if base_ok else 'FAIL'})")
+
+    # (c) in-graph dedup Loop + NonZero compaction vs reference.
+    c_count_ok = len(dedup_u) == len(ref_roots)
+    c_rel = float(np.max(np.abs(dedup_u - ref_roots) / ref_roots)) if c_count_ok else float("nan")
+    c_ok = c_count_ok and c_rel < 1e-10
+    keep_matches_host = bool(
+        np.array_equal(
+            roots_u[keep_u],
+            np.array(_dedup_consecutive(list(roots_u[mask_u]), DEDUP_TOL)),
+        )
+    )
+    ok &= c_ok and keep_matches_host
+    print(f"  (c) in-graph dedup Loop + NonZero compaction: {len(dedup_u)} roots, "
+          f"max rel err vs reference = {c_rel:.3e}  ({'PASS' if c_ok else 'FAIL'})")
+    print(f"      keep-mask matches host _dedup_consecutive semantics: {keep_matches_host}")
+
+    # (c) synthetic near-duplicate dedup check (TE l=1 has no natural
+    # duplicates, so exercise the tolerance logic explicitly).
+    vals = np.array(
+        [1.0, 1.0 + 0.4 * DEDUP_TOL, 1.0 + 1.7 * DEDUP_TOL, 2.0, 2.0, 3.0, 3.0 + 0.9 * DEDUP_TOL],
+        dtype=np.float64,
+    )
+    msk = np.array([True, True, True, True, False, True, True])
+    (keep_syn,) = run(build_dedup_only_graph(), ["keep_mask_out"], {"vals": vals, "mask": msk})
+    ref_dedup = _dedup_consecutive(list(vals[msk]), DEDUP_TOL)
+    got_dedup = list(vals[keep_syn])
+    syn_ok = got_dedup == ref_dedup
+    ok &= syn_ok
+    print(f"  (c) synthetic near-duplicate dedup vs _dedup_consecutive: "
+          f"{'PASS' if syn_ok else f'FAIL ({got_dedup} vs {ref_dedup})'}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Verdicts
+    # ------------------------------------------------------------- #
+    print("Per-sub-stage verdicts:")
+    print("--------------------------------------------------------------")
+    print("  (a) characteristic evaluation   EMITTABLE — closed forms (l=1) and")
+    print("      FIXED-count recurrences (upward ladder; 24-step Miller downward")
+    print("      with Where-lowered rescale; Where regime select). l is a graph")
+    print("      constant, so every Bessel loop unrolls. No Loop op needed.")
+    print("  (b) grid scan + sign change     EMITTABLE — fixed-shape (30000,)")
+    print("      mask via Slice/Mul/LessOrEqual/Min/Abs/IsNaN/IsInf/And.")
+    print("  (c) bracket extraction + dedup  BLOCKED for static shapes —")
+    print("      the dedup scan is sequential (carried last-retained value):")
+    print("      expressible-but-tortured as a 30000-trip ONNX Loop; the final")
+    print("      compaction is NonZero+Gather, which onnxruntime executes but")
+    print("      with a DATA-DEPENDENT output shape (the np.unique friction")
+    print("      class from G.6). Recommended: keep the dense (30000,) roots +")
+    print("      keep-mask in-graph; compact at the host boundary.")
+    print("  (d) bisection refinement        EMITTABLE, two ways —")
+    print("      unrolled 60× with Where convergence masking, AND as an ONNX")
+    print("      Loop (trip-count 60 + scalar all-lanes-converged condition).")
+    print("      The forms agree bit-exactly; per-lane early exit lowers to")
+    print("      masking, whole-loop early exit to the Loop condition.")
+    print()
+    print("Iterate-while finding (L4 spec implication):")
+    print("  ONNX `Loop` IS an iterate-while-with-prev: loop-carried state,")
+    print("  max trip count, scalar boolean continue-condition, and scan")
+    print("  outputs. It survives the graph-only constraint PROVIDED:")
+    print("    1. carried-state shapes are loop-invariant;")
+    print("    2. the continue condition is a SCALAR reduction (per-lane")
+    print("       convergence must lower to Where masking in the state);")
+    print("    3. results with data-dependent COUNTS stay dense+mask in the")
+    print("       graph and compact at the host boundary.")
+    print()
+    print(f"Overall: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
+++ b/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
@@ -45,6 +45,12 @@ The probe never self-compares: every numerical check is against
 ``reference/numpy/mie_roots.py`` (scipy ``spherical_jn``/``spherical_yn``
 + ``brentq``), scipy directly, or the J.1 baseline fixture.
 
+A one-node native f64 ``Cos`` control graph (mirror of graph (A) in
+``probe_tensor_eps_ramp.py``) asserts the ``NOT_IMPLEMENTED``
+session-create failure that motivates the ``Sin(x + π/2)`` fallback in
+``emit_cos_f64``; the assertion is folded into the overall PASS so the
+fallback row gets re-audited if a future onnxruntime adds the kernel.
+
 Run
 ===
 
@@ -422,6 +428,25 @@ def make_model(g: Emitter, name: str, inputs, outputs) -> onnx.ModelProto:
     )
 
 
+def build_native_cos_f64_graph() -> onnx.ModelProto:
+    """One-node native f64 ``Cos`` — the expected-failure control for
+    the ``emit_cos_f64`` fallback (mirror of graph (A) in
+    ``probe_tensor_eps_ramp.py``). Session creation must FAIL with
+    ``NOT_IMPLEMENTED`` under onnxruntime 1.26.0. If a future runtime
+    registers the f64 kernel, this control makes the probe exit
+    nonzero so the ``Sin(x + π/2)`` fallback row gets re-audited.
+    """
+    graph = oh.make_graph(
+        [oh.make_node("Cos", ["x"], ["y"])],
+        "native_cos_f64_control",
+        [oh.make_tensor_value_info("x", TensorProto.DOUBLE, ["N"])],
+        [oh.make_tensor_value_info("y", TensorProto.DOUBLE, ["N"])],
+    )
+    return oh.make_model(
+        graph, opset_imports=[oh.make_opsetid("", OPSET)], ir_version=9
+    )
+
+
 def build_characteristic_graph(l: int) -> onnx.ModelProto:
     g = Emitter()
     f = emit_characteristic_te(g, "ks", l)
@@ -688,6 +713,31 @@ def main() -> int:  # noqa: PLR0915
 
     dk = (K_MAX - K_MIN) / N_SAMPLES
     ks = (K_MIN + dk * np.arange(N_SAMPLES + 1)).astype(np.float64)
+
+    # ------------------------------------------------------------- #
+    # Control: native f64 Cos (expected failure — freshness signal)
+    # ------------------------------------------------------------- #
+    print("--- Control: native f64 Cos node (expected session-create failure) ---")
+    model_cos = build_native_cos_f64_graph()
+    onnx.checker.check_model(model_cos)  # schema-OK; the missing piece is the kernel
+    cos_failed = False
+    try:
+        ort.InferenceSession(model_cos.SerializeToString())
+    except Exception as e:  # noqa: BLE001
+        cos_failed = True
+        msg = repr(e)
+        if len(msg) > 400:
+            msg = msg[:380] + "...(truncated)"
+        print(f"  session create: FAIL (expected) — {msg}")
+    else:
+        print("  session create: OK — onnxruntime now registers an f64 Cos kernel;")
+        print("  the Stage (a) Sin(x+π/2) fallback row in the audit is STALE — re-audit.")
+    ok &= cos_failed
+    print(f"  emit_cos_f64 Sin(x+π/2) fallback still required: "
+          f"{'PASS' if cos_failed else 'FAIL'}")
+    print("  (f64 Tan/Atan kernels are likewise missing in 1.26.0, but this")
+    print("   pipeline never needs them — no control graph required.)")
+    print()
 
     # ------------------------------------------------------------- #
     # (a) characteristic function evaluation

--- a/reference/onnx/audit/sphere_mie/probe_tensor_eps_ramp.py
+++ b/reference/onnx/audit/sphere_mie/probe_tensor_eps_ramp.py
@@ -1,0 +1,673 @@
+"""Probe: ONNX expressibility of the anisotropic UPML tensor-ε pipeline.
+
+Epic #88, Phase J.6 (issue #175). This probe asks whether the
+**diagonal anisotropic** complex permittivity construction of the Mie
+slice (``reference/numpy/sphere_mie.py::build_anisotropic_pml_tensor_diag``,
+issue #171 / PR #179) and the per-axis cofactor-gram mass kernel +
+complex-symmetric scatter
+(``batched_nedelec_local_mass_anisotropic_diag`` /
+``assemble_global_nedelec_anisotropic``) can be expressed as pure ONNX
+opset-18 graphs.
+
+Relation to the H.5 probes
+==========================
+
+Phase H.5 (``../sphere_pml/probe_complex_eps_ramp.py``,
+``probe_complex_local_scatter.py``) established that opset 18's c128
+type is vestigial: no op constructs c128 from two f64 tensors, no
+arithmetic op accepts c128, and onnxruntime rejects c128 inputs even
+where the schema accepts them. The recommended lowering is
+**paired-real**: every c128 tensor becomes two f64 tensors.
+
+The NEW question for J.6 is whether that pair-lowering **composes
+cleanly with the tensor structure** — the constitutive datum is now a
+diagonal 3×3 tensor per tet, ``eps_diag (n_tets, 3) complex128``, and
+the mass kernel contracts a per-axis cofactor gram against it. Does
+the Re/Im split force extra reshapes or transposes?
+
+Strategy: three graphs
+======================
+
+  (A) **Native c128 control** — a minimal graph that multiplies a
+      real per-axis mass term by a c128 ``eps_diag`` input. Expected
+      to fail at session load (re-confirms the H.5 headline on this
+      pipeline's shapes; the failure is the load-bearing evidence).
+
+  (B) **Paired-real tensor-ε ramp** — tags (n,) int32 + centroids
+      (n, 3) f64 → ``eps_re``, ``eps_im`` (n, 3) f64. The UPML stretch
+      ``s = 1 − jσ/ω`` and its complex reciprocal ``1/s`` lower to
+      real arithmetic (the denominator ``|s|² = 1 + (σ/ω)²`` is real),
+      and the per-axis structure ``ε_α = bg·(s⁻¹ r̂_α² + s (1 − r̂_α²))``
+      is plain (n,1)-against-(n,3) broadcasting. Compared elementwise
+      against ``build_anisotropic_pml_tensor_diag``.
+
+  (C) **Paired-real anisotropic mass + scatter** — coords (m,4,3) +
+      ``eps_re``/``eps_im`` (m,3) + edge tables → per-element 6×6
+      Re/Im mass blocks AND the global (n_edges, n_edges) Re/Im
+      buffers via two ScatterND calls. The per-axis cofactor gram is
+      one Einsum (``epa,eqa->eapq``); the edge-pair Kronecker ladder
+      is a constant (4,4,6,6) coefficient tensor contracted by a
+      second Einsum; the ε-weighting is a third Einsum per channel.
+      Because the geometric factor is REAL and shared, the Re and Im
+      channels each cost ONE extra Einsum — not a 4-multiply complex
+      product — and no reshapes/transposes appear that the scalar
+      (H.5) lowering didn't already have. Compared against
+      ``batched_nedelec_local_mass_anisotropic_diag`` and
+      ``assemble_global_nedelec_anisotropic``.
+
+Run
+===
+
+    python3 reference/onnx/audit/sphere_mie/probe_tensor_eps_ramp.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+import onnx.checker
+import onnx.helper as oh
+import onnxruntime as ort
+from onnx import TensorProto
+
+HERE = Path(__file__).resolve().parent
+REFERENCE_ROOT = HERE.parent.parent.parent
+sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+
+from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+from sphere_pec import (  # noqa: E402
+    PHYS_PML_SHELL,
+    PHYS_SPHERE_INTERIOR,
+    R_BUFFER,
+    R_PML_INNER,
+    build_edges,
+)
+from sphere_mie import (  # noqa: E402
+    K0_REF,
+    SIGMA_0_DEFAULT,
+    assemble_global_nedelec_anisotropic,
+    batched_nedelec_local_mass_anisotropic_diag,
+    build_anisotropic_pml_tensor_diag,
+)
+
+OPSET = 18
+N_INSIDE = 1.5
+
+
+def _const(name: str, np_arr: np.ndarray) -> onnx.NodeProto:
+    dtype_map = {
+        np.dtype("float64"): TensorProto.DOUBLE,
+        np.dtype("int64"): TensorProto.INT64,
+        np.dtype("int32"): TensorProto.INT32,
+    }
+    return oh.make_node(
+        "Constant",
+        inputs=[],
+        outputs=[name],
+        value=oh.make_tensor(
+            name=name + "_value",
+            data_type=dtype_map[np_arr.dtype],
+            dims=list(np_arr.shape),
+            vals=np_arr.flatten().tolist(),
+        ),
+    )
+
+
+def edge_pair_coefficient_tensor() -> np.ndarray:
+    """Constant T (4, 4, 6, 6) with the edge-pair Kronecker ladder.
+
+    ``m_term[e, α, i, j] = Σ_pq gg_axis[e, α, p, q] · T[p, q, i, j]``
+    reproduces the four-term combination in
+    ``batched_nedelec_local_mass_anisotropic_diag``:
+
+        f_ac·gg[b,d] − f_ad·gg[b,c] − f_bc·gg[a,d] + f_bd·gg[a,c]
+
+    T is structural (depends only on TET_LOCAL_EDGES), so it is baked
+    into the graph as a Constant — no reshapes or transposes needed.
+    """
+    t = np.zeros((4, 4, 6, 6), dtype=np.float64)
+    for i, (a, b) in enumerate(TET_LOCAL_EDGES):
+        for j, (c, d) in enumerate(TET_LOCAL_EDGES):
+            f_ac = 2.0 if a == c else 1.0
+            f_ad = 2.0 if a == d else 1.0
+            f_bc = 2.0 if b == c else 1.0
+            f_bd = 2.0 if b == d else 1.0
+            t[b, d, i, j] += f_ac
+            t[b, c, i, j] -= f_ad
+            t[a, d, i, j] -= f_bc
+            t[a, c, i, j] += f_bd
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# Graph (A) — native c128 control (expected to fail at session load).
+# --------------------------------------------------------------------------- #
+
+
+def build_native_c128_graph(n_tets: int) -> onnx.ModelProto:
+    """Multiply a real (m, 3, 6, 6) mass term by a c128 (m, 3) eps_diag."""
+    nodes: list[onnx.NodeProto] = []
+    m_term_vi = oh.make_tensor_value_info(
+        "m_term", TensorProto.DOUBLE, [n_tets, 3, 6, 6]
+    )
+    eps_vi = oh.make_tensor_value_info(
+        "eps_diag", TensorProto.COMPLEX128, [n_tets, 3]
+    )
+    nodes.append(_const("shape_b", np.array([n_tets, 3, 1, 1], dtype=np.int64)))
+    # Reshape on c128 is schema-OK; the c128 Mul is the blocked op.
+    nodes.append(oh.make_node("Reshape", ["eps_diag", "shape_b"], ["eps_b"]))
+    nodes.append(oh.make_node("Mul", ["m_term", "eps_b"], ["m_axis_c128"]))
+    out_vi = oh.make_tensor_value_info(
+        "m_axis_c128", TensorProto.COMPLEX128, [n_tets, 3, 6, 6]
+    )
+    graph = oh.make_graph(
+        nodes,
+        name="tensor_eps_native_c128_probe",
+        inputs=[m_term_vi, eps_vi],
+        outputs=[out_vi],
+    )
+    return oh.make_model(
+        graph, opset_imports=[oh.make_opsetid("", OPSET)], ir_version=9
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Graph (B) — paired-real anisotropic tensor-ε ramp.
+# --------------------------------------------------------------------------- #
+
+
+def build_paired_real_tensor_ramp_graph() -> onnx.ModelProto:
+    """tags (n,) int32 + centroids (n, 3) f64 → eps_re, eps_im (n, 3) f64.
+
+    Mirrors ``build_anisotropic_pml_tensor_diag`` with the complex
+    stretch lowered to real arithmetic:
+
+        s      = 1 − jσ/ω          → (s_re, s_im) = (1, −σ/ω)
+        1/s    = conj(s)/|s|²      → (s_re/d, −s_im/d), d = s_re² + s_im²
+        ε_α    = bg·(s⁻¹ w_α + s (1 − w_α)),  w_α = r̂_α²
+
+    bg and w are real, so Re/Im factor through shared real tensors.
+    The per-axis structure is (n,1)-vs-(n,3) broadcasting only.
+    """
+    nodes: list[onnx.NodeProto] = []
+
+    tags_vi = oh.make_tensor_value_info("tags", TensorProto.INT32, ["N"])
+    cent_vi = oh.make_tensor_value_info("centroids", TensorProto.DOUBLE, ["N", 3])
+
+    width = R_BUFFER - R_PML_INNER
+    omega = max(float(K0_REF), 1e-12)
+
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("phys_interior", np.array(PHYS_SPHERE_INTERIOR, dtype=np.int32)))
+    nodes.append(_const("phys_pml", np.array(PHYS_PML_SHELL, dtype=np.int32)))
+    nodes.append(_const("n2", np.array(N_INSIDE * N_INSIDE, dtype=np.float64)))
+    nodes.append(_const("one", np.array(1.0, dtype=np.float64)))
+    nodes.append(_const("zero", np.array(0.0, dtype=np.float64)))
+    nodes.append(_const("r_inner", np.array(R_PML_INNER, dtype=np.float64)))
+    nodes.append(_const("inv_width", np.array(1.0 / width, dtype=np.float64)))
+    nodes.append(_const("sigma0", np.array(float(SIGMA_0_DEFAULT), dtype=np.float64)))
+    nodes.append(_const("neg_inv_omega", np.array(-1.0 / omega, dtype=np.float64)))
+    nodes.append(_const("r_guard", np.array(1e-12, dtype=np.float64)))
+
+    # r_c (n, 1) — keepdims so everything below broadcasts against (n, 3).
+    nodes.append(oh.make_node("Mul", ["centroids", "centroids"], ["c_sq"]))
+    nodes.append(oh.make_node("ReduceSum", ["c_sq", "ax1"], ["r2"], keepdims=1))
+    nodes.append(oh.make_node("Sqrt", ["r2"], ["r_c"]))
+
+    # Selector masks (n, 1).
+    nodes.append(oh.make_node("Equal", ["tags", "phys_interior"], ["is_int_flat"]))
+    nodes.append(oh.make_node("Equal", ["tags", "phys_pml"], ["is_pml_flat"]))
+    nodes.append(oh.make_node("Unsqueeze", ["is_int_flat", "ax1"], ["is_int"]))
+    nodes.append(oh.make_node("Unsqueeze", ["is_pml_flat", "ax1"], ["is_pml"]))
+    nodes.append(oh.make_node("Greater", ["r_c", "r_inner"], ["past_inner"]))
+    nodes.append(oh.make_node("And", ["is_pml", "past_inner"], ["in_shell"]))
+
+    # Background scalar bg (n, 1): n² inside, 1 elsewhere.
+    nodes.append(oh.make_node("Where", ["is_int", "n2", "one"], ["bg"]))
+
+    # Ramp: u = clip((r_c − R_PML_INNER)/Δ, 0, 1); σ = σ₀ u².
+    nodes.append(oh.make_node("Sub", ["r_c", "r_inner"], ["r_shift"]))
+    nodes.append(oh.make_node("Mul", ["r_shift", "inv_width"], ["u_raw"]))
+    nodes.append(oh.make_node("Clip", ["u_raw", "zero", "one"], ["u"]))
+    nodes.append(oh.make_node("Mul", ["u", "u"], ["u2"]))
+    nodes.append(oh.make_node("Mul", ["sigma0", "u2"], ["sigma"]))
+
+    # Complex stretch s = 1 − jσ/ω lowered: s_re = 1, s_im = −σ/ω.
+    nodes.append(oh.make_node("Mul", ["sigma", "neg_inv_omega"], ["s_im"]))
+    # 1/s = conj(s)/|s|²: denom = 1 + s_im² (s_re ≡ 1).
+    nodes.append(oh.make_node("Mul", ["s_im", "s_im"], ["s_im2"]))
+    nodes.append(oh.make_node("Add", ["one", "s_im2"], ["denom"]))
+    nodes.append(oh.make_node("Reciprocal", ["denom"], ["inv_denom"]))
+    nodes.append(oh.make_node("Neg", ["s_im"], ["neg_s_im"]))
+    nodes.append(oh.make_node("Mul", ["neg_s_im", "inv_denom"], ["sinv_im"]))
+    # sinv_re = s_re/denom = inv_denom (since s_re ≡ 1).
+
+    # Radial direction r̂ (n, 3), with the |c| ≈ 0 defensive guard.
+    nodes.append(oh.make_node("Greater", ["r_c", "r_guard"], ["r_pos"]))
+    nodes.append(oh.make_node("Reciprocal", ["r_c"], ["inv_r_raw"]))
+    nodes.append(oh.make_node("Where", ["r_pos", "inv_r_raw", "zero"], ["inv_r"]))
+    nodes.append(oh.make_node("Mul", ["centroids", "inv_r"], ["r_hat"]))
+    nodes.append(oh.make_node("Mul", ["r_hat", "r_hat"], ["w"]))
+    nodes.append(oh.make_node("Sub", ["one", "w"], ["one_minus_w"]))
+
+    # ε_α = bg·(s⁻¹ w_α + s (1 − w_α)) — Re and Im channels, (n,1)·(n,3).
+    nodes.append(oh.make_node("Mul", ["inv_denom", "w"], ["re_a"]))
+    # s_re ≡ 1 → s_re·(1−w) = one_minus_w.
+    nodes.append(oh.make_node("Add", ["re_a", "one_minus_w"], ["shell_re_unit"]))
+    nodes.append(oh.make_node("Mul", ["bg", "shell_re_unit"], ["shell_re"]))
+
+    nodes.append(oh.make_node("Mul", ["sinv_im", "w"], ["im_a"]))
+    nodes.append(oh.make_node("Mul", ["s_im", "one_minus_w"], ["im_b"]))
+    nodes.append(oh.make_node("Add", ["im_a", "im_b"], ["shell_im_unit"]))
+    nodes.append(oh.make_node("Mul", ["bg", "shell_im_unit"], ["shell_im"]))
+
+    # Default (interior / vacuum / shell-guard): real isotropic bg.
+    # Where broadcasts the (n,1) condition AND the (n,1)/scalar branches
+    # against the (n,3) shell values — no Expand/Reshape needed.
+    nodes.append(oh.make_node("Where", ["in_shell", "shell_re", "bg"], ["eps_re"]))
+    nodes.append(oh.make_node("Where", ["in_shell", "shell_im", "zero"], ["eps_im"]))
+
+    re_vi = oh.make_tensor_value_info("eps_re", TensorProto.DOUBLE, ["N", 3])
+    im_vi = oh.make_tensor_value_info("eps_im", TensorProto.DOUBLE, ["N", 3])
+
+    graph = oh.make_graph(
+        nodes,
+        name="tensor_eps_paired_real_ramp",
+        inputs=[tags_vi, cent_vi],
+        outputs=[re_vi, im_vi],
+    )
+    return oh.make_model(
+        graph, opset_imports=[oh.make_opsetid("", OPSET)], ir_version=9
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Graph (C) — paired-real anisotropic local mass + global scatter.
+# --------------------------------------------------------------------------- #
+
+
+def _emit_cross(nodes, a, b, out, tag):
+    """cross(a, b) for (m, 3) tensors via component Gather + Mul/Sub."""
+    for comp, idx in (("x", 0), ("y", 1), ("z", 2)):
+        nodes.append(_const(f"{tag}_i{comp}", np.array(idx, dtype=np.int64)))
+        nodes.append(
+            oh.make_node("Gather", [a, f"{tag}_i{comp}"], [f"{tag}_a{comp}"], axis=1)
+        )
+        nodes.append(
+            oh.make_node("Gather", [b, f"{tag}_i{comp}"], [f"{tag}_b{comp}"], axis=1)
+        )
+    pieces = []
+    for comp, (p, q) in (("x", ("y", "z")), ("y", ("z", "x")), ("z", ("x", "y"))):
+        nodes.append(
+            oh.make_node("Mul", [f"{tag}_a{p}", f"{tag}_b{q}"], [f"{tag}_m1{comp}"])
+        )
+        nodes.append(
+            oh.make_node("Mul", [f"{tag}_a{q}", f"{tag}_b{p}"], [f"{tag}_m2{comp}"])
+        )
+        nodes.append(
+            oh.make_node("Sub", [f"{tag}_m1{comp}", f"{tag}_m2{comp}"], [f"{tag}_c{comp}"])
+        )
+        nodes.append(
+            oh.make_node("Unsqueeze", [f"{tag}_c{comp}", "ax1"], [f"{tag}_cu{comp}"])
+        )
+        pieces.append(f"{tag}_cu{comp}")
+    nodes.append(oh.make_node("Concat", pieces, [out], axis=1))
+
+
+def build_paired_real_mass_scatter_graph(n_tets: int, n_edges: int) -> onnx.ModelProto:
+    """coords + paired-real eps_diag + edge tables → local 6×6 Re/Im
+    blocks and global (n_edges, n_edges) Re/Im buffers."""
+    nodes: list[onnx.NodeProto] = []
+
+    coords_vi = oh.make_tensor_value_info(
+        "coords", TensorProto.DOUBLE, [n_tets, 4, 3]
+    )
+    eps_re_vi = oh.make_tensor_value_info("eps_re", TensorProto.DOUBLE, [n_tets, 3])
+    eps_im_vi = oh.make_tensor_value_info("eps_im", TensorProto.DOUBLE, [n_tets, 3])
+    tei_vi = oh.make_tensor_value_info("tet_edge_idx", TensorProto.INT64, [n_tets, 6])
+    tes_vi = oh.make_tensor_value_info("tet_edge_sign", TensorProto.DOUBLE, [n_tets, 6])
+
+    nodes.append(_const("ax1", np.array([1], dtype=np.int64)))
+    nodes.append(_const("ax2", np.array([2], dtype=np.int64)))
+
+    # Vertex extraction v0..v3 (m, 3) and edge vectors.
+    for vi in range(4):
+        nodes.append(_const(f"vidx{vi}", np.array(vi, dtype=np.int64)))
+        nodes.append(oh.make_node("Gather", ["coords", f"vidx{vi}"], [f"v{vi}"], axis=1))
+    nodes.append(oh.make_node("Sub", ["v1", "v0"], ["e1"]))
+    nodes.append(oh.make_node("Sub", ["v2", "v0"], ["e2"]))
+    nodes.append(oh.make_node("Sub", ["v3", "v0"], ["e3"]))
+
+    # Cofactor vectors g1 = e2×e3, g2 = e3×e1, g3 = e1×e2, g0 = −(g1+g2+g3).
+    _emit_cross(nodes, "e2", "e3", "g1", "x1")
+    _emit_cross(nodes, "e3", "e1", "g2", "x2")
+    _emit_cross(nodes, "e1", "e2", "g3", "x3")
+    nodes.append(oh.make_node("Add", ["g1", "g2"], ["g12"]))
+    nodes.append(oh.make_node("Add", ["g12", "g3"], ["g123"]))
+    nodes.append(oh.make_node("Neg", ["g123"], ["g0"]))
+
+    # det = Σ e1·g1 (m,); scale = 1/(120 |det|) as (m, 1, 1).
+    nodes.append(oh.make_node("Mul", ["e1", "g1"], ["e1g1"]))
+    nodes.append(oh.make_node("ReduceSum", ["e1g1", "ax1"], ["det"], keepdims=0))
+    nodes.append(oh.make_node("Abs", ["det"], ["abs_det"]))
+    nodes.append(_const("c120", np.array(120.0, dtype=np.float64)))
+    nodes.append(oh.make_node("Mul", ["abs_det", "c120"], ["det120"]))
+    nodes.append(oh.make_node("Reciprocal", ["det120"], ["scale_flat"]))
+    nodes.append(_const("ax12", np.array([1, 2], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["scale_flat", "ax12"], ["scale"]))
+
+    # g_mat (m, 4, 3) via Unsqueeze + Concat.
+    for gi in range(4):
+        nodes.append(oh.make_node("Unsqueeze", [f"g{gi}", "ax1"], [f"g{gi}_u"]))
+    nodes.append(
+        oh.make_node("Concat", ["g0_u", "g1_u", "g2_u", "g3_u"], ["g_mat"], axis=1)
+    )
+
+    # Per-axis cofactor gram: gg_axis (m, 3, 4, 4) — ONE Einsum.
+    nodes.append(
+        oh.make_node("Einsum", ["g_mat", "g_mat"], ["gg_axis"], equation="epa,eqa->eapq")
+    )
+
+    # Edge-pair ladder: constant T (4,4,6,6), m_axis (m, 3, 6, 6).
+    nodes.append(_const("T_pairs", edge_pair_coefficient_tensor()))
+    nodes.append(
+        oh.make_node(
+            "Einsum", ["gg_axis", "T_pairs"], ["m_axis"], equation="eapq,pqij->eaij"
+        )
+    )
+
+    # ε-weighting: Re/Im channels share m_axis — one Einsum each.
+    nodes.append(
+        oh.make_node("Einsum", ["m_axis", "eps_re"], ["m_re_raw"], equation="eaij,ea->eij")
+    )
+    nodes.append(
+        oh.make_node("Einsum", ["m_axis", "eps_im"], ["m_im_raw"], equation="eaij,ea->eij")
+    )
+    nodes.append(oh.make_node("Mul", ["m_re_raw", "scale"], ["m_re_local"]))
+    nodes.append(oh.make_node("Mul", ["m_im_raw", "scale"], ["m_im_local"]))
+
+    # Sign outer product (real, shared) and signed blocks.
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax2"], ["sign_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_sign", "ax1"], ["sign_row"]))
+    nodes.append(oh.make_node("Mul", ["sign_col", "sign_row"], ["sign_outer"]))
+    nodes.append(oh.make_node("Mul", ["m_re_local", "sign_outer"], ["m_re_signed"]))
+    nodes.append(oh.make_node("Mul", ["m_im_local", "sign_outer"], ["m_im_signed"]))
+
+    # COO indices — identical to the H.5/G.6 pattern, shared by Re/Im.
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax2"], ["tei_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["tet_edge_idx", "ax1"], ["tei_row"]))
+    nodes.append(_const("target_shape", np.array([n_tets, 6, 6], dtype=np.int64)))
+    nodes.append(oh.make_node("Expand", ["tei_col", "target_shape"], ["rows_3d"]))
+    nodes.append(oh.make_node("Expand", ["tei_row", "target_shape"], ["cols_3d"]))
+    nodes.append(_const("shape_flat", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Reshape", ["rows_3d", "shape_flat"], ["rows_flat"]))
+    nodes.append(oh.make_node("Reshape", ["cols_3d", "shape_flat"], ["cols_flat"]))
+    nodes.append(oh.make_node("Reshape", ["m_re_signed", "shape_flat"], ["m_re_vals"]))
+    nodes.append(oh.make_node("Reshape", ["m_im_signed", "shape_flat"], ["m_im_vals"]))
+    nodes.append(_const("ax_neg1", np.array([-1], dtype=np.int64)))
+    nodes.append(oh.make_node("Unsqueeze", ["rows_flat", "ax_neg1"], ["rows_col"]))
+    nodes.append(oh.make_node("Unsqueeze", ["cols_flat", "ax_neg1"], ["cols_col"]))
+    nodes.append(oh.make_node("Concat", ["rows_col", "cols_col"], ["indices"], axis=1))
+
+    # Two zero buffers + two scatters (paired-real, H.5 disposition).
+    nodes.append(_const("shape_nn", np.array([n_edges, n_edges], dtype=np.int64)))
+    for ch in ("re", "im"):
+        nodes.append(
+            oh.make_node(
+                "ConstantOfShape",
+                inputs=["shape_nn"],
+                outputs=[f"zero_{ch}"],
+                value=oh.make_tensor(f"z{ch}", TensorProto.DOUBLE, [1], [0.0]),
+            )
+        )
+        nodes.append(
+            oh.make_node(
+                "ScatterND",
+                inputs=[f"zero_{ch}", "indices", f"m_{ch}_vals"],
+                outputs=[f"m_{ch}_global"],
+                reduction="add",
+            )
+        )
+
+    outs = [
+        oh.make_tensor_value_info("m_re_local", TensorProto.DOUBLE, [n_tets, 6, 6]),
+        oh.make_tensor_value_info("m_im_local", TensorProto.DOUBLE, [n_tets, 6, 6]),
+        oh.make_tensor_value_info("m_re_global", TensorProto.DOUBLE, [n_edges, n_edges]),
+        oh.make_tensor_value_info("m_im_global", TensorProto.DOUBLE, [n_edges, n_edges]),
+    ]
+    graph = oh.make_graph(
+        nodes,
+        name="tensor_eps_paired_real_mass_scatter",
+        inputs=[coords_vi, eps_re_vi, eps_im_vi, tei_vi, tes_vi],
+        outputs=outs,
+    )
+    return oh.make_model(
+        graph, opset_imports=[oh.make_opsetid("", OPSET)], ir_version=9
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Driver
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    print("== Probe: anisotropic UPML tensor-ε ramp + mass scatter (Phase J.6) ==")
+    print(f"onnx={onnx.__version__}  onnxruntime={ort.__version__}  opset={OPSET}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Test fixture for the ramp: 8 tets spanning all regions and
+    # axis-aligned / oblique radial directions.
+    # ------------------------------------------------------------- #
+    centroids_np = np.array(
+        [
+            [0.10, 0.10, 0.10],   # interior (oblique, r ≈ 0.17)
+            [0.50, 0.00, 0.00],   # interior (axis-aligned)
+            [1.20, 0.30, 0.00],   # vacuum gap
+            [1.40, 0.00, 0.30],   # PML tag but r ≤ R_PML_INNER → guard branch
+            [1.70, 0.00, 0.00],   # PML mid-ramp, x-aligned (w = (1,0,0))
+            [0.00, 1.80, 0.00],   # PML mid-ramp, y-aligned
+            [1.00, 1.00, 1.00],   # PML mid-ramp, oblique (r ≈ 1.73)
+            [1.50, 1.20, 0.80],   # PML past R_BUFFER → clamped u = 1
+        ],
+        dtype=np.float64,
+    )
+    tags_np = np.array(
+        [
+            PHYS_SPHERE_INTERIOR,
+            PHYS_SPHERE_INTERIOR,
+            999,
+            PHYS_PML_SHELL,
+            PHYS_PML_SHELL,
+            PHYS_PML_SHELL,
+            PHYS_PML_SHELL,
+            PHYS_PML_SHELL,
+        ],
+        dtype=np.int32,
+    )
+    # Sanity: row 3 really exercises the r ≤ R_PML_INNER shell guard.
+    assert np.linalg.norm(centroids_np[3]) <= R_PML_INNER
+
+    eps_ref = build_anisotropic_pml_tensor_diag(
+        tags_np, centroids_np, n_inside=N_INSIDE, sigma_0=SIGMA_0_DEFAULT, k0_ref=K0_REF
+    )
+
+    # ------------------------------------------------------------- #
+    # Graph (A) — native c128 control
+    # ------------------------------------------------------------- #
+    print("--- Graph (A): native c128 Mul over (m_term f64, eps_diag c128) ---")
+    model_a = build_native_c128_graph(n_tets=2)
+    try:
+        onnx.checker.check_model(model_a)
+        a_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_checker = f"FAIL ({e!r:.200})"
+    print(f"onnx.checker: {a_checker}")
+
+    a_rt = "skipped"
+    a_err = ""
+    try:
+        sess_a = ort.InferenceSession(model_a.SerializeToString())
+        sess_a.run(
+            ["m_axis_c128"],
+            {
+                "m_term": np.zeros((2, 3, 6, 6), dtype=np.float64),
+                "eps_diag": np.ones((2, 3), dtype=np.complex128),
+            },
+        )
+        a_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        a_rt = "FAIL"
+        a_err = repr(e)
+    print(f"onnxruntime execution: {a_rt}")
+    if a_err:
+        msg = a_err if len(a_err) < 400 else a_err[:380] + "...(truncated)"
+        print(f"  runtime error: {msg}")
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (B) — paired-real tensor ramp
+    # ------------------------------------------------------------- #
+    print("--- Graph (B): paired-real tensor-ε ramp (eps_re, eps_im (n,3)) ---")
+    model_b = build_paired_real_tensor_ramp_graph()
+    try:
+        onnx.checker.check_model(model_b)
+        b_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_checker = f"FAIL ({e!r})"
+    print(f"onnx.checker: {b_checker}")
+
+    b_rt = "skipped"
+    max_re_err = max_im_err = float("nan")
+    try:
+        sess_b = ort.InferenceSession(model_b.SerializeToString())
+        re_onnx, im_onnx = sess_b.run(
+            ["eps_re", "eps_im"], {"tags": tags_np, "centroids": centroids_np}
+        )
+        max_re_err = float(np.max(np.abs(re_onnx - eps_ref.real)))
+        max_im_err = float(np.max(np.abs(im_onnx - eps_ref.imag)))
+        b_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        b_rt = f"FAIL ({e!r})"
+    print(f"onnxruntime execution: {b_rt}")
+    if b_rt == "OK":
+        print(f"  max |eps_re_onnx - Re(eps_ref)| = {max_re_err:.3e}")
+        print(f"  max |eps_im_onnx - Im(eps_ref)| = {max_im_err:.3e}")
+    b_ok = b_rt == "OK" and max_re_err < 1e-13 and max_im_err < 1e-13
+    print()
+
+    # ------------------------------------------------------------- #
+    # Graph (C) — paired-real anisotropic mass + scatter
+    # ------------------------------------------------------------- #
+    print("--- Graph (C): paired-real anisotropic mass kernel + scatter ---")
+    # 2-tet mesh sharing a face (same as the H.5 scatter probe).
+    tets_np = np.array([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=np.int64)
+    nodes_np = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.5, 0.5, 0.5],
+        ],
+        dtype=np.float64,
+    )
+    n_tets = tets_np.shape[0]
+    edges, tet_edge_idx, tet_edge_sign = build_edges(tets_np)
+    n_edges = int(edges.shape[0])
+    tet_edge_sign_f64 = tet_edge_sign.astype(np.float64)
+    coords = nodes_np[tets_np, :]
+
+    # Non-trivial anisotropic ε: take REFERENCE ramp values from two of
+    # the synthetic centroids above — one interior (real isotropic) and
+    # the clamped oblique shell tet, whose unequal direction components
+    # (1.5, 1.2, 0.8)/|c| give three DISTINCT complex diagonal entries —
+    # so the mass test consumes genuinely anisotropic data.
+    eps_diag_c = np.vstack([eps_ref[1], eps_ref[7]])  # (2, 3) complex128
+    assert np.any(eps_diag_c.imag != 0.0)
+    assert not np.allclose(eps_diag_c[1].real, eps_diag_c[1, 0].real)
+    eps_re_np = np.ascontiguousarray(eps_diag_c.real)
+    eps_im_np = np.ascontiguousarray(eps_diag_c.imag)
+
+    m_local_ref = batched_nedelec_local_mass_anisotropic_diag(coords, eps_diag_c)
+    _k_ref, m_global_ref = assemble_global_nedelec_anisotropic(
+        nodes_np, tets_np, edges, tet_edge_idx, tet_edge_sign_f64, eps_diag_c
+    )
+    m_global_ref = m_global_ref.toarray()
+
+    model_c = build_paired_real_mass_scatter_graph(n_tets, n_edges)
+    try:
+        onnx.checker.check_model(model_c)
+        c_checker = "OK"
+    except Exception as e:  # noqa: BLE001
+        c_checker = f"FAIL ({e!r})"
+    print(f"onnx.checker: {c_checker}")
+
+    c_rt = "skipped"
+    errs = {}
+    try:
+        sess_c = ort.InferenceSession(model_c.SerializeToString())
+        outs = sess_c.run(
+            ["m_re_local", "m_im_local", "m_re_global", "m_im_global"],
+            {
+                "coords": coords,
+                "eps_re": eps_re_np,
+                "eps_im": eps_im_np,
+                "tet_edge_idx": tet_edge_idx,
+                "tet_edge_sign": tet_edge_sign_f64,
+            },
+        )
+        m_re_loc, m_im_loc, m_re_glob, m_im_glob = outs
+        errs["local Re"] = float(np.max(np.abs(m_re_loc - m_local_ref.real)))
+        errs["local Im"] = float(np.max(np.abs(m_im_loc - m_local_ref.imag)))
+        errs["global Re"] = float(np.max(np.abs(m_re_glob - m_global_ref.real)))
+        errs["global Im"] = float(np.max(np.abs(m_im_glob - m_global_ref.imag)))
+        c_rt = "OK"
+    except Exception as e:  # noqa: BLE001
+        c_rt = f"FAIL ({e!r})"
+    print(f"onnxruntime execution: {c_rt}")
+    c_ok = c_rt == "OK"
+    if c_rt == "OK":
+        for label, err in errs.items():
+            print(f"  max |{label} onnx - ref| = {err:.3e}")
+            # Einsum association order differs from the NumPy loop, so
+            # allow roundoff (values are O(0.01..0.1) on this mesh).
+            c_ok = c_ok and err < 1e-14
+        # Complex-symmetric (NOT Hermitian) check on the assembled global.
+        sym_re = float(np.max(np.abs(m_re_glob - m_re_glob.T)))
+        sym_im = float(np.max(np.abs(m_im_glob - m_im_glob.T)))
+        print(f"  complex-symmetry: max|Re(M)-Re(M)^T| = {sym_re:.3e}, "
+              f"max|Im(M)-Im(M)^T| = {sym_im:.3e}")
+        c_ok = c_ok and sym_re == 0.0 and sym_im == 0.0
+    print()
+
+    # ------------------------------------------------------------- #
+    # Verdict
+    # ------------------------------------------------------------- #
+    print("Verdicts:")
+    print("--------------------------------------------------------------")
+    print(f"  (A) native c128 tensor Mul:    schema={a_checker}, runtime={a_rt}")
+    print("      → BLOCKED (inherits H.5: no c128 kernel in onnxruntime).")
+    print(f"  (B) paired-real tensor ramp:   {'EXPRESSIBLE' if b_ok else 'FAILED'}")
+    print("      → the complex stretch s and 1/s lower to REAL arithmetic")
+    print("        (real denominator |s|²); the diagonal-tensor structure is")
+    print("        one broadcast axis, (n,1) against (n,3). No reshapes or")
+    print("        transposes beyond the scalar H.5 lowering.")
+    print(f"  (C) paired-real mass+scatter:  {'EXPRESSIBLE' if c_ok else 'FAILED'}")
+    print("      → per-axis cofactor gram = 1 Einsum; edge-pair ladder = 1")
+    print("        Einsum against a constant (4,4,6,6) tensor; ε-weighting =")
+    print("        1 Einsum PER CHANNEL sharing the real m_axis. Pair-lowering")
+    print("        composes cleanly: 2 extra Einsums + 1 extra ScatterND, not")
+    print("        a 4-multiply complex product, and zero extra reshapes.")
+    print()
+    overall = (a_rt == "FAIL") and b_ok and c_ok
+    print(f"Overall: {'FALLBACK (paired-real lowering) — composes cleanly with' if overall else 'PROBE FAILED for'} the tensor structure.")
+    return 0 if overall else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase J.6 of Epic #88: ONNX opset-18 expressibility audit for the Mie slice, mirroring F.1 / G.6 / H.5 / I.3. Audit-only — touches nothing outside `reference/onnx/audit/sphere_mie/`.

Closes #175

### Deliverables

- `reference/onnx/audit/sphere_mie/mie_operator_audit.md` — per-stage verdict tables, pinned versions (onnx 1.21.0 / onnxruntime 1.26.0 / opset 18), spec-implications section, re-run instructions.
- `probe_tensor_eps_ramp.py` — anisotropic UPML tensor-ε ramp + per-axis cofactor-gram mass + complex-symmetric scatter, validated against `reference/numpy/sphere_mie.py` (PR #179).
- `probe_root_finding_loop.py` — the full `find_roots` pipeline in-graph (TE l=1), validated against `reference/numpy/mie_roots.py` (PR #177) brentq roots and the J.1 catalogue fixture; never self-compares.

### Verdicts

**Target 1 (tensor-ε):** FALLBACK (paired-real), **composing cleanly** with the diagonal-tensor structure — the complex stretch and its reciprocal lower to real arithmetic (real denominator |s|²), the per-tet 3-vector is one broadcast/Einsum axis, and the Re/Im channels share every real intermediate. Marginal cost over the scalar H.5 lowering: 2 extra Einsums + 1 extra ScatterND, **zero** extra reshapes/transposes. Bit-exact (`0.000e+00`) on ramp, local 6×6 blocks, and the assembled global (which is exactly complex-symmetric).

**Target 2 (root finding):**
- (a) characteristic evaluation: **EMITTABLE** — all Bessel loops are fixed-count at graph-build time (closed forms l=1; unrolled upward ladder + 24-step Miller downward with Where-lowered rescale + Where regime select for l=4); errors ≤ 1.9e-14 vs scipy/reference.
- (b) grid scan + sign-change detection: **EMITTABLE** — fixed-shape (30000,) bracket mask, exact match to the `find_roots` acceptance conditions.
- (c) bracket extraction + dedup + compaction: **BLOCKED for static shapes** — the 1e-5 dedup is an inherently sequential scan (expressible-but-tortured as a 30000-trip `Loop`, probed and correct); compaction is `NonZero`+`Gather` (runs under ORT but data-dependent output shape — the G.6 `np.unique` class). Disposition: dense roots + keep-mask in-graph, compact at host.
- (d) bisection refinement: **EMITTABLE both ways** — unrolled 60× with Where convergence masking AND as `Loop(trip=60, cond)`; the two forms are **bit-identical**, match brentq reference roots to 4.6e-13 rel, and the J.1 baseline TE l=1 roots to 1.2e-12 abs (tol 2e-9).

### Iterate-while spec implication (for #5 / upstream whiteroom)

ONNX `Loop` IS a working `iterate-while-with-prev`: loop-carried state (incl. bool masks), max trip count, scalar boolean continue-condition, scan outputs. The L4 surface survives a graph-only backend provided: (1) carried-state shapes are loop-invariant; (2) the continue-condition is a scalar reduction — per-lane early exit must lower to Where masking inside the state; (3) iteration may not grow data-dependent-count outputs (dense+mask in-graph, compaction at host). Unroll-vs-Loop is a backend lowering choice, not semantic (bit-identical; 7160 vs 134 nodes).

### Surprise finding

onnxruntime 1.26.0 registers an f64 CPU kernel for `Sin` but **not** for `Cos`/`Tan`/`Atan` (`NOT_IMPLEMENTED` at session create). Lowered as `cos(x) = Sin(x + π/2)` (error ≲ ε·x); an f32 round-trip would have destroyed the 1e-10 root contract. Mirror image of the H.5 c128 finding: schema acceptance ≠ kernel coverage — an L4 conformance statement must pin the runtime, not just the IR.

## Test plan

- [x] `probe_tensor_eps_ramp.py` exits 0 (pinned venv: onnx 1.21.0, onnxruntime 1.26.0)
- [x] `probe_root_finding_loop.py` exits 0 (~8 s, including the 30000-trip dedup Loop)
- [x] No Rust changes; nothing outside `reference/onnx/` touched (no cargo run needed per issue AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)