### PR TITLE
Deterministic ARPACK iterations (fixed-seed v0 + rng) for reference eigensolves

### DIFF
--- a/reference/driver/eigensolve_from_sidecar.py
+++ b/reference/driver/eigensolve_from_sidecar.py
@@ -68,11 +68,34 @@ the JAX / NumPy baselines without language-specific code paths (see
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import sys
 from pathlib import Path
 
 import numpy as np
+
+
+def _deterministic_arpack_kwargs(n, solver, complex_pencil=False):
+    """Deterministic ARPACK kwargs (issue #191).
+
+    Fixed-seed normalized start vector ``v0`` so near-degenerate
+    clusters converge reproducibly run-to-run; on scipy >= 1.17 also a
+    fixed-seed ``rng``, because the rewritten ARPACK wrapper draws its
+    internal *restart* vectors from OS entropy even when ``v0`` is
+    pinned (older Fortran-ARPACK scipy is deterministic given ``v0``).
+    """
+    rng = np.random.default_rng(0)
+    if complex_pencil:
+        v0 = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    else:
+        v0 = rng.standard_normal(n)
+    v0 = v0 / np.linalg.norm(v0)
+    kwargs = {"v0": v0}
+    if "rng" in inspect.signature(solver).parameters:
+        kwargs["rng"] = np.random.default_rng(0)
+    return kwargs
+
 
 # ---------------------------------------------------------------------------
 # Per-backend metadata (cube-cavity path)
@@ -251,7 +274,12 @@ def _run_cube_cavity(args, sidecar: dict) -> None:
         import scipy.sparse.linalg as spla
         k_sp = sp.csr_matrix(k_int)
         m_sp = sp.csr_matrix(m_int)
-        eigvals, eigvecs = spla.eigsh(k_sp, k=args.k, M=m_sp, sigma=0.0, which="LM")
+        # Deterministic ARPACK iterations: reproducibility for
+        # near-degenerate clusters (issue #191).
+        det = _deterministic_arpack_kwargs(k_sp.shape[0], spla.eigsh)
+        eigvals, eigvecs = spla.eigsh(
+            k_sp, k=args.k, M=m_sp, sigma=0.0, which="LM", **det
+        )
         order = np.argsort(eigvals)
         eigvals = eigvals[order]
         eigvecs = eigvecs[:, order]
@@ -609,7 +637,12 @@ def _run_sphere_pec(args, sidecar: dict, sidecar_path: Path) -> None:
     k_sp = sp.csr_matrix(k_int_flat)
     m_sp = sp.csr_matrix(m_int_flat)
     print("[sphere-pec-driver] Running scipy.sparse.linalg.eigsh (shift-invert, sigma=0)...")
-    eigvals, eigvecs = spla.eigsh(k_sp, k=n_request, M=m_sp, sigma=0.0, which="LM")
+    # Deterministic ARPACK iterations: reproducibility for
+    # near-degenerate clusters (issue #191).
+    det = _deterministic_arpack_kwargs(k_sp.shape[0], spla.eigsh)
+    eigvals, eigvecs = spla.eigsh(
+        k_sp, k=n_request, M=m_sp, sigma=0.0, which="LM", **det
+    )
     order = np.argsort(eigvals)
     eigvals = eigvals[order]
 

--- a/reference/jax/cube_cavity.py
+++ b/reference/jax/cube_cavity.py
@@ -46,6 +46,7 @@ HERE = Path(__file__).resolve().parent
 REPO_REF = HERE.parent  # reference/
 sys.path.insert(0, str(REPO_REF / "numpy"))
 from cube_cavity_minimal import (  # noqa: E402
+    _deterministic_arpack_kwargs,
     cube_interior_mask,
     cube_tet_mesh,
 )
@@ -218,8 +219,11 @@ def solve_cube_cavity_jax(n: int = 4, side: float = 1.0, k: int = 5,
     else:
         k_sparse = sp.csr_matrix(k_int)
         m_sparse = sp.csr_matrix(m_int)
+        # Deterministic ARPACK iterations: reproducibility for
+        # near-degenerate clusters (issue #191).
+        det = _deterministic_arpack_kwargs(k_sparse.shape[0], spla.eigsh)
         eigvals, eigvecs = spla.eigsh(
-            k_sparse, k=k, M=m_sparse, sigma=0.0, which="LM"
+            k_sparse, k=k, M=m_sparse, sigma=0.0, which="LM", **det
         )
         order = np.argsort(eigvals)
         eigvals = eigvals[order]

--- a/reference/jax/sphere_pml.py
+++ b/reference/jax/sphere_pml.py
@@ -122,6 +122,7 @@ _nedelec_mass_batch_jax = _jax_pec._nedelec_mass_batch_jax
 
 # NumPy-side helpers (algorithmic source of truth shared with PEC).
 from sphere_pec import (  # noqa: E402  (numpy module via numpy/sphere_pec.py)
+    _deterministic_arpack_kwargs,
     PHYS_SPHERE_INTERIOR,
     PHYS_PML_SHELL,
     PHYS_VACUUM_GAP,
@@ -317,6 +318,12 @@ def eigensolve_complex(
     """
     K_c = K_int.astype(np.complex128)
     M_c = M_int.astype(np.complex128)
+    # Deterministic ARPACK iterations: reproducibility for
+    # near-degenerate clusters (issue #191). Complex pencil, so the
+    # start vector seeds both real and imaginary parts.
+    det = _deterministic_arpack_kwargs(
+        K_c.shape[0], scipy.sparse.linalg.eigs, complex_pencil=True
+    )
     eigvals, eigvecs = scipy.sparse.linalg.eigs(
         K_c,
         k=int(k_request),
@@ -324,6 +331,7 @@ def eigensolve_complex(
         sigma=complex(sigma),
         which="LM",
         tol=1e-10,
+        **det,
     )
     order = np.argsort(eigvals.real)
     return eigvals[order], eigvecs[:, order]

--- a/reference/numpy/cube_cavity.py
+++ b/reference/numpy/cube_cavity.py
@@ -63,6 +63,7 @@ Assembly + eigensolve:
 
 from __future__ import annotations
 
+import inspect
 import sys
 from pathlib import Path
 
@@ -158,6 +159,27 @@ def apply_dirichlet(K, M, mask):
 # --------------------------------------------------------------------------- #
 
 
+def _deterministic_arpack_kwargs(n, solver, complex_pencil=False):
+    """Deterministic ARPACK kwargs (issue #191).
+
+    Fixed-seed normalized start vector ``v0`` so near-degenerate
+    clusters converge reproducibly run-to-run; on scipy >= 1.17 also a
+    fixed-seed ``rng``, because the rewritten ARPACK wrapper draws its
+    internal *restart* vectors from OS entropy even when ``v0`` is
+    pinned (older Fortran-ARPACK scipy is deterministic given ``v0``).
+    """
+    rng = np.random.default_rng(0)
+    if complex_pencil:
+        v0 = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    else:
+        v0 = rng.standard_normal(n)
+    v0 = v0 / np.linalg.norm(v0)
+    kwargs = {"v0": v0}
+    if "rng" in inspect.signature(solver).parameters:
+        kwargs["rng"] = np.random.default_rng(0)
+    return kwargs
+
+
 def eigensolve(K, M, k: int = 5):
     """Lowest-k generalized eigenpairs of ``K x = λ M x``.
 
@@ -177,12 +199,16 @@ def eigensolve(K, M, k: int = 5):
     # eigsh's shift-and-invert path requires a sparse SPD K-σM; at σ=0 that
     # is just K, which is positive *semi*-definite (the constant mode is in
     # the null space, but Dirichlet-restricted K is SPD on the interior).
+    # Deterministic ARPACK iterations: reproducibility for
+    # near-degenerate clusters (issue #191).
+    det = _deterministic_arpack_kwargs(K.shape[0], scipy.sparse.linalg.eigsh)
     eigvals, eigvecs = scipy.sparse.linalg.eigsh(
         K.astype(np.float64),
         k=k,
         M=M.astype(np.float64),
         sigma=0.0,
         which="LM",
+        **det,
     )
     # eigsh in shift-invert mode returns eigenvalues not necessarily sorted.
     order = np.argsort(eigvals)

--- a/reference/numpy/cube_cavity_minimal.py
+++ b/reference/numpy/cube_cavity_minimal.py
@@ -54,6 +54,7 @@ The analytic targets for `side=1.0` are eigenvalues at
 
 from __future__ import annotations
 
+import inspect
 import sys
 from pathlib import Path
 
@@ -108,6 +109,27 @@ def restrict_to_interior(k_csr, m_csr, mask: np.ndarray):
     return k_int, m_int
 
 
+def _deterministic_arpack_kwargs(n, solver, complex_pencil=False):
+    """Deterministic ARPACK kwargs (issue #191).
+
+    Fixed-seed normalized start vector ``v0`` so near-degenerate
+    clusters converge reproducibly run-to-run; on scipy >= 1.17 also a
+    fixed-seed ``rng``, because the rewritten ARPACK wrapper draws its
+    internal *restart* vectors from OS entropy even when ``v0`` is
+    pinned (older Fortran-ARPACK scipy is deterministic given ``v0``).
+    """
+    rng = np.random.default_rng(0)
+    if complex_pencil:
+        v0 = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    else:
+        v0 = rng.standard_normal(n)
+    v0 = v0 / np.linalg.norm(v0)
+    kwargs = {"v0": v0}
+    if "rng" in inspect.signature(solver).parameters:
+        kwargs["rng"] = np.random.default_rng(0)
+    return kwargs
+
+
 def solve_cube_cavity(n: int = 4, side: float = 1.0, k: int = 5, dense: bool = False):
     """End-to-end cube-cavity scalar Helmholtz eigenproblem.
 
@@ -145,7 +167,12 @@ def solve_cube_cavity(n: int = 4, side: float = 1.0, k: int = 5, dense: bool = F
         eigvecs = eigvecs[:, :k]
     else:
         # Sparse path: ARPACK shift-and-invert at sigma=0.
-        eigvals, eigvecs = spla.eigsh(k_int, k=k, M=m_int, sigma=0.0, which="LM")
+        # Deterministic ARPACK iterations: reproducibility for
+        # near-degenerate clusters (issue #191).
+        det = _deterministic_arpack_kwargs(k_int.shape[0], spla.eigsh)
+        eigvals, eigvecs = spla.eigsh(
+            k_int, k=k, M=m_int, sigma=0.0, which="LM", **det
+        )
         # eigsh returns in ascending magnitude of (1/(lam-sigma)); sort by lam.
         order = np.argsort(eigvals)
         eigvals = eigvals[order]

--- a/reference/numpy/sphere_pec.py
+++ b/reference/numpy/sphere_pec.py
@@ -107,6 +107,7 @@ Public API
 
 from __future__ import annotations
 
+import inspect
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -466,6 +467,27 @@ def apply_dirichlet(K, M, interior_mask):
 # --------------------------------------------------------------------------- #
 
 
+def _deterministic_arpack_kwargs(n, solver, complex_pencil=False):
+    """Deterministic ARPACK kwargs (issue #191).
+
+    Fixed-seed normalized start vector ``v0`` so near-degenerate
+    clusters converge reproducibly run-to-run; on scipy >= 1.17 also a
+    fixed-seed ``rng``, because the rewritten ARPACK wrapper draws its
+    internal *restart* vectors from OS entropy even when ``v0`` is
+    pinned (older Fortran-ARPACK scipy is deterministic given ``v0``).
+    """
+    rng = np.random.default_rng(0)
+    if complex_pencil:
+        v0 = rng.standard_normal(n) + 1j * rng.standard_normal(n)
+    else:
+        v0 = rng.standard_normal(n)
+    v0 = v0 / np.linalg.norm(v0)
+    kwargs = {"v0": v0}
+    if "rng" in inspect.signature(solver).parameters:
+        kwargs["rng"] = np.random.default_rng(0)
+    return kwargs
+
+
 def eigensolve(K, M, k_request: int):
     """Lowest-``k_request`` generalized eigenpairs of ``K x = λ M x``.
 
@@ -486,12 +508,16 @@ def eigensolve(K, M, k_request: int):
     end of the spectrum of ``(K - σ M)^{-1} M`` and recovers the
     cluster + lowest physical modes in a single block of iterations.
     """
+    # Deterministic ARPACK iterations: reproducibility for
+    # near-degenerate clusters (issue #191).
+    det = _deterministic_arpack_kwargs(K.shape[0], scipy.sparse.linalg.eigsh)
     eigvals, eigvecs = scipy.sparse.linalg.eigsh(
         K.astype(np.float64),
         k=int(k_request),
         M=M.astype(np.float64),
         sigma=0.0,
         which="LM",
+        **det,
     )
     # eigsh in shift-invert mode returns eigenvalues not necessarily sorted.
     order = np.argsort(eigvals)


### PR DESCRIPTION
Closes #191

## Summary

Makes every ARPACK eigensolve under `reference/` deterministic, fixing the near-degenerate λ≈1.42-triplet CI flake diagnosed in the PR #189 review (TF-Java / ONNX sphere-PEC jobs intermittently drifting ~1.5e-3 past gates while assembly matched to 13 digits).

## Root cause — deeper than the issue diagnosis

The issue called out the missing `v0` start vector. While implementing, a second entropy source surfaced: **scipy >= 1.17's rewritten ARPACK wrapper draws internal *restart* vectors (reverse-communication `ido == 4`) from an OS-entropy-seeded `np.random.default_rng()` even when `v0` is pinned** (`scipy/sparse/linalg/_eigen/arpack/arpack.py`, the `ido == 4` branches). On the complex sphere-PML pencil this was empirically reproducible: identical matrices + identical `v0` still gave ~8e-4 eigenvalue scatter between calls, single-threaded, across fresh processes. Pinning `v0` alone is therefore insufficient on current scipy.

## Convention chosen

A shared helper `_deterministic_arpack_kwargs(n, solver, complex_pencil=False)` applied uniformly at every site:

- **`v0`**: fixed-seed normalized random vector, `np.random.default_rng(0).standard_normal(n)` (real+imag parts for complex pencils), normalized. Chose fixed-seed random over a constant vector because a constant vector lies in a highly symmetric subspace and risks deficient overlap with some symmetry sectors of the near-degenerate triplet; a generic random vector has O(1/sqrt(n)) overlap with every mode.
- **`rng=np.random.default_rng(0)`**: passed when the installed scipy's `eigs`/`eigsh` signature accepts it (scipy >= 1.17), pinning the restart vectors. Older Fortran-ARPACK scipy doesn't accept the kwarg and doesn't need it (deterministic given `v0`).

## Call sites fixed (exhaustive grep of `reference/` for `eigsh(`/`eigs(`)

1. `reference/driver/eigensolve_from_sidecar.py` — cube-cavity path (was :254)
2. `reference/driver/eigensolve_from_sidecar.py` — sphere-pec path (was :612)
3. `reference/numpy/sphere_pec.py` — `eigensolve()` (was :472; also covers `reference/jax/sphere_pec.py` and both gen_* baseline scripts, which import it)
4. `reference/numpy/cube_cavity.py` — `eigensolve()` (covers `gen_cube_cavity_baseline.py`)
5. `reference/numpy/cube_cavity_minimal.py` — sparse path (canonical helper for the cube family)
6. `reference/jax/cube_cavity.py` — sparse path (imports helper from `cube_cavity_minimal`)
7. `reference/jax/sphere_pml.py` — `eigensolve_complex()`, complex `eigs` shift-invert (imports helper from numpy `sphere_pec`)

Not touched (out of scope / no ARPACK): `reference/numpy/sphere_pml.py` (dense LAPACK ZGGEV per #160), all Mie paths, all Julia paths (dense per #160), driver sphere-pml/sphere-mie paths (dense).

## Baseline verification — none regenerated, all pass unchanged

- **Driver sphere-pec full-matrix path** (`make_numpy_sidecar.py` → `eigensolve_from_sidecar.py`): PASS vs `reference/fixtures/sphere_pec/baseline.json` at rtol 1e-5 (worst rel 5.3e-10); **two runs bit-for-bit identical**.
- **NumPy sphere-pec reference** (`run_sphere_pec`): worst rel vs baseline 5.3e-10 (gate 1e-5).
- **Driver invariants-only mode (PR #189)**: PASS on both committed summary sidecars (`tfjava_sidecar.json`, `onnx_sidecar.json`).
- **Driver cube-cavity ARPACK path** (n=10 sidecar): matches `cube_cavity/baseline.json` to 5.7e-14 abs.
- **NumPy cube reference + minimal sparse path**: worst rel 3.9e-15 vs baseline; repeats identical.
- **JAX cube** (n=4 dense vs `jax_baseline.json`: exact; n=10 ARPACK path vs NumPy baseline: 1.6e-15 rel); repeats identical.
- **JAX sphere-PML snapshot drift gate** (workflow comparator vs committed `sphere_pml/jax_baseline.json`): PASS, worst |Δ| 7.0e-4 vs tol 1e-3; **two full fixture regenerations bit-for-bit identical** (previously ~8e-4 scatter run-to-run).

## Tests

- `cargo test -p geode-validation --release`: all green (no Rust changes).
- `cargo fmt --all -- --check`: green.

## CI to watch

The previously flaky jobs — `tfjava-cube-cavity` sphere-pec job and the `onnx-cube-cavity` sphere-pec workflow — should be watched on this PR; recommend rerunning them twice to demonstrate stability (local two-run bit-for-bit reproduction above is the same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)