### PR TITLE
refactor(reference): package-qualified imports via PEP 420 namespace packages

### DIFF
--- a/reference/driver/emit_numpy_eigenvalues.py
+++ b/reference/driver/emit_numpy_eigenvalues.py
@@ -19,11 +19,13 @@ import json
 import sys
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parent
-REPO_REF = HERE.parent  # reference/
-sys.path.insert(0, str(REPO_REF / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from cube_cavity_minimal import solve_cube_cavity  # noqa: E402
+from reference.numpy.cube_cavity_minimal import solve_cube_cavity  # noqa: E402
 
 
 def main() -> int:

--- a/reference/driver/make_numpy_sidecar.py
+++ b/reference/driver/make_numpy_sidecar.py
@@ -50,7 +50,11 @@ import numpy as np
 
 _HERE = Path(__file__).resolve().parent
 _REPO_ROOT = _HERE.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "reference" / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 PROBLEMS = ("cube-cavity", "sphere-pec", "sphere-pml", "sphere-mie")
 
@@ -105,8 +109,8 @@ def _real_part_checked(mat: np.ndarray, name: str) -> np.ndarray:
 
 
 def _make_cube_cavity(args) -> dict:
-    from cube_cavity_minimal import assemble_global_p1, restrict_to_interior
-    from mesh import cube_interior_mask, cube_tet_mesh
+    from reference.numpy.cube_cavity_minimal import assemble_global_p1, restrict_to_interior
+    from reference.numpy.mesh import cube_interior_mask, cube_tet_mesh
 
     nodes, tets = cube_tet_mesh(args.n, args.side)
     k_csr, m_csr = assemble_global_p1(nodes, tets)
@@ -144,7 +148,7 @@ def _make_cube_cavity(args) -> dict:
 
 
 def _make_sphere_pec(args) -> dict:
-    from sphere_pec import (
+    from reference.numpy.sphere_pec import (
         apply_dirichlet,
         assemble_global_nedelec,
         build_edges,
@@ -204,7 +208,7 @@ def _make_sphere_pec(args) -> dict:
 def _make_sphere_complex(args, problem: str) -> dict:
     """Shared synthesis for sphere-pml (scalar complex epsilon) and
     sphere-mie (anisotropic UPML diagonal tensor epsilon)."""
-    from sphere_pec import (
+    from reference.numpy.sphere_pec import (
         apply_dirichlet,
         build_edges,
         read_sphere_fixture,
@@ -218,7 +222,7 @@ def _make_sphere_complex(args, problem: str) -> dict:
     )
 
     if problem == "sphere-pml":
-        from sphere_pml import (
+        from reference.numpy.sphere_pml import (
             assemble_global_nedelec_complex,
             build_complex_epsilon_r_pml,
             tet_centroid_radii,
@@ -237,7 +241,7 @@ def _make_sphere_complex(args, problem: str) -> dict:
         extra_inputs = {}
         epsilon_desc = "scalar-isotropic complex-epsilon PML"
     else:
-        from sphere_mie import (
+        from reference.numpy.sphere_mie import (
             assemble_global_nedelec_anisotropic,
             build_anisotropic_pml_tensor_diag,
             tet_centroids,

--- a/reference/jax/cube_cavity.py
+++ b/reference/jax/cube_cavity.py
@@ -44,8 +44,12 @@ import scipy.sparse.linalg as spla
 
 HERE = Path(__file__).resolve().parent
 REPO_REF = HERE.parent  # reference/
-sys.path.insert(0, str(REPO_REF / "numpy"))
-from cube_cavity_minimal import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.cube_cavity_minimal import (  # noqa: E402
     _deterministic_arpack_kwargs,
     cube_interior_mask,
     cube_tet_mesh,

--- a/reference/jax/gen_cube_cavity_fixture.py
+++ b/reference/jax/gen_cube_cavity_fixture.py
@@ -34,10 +34,13 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent  # reference/ -> repo root
-sys.path.insert(0, str(REPO_ROOT / "reference" / "jax"))
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
-from cube_cavity import solve_cube_cavity_jax  # noqa: E402
-from cube_cavity_minimal import solve_cube_cavity  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.jax.cube_cavity import solve_cube_cavity_jax  # noqa: E402
+from reference.numpy.cube_cavity_minimal import solve_cube_cavity  # noqa: E402
 
 
 def _git_commit() -> str:

--- a/reference/jax/gen_sphere_mie_fixture.py
+++ b/reference/jax/gen_sphere_mie_fixture.py
@@ -58,7 +58,6 @@ Usage
 from __future__ import annotations
 
 import argparse
-import importlib.util as _ilu
 import json
 import os
 import subprocess
@@ -69,9 +68,12 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent
-# NumPy reference dir first so bare module names resolve to the NumPy
-# modules; the JAX sphere_mie is loaded by explicit file path below.
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187). Package-qualified imports
+# disambiguate the same-named NumPy and JAX modules.
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 MESH_PATH = (
     REPO_ROOT / "reference" / "fixtures" / "sphere_pml_small" / "sphere.msh"
@@ -110,12 +112,11 @@ def _interleave_c128(z: np.ndarray) -> list[float]:
 
 
 def _load_jax_mie():
-    """Load reference/jax/sphere_mie.py by file path (the bare name
-    `sphere_mie` must keep resolving to the NumPy module)."""
-    spec = _ilu.spec_from_file_location("_jax_sphere_mie", HERE / "sphere_mie.py")
-    mod = _ilu.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    """Import reference.jax.sphere_mie lazily (defers the JAX import
+    until the solve is actually requested)."""
+    from reference.jax import sphere_mie as jax_sphere_mie
+
+    return jax_sphere_mie
 
 
 # --------------------------------------------------------------------------- #
@@ -158,13 +159,13 @@ def main() -> None:
     out_path = Path(args.out)
 
     jax_mie = _load_jax_mie()
-    from sphere_mie import (  # NumPy module (path-ordered import)
+    from reference.numpy.sphere_mie import (
         K0_REF,
         classify_modes_against_catalogue,
         load_mie_roots_catalogue,
         q_factor_from_lambda,
     )
-    from sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE
+    from reference.numpy.sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE
 
     print(f"Running anisotropic-UPML Mie JAX pipeline on {MESH_PATH} ...")
     print(f"  sigma_0 = {args.sigma0}, n_index = {N_INDEX}, k0_ref = {K0_REF}")

--- a/reference/jax/gen_sphere_pec_fixture.py
+++ b/reference/jax/gen_sphere_pec_fixture.py
@@ -34,8 +34,11 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent  # reference/ -> repo root
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
-sys.path.insert(0, str(REPO_ROOT / "reference" / "jax"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 
 def _git_commit() -> str:
@@ -326,7 +329,7 @@ def main():
 
     # Try to import JAX
     try:
-        from sphere_pec import solve_sphere_pec_jax, JaxSpherePecResult
+        from reference.jax.sphere_pec import solve_sphere_pec_jax, JaxSpherePecResult
     except ImportError as e:
         print(f"ERROR: Could not import JAX pipeline: {e}")
         print("Install JAX with: pip install 'jax[cpu]'")

--- a/reference/jax/gen_sphere_pml_fixture.py
+++ b/reference/jax/gen_sphere_pml_fixture.py
@@ -72,8 +72,11 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
-sys.path.insert(0, str(REPO_ROOT / "reference" / "jax"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 
 def _git_commit() -> str:
@@ -318,7 +321,7 @@ def main():
     out_path = Path(args.out)
 
     try:
-        from sphere_pml import solve_sphere_pml_jax, JaxSpherePmlResult
+        from reference.jax.sphere_pml import solve_sphere_pml_jax, JaxSpherePmlResult
     except ImportError as e:
         print(f"ERROR: Could not import JAX pipeline: {e}")
         print("Install JAX with: pip install 'jax[cpu]'")

--- a/reference/jax/sphere_mie.py
+++ b/reference/jax/sphere_mie.py
@@ -95,36 +95,26 @@ jax.config.update("jax_enable_x64", True)
 # ---------------------------------------------------------------------------
 # Import from siblings.
 #
-# The NumPy reference directory is pushed to the front of sys.path so
-# that bare module names (`sphere_pec`, `sphere_pml`, `sphere_mie`,
-# `nedelec_local_matrices`) always resolve to the *NumPy* modules —
-# the JAX siblings with the same file names are only ever loaded by
-# explicit file path under private module names (`_jax_*`). This is
-# the same collision-avoidance pattern as `reference/jax/sphere_pml.py`.
+# Package-qualified imports (`reference.numpy.*` vs `reference.jax.*`)
+# disambiguate the same-named NumPy and JAX modules; the shim below
+# only ensures the repo root is on sys.path so the `reference.*` PEP
+# 420 namespace packages resolve regardless of cwd (issue #187).
 # ---------------------------------------------------------------------------
 
 HERE = Path(__file__).resolve().parent
 REPO_REF = HERE.parent  # reference/
 
-sys.path.insert(0, str(REPO_REF / "numpy"))
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-import importlib.util as _ilu  # noqa: E402
-
-
-def _load_by_path(name: str, path: Path):
-    spec = _ilu.spec_from_file_location(name, path)
-    mod = _ilu.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-# JAX sphere-PEC kernels (curl-curl + local-edge table) by file path.
-_jax_pec = _load_by_path("_jax_sphere_pec_kernels", HERE / "sphere_pec.py")
+# JAX sphere-PEC kernels (curl-curl + local-edge table).
+from reference.jax import sphere_pec as _jax_pec  # noqa: E402
 _nedelec_cc_batch_jax = _jax_pec._nedelec_cc_batch_jax
 _LOCAL_EDGES_ARR = _jax_pec._LOCAL_EDGES_ARR  # (6, 2) int32
 
 # NumPy reference modules (algorithmic source of truth).
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     R_BUFFER,
     R_PML_INNER,
     R_SPHERE,
@@ -134,12 +124,12 @@ from sphere_pec import (  # noqa: E402
     sphere_pec_interior_edges,
     spurious_dim_from_derham,
 )
-from sphere_pml import eigensolve_complex_dense  # noqa: E402
+from reference.numpy.sphere_pml import eigensolve_complex_dense  # noqa: E402
 
 # The J.2 NumPy Mie module: constitutive tensor builder, λ → k helpers,
 # and the J.1 catalogue classification — all shared verbatim so the JAX
 # port differs from NumPy *only* in the assembly kernels.
-from sphere_mie import (  # noqa: E402
+from reference.numpy.sphere_mie import (  # noqa: E402
     K0_REF,
     SIGMA_0_DEFAULT,
     build_anisotropic_pml_tensor_diag,

--- a/reference/jax/sphere_pec.py
+++ b/reference/jax/sphere_pec.py
@@ -59,9 +59,13 @@ jax.config.update("jax_enable_x64", True)
 
 HERE = Path(__file__).resolve().parent
 REPO_REF = HERE.parent  # reference/
-sys.path.insert(0, str(REPO_REF / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     PHYS_SPHERE_INTERIOR,
     PHYS_VACUUM_GAP,
     R_BUFFER,

--- a/reference/jax/sphere_pml.py
+++ b/reference/jax/sphere_pml.py
@@ -104,24 +104,22 @@ jax.config.update("jax_enable_x64", True)
 HERE = Path(__file__).resolve().parent
 REPO_REF = HERE.parent  # reference/
 
-# Import the JAX kernels by *file path* to avoid name collision with the
-# NumPy `sphere_pec` module (same module name, different package).
-import importlib.util as _ilu
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187). Package-qualified imports
+# disambiguate the same-named NumPy and JAX modules.
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-_JAX_PEC_SPEC = _ilu.spec_from_file_location(
-    "_jax_sphere_pec_kernels", HERE / "sphere_pec.py"
-)
-_jax_pec = _ilu.module_from_spec(_JAX_PEC_SPEC)
-
-# Make the NumPy reference importable for the JAX module's `from sphere_pec import ...`.
-sys.path.insert(0, str(REPO_REF / "numpy"))
-_JAX_PEC_SPEC.loader.exec_module(_jax_pec)
+# JAX sphere-PEC kernels (sibling module; same basename as the NumPy
+# reference, disambiguated by the package path).
+from reference.jax import sphere_pec as _jax_pec  # noqa: E402
 
 _nedelec_cc_batch_jax = _jax_pec._nedelec_cc_batch_jax
 _nedelec_mass_batch_jax = _jax_pec._nedelec_mass_batch_jax
 
 # NumPy-side helpers (algorithmic source of truth shared with PEC).
-from sphere_pec import (  # noqa: E402  (numpy module via numpy/sphere_pec.py)
+from reference.numpy.sphere_pec import (  # noqa: E402
     _deterministic_arpack_kwargs,
     PHYS_SPHERE_INTERIOR,
     PHYS_PML_SHELL,

--- a/reference/numpy/cube_cavity.py
+++ b/reference/numpy/cube_cavity.py
@@ -71,15 +71,18 @@ import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg
 
-# Allow `python3 cube_cavity.py` to find the sibling modules regardless of cwd.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
 # Mesh primitives live in `mesh.py` (issue #103) and are re-exported
 # here so existing callers (`gen_cube_cavity_baseline.py`, downstream
 # tests) keep importing `cube_tet_mesh`, `load_msh`, `write_msh`, and
 # `cube_interior_mask` from `cube_cavity` without churn.
-from mesh import (  # noqa: E402, F401
+from reference.numpy.mesh import (  # noqa: E402, F401
     cube_interior_mask,
     cube_tet_mesh,
     load_msh,

--- a/reference/numpy/cube_cavity_minimal.py
+++ b/reference/numpy/cube_cavity_minimal.py
@@ -62,15 +62,18 @@ import numpy as np
 import scipy.sparse as sp
 import scipy.sparse.linalg as spla
 
-HERE = Path(__file__).resolve().parent
-sys.path.insert(0, str(HERE))
-from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
 # Mesh primitives live in `mesh.py` (issue #103) — re-exported here so
 # the JAX consumer (`reference/jax/cube_cavity.py`) keeps importing
 # `cube_tet_mesh` and `cube_interior_mask` from this module without
 # churn.
-from mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402, F401
+from reference.numpy.mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402, F401
 
 
 def assemble_global_p1(nodes: np.ndarray, tets: np.ndarray):

--- a/reference/numpy/gen_cube_cavity_baseline.py
+++ b/reference/numpy/gen_cube_cavity_baseline.py
@@ -66,8 +66,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "cube_cavity"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = FIXTURE_DIR / "unit_cube.msh"
 
-sys.path.insert(0, str(HERE))
-from cube_cavity import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.cube_cavity import (  # noqa: E402
     analytic_lowest_five,
     cube_tet_mesh,
     run_cube_cavity,

--- a/reference/numpy/gen_derham_baseline.py
+++ b/reference/numpy/gen_derham_baseline.py
@@ -49,8 +49,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "derham"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = REPO_ROOT / "reference" / "fixtures" / "sphere_pec" / "sphere.msh"
 
-sys.path.insert(0, str(HERE))
-from derham import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.derham import (  # noqa: E402
     _read_msh_tets,
     build_edges,
     build_faces,

--- a/reference/numpy/gen_mie_efficiencies_baseline.py
+++ b/reference/numpy/gen_mie_efficiencies_baseline.py
@@ -38,8 +38,12 @@ REPO_ROOT = HERE.parent.parent  # reference/numpy -> repo root
 FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "mie_efficiencies"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 
-sys.path.insert(0, str(HERE))
-from mie_efficiencies import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.mie_efficiencies import (  # noqa: E402
     N_INSIDE,
     R_SPHERE,
     _self_check,

--- a/reference/numpy/gen_mie_roots_baseline.py
+++ b/reference/numpy/gen_mie_roots_baseline.py
@@ -42,8 +42,12 @@ REPO_ROOT = HERE.parent.parent  # reference/numpy -> repo root
 FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "mie_roots"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 
-sys.path.insert(0, str(HERE))
-from mie_roots import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.mie_roots import (  # noqa: E402
     K_MAX,
     K_MIN,
     N_INSIDE,

--- a/reference/numpy/gen_nedelec_local_per_case.py
+++ b/reference/numpy/gen_nedelec_local_per_case.py
@@ -57,10 +57,12 @@ HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent  # reference/ -> repo root
 FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "nedelec_local"
 
-# Add this dir to sys.path so we can import the sibling module under the
-# same name regardless of cwd.
-sys.path.insert(0, str(HERE))
-from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
 
 
 def _ref_tet():

--- a/reference/numpy/gen_p1_local_per_case.py
+++ b/reference/numpy/gen_p1_local_per_case.py
@@ -46,10 +46,12 @@ HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent  # reference/ -> repo root
 FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "p1_local"
 
-# Add this dir to sys.path so we can import the sibling module under the
-# same name regardless of cwd.
-sys.path.insert(0, str(HERE))
-from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
 
 def _ref_tet():

--- a/reference/numpy/gen_sphere_mie_baseline.py
+++ b/reference/numpy/gen_sphere_mie_baseline.py
@@ -53,8 +53,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "sphere_mie"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = REPO_ROOT / "reference" / "fixtures" / "sphere_pml" / "sphere.msh"
 
-sys.path.insert(0, str(HERE))
-from sphere_mie import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.sphere_mie import (  # noqa: E402
     K0_REF,
     SIGMA_0_DEFAULT,
     classify_modes_against_catalogue,
@@ -62,7 +66,7 @@ from sphere_mie import (  # noqa: E402
     q_factor_from_lambda,
     run_sphere_mie,
 )
-from sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE  # noqa: E402
+from reference.numpy.sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE  # noqa: E402
 
 # --------------------------------------------------------------------------- #
 # Tolerances — full-mesh floors (see module docstring).

--- a/reference/numpy/gen_sphere_mie_small_baseline.py
+++ b/reference/numpy/gen_sphere_mie_small_baseline.py
@@ -77,8 +77,12 @@ MESH_PATH = (
     REPO_ROOT / "reference" / "fixtures" / "sphere_pml_small" / "sphere.msh"
 )
 
-sys.path.insert(0, str(HERE))
-from sphere_mie import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.sphere_mie import (  # noqa: E402
     K0_REF,
     SIGMA_0_DEFAULT,
     classify_modes_against_catalogue,
@@ -86,7 +90,7 @@ from sphere_mie import (  # noqa: E402
     q_factor_from_lambda,
     run_sphere_mie,
 )
-from sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE  # noqa: E402
+from reference.numpy.sphere_pec import R_BUFFER, R_PML_INNER, R_SPHERE  # noqa: E402
 
 # --------------------------------------------------------------------------- #
 # Tolerances applied to the on-disk baseline.

--- a/reference/numpy/gen_sphere_pec_baseline.py
+++ b/reference/numpy/gen_sphere_pec_baseline.py
@@ -110,8 +110,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "sphere_pec"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = FIXTURE_DIR / "sphere.msh"
 
-sys.path.insert(0, str(HERE))
-from sphere_pec import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.sphere_pec import (  # noqa: E402
     R_BUFFER,
     R_SPHERE,
     run_sphere_pec,

--- a/reference/numpy/gen_sphere_pml_baseline.py
+++ b/reference/numpy/gen_sphere_pml_baseline.py
@@ -79,8 +79,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "sphere_pml"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = FIXTURE_DIR / "sphere.msh"
 
-sys.path.insert(0, str(HERE))
-from sphere_pml import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.sphere_pml import (  # noqa: E402
     R_BUFFER,
     R_PML_INNER,
     R_SPHERE,

--- a/reference/numpy/gen_sphere_pml_small_baseline.py
+++ b/reference/numpy/gen_sphere_pml_small_baseline.py
@@ -102,8 +102,12 @@ FIXTURE_DIR = REPO_ROOT / "reference" / "fixtures" / "sphere_pml_small"
 FIXTURE_PATH = FIXTURE_DIR / "baseline.json"
 MESH_PATH = FIXTURE_DIR / "sphere.msh"
 
-sys.path.insert(0, str(HERE))
-from sphere_pml import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.sphere_pml import (  # noqa: E402
     R_BUFFER,
     R_PML_INNER,
     R_SPHERE,

--- a/reference/numpy/nedelec_local_matrices.py
+++ b/reference/numpy/nedelec_local_matrices.py
@@ -90,10 +90,12 @@ import numpy as np
 # Reuse the P1 reference's signed-volume / area-weighted-gradient
 # helpers verbatim. This is by design — the issue acceptance criteria
 # call out that the signed-volume computation should not be duplicated.
-HERE = Path(__file__).resolve().parent
-if str(HERE) not in sys.path:
-    sys.path.insert(0, str(HERE))
-from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
 # Canonical local edge order on a tet. Mirrors
 # ``crates/geode-core/src/mesh/mod.rs::TET_LOCAL_EDGES``; the order is

--- a/reference/numpy/sphere_mie.py
+++ b/reference/numpy/sphere_mie.py
@@ -90,15 +90,18 @@ import scipy.sparse
 import scipy.sparse.linalg
 
 HERE = Path(__file__).resolve().parent
-if str(HERE) not in sys.path:
-    sys.path.insert(0, str(HERE))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import TET_LOCAL_EDGES, _cofactor_gram  # noqa: E402
+from reference.numpy.nedelec_local_matrices import TET_LOCAL_EDGES, _cofactor_gram  # noqa: E402
 
 # Reuse the Phase G/H mesh I/O, edge enumeration, PEC mask, and d⁰-rank
 # classifier verbatim — this pipeline differs only in the constitutive
 # scaling on the mass.
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     PHYS_PML_SHELL,
     PHYS_SPHERE_INTERIOR,
     R_BUFFER,
@@ -111,7 +114,7 @@ from sphere_pec import (  # noqa: E402
     sphere_pec_interior_edges,
     spurious_dim_from_derham,
 )
-from sphere_pml import eigensolve_complex_dense  # noqa: E402
+from reference.numpy.sphere_pml import eigensolve_complex_dense  # noqa: E402
 
 # Reference wavenumber used by the anisotropic UPML stretching profile.
 # Mirror of `K0_REF` in `crates/geode-core/tests/mie_sphere.rs` and

--- a/reference/numpy/sphere_pec.py
+++ b/reference/numpy/sphere_pec.py
@@ -116,11 +116,12 @@ import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg
 
-# Allow `python3 sphere_pec.py` to find sibling modules regardless of cwd.
-HERE = Path(__file__).resolve().parent
-if str(HERE) not in sys.path:
-    sys.path.insert(0, str(HERE))
-from nedelec_local_matrices import (  # noqa: E402
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
+from reference.numpy.nedelec_local_matrices import (  # noqa: E402
     TET_LOCAL_EDGES,
     batched_nedelec_local_matrices,
 )
@@ -130,7 +131,7 @@ from nedelec_local_matrices import (  # noqa: E402
 # module (``derham.py``), not inlined here. Re-export under the original
 # names so existing consumers (Phase G fixture generators, downstream
 # tests) keep working without import churn.
-from derham import (  # noqa: E402
+from reference.numpy.derham import (  # noqa: E402
     DERHAM_RANK_THRESHOLD_REL,
     restrict_gradient_dense,
     spurious_dim_from_derham as _derham_spurious_dim,

--- a/reference/numpy/sphere_pml.py
+++ b/reference/numpy/sphere_pml.py
@@ -92,16 +92,18 @@ import scipy.linalg
 import scipy.sparse
 import scipy.sparse.linalg
 
-HERE = Path(__file__).resolve().parent
-if str(HERE) not in sys.path:
-    sys.path.insert(0, str(HERE))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+from reference.numpy.nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
 
 # Reuse the Phase G mesh I/O, edge enumeration, PEC mask, and d⁰-rank
 # classifier verbatim — the PML problem differs only in the constitutive
 # scaling on the mass.
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     PHYS_PML_SHELL,
     PHYS_SPHERE_INTERIOR,
     R_BUFFER,

--- a/reference/onnx/audit/derham/probe_d0_apply.py
+++ b/reference/onnx/audit/derham/probe_d0_apply.py
@@ -61,11 +61,13 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from derham import build_edges, gradient_map  # noqa: E402
+from reference.numpy.derham import build_edges, gradient_map  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/derham/probe_d1_apply.py
+++ b/reference/onnx/audit/derham/probe_d1_apply.py
@@ -64,11 +64,13 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from derham import (  # noqa: E402
+from reference.numpy.derham import (  # noqa: E402
     build_edges,
     build_faces,
     curl_map,

--- a/reference/onnx/audit/derham/probe_exactness_in_graph.py
+++ b/reference/onnx/audit/derham/probe_exactness_in_graph.py
@@ -62,9 +62,13 @@ from onnx import TensorProto
 
 HERE = Path(__file__).resolve().parent
 REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from derham import (  # noqa: E402
+from reference.numpy.derham import (  # noqa: E402
     _read_msh_tets,
     build_edges,
     build_faces,

--- a/reference/onnx/audit/probe_p1_local.py
+++ b/reference/onnx/audit/probe_p1_local.py
@@ -49,11 +49,13 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from p1_local_matrices import batched_p1_local_matrices  # noqa: E402
+from reference.numpy.p1_local_matrices import batched_p1_local_matrices  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
+++ b/reference/onnx/audit/sphere_mie/probe_root_finding_loop.py
@@ -73,10 +73,14 @@ from scipy.special import spherical_jn, spherical_yn
 
 HERE = Path(__file__).resolve().parent
 REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-import mie_roots  # noqa: E402
-from mie_roots import (  # noqa: E402
+from reference.numpy import mie_roots  # noqa: E402
+from reference.numpy.mie_roots import (  # noqa: E402
     DEDUP_TOL,
     K_MAX,
     K_MIN,

--- a/reference/onnx/audit/sphere_mie/probe_tensor_eps_ramp.py
+++ b/reference/onnx/audit/sphere_mie/probe_tensor_eps_ramp.py
@@ -73,19 +73,21 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
-from sphere_pec import (  # noqa: E402
+from reference.numpy.nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     PHYS_PML_SHELL,
     PHYS_SPHERE_INTERIOR,
     R_BUFFER,
     R_PML_INNER,
     build_edges,
 )
-from sphere_mie import (  # noqa: E402
+from reference.numpy.sphere_mie import (  # noqa: E402
     K0_REF,
     SIGMA_0_DEFAULT,
     assemble_global_nedelec_anisotropic,

--- a/reference/onnx/audit/sphere_pec/probe_edge_enumeration.py
+++ b/reference/onnx/audit/sphere_pec/probe_edge_enumeration.py
@@ -71,12 +71,14 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
-from sphere_pec import build_edges  # noqa: E402
+from reference.numpy.nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+from reference.numpy.sphere_pec import build_edges  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/sphere_pec/probe_nedelec_local.py
+++ b/reference/onnx/audit/sphere_pec/probe_nedelec_local.py
@@ -71,11 +71,13 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import (  # noqa: E402
+from reference.numpy.nedelec_local_matrices import (  # noqa: E402
     TET_LOCAL_EDGES,
     batched_nedelec_local_matrices,
 )

--- a/reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py
+++ b/reference/onnx/audit/sphere_pec/probe_nedelec_scatter.py
@@ -91,12 +91,14 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
-from sphere_pec import build_edges  # noqa: E402
+from reference.numpy.nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+from reference.numpy.sphere_pec import build_edges  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/sphere_pec/probe_pec_mask.py
+++ b/reference/onnx/audit/sphere_pec/probe_pec_mask.py
@@ -71,11 +71,13 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from sphere_pec import sphere_pec_interior_edges, R_BUFFER  # noqa: E402
+from reference.numpy.sphere_pec import sphere_pec_interior_edges, R_BUFFER  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py
+++ b/reference/onnx/audit/sphere_pml/probe_complex_eps_ramp.py
@@ -66,17 +66,19 @@ import onnx.helper as oh
 import onnxruntime as ort
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     PHYS_PML_SHELL,
     PHYS_SPHERE_INTERIOR,
     R_BUFFER,
     R_PML_INNER,
 )
-from sphere_pml import build_complex_epsilon_r_pml  # noqa: E402
+from reference.numpy.sphere_pml import build_complex_epsilon_r_pml  # noqa: E402
 
 OPSET = 18
 

--- a/reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py
+++ b/reference/onnx/audit/sphere_pml/probe_complex_local_scatter.py
@@ -61,12 +61,14 @@ import onnxruntime as ort
 import scipy.sparse
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[4])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
-from sphere_pec import build_edges  # noqa: E402
+from reference.numpy.nedelec_local_matrices import batched_nedelec_local_matrices  # noqa: E402
+from reference.numpy.sphere_pec import build_edges  # noqa: E402
 
 OPSET = 18
 N_LOCAL = 6

--- a/reference/onnx/cube_cavity/gen_cube_cavity_reduced.py
+++ b/reference/onnx/cube_cavity/gen_cube_cavity_reduced.py
@@ -28,13 +28,14 @@ import numpy as np
 import onnx
 import onnxruntime as ort
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent  # reference/
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
-sys.path.insert(0, str(HERE))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402
-from assembly_graph import build_cube_cavity_graph  # noqa: E402
+from reference.numpy.mesh import cube_interior_mask, cube_tet_mesh  # noqa: E402
+from reference.onnx.cube_cavity.assembly_graph import build_cube_cavity_graph  # noqa: E402
 
 
 def _scalar_input_field(value, dtype: str, description: str) -> dict:

--- a/reference/onnx/sphere_pec/assembly_graph.py
+++ b/reference/onnx/sphere_pec/assembly_graph.py
@@ -88,11 +88,13 @@ import onnx
 import onnx.helper as oh
 from onnx import TensorProto
 
-HERE = Path(__file__).resolve().parent
-REFERENCE_ROOT = HERE.parent.parent
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
+from reference.numpy.nedelec_local_matrices import TET_LOCAL_EDGES  # noqa: E402
 
 OPSET = 18
 IR_VERSION = 9

--- a/reference/onnx/sphere_pec/gen_sphere_pec_reduced.py
+++ b/reference/onnx/sphere_pec/gen_sphere_pec_reduced.py
@@ -50,10 +50,13 @@ import onnxruntime as ort
 
 HERE = Path(__file__).resolve().parent
 REFERENCE_ROOT = HERE.parent.parent  # reference/
-sys.path.insert(0, str(REFERENCE_ROOT / "numpy"))
-sys.path.insert(0, str(HERE))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
-from sphere_pec import (  # noqa: E402
+from reference.numpy.sphere_pec import (  # noqa: E402
     R_BUFFER,
     build_edges,
     build_epsilon_r,
@@ -61,7 +64,7 @@ from sphere_pec import (  # noqa: E402
     sphere_pec_interior_edges,
 )
 
-from assembly_graph import build_sphere_pec_graph  # noqa: E402
+from reference.onnx.sphere_pec.assembly_graph import build_sphere_pec_graph  # noqa: E402
 
 
 def _input_field(value_list, shape, dtype, description):

--- a/reference/tf_java/sphere_mie/gen_tfjava_baseline.py
+++ b/reference/tf_java/sphere_mie/gen_tfjava_baseline.py
@@ -74,7 +74,11 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 # Strict cross-IR window (#160 cluster closure): the TM_1,1 triplet.
 STRICT_MODE_WINDOW_LEN = 3
@@ -165,7 +169,7 @@ def main():
     # this line-for-line modulo accumulation order; the actual JVM
     # regeneration happens in CI via the tfjava-cube-cavity workflow
     # (sphere-mie-tfjava job) which builds + runs the Maven module.
-    from sphere_mie import (
+    from reference.numpy.sphere_mie import (
         classify_modes_against_catalogue,
         load_mie_roots_catalogue,
         q_factor_from_lambda,

--- a/reference/tf_java/sphere_pml/gen_tfjava_baseline.py
+++ b/reference/tf_java/sphere_pml/gen_tfjava_baseline.py
@@ -65,7 +65,11 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent.parent
-sys.path.insert(0, str(REPO_ROOT / "reference" / "numpy"))
+# Repo root on sys.path: `reference.*` resolves as PEP 420 namespace
+# packages regardless of cwd (issue #187).
+_REPO_ROOT_STR = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT_STR not in sys.path:
+    sys.path.insert(0, _REPO_ROOT_STR)
 
 
 def _git_commit() -> str:
@@ -349,7 +353,7 @@ def main():
     # this line-for-line modulo accumulation order; the actual JVM
     # regeneration happens in CI via the tfjava-cube-cavity workflow
     # (sphere-pml-tfjava job) which builds + runs the Maven module.
-    from sphere_pml import run_sphere_pml
+    from reference.numpy.sphere_pml import run_sphere_pml
 
     print(f"Running NumPy reference pipeline (σ₀={args.sigma0}, n_index={args.n_index})...")
     print("(TF-Java JVM path is numerically equivalent modulo scatterNd accumulation order;")


### PR DESCRIPTION
## Summary

Eliminates the per-file `sys.path` import dance across the reference tree. `reference/` is now importable as PEP 420 **implicit** namespace packages (`reference.numpy.*`, `reference.jax.*`, `reference.onnx.*`, `reference.driver`, `reference.tf_java.*`) — deliberately with **no `__init__.py`** in `reference/numpy/` or `reference/jax/`, so site-packages NumPy/JAX can never be shadowed (regular packages always beat namespace portions). All 44 affected files get one uniform, cwd-independent 2-line shim that puts the **repo root** (never `reference/` itself) on `sys.path`, then use package-qualified imports. The three `spec_from_file_location` / `_load_by_path` private loads in `reference/jax/` are deleted; the numpy/jax basename collisions (`sphere_pec`, `sphere_pml`, `sphere_mie`, `cube_cavity`) are now disambiguated by package path instead of path order.

## Changes

- `reference/numpy/` (17 files), `reference/jax/` (8), `reference/onnx/` (15), `reference/driver/` (2), `reference/tf_java/` (2): replace `sys.path.insert(0, <reference/numpy>)`-style dances with the uniform guarded repo-root shim (`Path(__file__).resolve().parents[N]`, depth-checked per file) + `from reference.numpy.X import ...` / `from reference.jax import X` imports
- `reference/jax/sphere_mie.py`, `sphere_pml.py`, `gen_sphere_mie_fixture.py`: `_load_by_path` / `spec_from_file_location` removed; JAX siblings imported as `from reference.jax import sphere_pec as _jax_pec` etc.
- `reference/onnx/{cube_cavity,sphere_pec}/gen_*_reduced.py`: `assembly_graph` imported via its existing regular package (`reference.onnx.sphere_pec.assembly_graph`), removing the second `sys.path.insert(0, HERE)`
- Dead `HERE` / `REFERENCE_ROOT` / `REPO_REF` variables and stale path-dance comments removed where the shim obsoleted them
- **No** workflow, doc, fixture, or Rust changes: all `python3 reference/...` CLI invocations are preserved verbatim by the shim

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No `__init__.py` named numpy/jax; third-party numpy/jax unshadowed | ✅ | `find reference -name __init__.py` → only the 2 pre-existing ONNX ones; `import numpy`/`import jax` resolve to site-packages even with `reference/` explicitly first on `sys.path` (namespace portions lose to regular packages) |
| `spec_from_file_location`/`_load_by_path` eliminated from `reference/jax/` | ✅ | `grep -r` over `reference/` returns zero hits |
| Existing CLI invocations in the 5 CI workflows run unchanged | ✅ | Workflows untouched (file-path invocations preserved by the shim); ran the exact `jax-sphere-mie.yml` invocation (`gen_sphere_mie_fixture.py --out ... --sigma0 5.0`) and `tfjava-cube-cavity.yml`'s `emit_numpy_eigenvalues.py --n 4 --side 1.0 --k 5` locally — both pass all internal gates |
| `reference/fixtures/**` byte-identical | ✅ | `git status` clean over fixtures; spot-regenerated `gen_mie_efficiencies_baseline.py` (NumPy), `gen_p1_local_per_case.py` (NumPy, from non-root cwd), and the JAX sphere-Mie fixture — numerics identical to committed files in every field (only the embedded provenance commit-hash string differs, inherent to regeneration; fixtures restored, not committed) |
| `cargo test -p geode-validation` green, zero Rust changes | ✅ | `cargo test --workspace --release` exit 0 (61 test binaries, all ok); `git diff` touches only `reference/**.py`; `cargo fmt --check` clean |
| `python3 -m compileall reference/` + clean module imports | ✅ | compileall passes; all 32 numpy/jax/driver modules + both tf_java generators import cleanly via `import reference.numpy.sphere_mie` etc. from repo root |
| Docs/audit-doc pinned invocations still copy-paste-correct | ✅ | Invocation style unchanged → no doc edits needed; shim is cwd-independent (`parents[N]` mechanically verified to resolve to repo root for all 44 files); `cd reference && python3 numpy/gen_p1_local_per_case.py` (README:221 form) runs correctly |

## Test Plan

Run locally (numpy/scipy/JAX installed): module-import sweep over all 32 importable modules, `compileall`, NumPy + JAX generator end-to-end runs with numeric diff against committed fixtures (zero numeric drift; JAX run includes its NumPy-agreement, σ₀=0-anchor, and autodiff hard gates), non-root-cwd generator run, numpy/jax shadowing edge case, full `cargo test --workspace --release` + `cargo fmt --check`.

**Not runnable locally** (toolchains absent): ONNX probes/generators (`onnx`/`onnxruntime` not installed — verified by `compileall` only), TF-Java JVM path, Julia. The onnx-cube-cavity, tfjava-cube-cavity, julia-cube-cavity, jax-sphere-mie, jax-sphere-pml CI workflows are the authoritative harness for those.

Note for reviewers: regenerating `p1_local` fixtures on **unmodified main** already produces description/formatting drift vs the committed files (committed fixtures predate generator-metadata wording changes; numerics identical). That drift is pre-existing and intentionally not addressed here — fixtures are committed untouched per the issue's regenerate-nothing mandate.

Closes #187