### PR TITLE
feat: deterministic driven solve A(ω)x = b with volumetric current source

### DIFF
--- a/crates/geode-core/src/complex_lanczos.rs
+++ b/crates/geode-core/src/complex_lanczos.rs
@@ -101,7 +101,7 @@ pub trait SparseComplexEigenSolver {
 }
 
 /// Compute `y += A · x` for complex `A` in CSC form.
-fn spmv_add(a: SparseColMatRef<'_, usize, c64>, x: &[c64], y: &mut [c64]) {
+pub(crate) fn spmv_add(a: SparseColMatRef<'_, usize, c64>, x: &[c64], y: &mut [c64]) {
     let col_ptr = a.col_ptr();
     let row_idx = a.row_idx();
     let val = a.val();
@@ -121,7 +121,7 @@ fn spmv_add(a: SparseColMatRef<'_, usize, c64>, x: &[c64], y: &mut [c64]) {
 }
 
 /// Compute `y = A · x` (overwrite) for complex sparse `A`.
-fn spmv(a: SparseColMatRef<'_, usize, c64>, x: &[c64], y: &mut [c64]) {
+pub(crate) fn spmv(a: SparseColMatRef<'_, usize, c64>, x: &[c64], y: &mut [c64]) {
     for v in y.iter_mut() {
         *v = c64::new(0.0, 0.0);
     }
@@ -195,7 +195,11 @@ fn shifted_pencil_complex(
 }
 
 /// Solve `A y = b` in-place via a precomputed complex sparse LU.
-fn solve_with_lu(lu: &Lu<usize, c64>, rhs: &[c64], out: &mut [c64]) -> Result<(), EigenError> {
+pub(crate) fn solve_with_lu(
+    lu: &Lu<usize, c64>,
+    rhs: &[c64],
+    out: &mut [c64],
+) -> Result<(), EigenError> {
     use faer::linalg::solvers::Solve;
     let n = rhs.len();
     let mut work: Mat<c64> = Mat::from_fn(n, 1, |i, _| rhs[i]);

--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -1,0 +1,600 @@
+//! Deterministic **driven** frequency-domain solve `A(ω) x = b` with a
+//! volumetric current source (Epic #193, issue #194).
+//!
+//! Where the eigenpencil path solves `(K − k² M) x = 0` for resonances,
+//! this module solves the *forced* problem at a prescribed frequency ω:
+//!
+//! ```text
+//! A(ω) x = b,        A(ω) = K − (ω/c)² M(ε),
+//! b_i = i ω μ₀ ∫_Ω N_i · J dV,
+//! ```
+//!
+//! in the codebase's natural units (`c = μ₀ = ε₀ = 1`, so `ω ≡ k₀` and
+//! eigenvalues of the pencil are `k²`). `K` is the Nédélec curl-curl
+//! stiffness, `M(ε)` the (possibly complex / anisotropic-diagonal) mass,
+//! and `J` a per-tet piecewise-constant current density.
+//!
+//! # Boundary conditions
+//!
+//! BCs compose with the driven system exactly as they do with the
+//! eigenpencil:
+//!
+//! - **PEC** — row/column elimination via a per-edge interior mask
+//!   (same mask helpers as the eigen path:
+//!   [`crate::nedelec_assembly::pec_interior_edge_mask`],
+//!   [`crate::nedelec_assembly::cube_pec_interior_edges`],
+//!   [`crate::nedelec_assembly::sphere_pec_interior_edges`]). Eliminated
+//!   edge DOFs are returned as exact zeros in the full-length solution.
+//! - **UPML / scalar PML** — enters through the *material*: a complex
+//!   scalar ε ([`crate::nedelec_assembly::build_complex_epsilon_r_pml`])
+//!   or a diagonal anisotropic tensor ε
+//!   ([`crate::nedelec_assembly::build_anisotropic_pml_tensor_diag`])
+//!   makes `M` complex, which makes `A(ω)` invertible for real ω and
+//!   absorbs outgoing radiation.
+//!
+//! # Solver
+//!
+//! Reuses the existing sparse complex factorization machinery from the
+//! shift-and-invert Lanczos path ([`crate::complex_lanczos`]): the
+//! interior-reduced `A(ω)` is built as a `faer` sparse CSC matrix from
+//! the assembly [`crate::assembly::SparsityPattern`], factored once with
+//! `sp_lu`, and solved directly. A direct sparse solve is sufficient at
+//! the mesh sizes this crate targets; iterative solvers are out of scope
+//! (issue #194).
+//!
+//! # Sign / time convention
+//!
+//! `exp(+jωt)` time convention, consistent with the rest of the codebase
+//! (see `silvermuller.rs` and the PML builders, which produce
+//! `Im(ε) < 0` for absorption). The strong form corresponding to the
+//! discrete system above is
+//!
+//! ```text
+//! ∇×∇×E − ω² ε E = i ω J,
+//! ```
+//!
+//! i.e. the source phase convention follows the issue statement
+//! (`b = iωμ₀ ∫ N · J`). A global phase flip of `J` only flips the phase
+//! of `x`; absorption direction is set by `Im(ε)` in `A`, not by `b`.
+//!
+//! # Autodiff
+//!
+//! The assembly of `K`, `M`, and `b` runs through the batched-local-
+//! kernel + `scatter(Add)` Burn path and preserves autodiff up to the
+//! host transfer. The sparse factorization itself is faer (CPU) and
+//! breaks the tape — same trade-off as the eigensolver layer
+//! ([`crate::eigen`]).
+
+use burn::tensor::backend::Backend;
+use faer::c64;
+use faer::sparse::{SparseColMat, Triplet};
+
+use crate::complex_lanczos::{solve_with_lu, spmv};
+use crate::eigen::burn_matrix_to_faer;
+use crate::nedelec_assembly::{
+    assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
+    assemble_nedelec_current_rhs, burn_complex_mass_to_faer, tet_centroids,
+};
+use crate::TetMesh;
+
+/// Errors produced by the driven-solve layer.
+#[derive(Debug, thiserror::Error)]
+pub enum DrivenError {
+    #[error("PEC interior mask length {got} disagrees with edge count {want}")]
+    MaskDimMismatch { got: usize, want: usize },
+    #[error("source has {got} per-tet entries but mesh has {want} tets")]
+    SourceDimMismatch { got: usize, want: usize },
+    #[error("material has {got} per-tet entries but mesh has {want} tets")]
+    MaterialDimMismatch { got: usize, want: usize },
+    #[error("driven system has no interior DOFs after PEC elimination")]
+    EmptyInterior,
+    #[error("sparse system assembly failed: {0}")]
+    SparseAssembly(String),
+    #[error("sparse LU factorization of A(ω) failed: {0}")]
+    Factorization(String),
+    #[error("sparse solve failed: {0}")]
+    Solve(String),
+}
+
+/// Per-tet material description for the driven solve.
+///
+/// Mirrors the material inputs the eigenpencil path accepts: a complex
+/// scalar relative permittivity per tet, or the diagonal-anisotropic
+/// UPML tensor per tet. The stiffness `K` is permittivity-independent
+/// in both cases.
+#[derive(Debug, Clone, Copy)]
+pub enum DrivenMaterials<'a> {
+    /// Scalar complex relative permittivity per tet (`ε_r ∈ ℂ`). Use
+    /// real values for plain dielectrics / PEC cavities and
+    /// [`crate::nedelec_assembly::build_complex_epsilon_r_pml`] for the
+    /// scalar-PML profile.
+    Scalar(&'a [c64]),
+    /// Diagonal anisotropic complex permittivity per tet in the global
+    /// Cartesian basis (`[ε_x, ε_y, ε_z]`), as produced by
+    /// [`crate::nedelec_assembly::build_anisotropic_pml_tensor_diag`]
+    /// for the UPML shell.
+    DiagTensor(&'a [[c64; 3]]),
+}
+
+/// Boundary conditions for the driven solve.
+///
+/// Currently the PEC interior-edge mask; the UPML/scalar-PML absorbing
+/// boundary is a *material* (see [`DrivenMaterials`]) and composes with
+/// the PEC outer wall exactly as in the eigenpencil tests.
+#[derive(Debug, Clone)]
+pub struct DrivenBcs<'a> {
+    /// Per-edge mask over `mesh.edges()` order: `true` = kept interior
+    /// DOF, `false` = PEC-eliminated edge (forced to zero).
+    pub pec_interior_mask: &'a [bool],
+}
+
+/// Volumetric current source, piecewise constant per tet.
+#[derive(Debug, Clone)]
+pub struct CurrentSource {
+    /// `[n_tets][3]` complex current density `J` per tet, in `mesh.tets`
+    /// order.
+    pub j_tet: Vec<[c64; 3]>,
+}
+
+impl CurrentSource {
+    /// Sample a continuous current density `J(x)` at every tet centroid.
+    pub fn from_centroids(mesh: &TetMesh, f: impl Fn([f64; 3]) -> [c64; 3]) -> Self {
+        let j_tet = tet_centroids(mesh).into_iter().map(f).collect();
+        Self { j_tet }
+    }
+}
+
+/// Solution of the driven system.
+#[derive(Debug, Clone)]
+pub struct DrivenSolution {
+    /// Full-length `[n_edges]` complex edge-DOF vector in `mesh.edges()`
+    /// order. PEC-eliminated edges carry exact zeros.
+    pub e_edges: Vec<c64>,
+    /// Number of interior (kept) DOFs after PEC elimination.
+    pub n_interior: usize,
+    /// Relative residual `‖A x − b‖₂ / ‖b‖₂` of the interior system,
+    /// computed post-solve as a numerical health check. For a healthy
+    /// direct sparse solve this is at the round-off floor.
+    pub residual_rel: f64,
+}
+
+/// Deterministic driven frequency-domain solve `A(ω) x = b` with a
+/// volumetric current source (issue #194).
+///
+/// Assembles the Nédélec curl-curl pencil `(K, M(ε))` on `mesh`, the
+/// current-source RHS `b_i = iω ∫ N_i · J dV` (natural units, `μ₀ = 1`),
+/// applies the PEC reduction from `bcs`, factors the interior
+/// `A(ω) = K − ω² M` once with faer's complex sparse LU, and returns the
+/// full-length edge field with zeros on eliminated edges.
+///
+/// `omega` is `ω/c = k₀` in the mesh's length units (the same
+/// normalization in which the eigenpencil's eigenvalues are `k²`).
+///
+/// # Errors
+///
+/// Returns [`DrivenError`] on input-shape mismatches or if the sparse
+/// factorization/solve fails (e.g. `ω²` collides with a real eigenvalue
+/// of a lossless pencil, making `A(ω)` singular).
+pub fn driven_solve<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    source: &CurrentSource,
+    device: &B::Device,
+) -> Result<DrivenSolution, DrivenError> {
+    let n_tets = mesh.n_tets();
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+
+    // --- Input validation -------------------------------------------------
+    if bcs.pec_interior_mask.len() != n_edges {
+        return Err(DrivenError::MaskDimMismatch {
+            got: bcs.pec_interior_mask.len(),
+            want: n_edges,
+        });
+    }
+    if source.j_tet.len() != n_tets {
+        return Err(DrivenError::SourceDimMismatch {
+            got: source.j_tet.len(),
+            want: n_tets,
+        });
+    }
+    let material_len = match materials {
+        DrivenMaterials::Scalar(eps) => eps.len(),
+        DrivenMaterials::DiagTensor(eps) => eps.len(),
+    };
+    if material_len != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: material_len,
+            want: n_tets,
+        });
+    }
+
+    // --- Edge tables ------------------------------------------------------
+    let tet_edges = mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+
+    // --- Assemble K, M(ε) on the Burn backend ------------------------------
+    let (nodes_t, tets_t) = crate::assembly::upload_mesh::<B>(mesh, device);
+    let sys = match materials {
+        DrivenMaterials::Scalar(eps) => assemble_global_nedelec_with_complex_epsilon(
+            nodes_t.clone(),
+            tets_t.clone(),
+            &tet_idx,
+            &tet_sign,
+            n_edges,
+            eps,
+        ),
+        DrivenMaterials::DiagTensor(eps) => assemble_global_nedelec_with_anisotropic_epsilon(
+            nodes_t.clone(),
+            tets_t.clone(),
+            &tet_idx,
+            &tet_sign,
+            n_edges,
+            eps,
+        ),
+    };
+
+    // --- Assemble the current-source RHS -----------------------------------
+    // The Burn RHS kernel is real-valued; a complex J runs as two passes
+    // (Re(J), Im(J)) — same split as the complex-ε mass assembly.
+    let j_re: Vec<[f64; 3]> = source
+        .j_tet
+        .iter()
+        .map(|j| [j[0].re, j[1].re, j[2].re])
+        .collect();
+    let j_im: Vec<[f64; 3]> = source
+        .j_tet
+        .iter()
+        .map(|j| [j[0].im, j[1].im, j[2].im])
+        .collect();
+    let rhs_re = assemble_nedelec_current_rhs(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &j_re,
+    );
+    let rhs_im = assemble_nedelec_current_rhs(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im);
+    let rhs_re: Vec<f64> = rhs_re.into_data().iter::<f64>().collect();
+    let rhs_im: Vec<f64> = rhs_im.into_data().iter::<f64>().collect();
+
+    // b = iωμ₀ ∫ N · J dV with μ₀ = 1:  iω (re + i·im) = ω(−im + i·re).
+    let b_full: Vec<c64> = rhs_re
+        .iter()
+        .zip(rhs_im.iter())
+        .map(|(&re, &im)| c64::new(-omega * im, omega * re))
+        .collect();
+
+    // --- Host transfer + PEC reduction -------------------------------------
+    let k_full = burn_matrix_to_faer(sys.k);
+    let m_full = burn_complex_mass_to_faer(sys.m_re, sys.m_im);
+
+    // Remap full edge indices → contiguous interior indices.
+    let mut remap = vec![-1_i64; n_edges];
+    let mut n_interior = 0_usize;
+    for (i, &keep) in bcs.pec_interior_mask.iter().enumerate() {
+        if keep {
+            remap[i] = n_interior as i64;
+            n_interior += 1;
+        }
+    }
+    if n_interior == 0 {
+        return Err(DrivenError::EmptyInterior);
+    }
+
+    // --- Sparse A(ω) = K − ω² M over the recorded sparsity pattern ---------
+    let omega2 = omega * omega;
+    let mut triplets: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(sys.sparsity.rows.len());
+    for (&r_u32, &c_u32) in sys.sparsity.rows.iter().zip(sys.sparsity.cols.iter()) {
+        let (r, c) = (r_u32 as usize, c_u32 as usize);
+        let (rr, cc) = (remap[r], remap[c]);
+        if rr < 0 || cc < 0 {
+            continue;
+        }
+        let a_val = c64::new(k_full[(r, c)], 0.0) - m_full[(r, c)] * omega2;
+        triplets.push(Triplet::new(rr as usize, cc as usize, a_val));
+    }
+    let a_int =
+        SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
+            .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+
+    let b_int: Vec<c64> = bcs
+        .pec_interior_mask
+        .iter()
+        .zip(b_full.iter())
+        .filter_map(|(&keep, &b)| if keep { Some(b) } else { None })
+        .collect();
+
+    // --- Factor once + direct solve (same machinery as complex Lanczos) ----
+    let lu = a_int
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+    let mut x_int = vec![c64::new(0.0, 0.0); n_interior];
+    solve_with_lu(&lu, &b_int, &mut x_int).map_err(|e| DrivenError::Solve(format!("{e}")))?;
+
+    // --- Post-solve residual check ------------------------------------------
+    let mut ax = vec![c64::new(0.0, 0.0); n_interior];
+    spmv(a_int.as_ref(), &x_int, &mut ax);
+    let mut res2 = 0.0_f64;
+    let mut b2 = 0.0_f64;
+    for i in 0..n_interior {
+        let r = ax[i] - b_int[i];
+        res2 += r.re * r.re + r.im * r.im;
+        b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+    }
+    let residual_rel = if b2 > 0.0 {
+        (res2 / b2).sqrt()
+    } else {
+        res2.sqrt()
+    };
+
+    // --- Scatter back to the full edge vector --------------------------------
+    let mut e_edges = vec![c64::new(0.0, 0.0); n_edges];
+    for (full_idx, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            e_edges[full_idx] = x_int[ri as usize];
+        }
+    }
+
+    Ok(DrivenSolution {
+        e_edges,
+        n_interior,
+        residual_rel,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nedelec_assembly::cube_pec_interior_edges;
+    use crate::{cube_tet_mesh, DefaultBackend};
+    use burn::tensor::backend::BackendTypes;
+
+    type B = DefaultBackend;
+
+    fn device() -> <B as BackendTypes>::Device {
+        <B as BackendTypes>::Device::default()
+    }
+
+    fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+        vec![c64::new(1.0, 0.0); mesh.n_tets()]
+    }
+
+    /// A zero current source must produce an exactly-zero field.
+    #[test]
+    fn zero_source_gives_zero_field() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let source = CurrentSource {
+            j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+        };
+        let sol = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            1.0,
+            &source,
+            &device(),
+        )
+        .expect("driven solve");
+        assert!(sol.e_edges.iter().all(|e| e.re == 0.0 && e.im == 0.0));
+    }
+
+    /// Linearity: doubling J doubles the field (up to round-off).
+    #[test]
+    fn solution_is_linear_in_source() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let s1 = CurrentSource::from_centroids(&mesh, |c| {
+            [
+                c64::new(0.0, 0.0),
+                c64::new(0.0, 0.0),
+                c64::new((std::f64::consts::PI * c[0]).sin(), 0.0),
+            ]
+        });
+        let s2 = CurrentSource {
+            j_tet: s1.j_tet.iter().map(|j| j.map(|x| x * 2.0)).collect(),
+        };
+        let omega = 1.0;
+        let sol1 = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &s1,
+            &device(),
+        )
+        .expect("solve s1");
+        let sol2 = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &s2,
+            &device(),
+        )
+        .expect("solve s2");
+
+        let norm1: f64 = sol1
+            .e_edges
+            .iter()
+            .map(|e| e.re * e.re + e.im * e.im)
+            .sum::<f64>()
+            .sqrt();
+        assert!(norm1 > 0.0, "nonzero source must excite a nonzero field");
+        for (a, b) in sol1.e_edges.iter().zip(sol2.e_edges.iter()) {
+            let d = *b - *a * 2.0;
+            assert!(
+                d.re.hypot(d.im) <= 1e-9 * norm1,
+                "linearity violated: 2·{a} vs {b}"
+            );
+        }
+    }
+
+    /// The post-solve residual must sit at the direct-solve round-off
+    /// floor, and PEC-eliminated edges must be exactly zero.
+    #[test]
+    fn residual_is_small_and_pec_edges_are_zero() {
+        let mesh = cube_tet_mesh(3, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let source = CurrentSource::from_centroids(&mesh, |_| {
+            [c64::new(0.0, 0.0), c64::new(0.0, 0.0), c64::new(1.0, 0.0)]
+        });
+        let sol = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            1.5,
+            &source,
+            &device(),
+        )
+        .expect("driven solve");
+        assert!(
+            sol.residual_rel < 1e-10,
+            "direct-solve residual too large: {}",
+            sol.residual_rel
+        );
+        for (i, &keep) in interior.iter().enumerate() {
+            if !keep {
+                assert_eq!(sol.e_edges[i], c64::new(0.0, 0.0));
+            }
+        }
+        assert!(sol
+            .e_edges
+            .iter()
+            .all(|e| e.re.is_finite() && e.im.is_finite()));
+    }
+
+    /// An isotropic DiagTensor material must agree with the Scalar
+    /// material path (the two assembly kernels are independent
+    /// implementations of the same integral).
+    #[test]
+    fn diag_tensor_matches_scalar_for_isotropic_epsilon() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps_scalar: Vec<c64> = vec![c64::new(1.8, -0.05); mesh.n_tets()];
+        let eps_diag: Vec<[c64; 3]> = eps_scalar.iter().map(|&e| [e, e, e]).collect();
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let source = CurrentSource::from_centroids(&mesh, |c| {
+            [
+                c64::new(c[1], 0.0),
+                c64::new(0.0, -0.5),
+                c64::new(1.0, c[0]),
+            ]
+        });
+        let omega = 2.0;
+        let sol_s = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps_scalar),
+            &bcs,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("scalar solve");
+        let sol_d = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::DiagTensor(&eps_diag),
+            &bcs,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("diag solve");
+
+        let norm: f64 = sol_s
+            .e_edges
+            .iter()
+            .map(|e| e.re * e.re + e.im * e.im)
+            .sum::<f64>()
+            .sqrt();
+        assert!(norm > 0.0);
+        let mut max_rel = 0.0_f64;
+        for (a, b) in sol_s.e_edges.iter().zip(sol_d.e_edges.iter()) {
+            let d = *a - *b;
+            max_rel = max_rel.max(d.re.hypot(d.im) / norm);
+        }
+        assert!(
+            max_rel < 1e-4,
+            "scalar vs diag-tensor isotropic mismatch: max relative diff {max_rel}"
+        );
+    }
+
+    /// Shape-mismatch inputs must error, not panic.
+    #[test]
+    fn input_validation_errors() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let good_source = CurrentSource {
+            j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+        };
+
+        let bad_mask = vec![true; 3];
+        let err = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &DrivenBcs {
+                pec_interior_mask: &bad_mask,
+            },
+            1.0,
+            &good_source,
+            &device(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DrivenError::MaskDimMismatch { .. }));
+
+        let bad_source = CurrentSource {
+            j_tet: vec![[c64::new(0.0, 0.0); 3]; 2],
+        };
+        let err = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            1.0,
+            &bad_source,
+            &device(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DrivenError::SourceDimMismatch { .. }));
+
+        let bad_eps = vec![c64::new(1.0, 0.0); 1];
+        let err = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&bad_eps),
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            1.0,
+            &good_source,
+            &device(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DrivenError::MaterialDimMismatch { .. }));
+    }
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod assembly;
 pub mod complex_eigen;
 pub mod complex_lanczos;
 pub mod derham;
+pub mod driven;
 pub mod eigen;
 pub mod fe_assemble;
 pub mod lanczos;
@@ -31,6 +32,9 @@ pub use assembly::{
 pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
+pub use driven::{
+    driven_solve, CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenSolution,
+};
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
     FaerDenseEigensolver,
@@ -55,15 +59,15 @@ pub use mie_open::{
     OPEN_SPACE_WGM_TABLE_N15,
 };
 pub use nedelec::{
-    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices, tet_edges,
-    NedelecLocalMatrices,
+    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices,
+    batched_nedelec_local_rhs, tet_edges, NedelecLocalMatrices,
 };
 pub use nedelec_assembly::{
     assemble_global_nedelec, assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_complex_epsilon, assemble_global_nedelec_with_epsilon,
-    build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, build_epsilon_r,
-    burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask, rank_via_svd,
-    restrict_gradient_dense, sphere_n_interior_nodes, sphere_pec_interior_edges,
+    assemble_nedelec_current_rhs, build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml,
+    build_epsilon_r, burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
+    rank_via_svd, restrict_gradient_dense, sphere_n_interior_nodes, sphere_pec_interior_edges,
     sphere_pec_node_interior_mask, spurious_dim_from_derham, tet_centroid_radii, tet_centroids,
     NedelecComplexGlobalSystem, NedelecGlobalSystem, DERHAM_RANK_THRESHOLD_REL,
 };

--- a/crates/geode-core/src/nedelec.rs
+++ b/crates/geode-core/src/nedelec.rs
@@ -276,6 +276,114 @@ pub fn batched_nedelec_local_matrices<B: Backend>(coords: Tensor<B, 3>) -> Nedel
     }
 }
 
+/// Batched first-order Nédélec element-local right-hand-side vector for
+/// a **piecewise-constant** volumetric current density `J`.
+///
+/// Computes, for each tet `T` and each local edge `i = (a, b)`,
+///
+/// ```text
+/// b_local_i = ∫_T N_i · J dV,
+/// ```
+///
+/// where `J` is held constant per element (typically sampled at the tet
+/// centroid). With the Whitney 1-form basis `N_i = λ_a ∇λ_b − λ_b ∇λ_a`
+/// and `∫_T λ_p dV = V/4`, the integral is closed-form:
+///
+/// ```text
+/// ∫_T N_i dV = (V/4) (∇λ_b − ∇λ_a)
+///            = sign(det J) / 24 · (g_b − g_a),
+/// ```
+///
+/// using `∇λ_p = g_p / det(J)` (cofactor vectors `g_p`) and
+/// `V = |det(J)| / 6`. Unlike the K/M kernels — where the gradients
+/// appear in **pairs** and the sign of `det(J)` cancels — the RHS is
+/// linear in the gradients, so the orientation sign of the tet must be
+/// kept.
+///
+/// # Arguments
+///
+/// * `coords` — `[n_elem, 4, 3]` per-tet vertex coordinates (same
+///   convention as [`batched_nedelec_local_matrices`]).
+/// * `j_tet` — `[n_elem, 3]` per-tet constant current density.
+///
+/// # Returns
+///
+/// `[n_elem, 6]` local RHS entries in canonical local-edge order
+/// ([`TET_LOCAL_EDGES`]). Sign-unaware: the per-tet local-vs-global
+/// orientation sign `s_i` must be applied at assembly time (a single
+/// factor `s_i`, not the `s_i s_j` outer product of the matrix path).
+///
+/// # Panics
+///
+/// Panics if `coords` is not `[*, 4, 3]` or `j_tet` is not `[*, 3]`
+/// with matching element counts.
+pub fn batched_nedelec_local_rhs<B: Backend>(
+    coords: Tensor<B, 3>,
+    j_tet: Tensor<B, 2>,
+) -> Tensor<B, 2> {
+    let dims = coords.dims();
+    let n_elem = dims[0];
+    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
+    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+    let j_dims = j_tet.dims();
+    assert_eq!(
+        j_dims,
+        [n_elem, 3],
+        "expected j_tet shape [n_elem, 3], got {:?}",
+        j_dims
+    );
+
+    // Same per-vertex / edge / cofactor / det machinery as the matrix
+    // kernels.
+    let v0 = coords
+        .clone()
+        .slice([0..n_elem, 0..1, 0..3])
+        .squeeze_dim::<2>(1);
+    let v1 = coords
+        .clone()
+        .slice([0..n_elem, 1..2, 0..3])
+        .squeeze_dim::<2>(1);
+    let v2 = coords
+        .clone()
+        .slice([0..n_elem, 2..3, 0..3])
+        .squeeze_dim::<2>(1);
+    let v3 = coords.slice([0..n_elem, 3..4, 0..3]).squeeze_dim::<2>(1);
+
+    let e1 = v1 - v0.clone();
+    let e2 = v2 - v0.clone();
+    let e3 = v3 - v0;
+
+    let g1 = e2.clone().cross(e3.clone(), 1);
+    let g2 = e3.clone().cross(e1.clone(), 1);
+    let g3 = e1.clone().cross(e2.clone(), 1);
+
+    let det = e1.mul(g1.clone()).sum_dim(1).squeeze_dim::<1>(1); // [n_elem]
+    let g0 = (g1.clone() + g2.clone() + g3.clone()).neg();
+
+    // sign(det) / 24 per element. det / |det| is exactly ±1 in floating
+    // point for non-degenerate tets (degenerate tets produce NaN here,
+    // exactly as they produce Inf/NaN in the K/M kernels).
+    let factor = det.clone().div(det.abs()).div_scalar(24.0); // [n_elem]
+
+    let g_mat = Tensor::<B, 2>::stack::<3>(vec![g0, g1, g2, g3], 1); // [n_elem, 4, 3]
+    let g_row = |p: usize| -> Tensor<B, 2> {
+        g_mat
+            .clone()
+            .slice([0..n_elem, p..p + 1, 0..3])
+            .squeeze_dim::<2>(1)
+    };
+
+    let mut entries: Vec<Tensor<B, 1>> = Vec::with_capacity(6);
+    for &(a, b) in TET_LOCAL_EDGES.iter() {
+        // (g_b − g_a) · J, per element.
+        let diff = g_row(b) - g_row(a); // [n_elem, 3]
+        let dot = diff.mul(j_tet.clone()).sum_dim(1).squeeze_dim::<1>(1); // [n_elem]
+        entries.push(dot.mul(factor.clone()));
+    }
+
+    Tensor::<B, 1>::stack::<2>(entries, 1) // [n_elem, 6]
+}
+
 /// Per-element Nédélec local mass matrix for a **diagonal anisotropic**
 /// permittivity tensor expressed in the global Cartesian basis.
 ///

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -963,6 +963,77 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
     }
 }
 
+/// Assemble the global Nédélec right-hand-side vector for a
+/// **piecewise-constant** volumetric current density `J`.
+///
+/// Computes `b_i = ∫_Ω N_i · J dV` over the global edge basis (no `iωμ₀`
+/// prefactor — that is applied by the caller, see
+/// [`crate::driven::driven_solve`]). Follows the same batched-local-
+/// kernel + autodiff-preserving 1-D `scatter(0, …, Add)` pattern as
+/// [`assemble_global_nedelec`]: the per-element `[n_elem, 6]` local RHS
+/// from [`crate::nedelec::batched_nedelec_local_rhs`] is multiplied by
+/// the per-DOF orientation sign `s_i` (a single factor — the RHS is
+/// linear in the basis, unlike the `s_i s_j` outer product of the
+/// matrix path) and scatter-added into a `[n_edges]` zero tensor.
+///
+/// # Arguments
+///
+/// * `nodes`, `tets`, `tet_edge_idx`, `tet_edge_sign`, `n_edges` — same
+///   as [`assemble_global_nedelec`].
+/// * `j_tet` — `[n_elem][3]` per-tet constant current density (typically
+///   `J(x)` sampled at tet centroids; see [`tet_centroids`]).
+///
+/// # Returns
+///
+/// Dense `[n_edges]` Burn tensor with the assembled linear functional.
+pub fn assemble_nedelec_current_rhs<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    n_edges: usize,
+    j_tet: &[[f64; 3]],
+) -> Tensor<B, 1> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(j_tet.len(), n_elem, "j_tet length mismatch");
+
+    // 1. Per-element local RHS.
+    let coords = gather_tet_coords(nodes, tets);
+    let j_flat: Vec<f32> = j_tet
+        .iter()
+        .flat_map(|row| row.iter().map(|&x| x as f32))
+        .collect();
+    let j_tensor = Tensor::<B, 2>::from_data(TensorData::new(j_flat, [n_elem, 3]), &device);
+    let local = crate::nedelec::batched_nedelec_local_rhs(coords, j_tensor); // [n_elem, 6]
+
+    // 2. Apply per-DOF orientation signs (single factor for a vector).
+    let sign_flat: Vec<f32> = tet_edge_sign
+        .iter()
+        .flat_map(|row| row.iter().map(|&s| s as f32))
+        .collect();
+    let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), &device);
+    let b_signed = local.mul(sign_2d);
+
+    // 3. Flat scatter indices: global edge index per (e, i).
+    let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 6);
+    for row in tet_edge_idx {
+        for &edge in row.iter() {
+            linear_idx.push(edge as i32);
+        }
+    }
+    let flat_indices =
+        Tensor::<B, 1, Int>::from_data(TensorData::new(linear_idx, [n_elem * 6]), &device);
+
+    // 4. Scatter-add into a [n_edges] zero tensor. Autodiff flows
+    //    through the values via IndexingUpdateOp::Add.
+    let b_flat = b_signed.reshape([n_elem * 6]);
+    let zeros = Tensor::<B, 1>::zeros([n_edges], &device);
+    zeros.scatter(0, flat_indices, b_flat, IndexingUpdateOp::Add)
+}
+
 /// Combine the real and imaginary parts of a Burn-resident complex
 /// mass matrix into an owned `faer::Mat<faer::c64>`.
 ///

--- a/crates/geode-core/tests/driven_manufactured.rs
+++ b/crates/geode-core/tests/driven_manufactured.rs
@@ -1,0 +1,262 @@
+//! Manufactured-solution validation of the driven solve (issue #194).
+//!
+//! # Manufactured solution
+//!
+//! On the unit PEC cube `[0,1]³` choose the analytic field
+//!
+//! ```text
+//! E(x, y, z) = (0, 0, ψ),     ψ = sin(πx) sin(πy),
+//! ```
+//!
+//! which satisfies `n × E = 0` on all six faces (E_x = E_y = 0
+//! everywhere; E_z vanishes on the four faces where ẑ is tangential).
+//! Since `∇·E = ∂_z ψ = 0`, the double curl reduces to `−ΔE`:
+//!
+//! ```text
+//! ∇×∇×E = (0, 0, 2π² ψ).
+//! ```
+//!
+//! The driven solve's strong form (natural units, `exp(+jωt)`; see
+//! `geode_core::driven` module docs) is `∇×∇×E − ω² E = iω J`, so the
+//! current that manufactures `E` is
+//!
+//! ```text
+//! J = (2π² − ω²) / (iω) · (0, 0, ψ) = −i (2π² − ω²)/ω · (0, 0, ψ).
+//! ```
+//!
+//! We drive at `ω = π` (`ω² = π² ≈ 9.87`), comfortably inside the gap
+//! between the gradient nullspace at λ = 0 and the lowest physical PEC
+//! cavity resonance at `λ = 2π² ≈ 19.74`, so `A(ω) = K − ω²M` is far
+//! from singular at every refinement level.
+//!
+//! # Error metric and expected order
+//!
+//! The discrete solution `x_h` is compared against the Nédélec edge
+//! interpolant of the analytic field, `x_a[e] = ∫_e E · dl` (4-point
+//! Gauss–Legendre per edge), in the mass-matrix norm
+//! `‖v‖_M = sqrt(v^H M v)` — a discrete L²(Ω) norm. For lowest-order
+//! Nédélec elements the L² convergence rate is **O(h)**; the
+//! solution-to-interpolant distance measured here may superconverge on
+//! the structured cube mesh, so the acceptance bound is `order ≥ 0.9`
+//! with the observed order printed for the record.
+//!
+//! `J` is sampled per-tet at centroids (midpoint quadrature), an O(h²)
+//! consistency perturbation that does not limit the O(h) rate.
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use std::f64::consts::PI;
+
+use geode_core::{
+    assemble_global_nedelec, batched_nedelec_local_rhs, burn_matrix_to_faer,
+    cube_pec_interior_edges, cube_tet_mesh, driven_solve, upload_mesh, CurrentSource,
+    DefaultBackend, DrivenBcs, DrivenMaterials,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// 4-point Gauss–Legendre nodes/weights on [0, 1].
+const GAUSS_4: [(f64, f64); 4] = [
+    (0.5 - 0.430568155797026, 0.173927422568727),
+    (0.5 - 0.169990521792428, 0.326072577431273),
+    (0.5 + 0.169990521792428, 0.326072577431273),
+    (0.5 + 0.430568155797026, 0.173927422568727),
+];
+
+fn psi(x: f64, y: f64) -> f64 {
+    (PI * x).sin() * (PI * y).sin()
+}
+
+/// Analytic edge DOF `∫_e E · dl` for `E = (0, 0, ψ)`, integrated from
+/// the lower-tagged endpoint to the higher-tagged endpoint (the global
+/// canonical edge direction).
+fn analytic_edge_dof(p: [f64; 3], q: [f64; 3]) -> f64 {
+    let dz = q[2] - p[2];
+    if dz == 0.0 {
+        return 0.0;
+    }
+    let mut acc = 0.0;
+    for &(t, w) in GAUSS_4.iter() {
+        let x = p[0] + t * (q[0] - p[0]);
+        let y = p[1] + t * (q[1] - p[1]);
+        acc += w * psi(x, y);
+    }
+    acc * dz
+}
+
+/// Run the manufactured-solution driven solve at refinement `n` and
+/// return the relative M-norm error against the analytic interpolant.
+fn manufactured_error(n: usize) -> f64 {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+
+    let omega = PI;
+    // J = −i (2π² − ω²)/ω (0, 0, ψ), sampled at tet centroids.
+    let j_amp = -(2.0 * PI * PI - omega * omega) / omega;
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(0.0, 0.0),
+            c64::new(0.0, 0.0),
+            c64::new(0.0, j_amp * psi(c[0], c[1])),
+        ]
+    });
+
+    let eps: Vec<c64> = vec![c64::new(1.0, 0.0); mesh.n_tets()];
+    let sol = driven_solve::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        &DrivenBcs {
+            pec_interior_mask: &interior,
+        },
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("driven solve");
+    assert!(
+        sol.residual_rel < 1e-8,
+        "n={n}: direct-solve residual {} above floor",
+        sol.residual_rel
+    );
+
+    // Analytic interpolant DOFs (zero on PEC edges by construction of E).
+    let x_a: Vec<f64> = edges
+        .iter()
+        .map(|e| analytic_edge_dof(mesh.nodes[e[0] as usize], mesh.nodes[e[1] as usize]))
+        .collect();
+
+    // M-norm error: assemble the vacuum mass for the discrete L² metric.
+    let tet_edges = mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+    let (nodes_t, tets_t) = upload_mesh::<B>(&mesh, &device());
+    let sys = assemble_global_nedelec(nodes_t, tets_t, &tet_idx, &tet_sign, edges.len());
+    let m = burn_matrix_to_faer(sys.m);
+
+    // err² = e^H M e with e = x_h − x_a; reference ‖x_a‖²_M = x_a^T M x_a.
+    let n_e = edges.len();
+    let e_vec: Vec<c64> = (0..n_e)
+        .map(|i| sol.e_edges[i] - c64::new(x_a[i], 0.0))
+        .collect();
+    let mut err2 = 0.0_f64;
+    let mut ref2 = 0.0_f64;
+    for i in 0..n_e {
+        let mut me = c64::new(0.0, 0.0);
+        let mut ma = 0.0_f64;
+        for j in 0..n_e {
+            let mij = m[(i, j)];
+            if mij != 0.0 {
+                me += e_vec[j] * mij;
+                ma += x_a[j] * mij;
+            }
+        }
+        // e^H M e — conjugate the left factor.
+        err2 += e_vec[i].re * me.re + e_vec[i].im * me.im;
+        ref2 += x_a[i] * ma;
+    }
+    assert!(ref2 > 0.0, "analytic interpolant must be nonzero");
+    let rel = (err2.max(0.0) / ref2).sqrt();
+    eprintln!(
+        "n = {n:>2}: h = {:.4}, relative M-norm error = {rel:.6e}",
+        1.0 / n as f64
+    );
+    rel
+}
+
+#[test]
+fn manufactured_solution_converges_under_refinement() {
+    let errs: Vec<f64> = [2_usize, 4, 8]
+        .iter()
+        .map(|&n| manufactured_error(n))
+        .collect();
+
+    // Errors must decrease monotonically under refinement.
+    assert!(
+        errs[1] < errs[0] && errs[2] < errs[1],
+        "errors not monotonically decreasing: {errs:?}"
+    );
+
+    let order_24 = (errs[0] / errs[1]).log2();
+    let order_48 = (errs[1] / errs[2]).log2();
+    eprintln!("observed convergence order: 2→4 = {order_24:.3}, 4→8 = {order_48:.3}");
+
+    // Lowest-order Nédélec gives O(h) in L²; superconvergence against
+    // the interpolant on the structured mesh may push this toward 2.
+    assert!(
+        order_48 > 0.9,
+        "observed order {order_48:.3} below the O(h) acceptance floor (errors: {errs:?})"
+    );
+}
+
+/// Hand-check of the local RHS kernel on the reference tet
+/// (0,0,0)-(1,0,0)-(0,1,0)-(0,0,1): with `det J = 1`, `V = 1/6`, and
+/// `∇λ = {(-1,-1,-1), x̂, ŷ, ẑ}`,
+///
+/// ```text
+/// ∫_T N_i dV = (V/4)(∇λ_b − ∇λ_a) = (1/24)(∇λ_b − ∇λ_a).
+/// ```
+#[test]
+fn local_rhs_reference_tet_hand_values() {
+    use burn::tensor::{Tensor, TensorData};
+
+    let dev = device();
+    let coords = Tensor::<B, 3>::from_data(
+        TensorData::new(
+            vec![
+                0.0_f32, 0.0, 0.0, // v0
+                1.0, 0.0, 0.0, // v1
+                0.0, 1.0, 0.0, // v2
+                0.0, 0.0, 1.0, // v3
+            ],
+            [1, 4, 3],
+        ),
+        &dev,
+    );
+
+    // ∇λ per vertex on the reference tet.
+    let grad = [
+        [-1.0_f64, -1.0, -1.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ];
+    let local_edges = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)];
+
+    for (axis, j_vec) in [
+        [1.0_f32, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.5, -2.0, 3.0],
+    ]
+    .iter()
+    .enumerate()
+    {
+        let j = Tensor::<B, 2>::from_data(TensorData::new(j_vec.to_vec(), [1, 3]), &dev);
+        let rhs = batched_nedelec_local_rhs(coords.clone(), j);
+        let got: Vec<f64> = rhs.into_data().iter::<f64>().collect();
+        assert_eq!(got.len(), 6);
+
+        for (i, &(a, b)) in local_edges.iter().enumerate() {
+            let want: f64 = (0..3)
+                .map(|k| (grad[b][k] - grad[a][k]) * j_vec[k] as f64)
+                .sum::<f64>()
+                / 24.0;
+            assert!(
+                (got[i] - want).abs() < 1e-6,
+                "case {axis}, local edge {i}: got {}, want {want}",
+                got[i]
+            );
+        }
+    }
+}

--- a/crates/geode-core/tests/driven_upml.rs
+++ b/crates/geode-core/tests/driven_upml.rs
@@ -1,0 +1,218 @@
+//! Driven-solve regression on an absorbing-boundary (UPML) case
+//! (issue #194, acceptance criterion 4).
+//!
+//! Uses the bundled layered sphere fixture (dielectric sphere →
+//! vacuum gap → UPML shell → outer PEC wall) and drives it with a
+//! ẑ-polarized volumetric current confined to the dielectric core.
+//! The UPML enters as the diagonal-anisotropic complex permittivity
+//! from [`geode_core::build_anisotropic_pml_tensor_diag`] — the same
+//! material path the eigenpencil tests use — composed with the PEC
+//! elimination on the outer wall, exercising the full
+//! "PEC + UPML compose with the driven system" contract.
+//!
+//! # Assertions
+//!
+//! 1. The solve succeeds, every DOF is finite, and the direct-solve
+//!    residual sits at the round-off floor.
+//! 2. The radiated field **decays through the absorbing shell**: the
+//!    mean per-length edge-field magnitude in the outer half of the
+//!    PML is far below the mean over the source region. This is the
+//!    driven-problem analog of the eigenmode tests' "the PML absorbs
+//!    radiation" check.
+//! 3. σ₀ = 0 regression: with absorption switched off, the
+//!    DiagTensor UPML material must reproduce the scalar-ε material
+//!    path (real dielectric everywhere) through the independent
+//!    anisotropic assembly kernel.
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+
+use geode_core::{
+    build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, driven_solve,
+    read_sphere_fixture, sphere_pec_interior_edges, tet_centroid_radii, tet_centroids,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, R_BUFFER, R_PML_INNER, R_SPHERE,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// ẑ-polarized current confined to the dielectric core (r < 0.5).
+fn core_dipole_source(mesh: &geode_core::TetMesh) -> CurrentSource {
+    CurrentSource::from_centroids(mesh, |c| {
+        let r = (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt();
+        let jz = if r < 0.5 * R_SPHERE { 1.0 } else { 0.0 };
+        [c64::new(0.0, 0.0), c64::new(0.0, 0.0), c64::new(jz, 0.0)]
+    })
+}
+
+/// Mean per-length |E·dl| over edges whose midpoint radius lies in
+/// `[r_lo, r_hi)`. Normalizing the edge DOF (a line integral) by edge
+/// length gives a field-strength proxy that is comparable across the
+/// fixture's differently-sized mesh regions.
+fn mean_field_in_shell(
+    mesh: &geode_core::TetMesh,
+    edges: &[[u32; 2]],
+    e_edges: &[c64],
+    r_lo: f64,
+    r_hi: f64,
+) -> f64 {
+    let mut acc = 0.0_f64;
+    let mut count = 0_usize;
+    for (e, &dof) in edges.iter().zip(e_edges.iter()) {
+        let p = mesh.nodes[e[0] as usize];
+        let q = mesh.nodes[e[1] as usize];
+        let mid = [
+            0.5 * (p[0] + q[0]),
+            0.5 * (p[1] + q[1]),
+            0.5 * (p[2] + q[2]),
+        ];
+        let r = (mid[0] * mid[0] + mid[1] * mid[1] + mid[2] * mid[2]).sqrt();
+        if r < r_lo || r >= r_hi {
+            continue;
+        }
+        let len = ((q[0] - p[0]).powi(2) + (q[1] - p[1]).powi(2) + (q[2] - p[2]).powi(2)).sqrt();
+        acc += dof.re.hypot(dof.im) / len;
+        count += 1;
+    }
+    assert!(
+        count > 0,
+        "no edges with midpoint radius in [{r_lo}, {r_hi})"
+    );
+    acc / count as f64
+}
+
+#[test]
+fn driven_solve_with_pec_and_upml_absorbs_radiation() {
+    let f = read_sphere_fixture().expect("fixture load");
+    let edges = f.mesh.edges();
+
+    let n_inside = 1.5_f64;
+    let sigma_0 = 5.0_f64;
+    // Drive near (but not on) the dielectric ground resonance
+    // k ≈ π/(n·R) ≈ 2.1; the complex UPML keeps A(ω) well-conditioned
+    // either way.
+    let omega = 1.8_f64;
+
+    let centroids = tet_centroids(&f.mesh);
+    let eps_diag = build_anisotropic_pml_tensor_diag(
+        &f.tet_physical_tags,
+        &centroids,
+        n_inside,
+        sigma_0,
+        omega,
+    );
+
+    let (_, interior) = sphere_pec_interior_edges(&f.mesh, R_BUFFER);
+    let source = core_dipole_source(&f.mesh);
+
+    let sol = driven_solve::<B>(
+        &f.mesh,
+        DrivenMaterials::DiagTensor(&eps_diag),
+        &DrivenBcs {
+            pec_interior_mask: &interior,
+        },
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("driven UPML solve");
+
+    // 1. Numerical health.
+    assert!(
+        sol.e_edges
+            .iter()
+            .all(|e| e.re.is_finite() && e.im.is_finite()),
+        "non-finite field values"
+    );
+    assert!(
+        sol.residual_rel < 1e-8,
+        "direct-solve residual too large: {}",
+        sol.residual_rel
+    );
+
+    // 2. The field must decay through the absorbing shell: compare the
+    //    source region (inside the dielectric) against the outer half
+    //    of the UPML.
+    let near = mean_field_in_shell(&f.mesh, &edges, &sol.e_edges, 0.0, R_SPHERE);
+    let pml_outer = mean_field_in_shell(
+        &f.mesh,
+        &edges,
+        &sol.e_edges,
+        0.5 * (R_PML_INNER + R_BUFFER),
+        R_BUFFER,
+    );
+    eprintln!(
+        "mean |E| proxy: source region = {near:.4e}, outer PML half = {pml_outer:.4e}, \
+         ratio = {:.4e}",
+        pml_outer / near
+    );
+    assert!(near > 0.0, "source region field must be nonzero");
+    assert!(
+        pml_outer < 0.3 * near,
+        "field does not decay through the UPML: outer-half mean {pml_outer:.4e} \
+         vs source-region mean {near:.4e}"
+    );
+}
+
+#[test]
+fn upml_sigma_zero_matches_scalar_material_path() {
+    let f = read_sphere_fixture().expect("fixture load");
+
+    let n_inside = 1.5_f64;
+    let omega = 1.8_f64;
+
+    let centroids = tet_centroids(&f.mesh);
+    let radii = tet_centroid_radii(&f.mesh);
+    // σ₀ = 0: both builders reduce to the real dielectric profile
+    // (ε = n² inside the sphere, 1 elsewhere).
+    let eps_diag =
+        build_anisotropic_pml_tensor_diag(&f.tet_physical_tags, &centroids, n_inside, 0.0, omega);
+    let eps_scalar = build_complex_epsilon_r_pml(&f.tet_physical_tags, &radii, n_inside, 0.0);
+
+    let (_, interior) = sphere_pec_interior_edges(&f.mesh, R_BUFFER);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &interior,
+    };
+    let source = core_dipole_source(&f.mesh);
+
+    let sol_diag = driven_solve::<B>(
+        &f.mesh,
+        DrivenMaterials::DiagTensor(&eps_diag),
+        &bcs,
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("diag-tensor σ₀=0 solve");
+    let sol_scalar = driven_solve::<B>(
+        &f.mesh,
+        DrivenMaterials::Scalar(&eps_scalar),
+        &bcs,
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("scalar σ₀=0 solve");
+
+    let norm: f64 = sol_scalar
+        .e_edges
+        .iter()
+        .map(|e| e.re * e.re + e.im * e.im)
+        .sum::<f64>()
+        .sqrt();
+    assert!(norm > 0.0);
+    let mut max_rel = 0.0_f64;
+    for (a, b) in sol_scalar.e_edges.iter().zip(sol_diag.e_edges.iter()) {
+        let d = *a - *b;
+        max_rel = max_rel.max(d.re.hypot(d.im) / norm);
+    }
+    eprintln!("σ₀ = 0 scalar vs diag-tensor: max relative diff = {max_rel:.3e}");
+    assert!(
+        max_rel < 1e-4,
+        "σ₀ = 0 UPML must reduce to the scalar dielectric path; \
+         max relative diff {max_rel:.3e}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the deterministic **driven** frequency-domain path (Epic #193, Phase 1): assemble and solve `A(ω) x = b` with `A(ω) = K − ω²/c² M(ε)` at a prescribed ω, with the volumetric current-source RHS `b_i = iωμ₀ ∫ N_i · J dV` over the Nédélec edge basis. Reuses the existing sparse complex LU factorization machinery from the shift-and-invert Lanczos path (no new solver); PEC and UPML compose with the driven system exactly as they do with the eigenpencil.

## Changes

- **`crates/geode-core/src/driven.rs`** (new): `driven_solve(mesh, materials, bcs, omega, source) -> DrivenSolution` plus `DrivenMaterials` (scalar complex ε / diagonal-anisotropic UPML tensor), `DrivenBcs` (PEC interior-edge mask), `CurrentSource` (per-tet `J`, with a centroid-sampling constructor), and `DrivenError`. Interior `A(ω)` is built sparse from the recorded `SparsityPattern`, factored once with faer `sp_lu`, solved directly, and a post-solve relative residual is returned as a health check. Module docs cover natural units (`c = μ₀ = 1`, `ω ≡ k₀`) and the `exp(+jωt)` sign convention.
- **`crates/geode-core/src/nedelec.rs`**: `batched_nedelec_local_rhs` — closed-form batched local kernel `∫_T N_i dV = (V/4)(∇λ_b − ∇λ_a) = sign(det J)/24 · (g_b − g_a)`, keeping the orientation sign that cancels in the K/M kernels but not in the RHS.
- **`crates/geode-core/src/nedelec_assembly.rs`**: `assemble_nedelec_current_rhs` — autodiff-preserving `scatter(Add)` global assembly with single-factor `s_i` orientation signs, mirroring the existing batched-kernel pattern.
- **`crates/geode-core/src/complex_lanczos.rs`**: `spmv`/`spmv_add`/`solve_with_lu` widened to `pub(crate)` so the driven path reuses the existing factorization/solve helpers.
- **Tests**: 5 unit tests in `driven.rs` (zero source, linearity, residual floor + PEC zeros, scalar-vs-DiagTensor isotropic consistency, input validation), `tests/driven_manufactured.rs` (manufactured-solution convergence + local-kernel hand values on the reference tet), `tests/driven_upml.rs` (UPML absorbing regression + σ₀ = 0 cross-path reduction).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `driven_solve(mesh, materials, bcs, omega, source) -> field` API in geode-core | ✅ | `geode_core::driven::driven_solve`, exported from `lib.rs`; returns full-length complex edge field + residual |
| RHS assembly for volumetric current source J(x) over Nédélec basis | ✅ | `batched_nedelec_local_rhs` + `assemble_nedelec_current_rhs`; hand-checked against closed-form values on the reference tet for 4 J vectors |
| Manufactured-solution test with observed convergence order | ✅ | PEC unit cube, `E = (0, 0, sin πx sin πy)`, ω = π: relative M-norm error vs the analytic edge interpolant = 7.20e-1 / 3.00e-1 / 9.45e-2 at n = 2/4/8 — **observed order 1.26 (2→4), 1.67 (4→8)**, at/above the O(h) lowest-order Nédélec rate |
| Driven solve works with PEC + UPML (absorbing-boundary regression) | ✅ | Sphere fixture, diagonal-anisotropic UPML + PEC outer wall, core dipole source: field decays ~500× (ratio 2.0e-3) from source region to outer PML half; σ₀ = 0 UPML reduces to the scalar material path to 1.4e-8 |
| Tests pass for new functionality | ✅ | `cargo test --workspace --release`: 58 suites, 279 passed, 0 failed, 43 ignored (pre-existing `--ignored` gevd-oracle tests, unchanged); `cargo clippy --workspace --tests -- -D warnings` clean; `cargo fmt --check` clean |

## Test Plan

- `cargo test -p geode-core --lib driven` — 5/5 pass
- `cargo test -p geode-core --test driven_manufactured -- --nocapture` — convergence numbers above
- `cargo test -p geode-core --test driven_upml -- --nocapture` — decay ratio + σ₀ = 0 reduction
- `cargo test --workspace --release` — full suite green (279 passed, 0 failed)
- `cargo fmt --check` + `cargo clippy --workspace --tests -- -D warnings` — clean

Closes #194