### PR TITLE
Enforce rustfmt in CI and fix accumulated format drift (#185)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Commits to ignore in `git blame` (GitHub honors this file natively;
+# locally: git config blame.ignoreRevsFile .git-blame-ignore-revs).
+
+# style: cargo fmt --all — fix accumulated format drift (#185)
+ddda725eb552510e225ad928c80ef21b3a5765d1

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,32 @@
+name: rustfmt
+
+# Issue #185 — enforce `cargo fmt` so format drift can't accumulate.
+#
+# Before this gate existed, ~11 files drifted from rustfmt and every PR
+# had to manually carve them out of its diff. The check is cheap (no
+# build, no dependency resolution — rustfmt only parses), so it runs
+# unconditionally on every push/PR rather than behind a path filter.
+#
+# All other workflows in this repo are specialized, path-filtered
+# physics/cross-check jobs; this is the one repo-wide lint gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  fmt:
+    name: cargo fmt --all -- --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -280,11 +280,7 @@ pub const DERHAM_RANK_THRESHOLD_REL: f64 = 1e-12;
 /// `crates/geode-core/tests/derham_kernel_dim.rs` (Issue #81) so it can
 /// be reused by integration tests, the geode-validation cross-checks,
 /// and downstream callers without copy-pasting the dense materialisation.
-pub fn restrict_gradient_dense(
-    mesh: &TetMesh,
-    edge_mask: &[bool],
-    node_mask: &[bool],
-) -> Mat<f64> {
+pub fn restrict_gradient_dense(mesh: &TetMesh, edge_mask: &[bool], node_mask: &[bool]) -> Mat<f64> {
     // Map global node index → interior column (None if boundary).
     let mut node_to_interior: Vec<Option<usize>> = Vec::with_capacity(node_mask.len());
     let mut n_interior_nodes = 0usize;
@@ -384,11 +380,7 @@ pub fn rank_via_svd(d0: &Mat<f64>, threshold_rel: f64) -> usize {
 ///
 /// `edge_mask.len()` must equal `mesh.edges().len()` and
 /// `node_mask.len()` must equal `mesh.n_nodes()`.
-pub fn spurious_dim_from_derham(
-    mesh: &TetMesh,
-    edge_mask: &[bool],
-    node_mask: &[bool],
-) -> usize {
+pub fn spurious_dim_from_derham(mesh: &TetMesh, edge_mask: &[bool], node_mask: &[bool]) -> usize {
     let d0 = restrict_gradient_dense(mesh, edge_mask, node_mask);
     rank_via_svd(&d0, DERHAM_RANK_THRESHOLD_REL)
 }

--- a/crates/geode-core/tests/assembly.rs
+++ b/crates/geode-core/tests/assembly.rs
@@ -222,7 +222,10 @@ fn assembly_preserves_autodiff() {
     let node_flat: Vec<<Ad as BackendTypes>::FloatElem> = mesh
         .nodes
         .iter()
-        .flat_map(|p| p.iter().map(|&x| x.elem::<<Ad as BackendTypes>::FloatElem>()))
+        .flat_map(|p| {
+            p.iter()
+                .map(|&x| x.elem::<<Ad as BackendTypes>::FloatElem>())
+        })
         .collect();
     let tet_flat: Vec<i32> = mesh
         .tets

--- a/crates/geode-core/tests/fe_assemble.rs
+++ b/crates/geode-core/tests/fe_assemble.rs
@@ -6,12 +6,12 @@
 
 use burn::tensor::backend::BackendTypes;
 
+use geode_core::fe_assemble::fe_assemble;
 use geode_core::{
     apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, assemble_global_p1, build_epsilon_r,
     burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, read_sphere_fixture,
     sphere_pec_interior_edges, upload_mesh, DefaultBackend, DirichletBc, ElementType, R_BUFFER,
 };
-use geode_core::fe_assemble::fe_assemble;
 
 type B = DefaultBackend;
 
@@ -126,7 +126,8 @@ fn fe_assemble_p1_interior_dof_count_is_smaller_than_total() {
     );
     assert!(
         n_interior < mesh.n_nodes(),
-        "interior DOF count {n_interior} must be < total {}", mesh.n_nodes()
+        "interior DOF count {n_interior} must be < total {}",
+        mesh.n_nodes()
     );
 }
 

--- a/crates/geode-core/tests/nedelec.rs
+++ b/crates/geode-core/tests/nedelec.rs
@@ -551,16 +551,10 @@ fn cube_assembly_k_symmetric_and_m_total_mass_positive() {
         for j in (i + 1)..n_edges {
             let kij = k[i * n_edges + j];
             let kji = k[j * n_edges + i];
-            assert!(
-                (kij - kji).abs() < 1e-4,
-                "K not symmetric ({i},{j})"
-            );
+            assert!((kij - kji).abs() < 1e-4, "K not symmetric ({i},{j})");
             let mij = m[i * n_edges + j];
             let mji = m[j * n_edges + i];
-            assert!(
-                (mij - mji).abs() < 1e-5,
-                "M not symmetric ({i},{j})"
-            );
+            assert!((mij - mji).abs() < 1e-5, "M not symmetric ({i},{j})");
         }
     }
 

--- a/crates/geode-core/tests/p1_local_matrices.rs
+++ b/crates/geode-core/tests/p1_local_matrices.rs
@@ -131,10 +131,7 @@ fn reference_unit_tet_stiffness_matches_analytic() {
     ];
     for (idx, (g, e)) in k.iter().zip(expected.iter()).enumerate() {
         let want = e / 6.0;
-        assert!(
-            (g - want).abs() < F32_TOL,
-            "K[{idx}] = {g}, want {want}"
-        );
+        assert!((g - want).abs() < F32_TOL, "K[{idx}] = {g}, want {want}");
     }
 }
 
@@ -151,10 +148,7 @@ fn reference_unit_tet_mass_matches_analytic() {
     ];
     for (idx, (g, e)) in m.iter().zip(pattern.iter()).enumerate() {
         let want = e / 120.0; // (V/20) = 1/120, times pattern entry
-        assert!(
-            (g - want).abs() < F32_TOL,
-            "M[{idx}] = {g}, want {want}"
-        );
+        assert!((g - want).abs() < F32_TOL, "M[{idx}] = {g}, want {want}");
     }
 }
 

--- a/crates/geode-validation/tests/sphere_pec_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_jax_reference.rs
@@ -150,8 +150,7 @@ fn run_burn_pipeline() -> BurnPipeline {
 
     // Algebraic spurious-mode dimension via de-Rham d⁰ rank (Issue #124).
     let node_interior_mask = sphere_pec_node_interior_mask(&fixture.mesh, R_BUFFER);
-    let spurious_dim =
-        spurious_dim_from_derham(&fixture.mesh, &interior_mask, &node_interior_mask);
+    let spurious_dim = spurious_dim_from_derham(&fixture.mesh, &interior_mask, &node_interior_mask);
 
     let device = <B as BackendTypes>::Device::default();
     let (nodes_t, tets_t) = upload_mesh::<B>(&fixture.mesh, &device);
@@ -263,24 +262,39 @@ fn sphere_pec_jax_integer_cross_checks() {
     let burn = run_burn_pipeline();
 
     let n_nodes_ref = fixture.output_f64("n_nodes").unwrap().data[0];
-    assert_eq!(burn.n_nodes, n_nodes_ref as usize,
-        "n_nodes: Burn = {}, JAX = {}", burn.n_nodes, n_nodes_ref);
+    assert_eq!(
+        burn.n_nodes, n_nodes_ref as usize,
+        "n_nodes: Burn = {}, JAX = {}",
+        burn.n_nodes, n_nodes_ref
+    );
 
     let n_tets_ref = fixture.output_f64("n_tets").unwrap().data[0];
-    assert_eq!(burn.n_tets, n_tets_ref as usize,
-        "n_tets: Burn = {}, JAX = {}", burn.n_tets, n_tets_ref);
+    assert_eq!(
+        burn.n_tets, n_tets_ref as usize,
+        "n_tets: Burn = {}, JAX = {}",
+        burn.n_tets, n_tets_ref
+    );
 
     let n_edges_ref = fixture.output_f64("n_edges").unwrap().data[0];
-    assert_eq!(burn.n_edges, n_edges_ref as usize,
-        "n_edges: Burn = {}, JAX = {}", burn.n_edges, n_edges_ref);
+    assert_eq!(
+        burn.n_edges, n_edges_ref as usize,
+        "n_edges: Burn = {}, JAX = {}",
+        burn.n_edges, n_edges_ref
+    );
 
     let n_int_ref = fixture.output_f64("n_interior_edges").unwrap().data[0];
-    assert_eq!(burn.n_interior_edges, n_int_ref as usize,
-        "n_interior_edges: Burn = {}, JAX = {}", burn.n_interior_edges, n_int_ref);
+    assert_eq!(
+        burn.n_interior_edges, n_int_ref as usize,
+        "n_interior_edges: Burn = {}, JAX = {}",
+        burn.n_interior_edges, n_int_ref
+    );
 
     let spurious_ref = fixture.output_f64("spurious_dim").unwrap().data[0];
-    assert_eq!(burn.spurious_dim, spurious_ref as usize,
-        "spurious_dim: Burn = {}, JAX = {}", burn.spurious_dim, spurious_ref);
+    assert_eq!(
+        burn.spurious_dim, spurious_ref as usize,
+        "spurious_dim: Burn = {}, JAX = {}",
+        burn.spurious_dim, spurious_ref
+    );
 }
 
 #[test]
@@ -446,7 +460,6 @@ fn sphere_pec_jax_spectrum_agrees() {
         "sphere_pec JAX cross-backend agreement: \
          lowest-spectrum max abs err {:.3e}, \
          lowest 5 physical eigenvalues within {:.0e} relative.",
-        max_abs,
-        tol.eigenvalue_rel
+        max_abs, tol.eigenvalue_rel
     );
 }

--- a/crates/geode-validation/tests/sphere_pec_julia_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_julia_reference.rs
@@ -58,7 +58,7 @@ type B = DefaultBackend;
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]  // spectrum_abs used only in the #[ignore]d eigensolve test
+#[allow(dead_code)] // spectrum_abs used only in the #[ignore]d eigensolve test
 struct BackendTolerances {
     /// Relative tolerance on K_int / M_int Frobenius norms.
     frobenius_rel: f64,
@@ -74,19 +74,19 @@ struct BackendTolerances {
 }
 
 const NDARRAY_F64_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  1e-4,    // Julia ↔ Burn ndarray, relaxed vs Julia↔NumPy (1e-8)
-    diagonal_abs:   1e-5,    // per-DOF absolute
-    spectrum_abs:   1e-3,    // near-zero spurious cluster is solver-dependent
-    eigenvalue_rel: 1e-5,    // Epic #88 cross-IR floor for physical modes
-    symmetry_abs:   1e-10,
+    frobenius_rel: 1e-4,  // Julia ↔ Burn ndarray, relaxed vs Julia↔NumPy (1e-8)
+    diagonal_abs: 1e-5,   // per-DOF absolute
+    spectrum_abs: 1e-3,   // near-zero spurious cluster is solver-dependent
+    eigenvalue_rel: 1e-5, // Epic #88 cross-IR floor for physical modes
+    symmetry_abs: 1e-10,
 };
 
 const GPU_F32_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  5e-4,
-    diagonal_abs:   5e-5,
-    spectrum_abs:   1e-2,
+    frobenius_rel: 5e-4,
+    diagonal_abs: 5e-5,
+    spectrum_abs: 1e-2,
     eigenvalue_rel: 5e-4,
-    symmetry_abs:   1e-6,
+    symmetry_abs: 1e-6,
 };
 
 fn active_backend_tolerances() -> BackendTolerances {
@@ -286,9 +286,9 @@ fn sphere_pec_julia_mesh_substages_agree() {
 
     // 1. Mesh shape — integer equality.
     let n_nodes_ref = fixture.output_f64("n_nodes").unwrap().data[0];
-    let n_tets_ref  = fixture.output_f64("n_tets").unwrap().data[0];
+    let n_tets_ref = fixture.output_f64("n_tets").unwrap().data[0];
     assert_eq!(burn.n_nodes, n_nodes_ref as usize, "n_nodes");
-    assert_eq!(burn.n_tets,  n_tets_ref  as usize, "n_tets");
+    assert_eq!(burn.n_tets, n_tets_ref as usize, "n_tets");
 
     // 2. ε_r — bit-exact (f64 ULP × max value).
     let eps_ref = fixture.output_f64("epsilon_r");
@@ -310,7 +310,10 @@ fn sphere_pec_julia_mesh_substages_agree() {
 
     // 4a. n_interior_edges — integer equality.
     let n_int_ref = fixture.output_f64("n_interior_edges").unwrap().data[0];
-    assert_eq!(burn.n_interior_edges, n_int_ref as usize, "n_interior_edges");
+    assert_eq!(
+        burn.n_interior_edges, n_int_ref as usize,
+        "n_interior_edges"
+    );
 
     // 4b. spurious_dim (= interior-node count) — integer equality.
     let spurious_dim_ref = fixture.output_f64("spurious_dim").unwrap().data[0];
@@ -318,8 +321,11 @@ fn sphere_pec_julia_mesh_substages_agree() {
 
     // 4c. n_spurious_observed (algebraic d⁰-rank, Issue #124) — integer equality.
     let n_sp_ref = fixture.output_f64("n_spurious_observed").unwrap().data[0];
-    assert_eq!(burn.spurious_dim, n_sp_ref as usize,
-               "n_spurious_observed: Burn = {}, Julia = {}", burn.spurious_dim, n_sp_ref as usize);
+    assert_eq!(
+        burn.spurious_dim, n_sp_ref as usize,
+        "n_spurious_observed: Burn = {}, Julia = {}",
+        burn.spurious_dim, n_sp_ref as usize
+    );
 }
 
 #[test]
@@ -340,8 +346,8 @@ fn sphere_pec_julia_assembly_substages_agree() {
 
     // 5a. Frobenius norms.
     let want_kf = fixture.output_f64("k_int_frobenius").unwrap().data[0];
-    let got_kf  = frobenius_norm(burn.k_int.as_ref());
-    let rel_kf  = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
+    let got_kf = frobenius_norm(burn.k_int.as_ref());
+    let rel_kf = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
     assert!(
         rel_kf < tol.frobenius_rel,
         "K_int Frobenius: rel err {rel_kf:.3e} exceeds {:.0e} \
@@ -350,8 +356,8 @@ fn sphere_pec_julia_assembly_substages_agree() {
     );
 
     let want_mf = fixture.output_f64("m_int_frobenius").unwrap().data[0];
-    let got_mf  = frobenius_norm(burn.m_int.as_ref());
-    let rel_mf  = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
+    let got_mf = frobenius_norm(burn.m_int.as_ref());
+    let rel_mf = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
     assert!(
         rel_mf < tol.frobenius_rel,
         "M_int Frobenius: rel err {rel_mf:.3e} exceeds {:.0e} \
@@ -367,8 +373,11 @@ fn sphere_pec_julia_assembly_substages_agree() {
     // matrix up to reordering, without assuming a shared global DOF numbering.
     let golden_k_diag = fixture.output_f64("k_int_diag").unwrap();
     let golden_m_diag = fixture.output_f64("m_int_diag").unwrap();
-    assert_eq!(golden_k_diag.data.len(), burn.k_int.nrows(),
-               "K_int diagonal length mismatch");
+    assert_eq!(
+        golden_k_diag.data.len(),
+        burn.k_int.nrows(),
+        "K_int diagonal length mismatch"
+    );
 
     let mut burn_k_diag: Vec<f64> = (0..burn.k_int.nrows())
         .map(|i| burn.k_int[(i, i)])
@@ -380,7 +389,9 @@ fn sphere_pec_julia_assembly_substages_agree() {
     let mut max_kd = 0.0_f64;
     for (got, want) in burn_k_diag.iter().zip(julia_k_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_kd { max_kd = err; }
+        if err > max_kd {
+            max_kd = err;
+        }
     }
     assert!(
         max_kd < tol.diagonal_abs,
@@ -398,7 +409,9 @@ fn sphere_pec_julia_assembly_substages_agree() {
     let mut max_md = 0.0_f64;
     for (got, want) in burn_m_diag.iter().zip(julia_m_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_md { max_md = err; }
+        if err > max_md {
+            max_md = err;
+        }
     }
     assert!(
         max_md < tol.diagonal_abs,
@@ -458,13 +471,15 @@ fn sphere_pec_julia_spectrum_agrees() {
     // Integer cross-check: Burn spurious_dim must match Julia n_spurious_observed.
     assert_eq!(
         burn.spurious_dim, n_sp_julia,
-        "n_spurious: Burn={}, Julia={}", burn.spurious_dim, n_sp_julia
+        "n_spurious: Burn={}, Julia={}",
+        burn.spurious_dim, n_sp_julia
     );
 
     assert!(
         n_sp_julia + n_physical <= burn_spectrum.len(),
         "spectrum too short: n_spurious={n_sp_julia}, n_physical={n_physical}, \
-         spectrum_len={}", burn_spectrum.len()
+         spectrum_len={}",
+        burn_spectrum.len()
     );
     let burn_physical = &burn_spectrum[n_sp_julia..n_sp_julia + n_physical];
 
@@ -507,8 +522,6 @@ fn sphere_pec_julia_spectrum_agrees() {
         .enumerate()
     {
         let rel = (got - want).abs() / want.abs().max(1.0);
-        println!(
-            "  physical[{i}]: Burn={got:.10e}  Julia={want:.10e}  rel={rel:.2e}"
-        );
+        println!("  physical[{i}]: Burn={got:.10e}  Julia={want:.10e}  rel={rel:.2e}");
     }
 }

--- a/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
@@ -97,19 +97,19 @@ struct BackendTolerances {
 }
 
 const NDARRAY_F64_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  1e-4,
-    diagonal_abs:   1e-5,
-    spectrum_abs:   1e-3,
+    frobenius_rel: 1e-4,
+    diagonal_abs: 1e-5,
+    spectrum_abs: 1e-3,
     eigenvalue_rel: 1e-5,
-    symmetry_abs:   1e-10,
+    symmetry_abs: 1e-10,
 };
 
 const GPU_F32_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  5e-4,
-    diagonal_abs:   5e-5,
-    spectrum_abs:   1e-2,
+    frobenius_rel: 5e-4,
+    diagonal_abs: 5e-5,
+    spectrum_abs: 1e-2,
     eigenvalue_rel: 5e-4,
-    symmetry_abs:   1e-6,
+    symmetry_abs: 1e-6,
 };
 
 fn active_backend_tolerances() -> BackendTolerances {
@@ -153,7 +153,7 @@ fn numpy_fixture_path() -> PathBuf {
 struct BurnPipeline {
     n_nodes: usize,
     n_tets: usize,
-    #[allow(dead_code)]  // assembled but not directly cross-checked in this harness
+    #[allow(dead_code)] // assembled but not directly cross-checked in this harness
     epsilon_r: Vec<f64>,
     n_edges: usize,
     n_interior_edges: usize,
@@ -308,9 +308,9 @@ fn sphere_pec_onnx_mesh_substages_agree() {
 
     // 1. Mesh shape — integer equality.
     let n_nodes_ref = onnx_fixture.output_f64("n_nodes").unwrap().data[0];
-    let n_tets_ref  = onnx_fixture.output_f64("n_tets").unwrap().data[0];
+    let n_tets_ref = onnx_fixture.output_f64("n_tets").unwrap().data[0];
     assert_eq!(burn.n_nodes, n_nodes_ref as usize, "n_nodes");
-    assert_eq!(burn.n_tets,  n_tets_ref  as usize, "n_tets");
+    assert_eq!(burn.n_tets, n_tets_ref as usize, "n_tets");
 
     // 2. Global edge count.
     let n_edges_ref = onnx_fixture.output_f64("n_edges").unwrap().data[0];
@@ -318,7 +318,10 @@ fn sphere_pec_onnx_mesh_substages_agree() {
 
     // 3. Interior edge count (after PEC elimination).
     let n_int_ref = onnx_fixture.output_f64("n_interior_edges").unwrap().data[0];
-    assert_eq!(burn.n_interior_edges, n_int_ref as usize, "n_interior_edges");
+    assert_eq!(
+        burn.n_interior_edges, n_int_ref as usize,
+        "n_interior_edges"
+    );
 
     eprintln!(
         "sphere_pec_onnx mesh: n_nodes={}, n_tets={}, n_edges={}, n_interior_edges={}, spurious_dim={}",
@@ -347,8 +350,8 @@ fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
     // 5a. Frobenius norms (compared to NumPy baseline, same cross-check target
     //     that the ONNX CI eigensolve driver uses).
     let want_kf = numpy_fixture.output_f64("k_int_frobenius").unwrap().data[0];
-    let got_kf  = frobenius_norm(burn.k_int.as_ref());
-    let rel_kf  = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
+    let got_kf = frobenius_norm(burn.k_int.as_ref());
+    let rel_kf = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
     assert!(
         rel_kf < tol.frobenius_rel,
         "K_int Frobenius: rel err {rel_kf:.3e} exceeds {:.0e} \
@@ -357,8 +360,8 @@ fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
     );
 
     let want_mf = numpy_fixture.output_f64("m_int_frobenius").unwrap().data[0];
-    let got_mf  = frobenius_norm(burn.m_int.as_ref());
-    let rel_mf  = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
+    let got_mf = frobenius_norm(burn.m_int.as_ref());
+    let rel_mf = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
     assert!(
         rel_mf < tol.frobenius_rel,
         "M_int Frobenius: rel err {rel_mf:.3e} exceeds {:.0e} \
@@ -385,8 +388,11 @@ fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
     //     agree directly, but we sort for robustness).
     let golden_k_diag = numpy_fixture.output_f64("k_int_diag").unwrap();
     let golden_m_diag = numpy_fixture.output_f64("m_int_diag").unwrap();
-    assert_eq!(golden_k_diag.data.len(), burn.k_int.nrows(),
-               "K_int diagonal length mismatch (Burn vs NumPy)");
+    assert_eq!(
+        golden_k_diag.data.len(),
+        burn.k_int.nrows(),
+        "K_int diagonal length mismatch (Burn vs NumPy)"
+    );
 
     let mut burn_k_diag: Vec<f64> = (0..burn.k_int.nrows())
         .map(|i| burn.k_int[(i, i)])
@@ -398,7 +404,9 @@ fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
     let mut max_kd = 0.0_f64;
     for (got, want) in burn_k_diag.iter().zip(numpy_k_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_kd { max_kd = err; }
+        if err > max_kd {
+            max_kd = err;
+        }
     }
     assert!(
         max_kd < tol.diagonal_abs,
@@ -416,7 +424,9 @@ fn sphere_pec_onnx_assembly_agrees_with_numpy_baseline() {
     let mut max_md = 0.0_f64;
     for (got, want) in burn_m_diag.iter().zip(numpy_m_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_md { max_md = err; }
+        if err > max_md {
+            max_md = err;
+        }
     }
     assert!(
         max_md < tol.diagonal_abs,
@@ -460,18 +470,23 @@ fn sphere_pec_onnx_spectrum_agrees() {
         dense_lowest_eigenvalues(burn.k_int.as_ref(), burn.m_int.as_ref(), n_request);
 
     // n_spurious from the NumPy baseline (algebraic d⁰-rank, Issue #124).
-    let n_sp = numpy_fixture.output_f64("n_spurious_observed").unwrap().data[0] as usize;
+    let n_sp = numpy_fixture
+        .output_f64("n_spurious_observed")
+        .unwrap()
+        .data[0] as usize;
 
     // Integer cross-check: Burn spurious_dim must match NumPy.
     assert_eq!(
         burn.spurious_dim, n_sp,
-        "n_spurious: Burn={}, NumPy={}", burn.spurious_dim, n_sp
+        "n_spurious: Burn={}, NumPy={}",
+        burn.spurious_dim, n_sp
     );
 
     assert!(
         n_sp + n_physical <= burn_spectrum.len(),
         "spectrum too short: n_spurious={n_sp}, n_physical={n_physical}, \
-         spectrum_len={}", burn_spectrum.len()
+         spectrum_len={}",
+        burn_spectrum.len()
     );
     let burn_physical = &burn_spectrum[n_sp..n_sp + n_physical];
 
@@ -514,8 +529,6 @@ fn sphere_pec_onnx_spectrum_agrees() {
         .enumerate()
     {
         let rel = (got - want).abs() / want.abs().max(1.0);
-        println!(
-            "  physical[{i}]: Burn={got:.10e}  NumPy={want:.10e}  rel={rel:.2e}"
-        );
+        println!("  physical[{i}]: Burn={got:.10e}  NumPy={want:.10e}  rel={rel:.2e}");
     }
 }

--- a/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
@@ -89,19 +89,19 @@ struct BackendTolerances {
 }
 
 const NDARRAY_F64_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  1e-4,
-    diagonal_abs:   1e-5,
-    spectrum_abs:   1e-3,
+    frobenius_rel: 1e-4,
+    diagonal_abs: 1e-5,
+    spectrum_abs: 1e-3,
     eigenvalue_rel: 1e-5,
-    symmetry_abs:   1e-10,
+    symmetry_abs: 1e-10,
 };
 
 const GPU_F32_TOLERANCES: BackendTolerances = BackendTolerances {
-    frobenius_rel:  5e-4,
-    diagonal_abs:   5e-5,
-    spectrum_abs:   1e-2,
+    frobenius_rel: 5e-4,
+    diagonal_abs: 5e-5,
+    spectrum_abs: 1e-2,
     eigenvalue_rel: 5e-4,
-    symmetry_abs:   1e-6,
+    symmetry_abs: 1e-6,
 };
 
 fn active_backend_tolerances() -> BackendTolerances {
@@ -145,7 +145,7 @@ fn numpy_fixture_path() -> PathBuf {
 struct BurnPipeline {
     n_nodes: usize,
     n_tets: usize,
-    #[allow(dead_code)]  // assembled but not directly cross-checked in this harness
+    #[allow(dead_code)] // assembled but not directly cross-checked in this harness
     epsilon_r: Vec<f64>,
     n_edges: usize,
     n_interior_edges: usize,
@@ -300,9 +300,9 @@ fn sphere_pec_tfjava_mesh_substages_agree() {
 
     // 1. Mesh shape — integer equality.
     let n_nodes_ref = tfjava_fixture.output_f64("n_nodes").unwrap().data[0];
-    let n_tets_ref  = tfjava_fixture.output_f64("n_tets").unwrap().data[0];
+    let n_tets_ref = tfjava_fixture.output_f64("n_tets").unwrap().data[0];
     assert_eq!(burn.n_nodes, n_nodes_ref as usize, "n_nodes");
-    assert_eq!(burn.n_tets,  n_tets_ref  as usize, "n_tets");
+    assert_eq!(burn.n_tets, n_tets_ref as usize, "n_tets");
 
     // 2. Global edge count.
     let n_edges_ref = tfjava_fixture.output_f64("n_edges").unwrap().data[0];
@@ -310,7 +310,10 @@ fn sphere_pec_tfjava_mesh_substages_agree() {
 
     // 3. Interior edge count (after PEC elimination).
     let n_int_ref = tfjava_fixture.output_f64("n_interior_edges").unwrap().data[0];
-    assert_eq!(burn.n_interior_edges, n_int_ref as usize, "n_interior_edges");
+    assert_eq!(
+        burn.n_interior_edges, n_int_ref as usize,
+        "n_interior_edges"
+    );
 
     eprintln!(
         "sphere_pec_tfjava mesh: n_nodes={}, n_tets={}, n_edges={}, n_interior_edges={}, spurious_dim={}",
@@ -339,8 +342,8 @@ fn sphere_pec_tfjava_assembly_agrees_with_numpy_baseline() {
     // 5a. Frobenius norms (compared to NumPy baseline, same cross-check target
     //     that the TF-Java CI eigensolve driver uses).
     let want_kf = numpy_fixture.output_f64("k_int_frobenius").unwrap().data[0];
-    let got_kf  = frobenius_norm(burn.k_int.as_ref());
-    let rel_kf  = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
+    let got_kf = frobenius_norm(burn.k_int.as_ref());
+    let rel_kf = (got_kf - want_kf).abs() / want_kf.abs().max(1.0);
     assert!(
         rel_kf < tol.frobenius_rel,
         "K_int Frobenius: rel err {rel_kf:.3e} exceeds {:.0e} \
@@ -349,8 +352,8 @@ fn sphere_pec_tfjava_assembly_agrees_with_numpy_baseline() {
     );
 
     let want_mf = numpy_fixture.output_f64("m_int_frobenius").unwrap().data[0];
-    let got_mf  = frobenius_norm(burn.m_int.as_ref());
-    let rel_mf  = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
+    let got_mf = frobenius_norm(burn.m_int.as_ref());
+    let rel_mf = (got_mf - want_mf).abs() / want_mf.abs().max(1.0);
     assert!(
         rel_mf < tol.frobenius_rel,
         "M_int Frobenius: rel err {rel_mf:.3e} exceeds {:.0e} \
@@ -377,8 +380,11 @@ fn sphere_pec_tfjava_assembly_agrees_with_numpy_baseline() {
     //     for robustness).
     let golden_k_diag = numpy_fixture.output_f64("k_int_diag").unwrap();
     let golden_m_diag = numpy_fixture.output_f64("m_int_diag").unwrap();
-    assert_eq!(golden_k_diag.data.len(), burn.k_int.nrows(),
-               "K_int diagonal length mismatch (Burn vs NumPy)");
+    assert_eq!(
+        golden_k_diag.data.len(),
+        burn.k_int.nrows(),
+        "K_int diagonal length mismatch (Burn vs NumPy)"
+    );
 
     let mut burn_k_diag: Vec<f64> = (0..burn.k_int.nrows())
         .map(|i| burn.k_int[(i, i)])
@@ -390,7 +396,9 @@ fn sphere_pec_tfjava_assembly_agrees_with_numpy_baseline() {
     let mut max_kd = 0.0_f64;
     for (got, want) in burn_k_diag.iter().zip(numpy_k_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_kd { max_kd = err; }
+        if err > max_kd {
+            max_kd = err;
+        }
     }
     assert!(
         max_kd < tol.diagonal_abs,
@@ -408,7 +416,9 @@ fn sphere_pec_tfjava_assembly_agrees_with_numpy_baseline() {
     let mut max_md = 0.0_f64;
     for (got, want) in burn_m_diag.iter().zip(numpy_m_diag.iter()) {
         let err = (got - want).abs();
-        if err > max_md { max_md = err; }
+        if err > max_md {
+            max_md = err;
+        }
     }
     assert!(
         max_md < tol.diagonal_abs,
@@ -452,18 +462,23 @@ fn sphere_pec_tfjava_spectrum_agrees() {
         dense_lowest_eigenvalues(burn.k_int.as_ref(), burn.m_int.as_ref(), n_request);
 
     // n_spurious from the NumPy baseline (algebraic d⁰-rank, Issue #124).
-    let n_sp = numpy_fixture.output_f64("n_spurious_observed").unwrap().data[0] as usize;
+    let n_sp = numpy_fixture
+        .output_f64("n_spurious_observed")
+        .unwrap()
+        .data[0] as usize;
 
     // Integer cross-check: Burn spurious_dim must match NumPy.
     assert_eq!(
         burn.spurious_dim, n_sp,
-        "n_spurious: Burn={}, NumPy={}", burn.spurious_dim, n_sp
+        "n_spurious: Burn={}, NumPy={}",
+        burn.spurious_dim, n_sp
     );
 
     assert!(
         n_sp + n_physical <= burn_spectrum.len(),
         "spectrum too short: n_spurious={n_sp}, n_physical={n_physical}, \
-         spectrum_len={}", burn_spectrum.len()
+         spectrum_len={}",
+        burn_spectrum.len()
     );
     let burn_physical = &burn_spectrum[n_sp..n_sp + n_physical];
 
@@ -506,8 +521,6 @@ fn sphere_pec_tfjava_spectrum_agrees() {
         .enumerate()
     {
         let rel = (got - want).abs() / want.abs().max(1.0);
-        println!(
-            "  physical[{i}]: Burn={got:.10e}  NumPy={want:.10e}  rel={rel:.2e}"
-        );
+        println!("  physical[{i}]: Burn={got:.10e}  NumPy={want:.10e}  rel={rel:.2e}");
     }
 }

--- a/crates/geode-validation/tests/sphere_pml_schema_smoke.rs
+++ b/crates/geode-validation/tests/sphere_pml_schema_smoke.rs
@@ -94,7 +94,10 @@ fn stub_fixture_loads_and_has_expected_schema() {
         fixture.outputs["eigenvalues_lowest_complex"].dtype, "c128",
         "the c128 schema branch must be exercised by at least one output field"
     );
-    assert_eq!(fixture.outputs["physical_eigenvalues_complex"].dtype, "c128");
+    assert_eq!(
+        fixture.outputs["physical_eigenvalues_complex"].dtype,
+        "c128"
+    );
     assert_eq!(fixture.outputs["q_factor_lowest_physical"].dtype, "f64");
 
     // Sanity on the input mesh-derived counts: pulled from the bundled
@@ -164,7 +167,10 @@ fn input_c128_decodes_real_imag_interleave() {
         eps.len(),
         "every tet should land in one of the three regions"
     );
-    assert!(n_real_dielectric > 0, "expected at least one dielectric tet");
+    assert!(
+        n_real_dielectric > 0,
+        "expected at least one dielectric tet"
+    );
     assert!(n_real_vacuum > 0, "expected at least one vacuum-gap tet");
     assert!(n_pml_lossy > 0, "expected at least one lossy PML-shell tet");
 }
@@ -219,8 +225,7 @@ fn complex_comparator_passes_on_exact_match() {
     // real-valued `compare` path. Confirms the dtype split is clean.
     for f in &report.fields {
         assert!(
-            f.field == "eigenvalues_lowest_complex"
-                || f.field == "physical_eigenvalues_complex",
+            f.field == "eigenvalues_lowest_complex" || f.field == "physical_eigenvalues_complex",
             "f64-dtype field {} leaked into the complex report",
             f.field
         );

--- a/crates/geode-validation/tests/sphere_pml_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_tfjava_reference.rs
@@ -315,7 +315,10 @@ fn tfjava_pml_physical_eigenvalues_agree_with_numpy_canonical() {
             diff < abs_tol,
             "physical[{i}]: |Δ| = {diff:.3e} exceeds {abs_tol:.0e} \
              (TF-Java = {} {:+}j, NumPy = {} {:+}j)",
-            t.re, t.im, n.re, n.im
+            t.re,
+            t.im,
+            n.re,
+            n.im
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #185

- **Format-only commit** (`ddda725`): `cargo fmt --all` over the 11 drifted files (rustfmt 1.9.0-stable). Verified format-only: whitespace-stripped content hashes match the pre-format files except for three rustfmt-canonical token effects — trailing commas dropped when multi-line signatures collapsed to one line (`nedelec_assembly.rs`), a closure body wrapped (`tests/assembly.rs`), and one `use` reordering (`tests/fe_assemble.rs`). No semantic changes.
- **CI gate commit**: new dedicated `.github/workflows/rustfmt.yml` running `cargo fmt --all -- --check` unconditionally on every push/PR to main. A dedicated workflow was chosen because every existing workflow is a specialized, path-filtered physics/cross-check job — there is no repo-wide Rust CI to bolt onto, and the check is cheap (parse-only, no build).
- Added `.git-blame-ignore-revs` recording the format commit so blame skips it (GitHub honors this natively; locally `git config blame.ignoreRevsFile .git-blame-ignore-revs`).

The two commits are kept separate so the blame story is clean.

## Files reformatted

- `crates/geode-core/src/nedelec_assembly.rs`
- `crates/geode-core/tests/{assembly,fe_assemble,nedelec,p1_local_matrices}.rs`
- `crates/geode-validation/tests/{sphere_pec_jax_reference,sphere_pec_julia_reference,sphere_pec_onnx_reference,sphere_pec_tfjava_reference,sphere_pml_schema_smoke,sphere_pml_tfjava_reference}.rs`

## Validation

- `cargo fmt --all -- --check` — passes
- `cargo test -p geode-core -p geode-validation --release` — green (default set; `#[ignore]`d tests excluded as usual)
- `cargo clippy --workspace --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)