### PR TITLE
feat: lift matched (full Sacks) UPML into Burn assembly / driven_solve

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -37,6 +37,15 @@
 //!   ([`crate::nedelec_assembly::build_anisotropic_pml_tensor_diag`])
 //!   makes `M` complex, which makes `A(ω)` invertible for real ω and
 //!   absorbs outgoing radiation.
+//! - **Matched (full Sacks) UPML** — also a material
+//!   ([`DrivenMaterials::MatchedUpml`], issue #199): both constitutive
+//!   tensors are stretched (`ε = ε_r·Λ`, `μ = Λ`), so the curl-curl
+//!   stiffness gains a complex full-3×3 weight `ν = Λ⁻¹` and the system
+//!   is `A(ω) = K(ν) + iωC(σ) − ω²M(ε)`. `Λ` is symmetric, so
+//!   `A(ω)ᵀ = A(ω)` still holds. Per-tet tensors come from
+//!   [`crate::scattering::build_matched_upml_materials`]; the
+//!   host-assembled oracle is
+//!   [`crate::scattering::solve_scattered_field_matched_upml`].
 //!
 //! # Solver
 //!
@@ -79,7 +88,8 @@ use crate::complex_lanczos::{solve_with_lu, spmv};
 use crate::eigen::burn_matrix_to_faer;
 use crate::nedelec_assembly::{
     assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
-    assemble_nedelec_current_rhs, burn_complex_mass_to_faer, tet_centroids,
+    assemble_global_nedelec_with_full_tensors, assemble_nedelec_current_rhs,
+    assemble_nedelec_current_rhs_quad4, burn_complex_mass_to_faer, tet_centroids,
 };
 use crate::TetMesh;
 
@@ -122,6 +132,21 @@ pub enum DrivenMaterials<'a> {
     /// [`crate::nedelec_assembly::build_anisotropic_pml_tensor_diag`]
     /// for the UPML shell.
     DiagTensor(&'a [[c64; 3]]),
+    /// Matched (full Sacks) UPML materials (issue #199): full 3×3
+    /// complex per-tet tensors for **both** constitutive weights, as
+    /// produced by [`crate::scattering::build_matched_upml_materials`].
+    /// The system becomes `A(ω) = K(ν) + iωC(σ) − ω²M(ε)` with
+    /// `ε = ε_r·Λ` and `ν = Λ⁻¹` — the stiffness is complex too, but
+    /// `Λ` is symmetric so the complex-symmetry invariant
+    /// `A(ω)ᵀ = A(ω)` is preserved.
+    MatchedUpml {
+        /// Per-tet full 3×3 complex permittivity tensor `ε = ε_r·Λ`
+        /// (mass weight) in the global Cartesian basis.
+        epsilon_tensor: &'a [[[c64; 3]; 3]],
+        /// Per-tet full 3×3 complex inverse-permeability tensor
+        /// `ν = μ⁻¹ = Λ⁻¹` (curl-curl weight).
+        nu_tensor: &'a [[[c64; 3]; 3]],
+    },
 }
 
 /// Boundary conditions for the driven solve.
@@ -149,6 +174,75 @@ impl CurrentSource {
     pub fn from_centroids(mesh: &TetMesh, f: impl Fn([f64; 3]) -> [c64; 3]) -> Self {
         let j_tet = tet_centroids(mesh).into_iter().map(f).collect();
         Self { j_tet }
+    }
+}
+
+/// Volumetric current source sampled at the **degree-2 (4-point)** tet
+/// quadrature points (issue #199) — for spatially varying `J(x)` whose
+/// per-tet variation matters (e.g. the plane-wave phase of the Mie
+/// scattered-field polarization current). The RHS is integrated with
+/// the same rule the host-side matched-UPML oracle uses
+/// ([`crate::scattering::solve_scattered_field_matched_upml`]), so the
+/// two paths agree to round-off for the same `J`.
+///
+/// For a per-tet-constant `J` this reduces exactly to
+/// [`CurrentSource`] (the rule integrates constant and linear
+/// integrands exactly).
+#[derive(Debug, Clone)]
+pub struct QuadCurrentSource {
+    /// `[n_tets][4][3]` complex current density at the four degree-2
+    /// quadrature points of each tet, in `mesh.tets` order. Point `q`
+    /// of a tet has barycentric weight
+    /// [`crate::nedelec::TET_QUAD4_A`] on vertex `q` and
+    /// [`crate::nedelec::TET_QUAD4_B`] on the other three.
+    pub j_quad: Vec<[[c64; 3]; 4]>,
+}
+
+impl QuadCurrentSource {
+    /// Sample `J(tet, x)` at every degree-2 quadrature point of every
+    /// tet. The closure signature matches the `j_at` argument of
+    /// [`crate::scattering::solve_scattered_field_matched_upml`], so a
+    /// host-oracle source closure (e.g.
+    /// [`crate::scattering::plane_wave_polarization_current`]) can be
+    /// passed directly.
+    pub fn from_fn(mesh: &TetMesh, f: impl Fn(usize, [f64; 3]) -> [c64; 3]) -> Self {
+        use crate::nedelec::{TET_QUAD4_A, TET_QUAD4_B};
+        let j_quad = mesh
+            .tets
+            .iter()
+            .enumerate()
+            .map(|(t, tet)| {
+                let verts: [[f64; 3]; 4] = std::array::from_fn(|v| mesh.nodes[tet[v] as usize]);
+                std::array::from_fn(|q| {
+                    let x_q: [f64; 3] = std::array::from_fn(|k| {
+                        (0..4)
+                            .map(|v| {
+                                let lam = if v == q { TET_QUAD4_A } else { TET_QUAD4_B };
+                                lam * verts[v][k]
+                            })
+                            .sum::<f64>()
+                    });
+                    f(t, x_q)
+                })
+            })
+            .collect();
+        Self { j_quad }
+    }
+}
+
+/// Internal RHS dispatch: per-tet-constant samples (centroid `J`) or
+/// degree-2 quadrature samples.
+enum RhsSamples<'a> {
+    Constant(&'a [[c64; 3]]),
+    Quad(&'a [[[c64; 3]; 4]]),
+}
+
+impl RhsSamples<'_> {
+    fn len(&self) -> usize {
+        match self {
+            RhsSamples::Constant(j) => j.len(),
+            RhsSamples::Quad(j) => j.len(),
+        }
     }
 }
 
@@ -225,6 +319,63 @@ pub fn driven_solve_with_sigma<B: Backend>(
     source: &CurrentSource,
     device: &B::Device,
 ) -> Result<DrivenSolution, DrivenError> {
+    driven_solve_impl::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        omega,
+        RhsSamples::Constant(&source.j_tet),
+        device,
+    )
+}
+
+/// [`driven_solve`] with a degree-2 quadrature source
+/// ([`QuadCurrentSource`]) for spatially varying `J(x)` (issue #199).
+/// Everything else (materials, σ, BCs, solver) is identical to
+/// [`driven_solve_with_sigma`].
+pub fn driven_solve_quad<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    source: &QuadCurrentSource,
+    device: &B::Device,
+) -> Result<DrivenSolution, DrivenError> {
+    driven_solve_with_sigma_quad::<B>(mesh, materials, None, bcs, omega, source, device)
+}
+
+/// [`driven_solve_quad`] with an optional per-tet conductivity — the
+/// quadrature-source counterpart of [`driven_solve_with_sigma`].
+pub fn driven_solve_with_sigma_quad<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    source: &QuadCurrentSource,
+    device: &B::Device,
+) -> Result<DrivenSolution, DrivenError> {
+    driven_solve_impl::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        omega,
+        RhsSamples::Quad(&source.j_quad),
+        device,
+    )
+}
+
+fn driven_solve_impl<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    rhs: RhsSamples<'_>,
+    device: &B::Device,
+) -> Result<DrivenSolution, DrivenError> {
     let n_tets = mesh.n_tets();
     let edges = mesh.edges();
     let n_edges = edges.len();
@@ -236,15 +387,27 @@ pub fn driven_solve_with_sigma<B: Backend>(
             want: n_edges,
         });
     }
-    if source.j_tet.len() != n_tets {
+    if rhs.len() != n_tets {
         return Err(DrivenError::SourceDimMismatch {
-            got: source.j_tet.len(),
+            got: rhs.len(),
             want: n_tets,
         });
     }
     let material_len = match materials {
         DrivenMaterials::Scalar(eps) => eps.len(),
         DrivenMaterials::DiagTensor(eps) => eps.len(),
+        DrivenMaterials::MatchedUpml {
+            epsilon_tensor,
+            nu_tensor,
+        } => {
+            if nu_tensor.len() != n_tets {
+                return Err(DrivenError::MaterialDimMismatch {
+                    got: nu_tensor.len(),
+                    want: n_tets,
+                });
+            }
+            epsilon_tensor.len()
+        }
     };
     if material_len != n_tets {
         return Err(DrivenError::MaterialDimMismatch {
@@ -273,24 +436,48 @@ pub fn driven_solve_with_sigma<B: Backend>(
         .collect();
 
     // --- Assemble K, M(ε) on the Burn backend ------------------------------
+    // The stiffness imaginary part is `None` for the ε-only material
+    // models (K is real there); the matched UPML stretches μ too, so
+    // its `K(Λ⁻¹)` carries an imaginary part.
     let (nodes_t, tets_t) = crate::assembly::upload_mesh::<B>(mesh, device);
-    let sys = match materials {
-        DrivenMaterials::Scalar(eps) => assemble_global_nedelec_with_complex_epsilon(
-            nodes_t.clone(),
-            tets_t.clone(),
-            &tet_idx,
-            &tet_sign,
-            n_edges,
-            eps,
-        ),
-        DrivenMaterials::DiagTensor(eps) => assemble_global_nedelec_with_anisotropic_epsilon(
-            nodes_t.clone(),
-            tets_t.clone(),
-            &tet_idx,
-            &tet_sign,
-            n_edges,
-            eps,
-        ),
+    let (k_re_t, k_im_t, m_re_t, m_im_t, sparsity) = match materials {
+        DrivenMaterials::Scalar(eps) => {
+            let sys = assemble_global_nedelec_with_complex_epsilon(
+                nodes_t.clone(),
+                tets_t.clone(),
+                &tet_idx,
+                &tet_sign,
+                n_edges,
+                eps,
+            );
+            (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+        }
+        DrivenMaterials::DiagTensor(eps) => {
+            let sys = assemble_global_nedelec_with_anisotropic_epsilon(
+                nodes_t.clone(),
+                tets_t.clone(),
+                &tet_idx,
+                &tet_sign,
+                n_edges,
+                eps,
+            );
+            (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+        }
+        DrivenMaterials::MatchedUpml {
+            epsilon_tensor,
+            nu_tensor,
+        } => {
+            let sys = assemble_global_nedelec_with_full_tensors(
+                nodes_t.clone(),
+                tets_t.clone(),
+                &tet_idx,
+                &tet_sign,
+                n_edges,
+                epsilon_tensor,
+                nu_tensor,
+            );
+            (sys.k_re, Some(sys.k_im), sys.m_re, sys.m_im, sys.sparsity)
+        }
     };
 
     // --- Assemble the conductivity damping matrix C(σ), if any -------------
@@ -309,27 +496,47 @@ pub fn driven_solve_with_sigma<B: Backend>(
     });
 
     // --- Assemble the current-source RHS -----------------------------------
-    // The Burn RHS kernel is real-valued; a complex J runs as two passes
-    // (Re(J), Im(J)) — same split as the complex-ε mass assembly.
-    let j_re: Vec<[f64; 3]> = source
-        .j_tet
-        .iter()
-        .map(|j| [j[0].re, j[1].re, j[2].re])
-        .collect();
-    let j_im: Vec<[f64; 3]> = source
-        .j_tet
-        .iter()
-        .map(|j| [j[0].im, j[1].im, j[2].im])
-        .collect();
-    let rhs_re = assemble_nedelec_current_rhs(
-        nodes_t.clone(),
-        tets_t.clone(),
-        &tet_idx,
-        &tet_sign,
-        n_edges,
-        &j_re,
-    );
-    let rhs_im = assemble_nedelec_current_rhs(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im);
+    // The Burn RHS kernels are real-valued; a complex J runs as two
+    // passes (Re(J), Im(J)) — same split as the complex-ε mass assembly.
+    let (rhs_re, rhs_im) = match rhs {
+        RhsSamples::Constant(j_tet) => {
+            let j_re: Vec<[f64; 3]> = j_tet.iter().map(|j| [j[0].re, j[1].re, j[2].re]).collect();
+            let j_im: Vec<[f64; 3]> = j_tet.iter().map(|j| [j[0].im, j[1].im, j[2].im]).collect();
+            let rhs_re = assemble_nedelec_current_rhs(
+                nodes_t.clone(),
+                tets_t.clone(),
+                &tet_idx,
+                &tet_sign,
+                n_edges,
+                &j_re,
+            );
+            let rhs_im =
+                assemble_nedelec_current_rhs(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im);
+            (rhs_re, rhs_im)
+        }
+        RhsSamples::Quad(j_quad) => {
+            let j_re: Vec<[[f64; 3]; 4]> = j_quad
+                .iter()
+                .map(|t| t.map(|q| [q[0].re, q[1].re, q[2].re]))
+                .collect();
+            let j_im: Vec<[[f64; 3]; 4]> = j_quad
+                .iter()
+                .map(|t| t.map(|q| [q[0].im, q[1].im, q[2].im]))
+                .collect();
+            let rhs_re = assemble_nedelec_current_rhs_quad4(
+                nodes_t.clone(),
+                tets_t.clone(),
+                &tet_idx,
+                &tet_sign,
+                n_edges,
+                &j_re,
+            );
+            let rhs_im = assemble_nedelec_current_rhs_quad4(
+                nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im,
+            );
+            (rhs_re, rhs_im)
+        }
+    };
     let rhs_re: Vec<f64> = rhs_re.into_data().iter::<f64>().collect();
     let rhs_im: Vec<f64> = rhs_im.into_data().iter::<f64>().collect();
 
@@ -341,8 +548,9 @@ pub fn driven_solve_with_sigma<B: Backend>(
         .collect();
 
     // --- Host transfer + PEC reduction -------------------------------------
-    let k_full = burn_matrix_to_faer(sys.k);
-    let m_full = burn_complex_mass_to_faer(sys.m_re, sys.m_im);
+    let k_full = burn_matrix_to_faer(k_re_t);
+    let k_im_full = k_im_t.map(burn_matrix_to_faer);
+    let m_full = burn_complex_mass_to_faer(m_re_t, m_im_t);
     let c_full = c_burn.map(burn_matrix_to_faer);
 
     // Remap full edge indices → contiguous interior indices.
@@ -360,14 +568,15 @@ pub fn driven_solve_with_sigma<B: Backend>(
 
     // --- Sparse A(ω) = K + iωC − ω² M over the recorded sparsity pattern ---
     let omega2 = omega * omega;
-    let mut triplets: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(sys.sparsity.rows.len());
-    for (&r_u32, &c_u32) in sys.sparsity.rows.iter().zip(sys.sparsity.cols.iter()) {
+    let mut triplets: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(sparsity.rows.len());
+    for (&r_u32, &c_u32) in sparsity.rows.iter().zip(sparsity.cols.iter()) {
         let (r, c) = (r_u32 as usize, c_u32 as usize);
         let (rr, cc) = (remap[r], remap[c]);
         if rr < 0 || cc < 0 {
             continue;
         }
-        let mut a_val = c64::new(k_full[(r, c)], 0.0) - m_full[(r, c)] * omega2;
+        let k_im_val = k_im_full.as_ref().map_or(0.0, |m| m[(r, c)]);
+        let mut a_val = c64::new(k_full[(r, c)], k_im_val) - m_full[(r, c)] * omega2;
         if let Some(cm) = &c_full {
             // Conduction loss: + iω C (exp(+jωt) convention).
             a_val += c64::new(0.0, omega * cm[(r, c)]);

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -35,8 +35,8 @@ pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
 pub use driven::{
-    driven_solve, driven_solve_with_sigma, CurrentSource, DrivenBcs, DrivenError, DrivenMaterials,
-    DrivenSolution,
+    driven_solve, driven_solve_quad, driven_solve_with_sigma, driven_solve_with_sigma_quad,
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenSolution, QuadCurrentSource,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
@@ -65,23 +65,28 @@ pub use mie_scattering::{
     mie_a_b, mie_coefficients, mie_efficiencies, mie_series_order, MieCoefficients, MieEfficiencies,
 };
 pub use nedelec::{
-    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices,
-    batched_nedelec_local_rhs, tet_edges, NedelecLocalMatrices,
+    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_mass_anisotropic_full,
+    batched_nedelec_local_matrices, batched_nedelec_local_rhs, batched_nedelec_local_rhs_quad4,
+    batched_nedelec_local_stiffness_weighted, tet_edges, NedelecLocalMatrices, TET_QUAD4_A,
+    TET_QUAD4_B,
 };
 pub use nedelec_assembly::{
     assemble_global_nedelec, assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_complex_epsilon, assemble_global_nedelec_with_epsilon,
-    assemble_nedelec_current_rhs, assemble_nedelec_sigma_damping,
+    assemble_global_nedelec_with_full_tensors, assemble_nedelec_current_rhs,
+    assemble_nedelec_current_rhs_quad4, assemble_nedelec_sigma_damping,
     build_anisotropic_pml_tensor_diag, build_complex_epsilon_eff, build_complex_epsilon_r_pml,
     build_epsilon_r, burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
     rank_via_svd, restrict_gradient_dense, sphere_n_interior_nodes, sphere_pec_interior_edges,
     sphere_pec_node_interior_mask, spurious_dim_from_derham, tet_centroid_radii, tet_centroids,
-    NedelecComplexGlobalSystem, NedelecGlobalSystem, DERHAM_RANK_THRESHOLD_REL,
+    NedelecComplexGlobalSystem, NedelecFullTensorGlobalSystem, NedelecGlobalSystem,
+    DERHAM_RANK_THRESHOLD_REL,
 };
 pub use p1::{batched_p1_local_matrices, P1LocalMatrices};
 pub use scattering::{
-    extinction_power, mie_polarization_source, plane_wave_e_inc, plane_wave_polarization_current,
-    q_from_power, scattered_flux_power, solve_scattered_field_matched_upml, upml_matched_tensors,
+    build_matched_upml_materials, extinction_power, mie_polarization_source, plane_wave_e_inc,
+    plane_wave_polarization_current, q_from_power, scattered_flux_power,
+    solve_scattered_field_matched_upml, upml_matched_tensors,
 };
 pub use silvermuller::assemble_silver_muller_surface;
 pub use silvermuller_self_consistent::{

--- a/crates/geode-core/src/nedelec.rs
+++ b/crates/geode-core/src/nedelec.rs
@@ -537,3 +537,291 @@ pub fn batched_nedelec_local_mass_anisotropic_diag<B: Backend>(
     let m_stacked = Tensor::<B, 1>::stack::<2>(m_entries, 1); // [n_elem, 36]
     m_stacked.reshape([n_elem, 6, 6])
 }
+
+/// Barycentric weight of the "own" vertex in the symmetric degree-2
+/// 4-point tet quadrature rule: point `q` has `λ_q = TET_QUAD4_A` and
+/// `λ_p = TET_QUAD4_B` for `p ≠ q`, with equal weights `V/4`. Shared
+/// with the host-side reference assembly in [`crate::scattering`] so
+/// the two paths integrate spatially varying sources identically.
+pub const TET_QUAD4_A: f64 = 0.585_410_196_624_968_5;
+/// Barycentric weight of the three "other" vertices in the degree-2
+/// 4-point tet rule (see [`TET_QUAD4_A`]).
+pub const TET_QUAD4_B: f64 = 0.138_196_601_125_010_5;
+
+/// Per-vertex cofactor vectors `g_p` (`[n_elem, 4, 3]`, row `p` = `g_p`)
+/// and the per-element determinant `det(J)` (`[n_elem]`) shared by the
+/// tensor-weighted kernels below. `∇λ_p = g_p / det(J)`.
+fn cofactor_rows_and_det<B: Backend>(coords: Tensor<B, 3>) -> (Tensor<B, 3>, Tensor<B, 1>) {
+    let dims = coords.dims();
+    let n_elem = dims[0];
+    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
+    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+
+    let v0 = coords
+        .clone()
+        .slice([0..n_elem, 0..1, 0..3])
+        .squeeze_dim::<2>(1);
+    let v1 = coords
+        .clone()
+        .slice([0..n_elem, 1..2, 0..3])
+        .squeeze_dim::<2>(1);
+    let v2 = coords
+        .clone()
+        .slice([0..n_elem, 2..3, 0..3])
+        .squeeze_dim::<2>(1);
+    let v3 = coords.slice([0..n_elem, 3..4, 0..3]).squeeze_dim::<2>(1);
+
+    let e1 = v1 - v0.clone();
+    let e2 = v2 - v0.clone();
+    let e3 = v3 - v0;
+
+    let g1 = e2.clone().cross(e3.clone(), 1);
+    let g2 = e3.clone().cross(e1.clone(), 1);
+    let g3 = e1.clone().cross(e2.clone(), 1);
+
+    let det = e1.mul(g1.clone()).sum_dim(1).squeeze_dim::<1>(1);
+    let g0 = (g1.clone() + g2.clone() + g3.clone()).neg();
+
+    let g_mat = Tensor::<B, 2>::stack::<3>(vec![g0, g1, g2, g3], 1); // [n_elem, 4, 3]
+    (g_mat, det)
+}
+
+/// Per-element Nédélec curl-curl (stiffness) matrix with a **full 3×3**
+/// per-tet weight tensor `W` on the curls (issue #199):
+///
+/// ```text
+/// K^W_ij = ∫_T (∇×N_i)ᵀ · W · (∇×N_j) dV = V · c_iᵀ W c_j,
+/// ```
+///
+/// where `c_i = 2(∇λ_a × ∇λ_b)` is the constant per-tet curl of Whitney
+/// edge basis `i = (a, b)`. This is the stiffness analogue of the
+/// weighted mass kernels: for the matched (full Sacks) UPML the curl
+/// weight is `W = Λ⁻¹` (`μ = Λ` stretched, so `μ⁻¹ = Λ⁻¹` lands on the
+/// curl-curl term). Complex weights run as two passes (`Re(W)`,
+/// `Im(W)`), exactly like the complex-ε mass path.
+///
+/// With `W = I` this reduces to the `k_local` of
+/// [`batched_nedelec_local_matrices`] (Lagrange identity
+/// `(u×v)·(w×z) = (u·w)(v·z) − (u·z)(v·w)`).
+///
+/// # Arguments
+///
+/// * `coords` — `[n_elem, 4, 3]` per-tet vertex coordinates.
+/// * `weight` — `[n_elem, 3, 3]` per-tet weight tensor in the global
+///   Cartesian basis (real; complex weights are split by the caller).
+///
+/// # Returns
+///
+/// `[n_elem, 6, 6]` local stiffness (sign-unaware, same orientation
+/// caveat as [`batched_nedelec_local_matrices`]).
+pub fn batched_nedelec_local_stiffness_weighted<B: Backend>(
+    coords: Tensor<B, 3>,
+    weight: Tensor<B, 3>,
+) -> Tensor<B, 3> {
+    let n_elem = coords.dims()[0];
+    let w_dims = weight.dims();
+    assert_eq!(
+        w_dims,
+        [n_elem, 3, 3],
+        "expected weight shape [n_elem, 3, 3], got {:?}",
+        w_dims
+    );
+
+    let (g_mat, det) = cofactor_rows_and_det(coords);
+
+    // Unnormalized curl directions: cr_i = g_a × g_b per local edge,
+    // shape [n_elem, 6, 3]. The physical curl is 2(∇λ_a × ∇λ_b)
+    // = 2 cr_i / det²; the dangling scale factors are folded below.
+    let g_row = |p: usize| -> Tensor<B, 2> {
+        g_mat
+            .clone()
+            .slice([0..n_elem, p..p + 1, 0..3])
+            .squeeze_dim::<2>(1)
+    };
+    let cr_rows: Vec<Tensor<B, 2>> = TET_LOCAL_EDGES
+        .iter()
+        .map(|&(a, b)| g_row(a).cross(g_row(b), 1))
+        .collect();
+    let cr = Tensor::<B, 2>::stack::<3>(cr_rows, 1); // [n_elem, 6, 3]
+
+    // K_ij = V · (2 cr_i / det²)ᵀ W (2 cr_j / det²)
+    //      = (|det|/6) · 4/det⁴ · cr_iᵀ W cr_j
+    //      = (2 / (3 |det|³)) · cr_iᵀ W cr_j.
+    // (det⁴ = |det|⁴ — even power.) Same f64-literal note as the scalar
+    // kernel: keep `2/3` in double precision.
+    let abs_det = det.abs();
+    let inv_abs_det = abs_det.recip();
+    let scale = (inv_abs_det.clone() * inv_abs_det.clone() * inv_abs_det).mul_scalar(2.0_f64 / 3.0);
+    let scale_3d = scale.unsqueeze_dim::<2>(1).unsqueeze_dim::<3>(2); // [n_elem, 1, 1]
+
+    cr.clone()
+        .matmul(weight)
+        .matmul(cr.swap_dims(1, 2))
+        .mul(scale_3d)
+}
+
+/// Per-element Nédélec local mass matrix for a **full 3×3** per-tet
+/// weight tensor `W` in the global Cartesian basis (issue #199):
+///
+/// ```text
+/// M^W_ij = ∫_T N_iᵀ · W · N_j dV.
+/// ```
+///
+/// Generalizes [`batched_nedelec_local_mass_anisotropic_diag`] by
+/// keeping the off-diagonal entries of `W` — required for the matched
+/// (full Sacks) UPML whose Cartesian tensor `ε = ε_r·Λ` has
+/// off-diagonals away from the coordinate axes. With
+/// `∫_T λ_p λ_q dV = (V/20)(1 + δ_pq)` the closed form is the scalar
+/// mass formula with the gradient gram `G_pq = ∇λ_p · ∇λ_q` replaced
+/// by the weighted gram `G^W_pq = ∇λ_pᵀ W ∇λ_q`:
+///
+/// ```text
+/// M^W_ij = (V/20) [   (1 + δ_ac) G^W_bd − (1 + δ_ad) G^W_bc
+///                   − (1 + δ_bc) G^W_ad + (1 + δ_bd) G^W_ac ].
+/// ```
+///
+/// Note `G^W` is asymmetric for asymmetric `W`; the index order above
+/// (first basis index contracts the **left** slot of `W`) matches the
+/// host-path reference in [`crate::scattering`]. Complex weights run as
+/// two passes (`Re(W)`, `Im(W)`).
+///
+/// # Arguments
+///
+/// * `coords` — `[n_elem, 4, 3]` per-tet vertex coordinates.
+/// * `weight` — `[n_elem, 3, 3]` per-tet weight tensor (real part or
+///   imaginary part of the complex constitutive tensor).
+///
+/// # Returns
+///
+/// `[n_elem, 6, 6]` local mass matrix (sign-unaware, same orientation
+/// caveat as [`batched_nedelec_local_matrices`]).
+pub fn batched_nedelec_local_mass_anisotropic_full<B: Backend>(
+    coords: Tensor<B, 3>,
+    weight: Tensor<B, 3>,
+) -> Tensor<B, 3> {
+    let n_elem = coords.dims()[0];
+    let w_dims = weight.dims();
+    assert_eq!(
+        w_dims,
+        [n_elem, 3, 3],
+        "expected weight shape [n_elem, 3, 3], got {:?}",
+        w_dims
+    );
+
+    let (g_mat, det) = cofactor_rows_and_det(coords);
+    let abs_det = det.abs();
+    let inv_abs_det = abs_det.recip();
+
+    // Weighted gram gw_pq = g_pᵀ W g_q, shape [n_elem, 4, 4]. The
+    // physical weighted gram is G^W_pq = gw_pq / det²; the /det² and
+    // (V/20) = (|det|/120) collapse into 1/(120 |det|) below.
+    let gw = g_mat.clone().matmul(weight).matmul(g_mat.swap_dims(1, 2));
+
+    let gw_entry = |p: usize, q: usize| -> Tensor<B, 1> {
+        gw.clone()
+            .slice([0..n_elem, p..p + 1, q..q + 1])
+            .squeeze_dim::<2>(1)
+            .squeeze_dim::<1>(1)
+    };
+
+    let mut m_entries: Vec<Tensor<B, 1>> = Vec::with_capacity(36);
+    for &(a, b) in TET_LOCAL_EDGES.iter() {
+        for &(c, d) in TET_LOCAL_EDGES.iter() {
+            let f_ac = if a == c { 2.0_f64 } else { 1.0_f64 };
+            let f_ad = if a == d { 2.0_f64 } else { 1.0_f64 };
+            let f_bc = if b == c { 2.0_f64 } else { 1.0_f64 };
+            let f_bd = if b == d { 2.0_f64 } else { 1.0_f64 };
+
+            let term = gw_entry(b, d).mul_scalar(f_ac)
+                - gw_entry(b, c).mul_scalar(f_ad)
+                - gw_entry(a, d).mul_scalar(f_bc)
+                + gw_entry(a, c).mul_scalar(f_bd);
+            m_entries.push(term.mul(inv_abs_det.clone()).div_scalar(120.0));
+        }
+    }
+
+    let m_stacked = Tensor::<B, 1>::stack::<2>(m_entries, 1); // [n_elem, 36]
+    m_stacked.reshape([n_elem, 6, 6])
+}
+
+/// Batched Nédélec element-local RHS with the **degree-2 (4-point)**
+/// tet quadrature for a spatially varying current density `J(x)`
+/// sampled at the quadrature points (issue #199):
+///
+/// ```text
+/// b_local_i = ∫_T N_i · J dV ≈ Σ_q (V/4) N_i(x_q) · J_q,
+/// ```
+///
+/// with the symmetric rule `λ_p(x_q) = TET_QUAD4_A` if `p = q` else
+/// `TET_QUAD4_B` ([`TET_QUAD4_A`]/[`TET_QUAD4_B`] — the same rule the
+/// host-side reference assembly in
+/// [`crate::scattering::solve_scattered_field_matched_upml`] uses, so
+/// the two RHS paths agree to round-off for the same samples).
+///
+/// # Closed form used
+///
+/// With `N_i = λ_a ∇λ_b − λ_b ∇λ_a`, `∇λ_p = g_p / det(J)`, and
+/// `D_qp = J_q · g_p`,
+///
+/// ```text
+/// b_i = sign(det)/24 · [ (A − B)(D_ab − D_ba) + B (S_b − S_a) ],
+/// S_p = Σ_q D_qp,
+/// ```
+///
+/// which reduces **exactly** to [`batched_nedelec_local_rhs`] for a
+/// per-tet-constant `J` (then `D_qp = J·g_p` for all `q` and
+/// `A + 3B = 1`). Complex `J` runs as two passes (Re, Im), like the
+/// constant-`J` path.
+///
+/// # Arguments
+///
+/// * `coords` — `[n_elem, 4, 3]` per-tet vertex coordinates.
+/// * `j_quad` — `[n_elem, 4, 3]` current density at the four degree-2
+///   quadrature points, in the rule's point order (point `q` is the
+///   one with weight `TET_QUAD4_A` on vertex `q`).
+///
+/// # Returns
+///
+/// `[n_elem, 6]` local RHS in canonical local-edge order, sign-unaware
+/// (same caveat as [`batched_nedelec_local_rhs`]).
+pub fn batched_nedelec_local_rhs_quad4<B: Backend>(
+    coords: Tensor<B, 3>,
+    j_quad: Tensor<B, 3>,
+) -> Tensor<B, 2> {
+    let n_elem = coords.dims()[0];
+    let j_dims = j_quad.dims();
+    assert_eq!(
+        j_dims,
+        [n_elem, 4, 3],
+        "expected j_quad shape [n_elem, 4, 3], got {:?}",
+        j_dims
+    );
+
+    let (g_mat, det) = cofactor_rows_and_det(coords);
+
+    // D[q][p] = J_q · g_p, shape [n_elem, 4, 4].
+    let d = j_quad.matmul(g_mat.swap_dims(1, 2));
+    // S[p] = Σ_q D[q][p], shape [n_elem, 4] (sum over the quad axis).
+    let s = d.clone().sum_dim(1).squeeze_dim::<2>(1);
+
+    let d_entry = |q: usize, p: usize| -> Tensor<B, 1> {
+        d.clone()
+            .slice([0..n_elem, q..q + 1, p..p + 1])
+            .squeeze_dim::<2>(1)
+            .squeeze_dim::<1>(1)
+    };
+    let s_entry =
+        |p: usize| -> Tensor<B, 1> { s.clone().slice([0..n_elem, p..p + 1]).squeeze_dim::<1>(1) };
+
+    // sign(det)/24 — same orientation handling as the constant-J RHS.
+    let factor = det.clone().div(det.abs()).div_scalar(24.0); // [n_elem]
+    let a_minus_b = TET_QUAD4_A - TET_QUAD4_B;
+
+    let mut entries: Vec<Tensor<B, 1>> = Vec::with_capacity(6);
+    for &(a, b) in TET_LOCAL_EDGES.iter() {
+        let t = (d_entry(a, b) - d_entry(b, a)).mul_scalar(a_minus_b)
+            + (s_entry(b) - s_entry(a)).mul_scalar(TET_QUAD4_B);
+        entries.push(t.mul(factor.clone()));
+    }
+    Tensor::<B, 1>::stack::<2>(entries, 1) // [n_elem, 6]
+}

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -20,12 +20,16 @@
 use std::collections::BTreeSet;
 
 use burn::tensor::backend::Backend;
+use burn::tensor::ElementConversion;
 use burn::tensor::Tensor;
 use burn::tensor::{IndexingUpdateOp, Int, TensorData};
 use faer::Mat;
 
 use crate::assembly::{gather_tet_coords, SparsityPattern};
-use crate::nedelec::{batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_matrices};
+use crate::nedelec::{
+    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_mass_anisotropic_full,
+    batched_nedelec_local_matrices, batched_nedelec_local_stiffness_weighted,
+};
 use crate::TetMesh;
 
 /// Assembled global Nédélec linear system in dense Burn-tensor form.
@@ -37,6 +41,29 @@ pub struct NedelecGlobalSystem<B: Backend> {
     pub m: Tensor<B, 2>,
     /// `(row, col)` index pairs touched during assembly. Always
     /// symmetric for the Nédélec curl-curl / mass pair.
+    pub sparsity: SparsityPattern,
+}
+
+/// Assembled global Nédélec system with **both** matrices complex:
+/// full-3×3-tensor-weighted curl-curl stiffness `K(ν)` and mass
+/// `M(ε)` (matched UPML, issue #199).
+///
+/// Where [`NedelecComplexGlobalSystem`] keeps `K` real (only ε is
+/// stretched), the matched (full Sacks) UPML stretches both
+/// constitutive tensors, so the curl-curl weight `ν = Λ⁻¹` is complex
+/// too. Combine with [`burn_complex_mass_to_faer`] (which is weight-
+/// agnostic — it just zips a Re/Im pair) on the host side.
+#[derive(Debug, Clone)]
+pub struct NedelecFullTensorGlobalSystem<B: Backend> {
+    /// Real part of the ν-weighted curl-curl stiffness, `[n_edges, n_edges]`.
+    pub k_re: Tensor<B, 2>,
+    /// Imaginary part of the ν-weighted curl-curl stiffness.
+    pub k_im: Tensor<B, 2>,
+    /// Real part of the ε-weighted mass matrix.
+    pub m_re: Tensor<B, 2>,
+    /// Imaginary part of the ε-weighted mass matrix.
+    pub m_im: Tensor<B, 2>,
+    /// `(row, col)` index pairs touched during assembly.
     pub sparsity: SparsityPattern,
 }
 
@@ -1061,6 +1088,143 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
     }
 }
 
+/// Upload one real component (Re or Im) of a per-tet 3×3 complex
+/// tensor field as a `[n_elem, 3, 3]` Burn tensor at the backend's
+/// full float precision (`B::FloatElem` — f64 on the ndarray CPU
+/// backend, f32 on the GPU backends; same idiom as
+/// [`crate::assembly::upload_mesh`]).
+fn upload_tensor33_component<B: Backend>(
+    field: &[[[faer::c64; 3]; 3]],
+    pick: impl Fn(&faer::c64) -> f64,
+    device: &B::Device,
+) -> Tensor<B, 3> {
+    let n_elem = field.len();
+    let flat: Vec<B::FloatElem> = field
+        .iter()
+        .flat_map(|t| t.iter().flat_map(|row| row.iter().map(|c| pick(c).elem())))
+        .collect();
+    Tensor::<B, 3>::from_data(TensorData::new(flat, [n_elem, 3, 3]), device)
+}
+
+/// Matched-UPML (full Sacks) variant of the global Nédélec assembly
+/// (issue #199): **full 3×3 complex** per-tet weight tensors on both
+/// the curl-curl stiffness and the mass,
+///
+/// ```text
+/// K(ν)_ij = ∫ (∇×N_i)ᵀ ν (∇×N_j) dV,    M(ε)_ij = ∫ N_iᵀ ε N_j dV,
+/// ```
+///
+/// with `ν = Λ⁻¹` (the `μ = Λ` stretch lands on the curl term) and
+/// `ε = ε_r·Λ` for the matched UPML
+/// ([`crate::scattering::upml_matched_tensors`] /
+/// [`crate::scattering::build_matched_upml_materials`]). Off-diagonal
+/// tensor entries are kept — unlike the diagonal-restriction
+/// approximation of [`build_anisotropic_pml_tensor_diag`] — so the
+/// result agrees with the host-assembled oracle
+/// ([`crate::scattering::solve_scattered_field_matched_upml`]) at
+/// assembly precision.
+///
+/// # Implementation / autodiff
+///
+/// Each complex weight is split into Re/Im passes through the new
+/// batched kernels ([`batched_nedelec_local_stiffness_weighted`],
+/// [`batched_nedelec_local_mass_anisotropic_full`]) — four kernel
+/// invocations total — and scattered through the same autodiff-
+/// preserving 1-D `scatter(0, …, Add)` path as every other assembler
+/// in this module. Combine Re/Im pairs on the host with
+/// [`burn_complex_mass_to_faer`].
+///
+/// # Symmetry
+///
+/// For symmetric weights (Λ and Λ⁻¹ are symmetric) all four outputs
+/// are symmetric, preserving the complex-symmetric (`Aᵀ = A`, NOT
+/// Hermitian) pencil invariant.
+pub fn assemble_global_nedelec_with_full_tensors<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    n_edges: usize,
+    epsilon_tensor: &[[[faer::c64; 3]; 3]],
+    nu_tensor: &[[[faer::c64; 3]; 3]],
+) -> NedelecFullTensorGlobalSystem<B> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        epsilon_tensor.len(),
+        n_elem,
+        "epsilon_tensor length mismatch"
+    );
+    assert_eq!(nu_tensor.len(), n_elem, "nu_tensor length mismatch");
+
+    // 1. Element-local weighted matrices: Re/Im pass per weight.
+    let coords = gather_tet_coords(nodes, tets);
+    let eps_re = upload_tensor33_component::<B>(epsilon_tensor, |c| c.re, &device);
+    let eps_im = upload_tensor33_component::<B>(epsilon_tensor, |c| c.im, &device);
+    let nu_re = upload_tensor33_component::<B>(nu_tensor, |c| c.re, &device);
+    let nu_im = upload_tensor33_component::<B>(nu_tensor, |c| c.im, &device);
+
+    let k_local_re = batched_nedelec_local_stiffness_weighted(coords.clone(), nu_re);
+    let k_local_im = batched_nedelec_local_stiffness_weighted(coords.clone(), nu_im);
+    let m_local_re = batched_nedelec_local_mass_anisotropic_full(coords.clone(), eps_re);
+    let m_local_im = batched_nedelec_local_mass_anisotropic_full(coords, eps_im);
+
+    // 2. Sign outer product (orientation flips).
+    let sign_flat: Vec<f32> = tet_edge_sign
+        .iter()
+        .flat_map(|row| row.iter().map(|&s| s as f32))
+        .collect();
+    let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), &device);
+    let sign_row = sign_2d.clone().unsqueeze_dim::<3>(2);
+    let sign_col = sign_2d.unsqueeze_dim::<3>(1);
+    let sign_outer = sign_row.mul(sign_col);
+
+    // 3. Flat scatter indices (shared by all four matrices).
+    let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
+    let n_edges_i32 = n_edges as i32;
+    for row in tet_edge_idx {
+        for i in 0..6 {
+            for j in 0..6 {
+                linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
+            }
+        }
+    }
+    let flat_indices =
+        Tensor::<B, 1, Int>::from_data(TensorData::new(linear_idx, [n_elem * 36]), &device);
+
+    // 4. Scatter-add each signed local matrix into a flat zero tensor.
+    let zeros_flat = Tensor::<B, 1>::zeros([n_edges * n_edges], &device);
+    let scatter_one = |local: Tensor<B, 3>| -> Tensor<B, 2> {
+        let signed = local.mul(sign_outer.clone());
+        zeros_flat
+            .clone()
+            .scatter(
+                0,
+                flat_indices.clone(),
+                signed.reshape([n_elem * 36]),
+                IndexingUpdateOp::Add,
+            )
+            .reshape([n_edges, n_edges])
+    };
+
+    let k_re = scatter_one(k_local_re);
+    let k_im = scatter_one(k_local_im);
+    let m_re = scatter_one(m_local_re);
+    let m_im = scatter_one(m_local_im);
+
+    let sparsity = sparsity_pattern_from_tet_edges(tet_edge_idx);
+
+    NedelecFullTensorGlobalSystem {
+        k_re,
+        k_im,
+        m_re,
+        m_im,
+        sparsity,
+    }
+}
+
 /// Assemble the global Nédélec right-hand-side vector for a
 /// **piecewise-constant** volumetric current density `J`.
 ///
@@ -1127,6 +1291,70 @@ pub fn assemble_nedelec_current_rhs<B: Backend>(
 
     // 4. Scatter-add into a [n_edges] zero tensor. Autodiff flows
     //    through the values via IndexingUpdateOp::Add.
+    let b_flat = b_signed.reshape([n_elem * 6]);
+    let zeros = Tensor::<B, 1>::zeros([n_edges], &device);
+    zeros.scatter(0, flat_indices, b_flat, IndexingUpdateOp::Add)
+}
+
+/// Degree-2 (4-point) quadrature variant of
+/// [`assemble_nedelec_current_rhs`] for a **spatially varying**
+/// current density sampled at the per-tet quadrature points
+/// (issue #199): `b_i = Σ_T Σ_q (V/4) N_i(x_q) · J(x_q)`.
+///
+/// Same batched-local-kernel
+/// ([`crate::nedelec::batched_nedelec_local_rhs_quad4`]) + sign +
+/// autodiff-preserving 1-D `scatter(0, …, Add)` structure as the
+/// constant-`J` assembler; reduces to it exactly when the four samples
+/// of a tet are equal. The samples are uploaded at the backend's full
+/// float precision (`B::FloatElem`).
+///
+/// * `j_quad` — `[n_elem][4][3]` per-tet current density at the four
+///   degree-2 quadrature points (see
+///   [`crate::nedelec::TET_QUAD4_A`] for the point convention; use
+///   [`crate::driven::QuadCurrentSource`] to sample a continuous
+///   `J(x)`).
+pub fn assemble_nedelec_current_rhs_quad4<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    n_edges: usize,
+    j_quad: &[[[f64; 3]; 4]],
+) -> Tensor<B, 1> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(j_quad.len(), n_elem, "j_quad length mismatch");
+
+    // 1. Per-element local RHS from the quadrature samples.
+    let coords = gather_tet_coords(nodes, tets);
+    let j_flat: Vec<B::FloatElem> = j_quad
+        .iter()
+        .flat_map(|t| t.iter().flat_map(|q| q.iter().map(|&x| x.elem())))
+        .collect();
+    let j_tensor = Tensor::<B, 3>::from_data(TensorData::new(j_flat, [n_elem, 4, 3]), &device);
+    let local = crate::nedelec::batched_nedelec_local_rhs_quad4(coords, j_tensor); // [n_elem, 6]
+
+    // 2. Apply per-DOF orientation signs (single factor for a vector).
+    let sign_flat: Vec<f32> = tet_edge_sign
+        .iter()
+        .flat_map(|row| row.iter().map(|&s| s as f32))
+        .collect();
+    let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), &device);
+    let b_signed = local.mul(sign_2d);
+
+    // 3. Flat scatter indices: global edge index per (e, i).
+    let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 6);
+    for row in tet_edge_idx {
+        for &edge in row.iter() {
+            linear_idx.push(edge as i32);
+        }
+    }
+    let flat_indices =
+        Tensor::<B, 1, Int>::from_data(TensorData::new(linear_idx, [n_elem * 6]), &device);
+
+    // 4. Scatter-add into a [n_edges] zero tensor.
     let b_flat = b_signed.reshape([n_elem * 6]);
     let zeros = Tensor::<B, 1>::zeros([n_edges], &device);
     zeros.scatter(0, flat_indices, b_flat, IndexingUpdateOp::Add)

--- a/crates/geode-core/src/scattering.rs
+++ b/crates/geode-core/src/scattering.rs
@@ -24,7 +24,7 @@
 //! equation is never posed inside the PML, so the formulation stays
 //! exact.
 //!
-//! # Matched UPML — why this module carries its own solve
+//! # Matched UPML — host oracle vs Burn path
 //!
 //! The eigenmode benchmarks' anisotropic UPML
 //! ([`crate::nedelec_assembly::build_anisotropic_pml_tensor_diag`])
@@ -50,12 +50,29 @@
 //! `A(ω) = K(Λ⁻¹) − ω² M(ε_r Λ)`. Because the lowest-order Nédélec
 //! curls are constant per tet and `∫ λ_p λ_q dV = (V/20)(1 + δ_pq)`
 //! is closed-form, both weighted matrices assemble exactly on the
-//! host (CPU, f64) without quadrature — this path deliberately skips
-//! the Burn batched-kernel layer (no autodiff through the benchmark;
-//! lifting the matched UPML into the Burn assembly layer so
-//! [`crate::driven::driven_solve`] can express it is tracked as
-//! follow-up work). The factorization reuses the same faer sparse LU
-//! as the driven solve.
+//! host (CPU, f64) without quadrature. The factorization reuses the
+//! same faer sparse LU as the driven solve.
+//!
+//! ## Burn path (issue #199) and the oracle decision: KEEP this solve
+//!
+//! The matched UPML is also expressible through the Burn batched-
+//! kernel layer: [`build_matched_upml_materials`] evaluates the per-tet
+//! `(ε_r·Λ, Λ⁻¹)` pair at tet centroids and
+//! [`crate::driven::DrivenMaterials::MatchedUpml`] feeds it to
+//! [`crate::driven::driven_solve`], which assembles `K(Λ⁻¹)` and
+//! `M(ε_rΛ)` through the autodiff-preserving scatter path
+//! ([`crate::nedelec_assembly::assemble_global_nedelec_with_full_tensors`]).
+//! The Burn path and this host path agree at assembly precision for
+//! the same `(σ₀, ω)` and the same per-tet-constant source
+//! (`tests/mie_driven_scattering.rs`).
+//!
+//! **Recorded decision**: `solve_scattered_field_matched_upml` is
+//! **kept** as an independent oracle rather than retired. It is the
+//! only assembly-independent cross-check of the Burn tensor-weighted
+//! kernels (closed-form host f64 assembly vs batched Burn scatter),
+//! exactly the role the CPU reference kernels play for the scalar
+//! path. Production/differentiable callers should prefer the Burn
+//! path via `driven_solve`.
 //!
 //! # Efficiency extraction — recorded choice (issue #195)
 //!
@@ -244,9 +261,11 @@ fn eval_curl(geom: &TetGeometry, dofs: &[c64; 6]) -> [c64; 3] {
 }
 
 /// Degree-2 4-point tet quadrature (barycentric points, equal weights
-/// `V/4`).
-const QUAD_A: f64 = 0.585_410_196_624_968_5;
-const QUAD_B: f64 = 0.138_196_601_125_010_5;
+/// `V/4`). Shared with the Burn-side quadrature RHS kernel
+/// ([`crate::nedelec::batched_nedelec_local_rhs_quad4`]) so the host
+/// and Burn paths integrate spatially varying sources identically.
+const QUAD_A: f64 = crate::nedelec::TET_QUAD4_A;
+const QUAD_B: f64 = crate::nedelec::TET_QUAD4_B;
 
 /// Extinction power via the volume optical theorem,
 ///
@@ -462,6 +481,65 @@ pub fn upml_matched_tensors(
     (lam, lam_inv)
 }
 
+/// Per-tet matched-UPML constitutive tensors for the Burn assembly
+/// path (issue #199): evaluates [`upml_matched_tensors`] at each tet
+/// centroid and returns `(ε, ν)` with `ε = ε_r·Λ` (mass weight) and
+/// `ν = Λ⁻¹` (curl-curl weight) — exactly the per-tet inputs the host
+/// path [`solve_scattered_field_matched_upml`] uses internally, so a
+/// [`crate::driven::driven_solve`] call with
+/// [`crate::driven::DrivenMaterials::MatchedUpml`] is a pure
+/// assembly-equivalence counterpart of the host solve.
+///
+/// - `ε_r = n_inside²` on tets tagged `interior_tag`, 1 elsewhere
+///   (the PML stretch multiplies on top).
+/// - `Λ ≠ I` only on tets tagged [`crate::mesh::PHYS_PML_SHELL`] with
+///   centroid radius beyond `R_PML_INNER` (identity in the interior /
+///   vacuum gap, and for `σ₀ = 0`).
+///
+/// `tet_physical_tags.len()` must equal the number of tets in `mesh`.
+#[allow(clippy::type_complexity)]
+pub fn build_matched_upml_materials(
+    mesh: &TetMesh,
+    tet_physical_tags: &[i32],
+    interior_tag: i32,
+    n_inside: f64,
+    sigma_0: f64,
+    omega: f64,
+) -> (Vec<[[c64; 3]; 3]>, Vec<[[c64; 3]; 3]>) {
+    assert_eq!(
+        tet_physical_tags.len(),
+        mesh.n_tets(),
+        "one physical tag per tet"
+    );
+    let centroids = crate::nedelec_assembly::tet_centroids(mesh);
+    let identity = {
+        let mut w = [[c64::new(0.0, 0.0); 3]; 3];
+        for (k, row) in w.iter_mut().enumerate() {
+            row[k] = c64::new(1.0, 0.0);
+        }
+        w
+    };
+
+    let mut eps_tensor = Vec::with_capacity(mesh.n_tets());
+    let mut nu_tensor = Vec::with_capacity(mesh.n_tets());
+    for (c, &tag) in centroids.iter().zip(tet_physical_tags.iter()) {
+        let eps_r = if tag == interior_tag {
+            n_inside * n_inside
+        } else {
+            1.0
+        };
+        let (lam, lam_inv) = if tag == crate::mesh::PHYS_PML_SHELL {
+            upml_matched_tensors(*c, sigma_0, omega)
+        } else {
+            (identity, identity)
+        };
+        let eps = lam.map(|row| row.map(|v| v * c64::new(eps_r, 0.0)));
+        eps_tensor.push(eps);
+        nu_tensor.push(lam_inv);
+    }
+    (eps_tensor, nu_tensor)
+}
+
 /// Quadratic form `aᵀ W b` for a complex 3×3 tensor and real vectors.
 fn sandwich(w: &[[c64; 3]; 3], a: [f64; 3], b: [f64; 3]) -> c64 {
     let mut acc = c64::new(0.0, 0.0);
@@ -475,8 +553,11 @@ fn sandwich(w: &[[c64; 3]; 3], a: [f64; 3], b: [f64; 3]) -> c64 {
 
 /// Scattered-field driven solve with the **matched** (full Sacks)
 /// UPML: `A(ω) x = b` with `A(ω) = K(Λ⁻¹) − ω² M(ε_r Λ)` assembled
-/// exactly on the host (see module docs for why this benchmark cannot
-/// use the ε-only UPML of [`crate::driven::driven_solve`]).
+/// exactly on the host. Kept as the **independent oracle** for the
+/// Burn-path matched UPML
+/// ([`crate::driven::DrivenMaterials::MatchedUpml`] +
+/// [`build_matched_upml_materials`]) — see the module docs for the
+/// recorded retire-vs-keep decision.
 ///
 /// - `pec_interior_mask` — per-edge keep mask over `mesh.edges()`
 ///   order (e.g. from

--- a/crates/geode-core/tests/matched_upml_burn.rs
+++ b/crates/geode-core/tests/matched_upml_burn.rs
@@ -1,0 +1,500 @@
+//! Validation of the Burn-path matched (full Sacks) UPML assembly
+//! (issue #199): full-3×3 complex tensor weights on both the curl-curl
+//! stiffness `K(ν = Λ⁻¹)` and the mass `M(ε = ε_r·Λ)`.
+//!
+//! Pins down:
+//!
+//! 1. **Reduction to the scalar path** — identity weights make the
+//!    full-tensor assembler agree with the established complex-ε
+//!    scalar assembler entrywise (independent kernels, same integral).
+//! 2. **Reduction to the diag kernel** — a diagonal ε tensor agrees
+//!    with [`geode_core::assemble_global_nedelec_with_anisotropic_epsilon`].
+//! 3. **Λ-weighted complex symmetry** (acceptance criterion (c)) —
+//!    `K(Λ⁻¹)ᵀ = K(Λ⁻¹)`, `M(ε_rΛ)ᵀ = M(ε_rΛ)`, and the full pencil
+//!    `A(ω) = K(Λ⁻¹) + iωC(σ) − ω²M(ε_rΛ)` satisfies `A(ω)ᵀ = A(ω)`
+//!    with σ₀ > 0 and σ > 0 (complex-symmetric, NOT Hermitian — same
+//!    invariant as `tests/sigma_conductivity.rs`).
+//! 4. **Autodiff** (acceptance criterion (e)) — gradients w.r.t. node
+//!    coordinates flow through all four scattered outputs.
+//! 5. **Input validation** — a wrong-length ν tensor errors, not
+//!    panics.
+//!
+//! The Burn-vs-host assembly-equivalence tests (σ₀ ∈ {0, 25} against
+//! [`geode_core::solve_scattered_field_matched_upml`]) live next to
+//! the benchmark in `tests/mie_driven_scattering.rs`.
+
+use burn::tensor::backend::BackendTypes;
+use burn::tensor::{Int, Tensor, TensorData};
+use faer::c64;
+
+use geode_core::{
+    assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
+    assemble_global_nedelec_with_full_tensors, assemble_nedelec_sigma_damping,
+    build_matched_upml_materials, cube_pec_interior_edges, cube_tet_mesh, driven_solve,
+    tet_centroids, upload_mesh, CurrentSource, DefaultBackend, DrivenBcs, DrivenError,
+    DrivenMaterials, TetMesh, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR, PHYS_VACUUM_GAP, R_PML_INNER,
+    R_SPHERE,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn readback_f64<const D: usize>(t: Tensor<B, D>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+/// Per-tet edge index/sign tables in the form the assemblers take.
+fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+    let tet_edges = mesh.tet_edges();
+    let idx = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let sign = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+    (idx, sign)
+}
+
+fn identity_tensor() -> [[c64; 3]; 3] {
+    let mut w = [[c64::new(0.0, 0.0); 3]; 3];
+    for (k, row) in w.iter_mut().enumerate() {
+        row[k] = c64::new(1.0, 0.0);
+    }
+    w
+}
+
+fn max_asymmetry(flat: &[f64], n: usize) -> f64 {
+    let mut worst = 0.0_f64;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            worst = worst.max((flat[i * n + j] - flat[j * n + i]).abs());
+        }
+    }
+    worst
+}
+
+fn max_abs_diff(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .fold(0.0_f64, |acc, (&x, &y)| acc.max((x - y).abs()))
+}
+
+fn max_abs(a: &[f64]) -> f64 {
+    a.iter().fold(0.0_f64, |acc, &x| acc.max(x.abs()))
+}
+
+/// Synthetic physical tags for a cube mesh spanning the matched-UPML
+/// radial shell: interior / vacuum gap / PML shell by centroid radius.
+fn radial_tags(mesh: &TetMesh) -> Vec<i32> {
+    tet_centroids(mesh)
+        .iter()
+        .map(|c| {
+            let r = (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt();
+            if r < R_SPHERE {
+                PHYS_SPHERE_INTERIOR
+            } else if r < R_PML_INNER {
+                PHYS_VACUUM_GAP
+            } else {
+                PHYS_PML_SHELL
+            }
+        })
+        .collect()
+}
+
+/// Identity weights collapse the full-tensor assembler onto the
+/// established scalar complex-ε path: `K(I)` must equal the real
+/// curl-curl `K` (with zero imaginary part) and `M(ε·I)` the scalar
+/// complex mass, entrywise. The two assemblers share no kernel code
+/// for the weighted contraction, so this is a real cross-check.
+#[test]
+fn full_tensor_assembly_reduces_to_scalar_path_for_identity_weights() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let dev = device();
+    let (nodes_t, tets_t) = upload_mesh::<B>(&mesh, &dev);
+
+    let eps_scalar: Vec<c64> = (0..mesh.n_tets())
+        .map(|e| c64::new(1.5 + 0.25 * (e % 4) as f64, -0.125 * (e % 3) as f64))
+        .collect();
+    let eps_tensor: Vec<[[c64; 3]; 3]> = eps_scalar
+        .iter()
+        .map(|&e| {
+            let mut w = [[c64::new(0.0, 0.0); 3]; 3];
+            for (k, row) in w.iter_mut().enumerate() {
+                row[k] = e;
+            }
+            w
+        })
+        .collect();
+    let nu_tensor: Vec<[[c64; 3]; 3]> = vec![identity_tensor(); mesh.n_tets()];
+
+    let sys_full = assemble_global_nedelec_with_full_tensors::<B>(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_tensor,
+        &nu_tensor,
+    );
+    let sys_scalar = assemble_global_nedelec_with_complex_epsilon::<B>(
+        nodes_t,
+        tets_t,
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_scalar,
+    );
+
+    let k_re = readback_f64(sys_full.k_re);
+    let k_im = readback_f64(sys_full.k_im);
+    let m_re = readback_f64(sys_full.m_re);
+    let m_im = readback_f64(sys_full.m_im);
+    let k_ref = readback_f64(sys_scalar.k);
+    let m_re_ref = readback_f64(sys_scalar.m_re);
+    let m_im_ref = readback_f64(sys_scalar.m_im);
+
+    let scale = max_abs(&k_ref).max(max_abs(&m_re_ref));
+    assert!(scale > 0.0);
+    let tol = 1e-5 * scale;
+
+    assert!(
+        max_abs_diff(&k_re, &k_ref) < tol,
+        "K(I) disagrees with the scalar curl-curl K: {:.3e}",
+        max_abs_diff(&k_re, &k_ref)
+    );
+    assert!(
+        max_abs(&k_im) < tol,
+        "K(I) must have zero imaginary part, got max {:.3e}",
+        max_abs(&k_im)
+    );
+    assert!(
+        max_abs_diff(&m_re, &m_re_ref) < tol,
+        "Re M(ε·I) disagrees with the scalar complex mass: {:.3e}",
+        max_abs_diff(&m_re, &m_re_ref)
+    );
+    assert!(
+        max_abs_diff(&m_im, &m_im_ref) < tol,
+        "Im M(ε·I) disagrees with the scalar complex mass: {:.3e}",
+        max_abs_diff(&m_im, &m_im_ref)
+    );
+}
+
+/// A purely diagonal ε tensor collapses the full-3×3 mass kernel onto
+/// the established diagonal-anisotropic kernel.
+#[test]
+fn full_tensor_mass_reduces_to_diag_kernel_for_diagonal_weight() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let dev = device();
+    let (nodes_t, tets_t) = upload_mesh::<B>(&mesh, &dev);
+
+    let eps_diag: Vec<[c64; 3]> = (0..mesh.n_tets())
+        .map(|e| {
+            [
+                c64::new(1.5, -0.5),
+                c64::new(2.25 + 0.25 * (e % 2) as f64, 0.25),
+                c64::new(0.75, -0.125),
+            ]
+        })
+        .collect();
+    let eps_tensor: Vec<[[c64; 3]; 3]> = eps_diag
+        .iter()
+        .map(|d| {
+            let mut w = [[c64::new(0.0, 0.0); 3]; 3];
+            for (k, row) in w.iter_mut().enumerate() {
+                row[k] = d[k];
+            }
+            w
+        })
+        .collect();
+    let nu_tensor: Vec<[[c64; 3]; 3]> = vec![identity_tensor(); mesh.n_tets()];
+
+    let sys_full = assemble_global_nedelec_with_full_tensors::<B>(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_tensor,
+        &nu_tensor,
+    );
+    let sys_diag = assemble_global_nedelec_with_anisotropic_epsilon::<B>(
+        nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &eps_diag,
+    );
+
+    let m_re = readback_f64(sys_full.m_re);
+    let m_im = readback_f64(sys_full.m_im);
+    let m_re_ref = readback_f64(sys_diag.m_re);
+    let m_im_ref = readback_f64(sys_diag.m_im);
+
+    let scale = max_abs(&m_re_ref);
+    assert!(scale > 0.0);
+    let tol = 1e-5 * scale;
+    assert!(
+        max_abs_diff(&m_re, &m_re_ref) < tol,
+        "Re M(diag ε) full-kernel vs diag-kernel mismatch: {:.3e}",
+        max_abs_diff(&m_re, &m_re_ref)
+    );
+    assert!(
+        max_abs_diff(&m_im, &m_im_ref) < tol,
+        "Im M(diag ε) full-kernel vs diag-kernel mismatch: {:.3e}",
+        max_abs_diff(&m_im, &m_im_ref)
+    );
+}
+
+/// Acceptance criterion (c): the Λ-weighted pencil stays
+/// complex-symmetric. `K(Λ⁻¹)ᵀ = K(Λ⁻¹)`, `M(ε_rΛ)ᵀ = M(ε_rΛ)`, and
+/// `A(ω) = K(Λ⁻¹) + iωC(σ) − ω²M(ε_rΛ)` satisfies `A(ω)ᵀ = A(ω)` with
+/// σ₀ > 0 (full Sacks stretch with off-diagonal Cartesian entries) and
+/// a nonzero conductivity composed on top (#196).
+#[test]
+fn lambda_weighted_pencil_stays_complex_symmetric() {
+    // Cube spanning [0, 2]³: centroid radii reach ≈ 3.2, so a healthy
+    // fraction of tets sits beyond R_PML_INNER = 1.5 and picks up the
+    // full (off-diagonal) Λ stretch.
+    let mesh = cube_tet_mesh(2, 2.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let dev = device();
+    let (nodes_t, tets_t) = upload_mesh::<B>(&mesh, &dev);
+
+    let omega = 1.7;
+    let sigma_0 = 25.0;
+    let tags = radial_tags(&mesh);
+    assert!(
+        tags.contains(&PHYS_PML_SHELL),
+        "test mesh must reach into the PML shell"
+    );
+    let (eps_tensor, nu_tensor) =
+        build_matched_upml_materials(&mesh, &tags, PHYS_SPHERE_INTERIOR, 1.5, sigma_0, omega);
+
+    let sys = assemble_global_nedelec_with_full_tensors::<B>(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_tensor,
+        &nu_tensor,
+    );
+    // Spatially varying conductivity on top (σ-composition, #196).
+    let sigma: Vec<f64> = tet_centroids(&mesh)
+        .iter()
+        .map(|c| 0.5 + 2.0 * c[0] + c[1])
+        .collect();
+    let c =
+        assemble_nedelec_sigma_damping::<B>(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &sigma);
+
+    let k_re = readback_f64(sys.k_re);
+    let k_im = readback_f64(sys.k_im);
+    let m_re = readback_f64(sys.m_re);
+    let m_im = readback_f64(sys.m_im);
+    let c = readback_f64(c);
+
+    let scale = [&k_re, &k_im, &m_re, &m_im, &c]
+        .iter()
+        .fold(0.0_f64, |a, v| a.max(max_abs(v)));
+    assert!(scale > 0.0);
+    let tol = 1e-5 * scale;
+
+    // The stretch must actually be active: K picks up an imaginary part.
+    assert!(
+        max_abs(&k_im) > tol,
+        "Λ⁻¹ stretch produced no imaginary stiffness — test setup is degenerate"
+    );
+
+    assert!(
+        max_asymmetry(&k_re, n_edges) < tol,
+        "Re K(Λ⁻¹) lost symmetry"
+    );
+    assert!(
+        max_asymmetry(&k_im, n_edges) < tol,
+        "Im K(Λ⁻¹) lost symmetry"
+    );
+    assert!(
+        max_asymmetry(&m_re, n_edges) < tol,
+        "Re M(ε_rΛ) lost symmetry"
+    );
+    assert!(
+        max_asymmetry(&m_im, n_edges) < tol,
+        "Im M(ε_rΛ) lost symmetry"
+    );
+
+    // Full pencil A(ω) = K(Λ⁻¹) + iωC − ω²M(ε_rΛ): Aᵀ = A.
+    let omega2 = omega * omega;
+    let a_re: Vec<f64> = (0..n_edges * n_edges)
+        .map(|i| k_re[i] - omega2 * m_re[i])
+        .collect();
+    let a_im: Vec<f64> = (0..n_edges * n_edges)
+        .map(|i| k_im[i] + omega * c[i] - omega2 * m_im[i])
+        .collect();
+    assert!(
+        max_asymmetry(&a_re, n_edges) < tol,
+        "Re(A(ω)) not symmetric with Λ-weighted K and σ > 0"
+    );
+    assert!(
+        max_asymmetry(&a_im, n_edges) < tol,
+        "Im(A(ω)) not symmetric with Λ-weighted K and σ > 0"
+    );
+}
+
+/// Acceptance criterion (e): autodiff smoke through the full-tensor
+/// assembly — gradients w.r.t. node coordinates must exist, be finite,
+/// and be nonzero somewhere for all four scattered outputs.
+#[test]
+fn full_tensor_assembly_preserves_autodiff() {
+    use burn::backend::Autodiff;
+    type Ad = Autodiff<B>;
+
+    let mesh = cube_tet_mesh(2, 2.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let tags = radial_tags(&mesh);
+    let (eps_tensor, nu_tensor) =
+        build_matched_upml_materials(&mesh, &tags, PHYS_SPHERE_INTERIOR, 1.5, 25.0, 1.7);
+
+    let n = mesh.n_nodes();
+    let n_elem = mesh.n_tets();
+    let ad_dev = <Ad as BackendTypes>::Device::default();
+    let node_flat: Vec<f32> = mesh
+        .nodes
+        .iter()
+        .flat_map(|p| p.iter().map(|&x| x as f32))
+        .collect();
+    let tet_flat: Vec<i32> = mesh
+        .tets
+        .iter()
+        .flat_map(|t| t.iter().map(|&i| i as i32))
+        .collect();
+    let nodes =
+        Tensor::<Ad, 2>::from_data(TensorData::new(node_flat, [n, 3]), &ad_dev).require_grad();
+    let tets = Tensor::<Ad, 2, Int>::from_data(TensorData::new(tet_flat, [n_elem, 4]), &ad_dev);
+
+    let sys = assemble_global_nedelec_with_full_tensors::<Ad>(
+        nodes.clone(),
+        tets,
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_tensor,
+        &nu_tensor,
+    );
+    let loss = sys.k_re.powf_scalar(2.0).sum()
+        + sys.k_im.powf_scalar(2.0).sum()
+        + sys.m_re.powf_scalar(2.0).sum()
+        + sys.m_im.powf_scalar(2.0).sum();
+    let grads = loss.backward();
+    let dnodes = nodes
+        .grad(&grads)
+        .expect("gradient w.r.t. nodes should exist");
+    let dnodes_vec: Vec<f64> = dnodes.into_data().iter::<f64>().collect();
+    assert!(
+        dnodes_vec.iter().all(|g| g.is_finite()),
+        "all gradients must be finite"
+    );
+    assert!(
+        dnodes_vec.iter().any(|g| g.abs() > 1e-6),
+        "gradient should be non-zero somewhere"
+    );
+}
+
+/// The degree-2 quadrature RHS ([`geode_core::QuadCurrentSource`] /
+/// `driven_solve_quad`) must reduce to the per-tet-constant RHS path
+/// for a constant-per-tet `J` — the rule integrates the Whitney basis
+/// times a constant exactly, and the kernel collapses algebraically
+/// (`A + 3B = 1`).
+#[test]
+fn quad_source_reduces_to_constant_source_for_constant_j() {
+    use geode_core::{driven_solve_quad, QuadCurrentSource};
+
+    let mesh = cube_tet_mesh(2, 1.0);
+    let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &interior,
+    };
+    let eps: Vec<c64> = vec![c64::new(1.5, -0.05); mesh.n_tets()];
+    let omega = 2.0;
+
+    // Per-tet-constant but tet-varying J.
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(c[1], 0.0),
+            c64::new(0.0, -0.5),
+            c64::new(1.0, c[0]),
+        ]
+    });
+    let quad_source = QuadCurrentSource::from_fn(&mesh, |t, _x| source.j_tet[t]);
+
+    let sol_const = driven_solve::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        &bcs,
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("constant-J solve");
+    let sol_quad = driven_solve_quad::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        &bcs,
+        omega,
+        &quad_source,
+        &device(),
+    )
+    .expect("quad-J solve");
+
+    let norm: f64 = sol_const
+        .e_edges
+        .iter()
+        .map(|e| e.norm_sqr())
+        .sum::<f64>()
+        .sqrt();
+    assert!(norm > 0.0);
+    let mut max_rel = 0.0_f64;
+    for (a, b) in sol_const.e_edges.iter().zip(sol_quad.e_edges.iter()) {
+        max_rel = max_rel.max((*a - *b).norm() / norm);
+    }
+    eprintln!("quad vs constant RHS (constant J): max relative diff = {max_rel:.3e}");
+    assert!(
+        max_rel < 1e-4,
+        "degree-2 quadrature RHS must reduce to the constant-J RHS for \
+         per-tet-constant J; max relative diff {max_rel:.3e}"
+    );
+}
+
+/// A wrong-length ν tensor must error, not panic.
+#[test]
+fn matched_upml_dim_mismatch_errors() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    };
+    let eps_tensor: Vec<[[c64; 3]; 3]> = vec![identity_tensor(); mesh.n_tets()];
+    let bad_nu: Vec<[[c64; 3]; 3]> = vec![identity_tensor(); 2];
+
+    let err = driven_solve::<B>(
+        &mesh,
+        DrivenMaterials::MatchedUpml {
+            epsilon_tensor: &eps_tensor,
+            nu_tensor: &bad_nu,
+        },
+        &DrivenBcs {
+            pec_interior_mask: &interior,
+        },
+        1.0,
+        &source,
+        &device(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, DrivenError::MaterialDimMismatch { .. }));
+}

--- a/crates/geode-core/tests/mie_driven_scattering.rs
+++ b/crates/geode-core/tests/mie_driven_scattering.rs
@@ -50,10 +50,11 @@
 use faer::c64;
 
 use geode_core::{
-    driven_solve, extinction_power, mie_efficiencies, mie_polarization_source,
-    plane_wave_polarization_current, q_from_power, scattered_flux_power,
-    solve_scattered_field_matched_upml, sphere_pec_interior_edges, DefaultBackend, DrivenBcs,
-    DrivenMaterials, PHYS_SPHERE_INTERIOR, R_BUFFER, R_PML_INNER, R_SPHERE,
+    build_matched_upml_materials, driven_solve, driven_solve_quad, extinction_power,
+    mie_efficiencies, mie_polarization_source, plane_wave_polarization_current, q_from_power,
+    scattered_flux_power, solve_scattered_field_matched_upml, sphere_pec_interior_edges,
+    DefaultBackend, DrivenBcs, DrivenMaterials, QuadCurrentSource, PHYS_SPHERE_INTERIOR, R_BUFFER,
+    R_PML_INNER, R_SPHERE,
 };
 
 const N_INSIDE: f64 = 1.5;
@@ -260,5 +261,225 @@ fn matched_upml_sigma_zero_reduces_to_driven_solve() {
         max_rel < 1e-4,
         "host matched-UPML assembly at σ₀ = 0 must reproduce driven_solve; \
          max relative diff {max_rel:.3e}"
+    );
+}
+
+/// Burn-path matched UPML vs host oracle (issue #199, acceptance
+/// criterion (a)): `driven_solve` with
+/// [`DrivenMaterials::MatchedUpml`] (per-tet `(ε_rΛ, Λ⁻¹)` from
+/// [`build_matched_upml_materials`], assembled through the Burn
+/// batched-kernel + scatter path) must agree with the host-assembled
+/// [`solve_scattered_field_matched_upml`] at assembly/solver precision
+/// for the same `(σ₀, ω)`, at σ₀ = 0 **and** σ₀ = 25 (the benchmark
+/// strength, where Λ carries off-diagonal Cartesian entries).
+///
+/// Both paths integrate the same spatially varying plane-wave
+/// polarization current with the same degree-2 quadrature rule
+/// ([`QuadCurrentSource`] vs the host's internal rule, identical
+/// points), so this is a pure assembly-equivalence test. Observed
+/// ~1e-12 on the f64 `ndarray` backend; the 1e-4 band matches the
+/// repo's cross-kernel tolerance on the default f32 GPU backend.
+#[test]
+fn matched_upml_burn_path_matches_host_oracle() {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+
+    let fixture = geode_core::read_sphere_fixture().expect("bundled sphere fixture");
+    let mesh = &fixture.mesh;
+    // ka = 1.9 sits on the TM_1,1 resonance feature — the operating
+    // point where the matched UPML matters most.
+    let omega = 1.9_f64;
+
+    let (_, interior) = sphere_pec_interior_edges(mesh, R_BUFFER);
+    let j_at = plane_wave_polarization_current(
+        &fixture.tet_physical_tags,
+        PHYS_SPHERE_INTERIOR,
+        N_INSIDE,
+        omega,
+    );
+    let source = QuadCurrentSource::from_fn(mesh, &j_at);
+
+    for &sigma_0 in &[0.0_f64, SIGMA_0] {
+        let sol_host = solve_scattered_field_matched_upml(
+            mesh,
+            &fixture.tet_physical_tags,
+            PHYS_SPHERE_INTERIOR,
+            &interior,
+            N_INSIDE,
+            sigma_0,
+            omega,
+            &j_at,
+        )
+        .expect("host matched-UPML solve");
+
+        let (eps_tensor, nu_tensor) = build_matched_upml_materials(
+            mesh,
+            &fixture.tet_physical_tags,
+            PHYS_SPHERE_INTERIOR,
+            N_INSIDE,
+            sigma_0,
+            omega,
+        );
+        let sol_burn = driven_solve_quad::<B>(
+            mesh,
+            DrivenMaterials::MatchedUpml {
+                epsilon_tensor: &eps_tensor,
+                nu_tensor: &nu_tensor,
+            },
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            omega,
+            &source,
+            &<B as BackendTypes>::Device::default(),
+        )
+        .expect("Burn matched-UPML solve");
+
+        let norm: f64 = sol_host
+            .e_edges
+            .iter()
+            .map(|e| e.norm_sqr())
+            .sum::<f64>()
+            .sqrt();
+        assert!(norm > 0.0, "σ₀ = {sigma_0}: source must excite a field");
+        let mut max_rel = 0.0_f64;
+        for (a, b) in sol_host.e_edges.iter().zip(sol_burn.e_edges.iter()) {
+            max_rel = max_rel.max((*a - *b).norm() / norm);
+        }
+        eprintln!(
+            "σ₀ = {sigma_0}: host vs Burn matched-UPML edge fields: \
+             max relative diff = {max_rel:.3e}"
+        );
+        assert!(
+            max_rel < 1e-4,
+            "σ₀ = {sigma_0}: Burn matched-UPML path must agree with the host \
+             oracle at assembly precision; max relative diff {max_rel:.3e}"
+        );
+    }
+}
+
+/// Acceptance criterion (b): the Mie driven benchmark **through the
+/// Burn path** reproduces (or improves) the recorded host-path
+/// accuracy, `max_rel_err_q_ext ≤ 1.688e-1` and
+/// `max_rel_err_q_sca ≤ 1.869e-1`
+/// (`benchmarks/mie_sphere/driven_results.toml`). The quadrature
+/// source ([`QuadCurrentSource`]) integrates the plane-wave phase with
+/// the same degree-2 rule as the host benchmark, so per-point Q values
+/// match the recorded ones to assembly precision; the per-point
+/// calibrated bands are also asserted.
+#[test]
+fn burn_matched_upml_reproduces_benchmark_accuracy() {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+
+    // Pinned maxima from benchmarks/mie_sphere/driven_results.toml
+    // (host matched-UPML path, σ₀ = 25).
+    const MAX_REL_ERR_Q_EXT: f64 = 1.687635419282027e-1;
+    const MAX_REL_ERR_Q_SCA: f64 = 1.868695905294832e-1;
+    // The Burn path reproduces the host figures to assembly precision,
+    // not bit-exactly: observed |Δ| ≲ 1e-6 (relative) on the f32 wgpu
+    // backend, ~1e-12 on the f64 ndarray backend. The 1e-3 relative
+    // headroom keeps the bound meaningful (0.02 % absolute on Q) while
+    // not flagging backend round-off as a regression.
+    const ASSEMBLY_PRECISION_HEADROOM: f64 = 1.0 + 1e-3;
+
+    let fixture = geode_core::read_sphere_fixture().expect("bundled sphere fixture");
+    let mesh = &fixture.mesh;
+    let (_, interior) = sphere_pec_interior_edges(mesh, R_BUFFER);
+    let device = <B as BackendTypes>::Device::default();
+
+    let mut max_ext = 0.0_f64;
+    let mut max_sca = 0.0_f64;
+    for &(ka, band) in &KA_BANDS {
+        let omega = ka / R_SPHERE;
+        let j_at = plane_wave_polarization_current(
+            &fixture.tet_physical_tags,
+            PHYS_SPHERE_INTERIOR,
+            N_INSIDE,
+            omega,
+        );
+        let source = QuadCurrentSource::from_fn(mesh, j_at);
+        let (eps_tensor, nu_tensor) = build_matched_upml_materials(
+            mesh,
+            &fixture.tet_physical_tags,
+            PHYS_SPHERE_INTERIOR,
+            N_INSIDE,
+            SIGMA_0,
+            omega,
+        );
+        let sol = driven_solve_quad::<B>(
+            mesh,
+            DrivenMaterials::MatchedUpml {
+                epsilon_tensor: &eps_tensor,
+                nu_tensor: &nu_tensor,
+            },
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            omega,
+            &source,
+            &device,
+        )
+        .expect("Burn matched-UPML solve");
+        assert!(
+            sol.residual_rel < 1e-8,
+            "ka = {ka}: direct-solve residual {} above round-off floor",
+            sol.residual_rel
+        );
+
+        let q_ext = q_from_power(
+            extinction_power(
+                mesh,
+                &fixture.tet_physical_tags,
+                PHYS_SPHERE_INTERIOR,
+                N_INSIDE,
+                omega,
+                &sol.e_edges,
+            ),
+            R_SPHERE,
+        );
+        let q_sca = q_from_power(
+            scattered_flux_power(mesh, omega, &sol.e_edges, R_OBS),
+            R_SPHERE,
+        );
+        let analytic = mie_efficiencies(N_INSIDE, ka);
+        let err_ext = (q_ext - analytic.q_ext).abs() / analytic.q_ext;
+        let err_sca = (q_sca - analytic.q_sca).abs() / analytic.q_sca;
+        eprintln!(
+            "Burn path ka = {ka:4.2}: Q_ext err {:.2}%, Q_sca err {:.2}% [band {:.0}%]",
+            100.0 * err_ext,
+            100.0 * err_sca,
+            100.0 * band
+        );
+        assert!(
+            err_ext < band && err_sca < band,
+            "ka = {ka}: Burn-path Q errors ({:.2}% / {:.2}%) exceed the \
+             calibrated {:.0}% band",
+            100.0 * err_ext,
+            100.0 * err_sca,
+            100.0 * band
+        );
+        max_ext = max_ext.max(err_ext);
+        max_sca = max_sca.max(err_sca);
+    }
+    eprintln!(
+        "Burn-path driven Mie sweep: max rel err Q_ext = {:.4}% (host benchmark {:.4}%), \
+         Q_sca = {:.4}% (host benchmark {:.4}%)",
+        100.0 * max_ext,
+        100.0 * MAX_REL_ERR_Q_EXT,
+        100.0 * max_sca,
+        100.0 * MAX_REL_ERR_Q_SCA
+    );
+    assert!(
+        max_ext <= MAX_REL_ERR_Q_EXT * ASSEMBLY_PRECISION_HEADROOM,
+        "Burn-path max Q_ext rel err {:.6e} exceeds the recorded benchmark {:.6e}",
+        max_ext,
+        MAX_REL_ERR_Q_EXT
+    );
+    assert!(
+        max_sca <= MAX_REL_ERR_Q_SCA * ASSEMBLY_PRECISION_HEADROOM,
+        "Burn-path max Q_sca rel err {:.6e} exceeds the recorded benchmark {:.6e}",
+        max_sca,
+        MAX_REL_ERR_Q_SCA
     );
 }


### PR DESCRIPTION
## Summary

Lifts the matched (full Sacks) UPML out of the host-only assembly in `scattering.rs` and into the Burn batched-kernel layer, so `driven_solve` can express `A(ω) = K(Λ⁻¹) + iωC(σ) − ω²M(ε_rΛ)` with autodiff preserved up to the host transfer. The host path is kept as the independent assembly oracle (recorded decision, see below).

## Changes

- **`nedelec.rs`** — two new batched kernels with a **full 3×3** per-tet weight (the curator-flagged critical requirement; the existing mass kernel is diagonal-only and cannot reproduce the host's off-diagonal Λ):
  - `batched_nedelec_local_stiffness_weighted`: `K^W_ij = V·c_iᵀ W c_j` over the constant per-tet Whitney curls (reduces to the scalar `k_local` for `W = I` via the Lagrange identity).
  - `batched_nedelec_local_mass_anisotropic_full`: scalar mass closed form with the gradient gram replaced by the weighted gram `∇λ_pᵀ W ∇λ_q` (generalizes the diag-only kernel).
  - `batched_nedelec_local_rhs_quad4` + shared `TET_QUAD4_A/B` consts: degree-2 (4-point) quadrature RHS for spatially varying `J(x)`, algebraically reducing to the constant-`J` kernel for constant samples. Needed so the Burn-path benchmark integrates the plane-wave phase identically to the host (criterion (b)).
- **`nedelec_assembly.rs`** — `assemble_global_nedelec_with_full_tensors` (4 kernel passes: Re/Im × K/M, weights uploaded at `B::FloatElem` precision, same sign-outer-product + 1-D `scatter(Add)` path) returning `NedelecFullTensorGlobalSystem` (complex K **and** complex M); `assemble_nedelec_current_rhs_quad4`.
- **`driven.rs`** — `DrivenMaterials::MatchedUpml { epsilon_tensor, nu_tensor }`; dispatch handles the now-complex stiffness (`k_im` is `None` for the ε-only variants); `QuadCurrentSource` + `driven_solve_quad` / `driven_solve_with_sigma_quad` (internal refactor to a shared `driven_solve_impl`, constant-`J` path unchanged); σ-composition (#196) works unchanged on top.
- **`scattering.rs`** — `build_matched_upml_materials` (per-tet `(ε_rΛ, Λ⁻¹)` at centroids via `upml_matched_tensors`, identical inputs to the host loop); module docs record the oracle decision; quadrature consts now shared with `nedelec.rs`.
- **Tests** — new `tests/matched_upml_burn.rs` (kernel reductions, Λ-weighted complex symmetry with σ-composition, autodiff, quad-RHS reduction, input validation) and two new tests in `tests/mie_driven_scattering.rs` (Burn-vs-host oracle at σ₀ ∈ {0, 25}; Burn-path benchmark accuracy vs the pinned TOML maxima).

## Retire-vs-keep decision (criterion (d))

**KEEP** `solve_scattered_field_matched_upml` as the independent host oracle, per the curator recommendation: it is the only assembly-independent (closed-form, host f64) cross-check of the new Burn tensor-weighted kernels. Recorded in the `scattering.rs` module docs; production/differentiable callers should prefer the Burn path via `driven_solve`. The benchmark example and `driven_results.toml` stay on the host path (unchanged), with the Burn path pinned to the same accuracy by test.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| (a) Burn vs host agreement at assembly precision, σ₀ ∈ {0, 25}, 774-node fixture | ✅ | `matched_upml_burn_path_matches_host_oracle` at ω = 1.9: max edge-field rel diff **1.77e-14** (σ₀ = 0) and **1.27e-15** (σ₀ = 25) on the f64 ndarray backend (target ≲ 1e-10); 1.3e-6 / 2.2e-7 on the f32 wgpu backend (asserted < 1e-4, the repo's cross-backend band) |
| (b) Burn-path Mie benchmark reproduces pinned accuracy | ✅ | `burn_matched_upml_reproduces_benchmark_accuracy`: max rel err Q_ext **16.8764 %** (pinned 16.8764 %), Q_sca **18.6870 %** (pinned 18.6870 %) — identical to the host benchmark to assembly precision (quadrature source); per-point calibrated bands also asserted |
| (c) Complex-symmetry regression with Λ-weighted K | ✅ | `lambda_weighted_pencil_stays_complex_symmetric`: `K(Λ⁻¹)ᵀ = K(Λ⁻¹)` (Re and Im), `M(ε_rΛ)ᵀ = M(ε_rΛ)`, `A(ω)ᵀ = A(ω)` with σ₀ = 25 and varying σ > 0, following the `max_asymmetry` pattern of `tests/sigma_conductivity.rs` |
| (d) Retire-vs-keep decision recorded | ✅ | KEEP as oracle — PR description + `scattering.rs` module docs ("Burn path (issue #199) and the oracle decision") |
| (e) Autodiff preserved | ✅ | All four matrices assemble through pure Burn tensor ops + `scatter(0, …, Add)`; `full_tensor_assembly_preserves_autodiff` checks finite, nonzero node-coordinate gradients through the full-tensor assembly |
| Item 4 of issue body (eigenmode re-run / #33) | ➖ | Out of scope per curator; not implemented |

## Test Plan

- `cargo test --workspace --release` (default wgpu backend): **all green**, 0 failures (new: 6 tests in `matched_upml_burn.rs`, 2 in `mie_driven_scattering.rs`)
- `cargo test -p geode-core --release --no-default-features --features ndarray --test mie_driven_scattering --test matched_upml_burn`: all green (f64 precision figures above)
- `cargo clippy --workspace --tests -- -D warnings`: clean (both default and ndarray feature sets)
- `cargo fmt --check`: clean
- Benchmark TOML untouched (benchmark stays on the host oracle path; regenerating is only required if the example switches paths, which it deliberately does not)

Closes #199