### PR TITLE
fix(driver): invariants-only smoke for summary sphere-PEC sidecars (#186)

### DIFF
--- a/reference/driver/README.md
+++ b/reference/driver/README.md
@@ -9,10 +9,11 @@ that the friction-mining loop wants to highlight.
 ## `eigensolve_from_sidecar.py` — consolidated entry point
 
 Single script parameterised by `--backend {tfjava|onnx}` and
-`--problem {cube-cavity|sphere-pec}`. Consumes the fixture-schema
-JSON sidecar emitted by one of the assembly backends and runs the
-appropriate SciPy eigensolve, then emits a second fixture-schema
-JSON with the eigenvalues for cross-IR comparison.
+`--problem {cube-cavity|sphere-pec|sphere-pml|sphere-mie}`. Consumes
+the fixture-schema JSON sidecar emitted by one of the assembly
+backends and runs the appropriate SciPy eigensolve, then emits a
+second fixture-schema JSON with the eigenvalues for cross-IR
+comparison.
 
 ```bash
 # Cube cavity (scalar Helmholtz, P1, default problem):
@@ -29,6 +30,79 @@ python3 reference/driver/eigensolve_from_sidecar.py \
     --baseline reference/fixtures/sphere_pec/baseline.json \
     --rtol 1e-5 --k 5 \
     --out path/to/eigenresult_sphere_pec.json
+```
+
+### Summary sidecars (invariants-only mode, sphere-PEC)
+
+The checked-in fixtures `reference/fixtures/sphere_pec/tfjava_sidecar.json`
+and `onnx_sidecar.json` are **summary** sidecars: their `outputs` carry
+scalar assembly invariants (`k_int_frobenius`, `m_int_frobenius`,
+`k_diag_sum`, `m_diag_sum`, mesh counts) instead of the full matrices
+(3300x3300 dense f64 would be ~90 MB of JSON each — see the docblock in
+`crates/geode-validation/tests/sphere_pec_tfjava_reference.rs`).
+
+The driver auto-detects a summary sidecar (no `outputs.k_int`) and runs
+an **invariants-only comparison** against the NumPy baseline instead of
+an eigensolve, clearly labelling the output. The gate is 1e-4 relative,
+matching the Rust harness `frobenius_rel`. The live CI paths are
+unaffected: CI regenerates full sidecars from the JVM / ONNX assembly
+runs, which take the full eigensolve path (issue #186).
+
+```bash
+# Smoke the checked-in summary fixtures (no eigensolve):
+python3 reference/driver/eigensolve_from_sidecar.py \
+    reference/fixtures/sphere_pec/tfjava_sidecar.json \
+    --backend tfjava --problem sphere-pec \
+    --out /tmp/invariants_pec_tfjava.json
+python3 reference/driver/eigensolve_from_sidecar.py \
+    reference/fixtures/sphere_pec/onnx_sidecar.json \
+    --backend onnx --problem sphere-pec \
+    --out /tmp/invariants_pec_onnx.json
+```
+
+## `make_numpy_sidecar.py` — local smoke for the full-matrix paths
+
+The other problem families check in no sidecar at all (CI synthesizes
+them from the live TF-Java / ONNX assemblies). To smoke the driver's
+full-matrix eigensolve paths locally without a Java/ONNX toolchain,
+`make_numpy_sidecar.py` synthesizes a schema-compatible sidecar from
+the in-tree NumPy reference assemblies (the issue-174 recovery
+pattern):
+
+```bash
+# Cube cavity:
+python3 reference/driver/make_numpy_sidecar.py \
+    --problem cube-cavity --n 4 --out /tmp/reduced_kM.json
+python3 reference/driver/eigensolve_from_sidecar.py \
+    /tmp/reduced_kM.json --backend tfjava --k 5 \
+    --out /tmp/eigenresult.json
+
+# Sphere PML (small 48-node mesh; gate vs the small baseline):
+python3 reference/driver/make_numpy_sidecar.py \
+    --problem sphere-pml --out /tmp/reduced_kM_sphere_pml.json
+python3 reference/driver/eigensolve_from_sidecar.py \
+    /tmp/reduced_kM_sphere_pml.json \
+    --backend tfjava --problem sphere-pml --k 5 \
+    --baseline reference/fixtures/sphere_pml_small/baseline.json \
+    --rtol 1e-4 --out /tmp/eigenresult_sphere_pml.json
+
+# Sphere Mie (small mesh, tensor-ε UPML; hard per-position gate):
+python3 reference/driver/make_numpy_sidecar.py \
+    --problem sphere-mie --out /tmp/reduced_kM_sphere_mie.json
+python3 reference/driver/eigensolve_from_sidecar.py \
+    /tmp/reduced_kM_sphere_mie.json \
+    --backend tfjava --problem sphere-mie --k 5 \
+    --baseline reference/fixtures/sphere_mie_small/baseline.json \
+    --rtol 1e-4 --out /tmp/eigenresult_sphere_mie.json
+
+# Sphere PEC full-matrix path (CI-sized: ~430 MB temp JSON, minutes):
+python3 reference/driver/make_numpy_sidecar.py \
+    --problem sphere-pec --out /tmp/reduced_kM_sphere_pec.json
+python3 reference/driver/eigensolve_from_sidecar.py \
+    /tmp/reduced_kM_sphere_pec.json \
+    --backend tfjava --problem sphere-pec --k 5 \
+    --baseline reference/fixtures/sphere_pec/baseline.json \
+    --rtol 1e-5 --out /tmp/eigenresult_sphere_pec.json
 ```
 
 Why a separate driver? Both TF-Java and ONNX lack a native sparse

--- a/reference/driver/eigensolve_from_sidecar.py
+++ b/reference/driver/eigensolve_from_sidecar.py
@@ -10,6 +10,11 @@ the multi-backend reference set:
   sphere (Phase G / issue #134). Always ARPACK shift-and-invert at
   ``sigma=0`` to recover the gradient nullspace, then the d⁰-rank
   spurious-mode classifier (PR #126) filters the physical modes.
+  SUMMARY sidecars (the checked-in fixtures under
+  ``reference/fixtures/sphere_pec/``, which carry only scalar invariants
+  instead of the ~90 MB dense matrices) are auto-detected and routed to
+  an invariants-only comparison vs the NumPy baseline — no eigensolve
+  (issue #186).
 * ``--problem sphere-pml`` — vector Nédélec curl-curl with scalar-isotropic
   complex-ε PML on the PEC-bounded sphere (Phase H / issue #156). Loads
   the (K_int, Re(M_int), Im(M_int)) triple from the sidecar, fuses the
@@ -160,6 +165,11 @@ PROBLEMS = ("cube-cavity", "sphere-pec", "sphere-pml", "sphere-mie")
 # Per-fixture spurious-dim fallback when no baseline.json is supplied.
 # Matches the historical fallback in eigensolve_sphere_pec_sidecar.py.
 SPHERE_PEC_SPURIOUS_DIM_FALLBACK = 368
+# Relative gate for the invariants-only sphere-PEC comparison (summary
+# sidecars without embedded matrices). Matches `frobenius_rel` for the
+# f64 ndarray path in the Rust harness
+# (crates/geode-validation/tests/sphere_pec_{tfjava,onnx}_reference.rs).
+SPHERE_PEC_INVARIANTS_REL = 1e-4
 # Sphere-PML shares the same mesh (774 nodes, 3335 tets) as sphere-PEC, so
 # the d⁰-rank spurious-mode count is identical (gradient kernel of the
 # Nédélec curl-curl is invariant under complex-ε scaling on the mass —
@@ -303,6 +313,206 @@ def _run_cube_cavity(args, sidecar: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _find_sphere_pec_baseline(args, sidecar_path: Path) -> Path | None:
+    """Locate the NumPy sphere-PEC baseline: explicit --baseline first,
+    then the legacy relative heuristic, then a repo-root walk-up (the
+    sphere-mie pattern — robust to nested target/out layouts)."""
+    if args.baseline is not None and Path(args.baseline).exists():
+        return Path(args.baseline)
+    default_bl = sidecar_path.parent.parent.parent / "fixtures" / "sphere_pec" / "baseline.json"
+    if default_bl.exists():
+        return default_bl
+    for ancestor in sidecar_path.resolve().parents:
+        cand = ancestor / "reference" / "fixtures" / "sphere_pec" / "baseline.json"
+        if cand.exists():
+            return cand
+    return None
+
+
+def _run_sphere_pec_invariants_only(
+    args, sidecar: dict, sidecar_path: Path, sphere_meta: dict
+) -> None:
+    """Invariants-only comparison for SUMMARY sphere-PEC sidecars.
+
+    The checked-in fixtures `reference/fixtures/sphere_pec/tfjava_sidecar.json`
+    and `onnx_sidecar.json` deliberately do NOT embed the full K_int / M_int
+    matrices (3300x3300 dense f64 = ~90 MB JSON each — see the docblock in
+    crates/geode-validation/tests/sphere_pec_tfjava_reference.rs). They carry
+    scalar invariants instead: Frobenius norms, diagonal sums, and mesh
+    counts. This mode compares those invariants against the NumPy baseline
+    (reference/fixtures/sphere_pec/baseline.json) and clearly labels the
+    output as invariants-only — NO eigensolve is performed.
+
+    The live CI paths are unaffected: CI regenerates full sidecars from the
+    JVM / ONNX assembly runs, which take the full-matrix eigensolve path.
+    """
+    outputs = sidecar["outputs"]
+    print(
+        "[sphere-pec-driver] Summary sidecar detected (no embedded "
+        "k_int/m_int matrices)."
+    )
+    print(
+        "[sphere-pec-driver] Running INVARIANTS-ONLY comparison vs the "
+        "NumPy baseline — no eigensolve is performed in this mode."
+    )
+
+    baseline_path = _find_sphere_pec_baseline(args, sidecar_path)
+    if baseline_path is None:
+        print(
+            "[sphere-pec-driver] ERROR: invariants-only mode requires the "
+            "NumPy baseline (reference/fixtures/sphere_pec/baseline.json); "
+            "none found. Pass --baseline explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    with open(baseline_path) as f:
+        baseline = json.load(f)
+    bl_outputs = baseline["outputs"]
+    print(f"[sphere-pec-driver] Baseline: {baseline_path}")
+
+    rel_tol = SPHERE_PEC_INVARIANTS_REL
+    rows: list[tuple[str, float, float, float, bool]] = []
+    all_ok = True
+    skipped: list[str] = []
+
+    # --- Integer mesh counts (exact agreement) ---
+    for key in ("n_nodes", "n_tets", "n_edges", "n_interior_edges"):
+        if key in outputs and key in bl_outputs:
+            got = float(outputs[key]["data"][0])
+            want = float(bl_outputs[key]["data"][0])
+            ok = abs(got - want) < 0.5
+            rows.append((key, got, want, abs(got - want), ok))
+            all_ok &= ok
+        else:
+            skipped.append(key)
+
+    # --- Frobenius norms (relative gate, matches the Rust harness) ---
+    for key in ("k_int_frobenius", "m_int_frobenius"):
+        if key not in outputs or key not in bl_outputs:
+            print(
+                f"[sphere-pec-driver] ERROR: invariant `{key}` missing from "
+                f"{'sidecar' if key not in outputs else 'baseline'}; cannot "
+                "run the invariants-only comparison.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        got = float(outputs[key]["data"][0])
+        want = float(bl_outputs[key]["data"][0])
+        rel = abs(got - want) / max(abs(want), 1e-30)
+        ok = rel < rel_tol
+        rows.append((key, got, want, rel, ok))
+        all_ok &= ok
+
+    # --- Diagonal sums vs sum(baseline per-DOF diagonal) ---
+    # The TF-Java summary fixture carries 0.0 placeholders for the diag
+    # sums (the JVM dump predates the field); skip those with a note
+    # rather than failing on a known-unpopulated value.
+    for sum_key, diag_key in (("k_diag_sum", "k_int_diag"), ("m_diag_sum", "m_int_diag")):
+        if sum_key not in outputs or diag_key not in bl_outputs:
+            skipped.append(sum_key)
+            continue
+        got = float(outputs[sum_key]["data"][0])
+        if got == 0.0:
+            print(
+                f"[sphere-pec-driver] NOTE: sidecar `{sum_key}` is the 0.0 "
+                "placeholder (unpopulated in this fixture); skipping."
+            )
+            skipped.append(sum_key)
+            continue
+        want = float(np.sum(np.asarray(bl_outputs[diag_key]["data"], dtype=np.float64)))
+        rel = abs(got - want) / max(abs(want), 1e-30)
+        ok = rel < rel_tol
+        rows.append((sum_key, got, want, rel, ok))
+        all_ok &= ok
+
+    # --- Report ---
+    print(
+        f"\n[sphere-pec-driver] Invariants-only comparison "
+        f"({sphere_meta['comparison_header']} sidecar vs NumPy baseline, "
+        f"rel gate {rel_tol:.0e}):"
+    )
+    print(f"  {'invariant':<22}  {'sidecar':>20}  {'baseline':>20}  {'delta':>10}")
+    for name, got, want, delta, ok in rows:
+        flag = "" if ok else "  <-- FAIL"
+        print(f"  {name:<22}  {got:>20.12e}  {want:>20.12e}  {delta:>10.2e}{flag}")
+    if skipped:
+        print(f"  (skipped: {', '.join(skipped)})")
+
+    if all_ok:
+        print(
+            f"[sphere-pec-driver] PASS (invariants-only): all available "
+            f"invariants agree with the NumPy baseline to < {rel_tol:.0e} "
+            "relative."
+        )
+    else:
+        print(
+            "[sphere-pec-driver] FAIL (invariants-only): some invariants "
+            "disagree with the NumPy baseline.",
+        )
+
+    # --- Emit a clearly-labelled invariants-only result fixture ---
+    result_fixture = {
+        "schema_version": "1",
+        "fixture_id": (
+            f"sphere_pec/n774_pec_invariants_only_{sphere_meta['fixture_id_suffix']}"
+        ),
+        "description": (
+            "INVARIANTS-ONLY comparison result for a summary sphere-PEC "
+            "sidecar (no embedded K_int/M_int matrices, so no eigensolve "
+            "was performed). Scalar assembly invariants (Frobenius norms, "
+            "diagonal sums, mesh counts) compared against "
+            "reference/fixtures/sphere_pec/baseline.json. This is the "
+            "smoke path for the checked-in summary fixtures; the full "
+            "eigensolve path runs in CI against the live assembly sidecar."
+        ),
+        "units": "dimensionless invariants; dimensionless mesh coordinates",
+        "inputs": {
+            "mode": {
+                "shape": [0], "dtype": "f64",
+                "description": "invariants-only (summary sidecar; no eigensolve)",
+                "data": [],
+            },
+        },
+        "outputs": {
+            "invariants_match": {
+                "shape": [1], "dtype": "f64",
+                "description": (
+                    f"1.0 if every available invariant agreed with the NumPy "
+                    f"baseline to < {rel_tol:.0e} relative, else 0.0."
+                ),
+                "tolerance_abs": 0.5,
+                "data": [1.0 if all_ok else 0.0],
+            },
+            **{
+                name: {
+                    "shape": [1], "dtype": "f64",
+                    "description": (
+                        f"Sidecar invariant `{name}` (baseline value "
+                        f"{want:.12e}, delta {delta:.2e})."
+                    ),
+                    "tolerance_abs": rel_tol * max(abs(want), 1.0),
+                    "data": [got],
+                }
+                for name, got, want, delta, _ok in rows
+            },
+        },
+        "provenance": {
+            "source": sphere_meta["provenance_source"],
+            "verified_against": str(baseline_path),
+            "issue": "#186 (summary-sidecar invariants-only smoke; parent #134)",
+        },
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(result_fixture, f, indent=2)
+        f.write("\n")
+    print(f"[sphere-pec-driver] Wrote {out_path} (invariants-only result)")
+
+    if not all_ok:
+        sys.exit(5)
+
+
 def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
     import scipy.sparse as sp
     import scipy.sparse.linalg as spla
@@ -319,6 +529,26 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
         )
         sys.exit(1)
     sphere_meta = SPHERE_PEC_BACKENDS[args.backend]
+
+    # --- Summary-sidecar dispatch (issue #186) ---
+    # The checked-in fixtures under reference/fixtures/sphere_pec/ are
+    # summary sidecars: their `outputs` carry only scalar invariants
+    # (Frobenius norms, diag sums, counts), not the full matrices. Route
+    # those to the invariants-only comparison; full sidecars (the live
+    # CI path) continue through the eigensolve below unchanged.
+    outputs = sidecar.get("outputs", {})
+    if "k_int" not in outputs or "m_int" not in outputs:
+        if "k_int_frobenius" in outputs and "m_int_frobenius" in outputs:
+            _run_sphere_pec_invariants_only(args, sidecar, sidecar_path, sphere_meta)
+            return
+        print(
+            "[sphere-pec-driver] ERROR: sidecar outputs carry neither the "
+            "full matrices (k_int, m_int) nor the summary invariants "
+            "(k_int_frobenius, m_int_frobenius); unrecognized sidecar "
+            f"schema. Keys present: {sorted(outputs)}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
 
     # --- Load K_int, M_int ---
     k_int_flat = _load_field(sidecar, "outputs", "k_int")

--- a/reference/driver/make_numpy_sidecar.py
+++ b/reference/driver/make_numpy_sidecar.py
@@ -1,0 +1,375 @@
+"""Synthesize a full-matrix assembly sidecar from the NumPy references.
+
+Smoke-test companion to ``eigensolve_from_sidecar.py`` (issue #186).
+
+In CI the full sidecars are produced by the live TF-Java / ONNX assembly
+runs, so the full-matrix eigensolve path of the driver is only ever
+exercised against freshly generated artifacts. The checked-in
+``reference/fixtures/sphere_pec/*_sidecar.json`` fixtures are deliberately
+SUMMARY sidecars (scalar invariants only — embedding the 3300x3300 dense
+matrices would cost ~90 MB of JSON each), and the other problem families
+check in no sidecar at all.
+
+This script closes the local-smoke gap: it runs the in-tree NumPy
+reference assembly for any of the four problem families and emits a
+sidecar with the same ``outputs`` schema the JVM / ONNX dumps produce,
+so the driver's full-matrix eigensolve path can be smoke-tested without
+a Java or ONNX toolchain (the pattern the issue-174 recovery used to
+validate the sphere-mie mode).
+
+Usage
+=====
+    # Cube cavity (scalar Helmholtz, P1):
+    python3 reference/driver/make_numpy_sidecar.py \\
+        --problem cube-cavity --n 4 --out /tmp/reduced_kM.json
+
+    # Sphere PEC (full 774-node mesh; ~430 MB JSON, CI-sized):
+    python3 reference/driver/make_numpy_sidecar.py \\
+        --problem sphere-pec --out /tmp/reduced_kM_sphere_pec.json
+
+    # Sphere PML (small 48-node mesh by default):
+    python3 reference/driver/make_numpy_sidecar.py \\
+        --problem sphere-pml --out /tmp/reduced_kM_sphere_pml.json
+
+    # Sphere Mie (small 48-node mesh, tensor-epsilon UPML):
+    python3 reference/driver/make_numpy_sidecar.py \\
+        --problem sphere-mie --out /tmp/reduced_kM_sphere_mie.json
+
+See ``reference/driver/README.md`` for the per-mode smoke invocations
+that consume these sidecars.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "reference" / "numpy"))
+
+PROBLEMS = ("cube-cavity", "sphere-pec", "sphere-pml", "sphere-mie")
+
+# Imaginary parts of the stiffness matrix above this bound indicate the
+# assembly no longer matches the (real K, complex M) sidecar schema.
+_K_IMAG_ABS_MAX = 1e-12
+
+
+def _f64_field(arr: np.ndarray, description: str) -> dict:
+    arr = np.ascontiguousarray(arr, dtype=np.float64)
+    return {
+        "shape": list(arr.shape),
+        "dtype": "f64",
+        "description": description,
+        "data": arr.ravel().tolist(),
+    }
+
+
+def _scalar_input(value: float, dtype: str, description: str) -> dict:
+    data = [int(value)] if dtype == "i64" else [float(value)]
+    return {"shape": [1], "dtype": dtype, "description": description, "data": data}
+
+
+def _count_outputs(n_nodes: int, n_tets: int, n_edges: int, n_int: int) -> dict:
+    return {
+        "n_nodes": _f64_field(np.array([float(n_nodes)]), "Number of mesh nodes."),
+        "n_tets": _f64_field(np.array([float(n_tets)]), "Number of tetrahedra."),
+        "n_edges": _f64_field(np.array([float(n_edges)]), "Total global edge count."),
+        "n_interior_edges": _f64_field(
+            np.array([float(n_int)]), "Interior edge count after PEC elimination."
+        ),
+    }
+
+
+def _real_part_checked(mat: np.ndarray, name: str) -> np.ndarray:
+    """Take Re(mat), asserting Im(mat) is at f64 roundoff (schema guard)."""
+    if np.iscomplexobj(mat):
+        im_max = float(np.max(np.abs(mat.imag))) if mat.size else 0.0
+        if im_max > _K_IMAG_ABS_MAX:
+            raise ValueError(
+                f"{name} has non-negligible imaginary part (max |Im| = "
+                f"{im_max:.3e}); the sidecar schema expects a real-valued "
+                "stiffness."
+            )
+        return np.ascontiguousarray(mat.real)
+    return mat
+
+
+# ---------------------------------------------------------------------------
+# Per-problem synthesis
+# ---------------------------------------------------------------------------
+
+
+def _make_cube_cavity(args) -> dict:
+    from cube_cavity_minimal import assemble_global_p1, restrict_to_interior
+    from mesh import cube_interior_mask, cube_tet_mesh
+
+    nodes, tets = cube_tet_mesh(args.n, args.side)
+    k_csr, m_csr = assemble_global_p1(nodes, tets)
+    mask = cube_interior_mask(nodes, args.side)
+    k_int, m_int = restrict_to_interior(k_csr, m_csr, mask)
+    k_int = k_int.toarray()
+    m_int = m_int.toarray()
+    n_int = k_int.shape[0]
+    print(f"[make-sidecar] cube-cavity: n={args.n}, side={args.side}, n_int={n_int}")
+
+    return {
+        "schema_version": "1",
+        "fixture_id": f"cube_cavity/n{args.n}_numpy_sidecar",
+        "description": (
+            "Full-matrix cube-cavity sidecar synthesized from the NumPy "
+            "reference assembly (reference/numpy/cube_cavity_minimal.py) "
+            "for local driver smoke (issue #186). Mirrors the schema of "
+            "the TF-Java / ONNX reduced_kM.json CI dumps."
+        ),
+        "units": "dimensionless",
+        "inputs": {
+            "n": _scalar_input(args.n, "i64", "Cells per side."),
+            "side": _scalar_input(args.side, "f64", "Cube side."),
+        },
+        "outputs": {
+            "k_int": _f64_field(k_int, "Interior stiffness matrix (dense f64)."),
+            "m_int": _f64_field(m_int, "Interior mass matrix (dense f64)."),
+        },
+        "provenance": {
+            "source": "reference/numpy/cube_cavity_minimal.py via "
+                      "reference/driver/make_numpy_sidecar.py",
+            "issue": "#186",
+        },
+    }
+
+
+def _make_sphere_pec(args) -> dict:
+    from sphere_pec import (
+        apply_dirichlet,
+        assemble_global_nedelec,
+        build_edges,
+        build_epsilon_r,
+        read_sphere_fixture,
+        sphere_pec_interior_edges,
+    )
+
+    fixture = read_sphere_fixture(args.mesh)
+    epsilon_r = build_epsilon_r(fixture.tet_physical_tags, n_inside=args.n_index)
+    edges, tet_edge_idx, tet_edge_sign = build_edges(fixture.tets)
+    interior_mask, _ = sphere_pec_interior_edges(
+        fixture.nodes, edges, r_outer=args.r_buffer
+    )
+    K, M = assemble_global_nedelec(
+        fixture.nodes, fixture.tets, edges, tet_edge_idx, tet_edge_sign, epsilon_r
+    )
+    k_int, m_int = apply_dirichlet(K, M, interior_mask)
+    k_int = k_int.toarray()
+    m_int = m_int.toarray()
+    n_int = k_int.shape[0]
+    print(
+        f"[make-sidecar] sphere-pec: mesh={args.mesh}, "
+        f"n_nodes={fixture.n_nodes}, n_tets={fixture.n_tets}, n_int={n_int}"
+    )
+
+    sidecar = {
+        "schema_version": "1",
+        "fixture_id": f"sphere_pec/n{fixture.n_nodes}_pec_numpy_sidecar",
+        "description": (
+            "Full-matrix sphere-PEC sidecar synthesized from the NumPy "
+            "reference assembly (reference/numpy/sphere_pec.py) for local "
+            "driver smoke (issue #186). Mirrors the schema of the "
+            "reduced_kM_sphere_pec.json CI dumps."
+        ),
+        "units": "dimensionless mesh coordinates",
+        "inputs": {
+            "n_index": _scalar_input(
+                args.n_index, "f64", "Refractive index inside the sphere."
+            ),
+            "r_buffer": _scalar_input(args.r_buffer, "f64", "Outer PEC wall radius."),
+        },
+        "outputs": {
+            **_count_outputs(fixture.n_nodes, fixture.n_tets, len(edges), n_int),
+            "k_int": _f64_field(k_int, "Interior curl-curl stiffness (dense f64)."),
+            "m_int": _f64_field(m_int, "Interior epsilon-weighted mass (dense f64)."),
+        },
+        "provenance": {
+            "source": "reference/numpy/sphere_pec.py via "
+                      "reference/driver/make_numpy_sidecar.py",
+            "issue": "#186",
+        },
+    }
+    return sidecar
+
+
+def _make_sphere_complex(args, problem: str) -> dict:
+    """Shared synthesis for sphere-pml (scalar complex epsilon) and
+    sphere-mie (anisotropic UPML diagonal tensor epsilon)."""
+    from sphere_pec import (
+        apply_dirichlet,
+        build_edges,
+        read_sphere_fixture,
+        sphere_pec_interior_edges,
+    )
+
+    fixture = read_sphere_fixture(args.mesh)
+    edges, tet_edge_idx, tet_edge_sign = build_edges(fixture.tets)
+    interior_mask, _ = sphere_pec_interior_edges(
+        fixture.nodes, edges, r_outer=args.r_buffer
+    )
+
+    if problem == "sphere-pml":
+        from sphere_pml import (
+            assemble_global_nedelec_complex,
+            build_complex_epsilon_r_pml,
+            tet_centroid_radii,
+        )
+
+        centroid_radii = tet_centroid_radii(fixture.nodes, fixture.tets)
+        eps = build_complex_epsilon_r_pml(
+            fixture.tet_physical_tags,
+            centroid_radii,
+            n_inside=args.n_index,
+            sigma_0=args.sigma0,
+        )
+        K, M = assemble_global_nedelec_complex(
+            fixture.nodes, fixture.tets, edges, tet_edge_idx, tet_edge_sign, eps
+        )
+        extra_inputs = {}
+        epsilon_desc = "scalar-isotropic complex-epsilon PML"
+    else:
+        from sphere_mie import (
+            assemble_global_nedelec_anisotropic,
+            build_anisotropic_pml_tensor_diag,
+            tet_centroids,
+        )
+
+        centroids = tet_centroids(fixture.nodes, fixture.tets)
+        eps = build_anisotropic_pml_tensor_diag(
+            fixture.tet_physical_tags,
+            centroids,
+            n_inside=args.n_index,
+            sigma_0=args.sigma0,
+            k0_ref=args.k0_ref,
+        )
+        K, M = assemble_global_nedelec_anisotropic(
+            fixture.nodes, fixture.tets, edges, tet_edge_idx, tet_edge_sign, eps
+        )
+        extra_inputs = {
+            "k0_ref": _scalar_input(
+                args.k0_ref, "f64", "Reference wavenumber in the UPML stretch."
+            ),
+        }
+        epsilon_desc = "anisotropic UPML diagonal tensor epsilon"
+
+    k_int, m_int = apply_dirichlet(K, M, interior_mask)
+    k_int = np.asarray(k_int.todense())
+    m_int = np.asarray(m_int.todense())
+    n_int = k_int.shape[0]
+    k_int_real = _real_part_checked(k_int, "K_int")
+    print(
+        f"[make-sidecar] {problem}: mesh={args.mesh}, "
+        f"n_nodes={fixture.n_nodes}, n_tets={fixture.n_tets}, n_int={n_int}"
+    )
+
+    tag = "pml" if problem == "sphere-pml" else "aniso_upml_mie"
+    return {
+        "schema_version": "1",
+        "fixture_id": f"{problem.replace('-', '_')}/n{fixture.n_nodes}_{tag}_numpy_sidecar",
+        "description": (
+            f"Full-matrix {problem} sidecar ({epsilon_desc}) synthesized "
+            "from the NumPy reference assembly for local driver smoke "
+            "(issue #186). Mirrors the (k_int, m_re_int, m_im_int) schema "
+            "of the TF-Java CI dumps (Re/Im split because TF-Java 1.0.0 "
+            "has no native c128 typed value)."
+        ),
+        "units": "dimensionless mesh coordinates",
+        "inputs": {
+            "sigma_0": _scalar_input(
+                args.sigma0, "f64", "PML absorption strength at r=R_BUFFER."
+            ),
+            **extra_inputs,
+            "n_index": _scalar_input(
+                args.n_index, "f64", "Refractive index in the dielectric."
+            ),
+            "r_buffer": _scalar_input(args.r_buffer, "f64", "Outer PEC wall radius."),
+        },
+        "outputs": {
+            **_count_outputs(fixture.n_nodes, fixture.n_tets, len(edges), n_int),
+            "k_int": _f64_field(
+                k_int_real, "Interior curl-curl stiffness (real-valued, dense f64)."
+            ),
+            "m_re_int": _f64_field(m_int.real, "Re(M_int) (dense f64)."),
+            "m_im_int": _f64_field(m_int.imag, "Im(M_int) (dense f64)."),
+        },
+        "provenance": {
+            "source": (
+                f"reference/numpy/{problem.replace('-', '_')}.py via "
+                "reference/driver/make_numpy_sidecar.py"
+            ),
+            "issue": "#186",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Synthesize a full-matrix assembly sidecar from the in-tree "
+            "NumPy references for eigensolve_from_sidecar.py smoke runs."
+        )
+    )
+    parser.add_argument(
+        "--problem", required=True, choices=list(PROBLEMS), metavar="PROBLEM",
+        help="Problem family. One of: " + ", ".join(PROBLEMS),
+    )
+    parser.add_argument("--out", required=True, help="Output sidecar JSON path.")
+    parser.add_argument(
+        "--mesh", default=None,
+        help=(
+            "Mesh path (sphere problems). Defaults: sphere-pec -> "
+            "reference/fixtures/sphere_pec/sphere.msh; sphere-pml / "
+            "sphere-mie -> reference/fixtures/sphere_pml_small/sphere.msh "
+            "(small mesh; pass the full sphere_pml mesh for a CI-sized run)."
+        ),
+    )
+    parser.add_argument("--n", type=int, default=4, help="[cube-cavity] Cells per side.")
+    parser.add_argument("--side", type=float, default=1.0, help="[cube-cavity] Cube side.")
+    parser.add_argument("--n-index", type=float, default=1.5,
+                        help="[sphere-*] Dielectric refractive index.")
+    parser.add_argument("--r-buffer", type=float, default=2.0,
+                        help="[sphere-*] Outer PEC wall radius.")
+    parser.add_argument("--sigma0", type=float, default=5.0,
+                        help="[sphere-pml/-mie] PML absorption strength.")
+    parser.add_argument("--k0-ref", type=float, default=2.0,
+                        help="[sphere-mie] UPML reference wavenumber.")
+    args = parser.parse_args()
+
+    if args.mesh is None:
+        if args.problem == "sphere-pec":
+            args.mesh = str(_REPO_ROOT / "reference/fixtures/sphere_pec/sphere.msh")
+        elif args.problem in ("sphere-pml", "sphere-mie"):
+            args.mesh = str(_REPO_ROOT / "reference/fixtures/sphere_pml_small/sphere.msh")
+
+    if args.problem == "cube-cavity":
+        sidecar = _make_cube_cavity(args)
+    elif args.problem == "sphere-pec":
+        sidecar = _make_sphere_pec(args)
+    else:
+        sidecar = _make_sphere_complex(args, args.problem)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(sidecar, f, separators=(",", ":"))
+        f.write("\n")
+    size_mb = out_path.stat().st_size / (1024 * 1024)
+    print(f"[make-sidecar] Wrote {out_path} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #186

## Summary

`eigensolve_from_sidecar.py --problem sphere-pec` crashed with `KeyError: 'k_int'` on the checked-in fixtures `reference/fixtures/sphere_pec/tfjava_sidecar.json` / `onnx_sidecar.json`, because those are **summary** sidecars (scalar invariants only) while the driver unconditionally expected full matrices.

**Option chosen: 1 (driver handles summary sidecars, invariants-only mode).** Why:

- The summary format is deliberate size control: the Rust harness docblock (`crates/geode-validation/tests/sphere_pec_tfjava_reference.rs`) records that embedding the 3300x3300 dense matrices would cost ~90 MB JSON each — option 2 (regenerate with full matrices) is rejected on size.
- Option 3 (drop the checked-in sidecars) would break `cargo test -p geode-validation`: both `sphere_pec_tfjava_reference.rs` and `sphere_pec_onnx_reference.rs` load these fixtures and validate their schema/invariants.
- Invariants-only mode keeps the fixtures small AND gives them a working smoke path.

## Changes

- `reference/driver/eigensolve_from_sidecar.py`: `_run_sphere_pec` detects a sidecar without `outputs.k_int`/`m_int`; if the Frobenius/diag invariants are present it routes to a new `_run_sphere_pec_invariants_only` comparison vs the NumPy baseline (counts exact; Frobenius norms and diag sums at 1e-4 relative — matching the Rust harness `frobenius_rel`). Output is clearly labelled invariants-only (no eigensolve) and the emitted JSON fixture carries an `invariants_match` flag. TF-Java's `0.0` diag-sum placeholders are skipped with a note. Unrecognized schemas exit 3; invariant mismatches exit 5. The full-matrix path is byte-for-byte unchanged.
- `reference/driver/make_numpy_sidecar.py` (new): synthesizes full-matrix sidecars from the in-tree NumPy reference assemblies (cube-cavity, sphere-pec, sphere-pml, sphere-mie) so the driver's full eigensolve paths have a documented local smoke without a Java/ONNX toolchain (the issue-174 recovery pattern).
- `reference/driver/README.md` + driver docstring: documents the summary-sidecar invariants-only mode and per-mode smoke invocations.

## Smoke results (all four problem modes)

| Mode | Sidecar | Result |
|---|---|---|
| sphere-pec (summary, tfjava fixture) | checked-in `tfjava_sidecar.json` | PASS invariants-only (all deltas 0; diag sums skipped as 0.0 placeholders) |
| sphere-pec (summary, onnx fixture) | checked-in `onnx_sidecar.json` | PASS invariants-only (max rel 8.1e-14, incl. diag sums) |
| sphere-pec (full matrices, regression) | synthesized CI-sized 774-node sidecar | PASS vs baseline at 1e-5 rel (max 3.7e-10) |
| cube-cavity | synthesized n=4 | green (dense eigh, lambda0=3.75e1) |
| sphere-pml | synthesized small mesh vs `sphere_pml_small/baseline.json` | PASS, all \|delta\| = 0 |
| sphere-mie | synthesized small mesh vs `sphere_mie_small/baseline.json` | hard gate PASS at 1e-4 abs, max \|delta\| = 0 |

Legacy shim `eigensolve_sphere_pec_sidecar.py` also verified on the summary fixture (delegates correctly). Negative tests: corrupted Frobenius exits 5; sidecar with neither matrices nor invariants exits 3; missing baseline exits 2 with a clear message.

## CI compatibility

Read `.github/workflows/tfjava-cube-cavity.yml` (cube, sphere-pec, sphere-pml, sphere-mie jobs) and `onnx-cube-cavity.yml` (cube, sphere-pec): all feed **freshly generated full-matrix sidecars** from the live JVM/ONNX assemblies into the driver, so they take the unchanged full eigensolve path. The summary-sidecar branch only triggers when `outputs.k_int` is absent.

## Test plan

- [x] `cargo test -p geode-validation --release` — all green (including `sphere_pec_tfjava_reference` and `sphere_pec_onnx_reference`)
- [x] Driver smoke for all four problem modes (table above)
- [x] Negative tests for the new exit codes