### PR TITLE
feat: Palace-style uniform lumped port for driven_solve (excitation + R termination, V/I bookkeeping)

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -46,6 +46,15 @@
 //!   [`crate::scattering::build_matched_upml_materials`]; the
 //!   host-assembled oracle is
 //!   [`crate::scattering::solve_scattered_field_matched_upml`].
+//! - **Lumped port** (issue #202) — a Palace-style uniform port on a
+//!   boundary surface Γ_p ([`crate::lumped_port::LumpedPort`], passed
+//!   to [`driven_solve_with_ports`]): a resistive termination adds the
+//!   iω-scaled tangential surface mass `(jω/Z_s) S_p` to `A(ω)`
+//!   (`Z_s = R·w/l`; real symmetric `S_p`, so `A(ω)ᵀ = A(ω)` is
+//!   preserved), and a non-zero incident voltage `V_inc` adds the
+//!   surface drive `b_i += (2jω/Z_s)(V_inc/l) ∮ N_i · ê dS` to the
+//!   RHS. See `lumped_port.rs` for the derivation and the V/I
+//!   bookkeeping helpers.
 //!
 //! # Solver
 //!
@@ -86,6 +95,7 @@ use faer::sparse::{SparseColMat, Triplet};
 
 use crate::complex_lanczos::{solve_with_lu, spmv};
 use crate::eigen::burn_matrix_to_faer;
+use crate::lumped_port::{assemble_port_flux, assemble_port_surface_mass, LumpedPort};
 use crate::nedelec_assembly::{
     assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
     assemble_global_nedelec_with_full_tensors, assemble_nedelec_current_rhs,
@@ -106,6 +116,8 @@ pub enum DrivenError {
     SigmaDimMismatch { got: usize, want: usize },
     #[error("driven system has no interior DOFs after PEC elimination")]
     EmptyInterior,
+    #[error("invalid lumped port {index}: {reason}")]
+    InvalidPort { index: usize, reason: String },
     #[error("sparse system assembly failed: {0}")]
     SparseAssembly(String),
     #[error("sparse LU factorization of A(ω) failed: {0}")]
@@ -324,6 +336,54 @@ pub fn driven_solve_with_sigma<B: Backend>(
         materials,
         sigma_tet,
         bcs,
+        &[],
+        omega,
+        RhsSamples::Constant(&source.j_tet),
+        device,
+    )
+}
+
+/// [`driven_solve_with_sigma`] with **lumped ports** (issue #202).
+///
+/// Each [`LumpedPort`] contributes two boundary-surface terms on its
+/// port surface Γ_p (Palace-style uniform port, surface impedance
+/// `Z_s = R·w/l`):
+///
+/// ```text
+/// A(ω) += (jω/Z_s) S_p,                        S_p = ∮ (n×N_i)·(n×N_j) dS
+/// b_i  += (2jω/Z_s) (V_inc/l) ∮ N_i · ê dS     (only if V_inc ≠ 0)
+/// ```
+///
+/// The admittance term is a real-symmetric surface mass scaled by `jω`,
+/// so the complex-symmetry invariant `A(ω)ᵀ = A(ω)` (PR #55) is
+/// preserved with ports present. Ports compose with PEC walls the same
+/// way the other surface terms do: PEC-eliminated edges are dropped
+/// from both the port matrix rows/columns and the port RHS.
+///
+/// Port voltage / current / input impedance are read off the solution
+/// with [`crate::lumped_port::port_voltage`],
+/// [`crate::lumped_port::port_current`] and
+/// [`crate::lumped_port::port_input_impedance`].
+///
+/// An empty `ports` slice reproduces [`driven_solve_with_sigma`]
+/// exactly.
+#[allow(clippy::too_many_arguments)]
+pub fn driven_solve_with_ports<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
+    omega: f64,
+    source: &CurrentSource,
+    device: &B::Device,
+) -> Result<DrivenSolution, DrivenError> {
+    driven_solve_impl::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        ports,
         omega,
         RhsSamples::Constant(&source.j_tet),
         device,
@@ -361,17 +421,20 @@ pub fn driven_solve_with_sigma_quad<B: Backend>(
         materials,
         sigma_tet,
         bcs,
+        &[],
         omega,
         RhsSamples::Quad(&source.j_quad),
         device,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn driven_solve_impl<B: Backend>(
     mesh: &TetMesh,
     materials: DrivenMaterials<'_>,
     sigma_tet: Option<&[f64]>,
     bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
     omega: f64,
     rhs: RhsSamples<'_>,
     device: &B::Device,
@@ -421,6 +484,36 @@ fn driven_solve_impl<B: Backend>(
                 got: sigma.len(),
                 want: n_tets,
             });
+        }
+    }
+    for (index, port) in ports.iter().enumerate() {
+        let invalid = |reason: &str| DrivenError::InvalidPort {
+            index,
+            reason: reason.to_string(),
+        };
+        if port.faces.is_empty() {
+            return Err(invalid("port has no faces"));
+        }
+        if !(port.resistance.is_finite() && port.resistance > 0.0) {
+            return Err(invalid("resistance must be finite and positive"));
+        }
+        if !(port.width.is_finite() && port.width > 0.0) {
+            return Err(invalid("width must be finite and positive"));
+        }
+        if !(port.length.is_finite() && port.length > 0.0) {
+            return Err(invalid("length must be finite and positive"));
+        }
+        let e_norm = (port.e_hat[0].powi(2) + port.e_hat[1].powi(2) + port.e_hat[2].powi(2)).sqrt();
+        if (e_norm - 1.0).abs() >= 1e-8 || e_norm.is_nan() {
+            return Err(invalid("e_hat must be a unit vector"));
+        }
+        let n_nodes = mesh.n_nodes() as u32;
+        if port
+            .faces
+            .iter()
+            .any(|f| f.iter().any(|&node| node >= n_nodes))
+        {
+            return Err(invalid("face node index out of range"));
         }
     }
 
@@ -541,11 +634,28 @@ fn driven_solve_impl<B: Backend>(
     let rhs_im: Vec<f64> = rhs_im.into_data().iter::<f64>().collect();
 
     // b = iωμ₀ ∫ N · J dV with μ₀ = 1:  iω (re + i·im) = ω(−im + i·re).
-    let b_full: Vec<c64> = rhs_re
+    let mut b_full: Vec<c64> = rhs_re
         .iter()
         .zip(rhs_im.iter())
         .map(|(&re, &im)| c64::new(-omega * im, omega * re))
         .collect();
+
+    // --- Lumped-port excitation (issue #202) --------------------------------
+    // Matched-source port drive: b_i += (2jω/Z_s)(V_inc/l) ∮ N_i · ê dS.
+    // The flux vector f_i = ∮ N_i · ê dS doubles as the port-voltage
+    // readout functional (see lumped_port.rs).
+    for port in ports {
+        if port.v_inc == c64::new(0.0, 0.0) {
+            continue;
+        }
+        let zs = port.surface_impedance();
+        let e_inc = port.v_inc * (1.0 / port.length);
+        let drive = c64::new(0.0, 2.0 * omega / zs) * e_inc;
+        let flux = assemble_port_flux(mesh, port.faces, port.e_hat, &edges);
+        for (b, f) in b_full.iter_mut().zip(flux.iter()) {
+            *b += drive * *f;
+        }
+    }
 
     // --- Host transfer + PEC reduction -------------------------------------
     let k_full = burn_matrix_to_faer(k_re_t);
@@ -583,6 +693,25 @@ fn driven_solve_impl<B: Backend>(
         }
         triplets.push(Triplet::new(rr as usize, cc as usize, a_val));
     }
+
+    // --- Lumped-port admittance terms (issue #202) --------------------------
+    // A(ω) += (jω/Z_s) S_p per port. S_p is real symmetric, so the
+    // complex-symmetry invariant A(ω)ᵀ = A(ω) is preserved. The port
+    // faces are boundary faces of mesh tets, so every (r, c) pair below
+    // already exists in the volume sparsity pattern; faer's
+    // `try_new_from_triplets` sums duplicate entries.
+    for port in ports {
+        let zs = port.surface_impedance();
+        let scale = c64::new(0.0, omega / zs);
+        for (r, c, v) in assemble_port_surface_mass(mesh, port.faces, &edges) {
+            let (rr, cc) = (remap[r], remap[c]);
+            if rr < 0 || cc < 0 {
+                continue;
+            }
+            triplets.push(Triplet::new(rr as usize, cc as usize, scale * v));
+        }
+    }
+
     let a_int =
         SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
             .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod driven;
 pub mod eigen;
 pub mod fe_assemble;
 pub mod lanczos;
+pub mod lumped_port;
 pub mod mesh;
 pub mod mie;
 pub mod mie_open;
@@ -35,8 +36,9 @@ pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
 pub use driven::{
-    driven_solve, driven_solve_quad, driven_solve_with_sigma, driven_solve_with_sigma_quad,
-    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenSolution, QuadCurrentSource,
+    driven_solve, driven_solve_quad, driven_solve_with_ports, driven_solve_with_sigma,
+    driven_solve_with_sigma_quad, CurrentSource, DrivenBcs, DrivenError, DrivenMaterials,
+    DrivenSolution, QuadCurrentSource,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
@@ -44,6 +46,10 @@ pub use eigen::{
 };
 pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
 pub use lanczos::{SparseEigenSolver, SparseShiftInvertLanczos};
+pub use lumped_port::{
+    assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
+    port_voltage, LumpedPort,
+};
 #[allow(deprecated)]
 pub use mesh::PHYS_VACUUM_BUFFER;
 pub use mesh::{

--- a/crates/geode-core/src/lumped_port.rs
+++ b/crates/geode-core/src/lumped_port.rs
@@ -1,0 +1,581 @@
+//! Palace-style **uniform lumped port** (Epic #193, issue #202).
+//!
+//! A lumped port is a rectangular boundary surface Γ_p bridging two
+//! conductors — width `w` along the conductors, gap length `l` across
+//! them — that carries both the **excitation** that drives a structure
+//! and the **resistive termination** `R` that loads it. The port field
+//! is assumed uniform across the gap with unit direction `ê` (Palace's
+//! "uniform" port), and the lumped resistance maps to the surface
+//! impedance
+//!
+//! ```text
+//! Z_s = R · w / l        (units of η₀; natural units η₀ = 1)
+//! ```
+//!
+//! # Boundary condition and weak form
+//!
+//! With the codebase's `exp(+jωt)` convention (`∇×E = −jωH`, μ₀ = 1)
+//! the matched-source port boundary condition on Γ_p (outward normal
+//! `n`) is the Robin condition
+//!
+//! ```text
+//! n × (∇×E) + (jω/Z_s) n × (n × E) = −(2jω/Z_s) E_inc,
+//! E_inc = (V_inc / l) ê,
+//! ```
+//!
+//! which is exact for a superposition of an incident wave (drive,
+//! entering the domain) and an outgoing wave (reflection), both with
+//! wave impedance `Z_s`. Setting `Z_s = 1`, `V_inc = 0` recovers the
+//! first-order Silver-Müller absorber (see `silvermuller.rs`, whose
+//! derivation this module follows). In the curl-curl weak form the
+//! boundary term `−∮ (n×v)·(∇×E)` then contributes
+//!
+//! - **Termination** — a port admittance term on the system matrix:
+//!   `A(ω) += (jω/Z_s) S_p`, with the real-symmetric tangential surface
+//!   mass `S_p[i,j] = ∮_{Γ_p} (n×N_i)·(n×N_j) dS = ∮ N_i·N_j dS`
+//!   (BAC-CAB rank reduction on flat faces, as in `silvermuller.rs`).
+//!   Real `R` keeps `A(ω)ᵀ = A(ω)` — the complex-symmetry invariant
+//!   (PR #55) is preserved.
+//! - **Excitation** — a surface-current-like RHS:
+//!   `b_i += (2jω/Z_s)(V_inc/l) ∮_{Γ_p} N_i · ê dS`, the boundary
+//!   analogue of the volumetric `b_i = jω ∫ N_i · J dV` drive.
+//!
+//! # Port voltage / current bookkeeping
+//!
+//! The circuit quantities needed to read an input impedance off the
+//! field solution (full `Z(ω) → L/R/Q` extraction is issue #203):
+//!
+//! ```text
+//! V  = (1/w) ∮_{Γ_p} E · ê dS          (gap line integral of E,
+//!                                       averaged across the width)
+//! I  = (2 V_inc − V) / R               (admittance relation of the
+//!                                       Thevenin port: source 2·V_inc
+//!                                       behind R)
+//! Z_in = V / I
+//! ```
+//!
+//! With these conventions a structure that presents a matched load
+//! (`Z_in = R`) absorbs the drive completely (`V = V_inc`), and the
+//! analytic transmission-line oracle (PEC-shorted parallel-plate line
+//! of length `d`, characteristic impedance `Z₀ = l/w`) reads
+//! `Z_in = j Z₀ tan(ωd)` — see `tests/lumped_port.rs`.
+//!
+//! # Discretization
+//!
+//! Same first-order Whitney triangle kernel as the Silver-Müller
+//! surface matrix: the mass integrand `N_i·N_j` is degree-2 in
+//! barycentric coordinates and is integrated with the 3-point
+//! edge-midpoint rule (Hammer-Stroud, degree-2 exact); the flux
+//! integrand `N_i·ê` is degree-1 with the closed form
+//! `∫_T N_e dA = (area/3)(∇λ_b − ∇λ_a)`. Edge orientation signs follow
+//! the lower-tag-first global convention of `nedelec_assembly`.
+//!
+//! Assembly here is host-side `f64` (like
+//! [`crate::silvermuller::assemble_silver_muller_surface`]); the port
+//! terms are frequency-independent real matrices/vectors scaled by
+//! `jω/Z_s` at solve time inside [`crate::driven`].
+
+use std::collections::HashMap;
+
+use faer::c64;
+
+use crate::TetMesh;
+
+/// Palace-style uniform lumped port specification.
+///
+/// The port surface is given as an explicit triangle list (gmsh
+/// physical-group mapping arrives with Phase 3 meshing). All triangles
+/// must be faces of the volume mesh on its boundary, and `e_hat` must
+/// be a **unit** vector tangential to the port plane, pointing across
+/// the gap (from one conductor to the other).
+#[derive(Debug, Clone)]
+pub struct LumpedPort<'a> {
+    /// Port surface triangles: `[n][3]` 0-based node indices into
+    /// `mesh.nodes`. Winding order does not matter (the tangential
+    /// kernel is orientation-free, like the Silver-Müller one).
+    pub faces: &'a [[u32; 3]],
+    /// Uniform unit field direction `ê` across the gap (tangential to
+    /// the port faces).
+    pub e_hat: [f64; 3],
+    /// Lumped port resistance `R` in natural units (units of η₀).
+    pub resistance: f64,
+    /// Port width `w` (extent perpendicular to `ê`, along the
+    /// conductors).
+    pub width: f64,
+    /// Gap length `l` (extent along `ê`, between the conductors).
+    pub length: f64,
+    /// Incident (drive) voltage `V_inc` across the gap. Zero makes the
+    /// port a passive resistive termination.
+    pub v_inc: c64,
+}
+
+impl LumpedPort<'_> {
+    /// Surface impedance of the uniform port: `Z_s = R · w / l`.
+    pub fn surface_impedance(&self) -> f64 {
+        self.resistance * self.width / self.length
+    }
+}
+
+/// Per-face Whitney geometry shared by the mass and flux kernels.
+struct FaceGeometry {
+    /// Triangle area.
+    area: f64,
+    /// In-plane gradients of the three barycentric coordinates.
+    grad_lambda: [[f64; 3]; 3],
+    /// `(global_edge_index, orientation_sign)` for the three local
+    /// edges in [`TRI_LOCAL_EDGES`] order.
+    edge_info: [(u32, i8); 3],
+}
+
+/// Local edge order on a triangle face (lower local index first),
+/// matching `silvermuller.rs`.
+const TRI_LOCAL_EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
+
+fn face_geometry(
+    tri: &[u32; 3],
+    v: &[[f64; 3]; 3],
+    edge_lookup: &HashMap<(u32, u32), u32>,
+) -> FaceGeometry {
+    let e10 = sub3(v[1], v[0]);
+    let e20 = sub3(v[2], v[0]);
+    let cross = cross3(e10, e20);
+    let two_area = norm3(cross);
+    let area = 0.5 * two_area;
+    let n_hat = [
+        cross[0] / two_area,
+        cross[1] / two_area,
+        cross[2] / two_area,
+    ];
+
+    // In-plane gradients of triangle barycentric coords:
+    //   ∇λ_k = (n_hat × edge_opposite_k) / (2 area).
+    let opp = [sub3(v[2], v[1]), sub3(v[0], v[2]), sub3(v[1], v[0])];
+    let grad_lambda: [[f64; 3]; 3] = [
+        scale3(cross3(n_hat, opp[0]), 1.0 / two_area),
+        scale3(cross3(n_hat, opp[1]), 1.0 / two_area),
+        scale3(cross3(n_hat, opp[2]), 1.0 / two_area),
+    ];
+
+    // Global-edge mapping + orientation sign (lower-tag-first), same
+    // convention as the volume assembly and silvermuller.rs.
+    let mut edge_info: [(u32, i8); 3] = [(0, 1); 3];
+    for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+        let ga = tri[la];
+        let gb = tri[lb];
+        let (lo, hi, sign) = if ga < gb {
+            (ga, gb, 1i8)
+        } else {
+            (gb, ga, -1i8)
+        };
+        let gidx = *edge_lookup
+            .get(&(lo, hi))
+            .expect("port face edge must appear in global edge table");
+        edge_info[k] = (gidx, sign);
+    }
+
+    FaceGeometry {
+        area,
+        grad_lambda,
+        edge_info,
+    }
+}
+
+fn edge_lookup(edges: &[[u32; 2]]) -> HashMap<(u32, u32), u32> {
+    let mut lookup = HashMap::with_capacity(edges.len());
+    for (idx, e) in edges.iter().enumerate() {
+        lookup.insert((e[0], e[1]), idx as u32);
+    }
+    lookup
+}
+
+/// Assemble the **tangential surface mass** of a port surface as signed
+/// global triplets:
+///
+/// ```text
+/// S_p[i, j] = ∮_{Γ_p} (n × N_i) · (n × N_j) dS = ∮_{Γ_p} N_i · N_j dS
+/// ```
+///
+/// Returns `(row, col, value)` triplets over global edge indices
+/// (duplicate entries to be summed by the caller, e.g. faer's
+/// `try_new_from_triplets`). The assembled matrix is real symmetric, so
+/// scaling by `jω/Z_s` preserves the complex-symmetry invariant
+/// `A(ω)ᵀ = A(ω)`.
+///
+/// Same kernel as
+/// [`crate::silvermuller::assemble_silver_muller_surface`] (3-point
+/// edge-midpoint quadrature, degree-2 exact) in sparse triplet form —
+/// the unit tests cross-validate the two implementations.
+///
+/// # Panics
+///
+/// Panics if a face references an edge absent from `edges` (i.e. the
+/// triangles are not faces of the volume mesh).
+pub fn assemble_port_surface_mass(
+    mesh: &TetMesh,
+    faces: &[[u32; 3]],
+    edges: &[[u32; 2]],
+) -> Vec<(usize, usize, f64)> {
+    let lookup = edge_lookup(edges);
+    let mut triplets = Vec::with_capacity(faces.len() * 9);
+
+    // λ values at the three edge midpoints (degree-2 exact rule).
+    const BARYCENTRIC_MIDPOINTS: [[f64; 3]; 3] = [
+        [0.5, 0.5, 0.0], // m_01
+        [0.5, 0.0, 0.5], // m_02
+        [0.0, 0.5, 0.5], // m_12
+    ];
+
+    for tri in faces {
+        let v: [[f64; 3]; 3] = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let geo = face_geometry(tri, &v, &lookup);
+
+        let weight = geo.area / 3.0;
+        let mut block = [[0.0_f64; 3]; 3];
+        for lam in BARYCENTRIC_MIDPOINTS.iter() {
+            // Whitney trace N_e(λ) = λ_la ∇λ_lb − λ_lb ∇λ_la.
+            let mut basis_q: [[f64; 3]; 3] = [[0.0; 3]; 3];
+            for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+                let term_a = scale3(geo.grad_lambda[lb], lam[la]);
+                let term_b = scale3(geo.grad_lambda[la], lam[lb]);
+                basis_q[k] = sub3(term_a, term_b);
+            }
+            for i in 0..3 {
+                for j in 0..3 {
+                    block[i][j] += weight * dot3(basis_q[i], basis_q[j]);
+                }
+            }
+        }
+
+        for (row, &(gi, si)) in block.iter().zip(geo.edge_info.iter()) {
+            for (&val, &(gj, sj)) in row.iter().zip(geo.edge_info.iter()) {
+                triplets.push((gi as usize, gj as usize, val * (si as f64) * (sj as f64)));
+            }
+        }
+    }
+
+    triplets
+}
+
+/// Assemble the **port flux vector**
+///
+/// ```text
+/// f_i = ∮_{Γ_p} N_i · ê dS
+/// ```
+///
+/// as a full-length `[n_edges]` real vector (non-zero only on port-face
+/// edges). This single vector serves both port roles:
+///
+/// - **excitation**: `b_i += (2jω/Z_s)(V_inc/l) f_i`,
+/// - **voltage readout**: `V = (1/w) Σ_i f_i E_i` (see
+///   [`port_voltage`]),
+///
+/// which is the discrete reciprocity structure that makes the port
+/// drive/measure pair adjoint-consistent.
+///
+/// The integrand is degree-1 in barycentric coordinates, integrated
+/// with the closed form `∫_T N_e dA = (area/3)(∇λ_b − ∇λ_a)`. Only the
+/// in-plane component of `e_hat` contributes (the Whitney traces are
+/// tangential); `e_hat` should be a unit vector tangential to Γ_p.
+///
+/// # Panics
+///
+/// Panics if a face references an edge absent from `edges`.
+pub fn assemble_port_flux(
+    mesh: &TetMesh,
+    faces: &[[u32; 3]],
+    e_hat: [f64; 3],
+    edges: &[[u32; 2]],
+) -> Vec<f64> {
+    let lookup = edge_lookup(edges);
+    let mut flux = vec![0.0_f64; edges.len()];
+
+    for tri in faces {
+        let v: [[f64; 3]; 3] = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let geo = face_geometry(tri, &v, &lookup);
+
+        for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+            let (gi, si) = geo.edge_info[k];
+            // ∫_T N_e dA = (area/3)(∇λ_lb − ∇λ_la).
+            let integral = scale3(
+                sub3(geo.grad_lambda[lb], geo.grad_lambda[la]),
+                geo.area / 3.0,
+            );
+            flux[gi as usize] += dot3(integral, e_hat) * (si as f64);
+        }
+    }
+
+    flux
+}
+
+/// Port voltage from the field projection:
+///
+/// ```text
+/// V = (1/w) ∮_{Γ_p} E · ê dS = (1/w) Σ_i f_i E_i,
+/// ```
+///
+/// the line integral of `E` along `ê` across the gap, averaged over the
+/// port width (for the uniform port the line integral is the same on
+/// every line, up to discretization).
+///
+/// `e_edges` is the full-length edge-DOF vector in `mesh.edges()`
+/// order, e.g. [`crate::driven::DrivenSolution::e_edges`]; `edges` is
+/// that same edge table.
+pub fn port_voltage(
+    mesh: &TetMesh,
+    port: &LumpedPort<'_>,
+    edges: &[[u32; 2]],
+    e_edges: &[c64],
+) -> c64 {
+    let flux = assemble_port_flux(mesh, port.faces, port.e_hat, edges);
+    let mut v = c64::new(0.0, 0.0);
+    for (f, e) in flux.iter().zip(e_edges.iter()) {
+        v += *e * *f;
+    }
+    v * (1.0 / port.width)
+}
+
+/// Port current from the admittance relation of the Thevenin port
+/// (ideal source `2·V_inc` behind the lumped resistance `R`):
+///
+/// ```text
+/// I = (2 V_inc − V) / R.
+/// ```
+///
+/// `I` is the current delivered into the structure; for a matched load
+/// (`V = V_inc`) it is `V_inc / R`.
+pub fn port_current(port: &LumpedPort<'_>, v_port: c64) -> c64 {
+    (port.v_inc * 2.0 - v_port) * (1.0 / port.resistance)
+}
+
+/// Input impedance seen at the port: `Z_in = V / I` with `V` from
+/// [`port_voltage`] and `I` from [`port_current`].
+///
+/// This is the structure's input impedance **excluding** the port's own
+/// resistance `R` (the source impedance) — the quantity the
+/// transmission-line oracle compares against `j Z₀ tan(ωd)`. The
+/// full `Z(ω) → L/R/Q/S` extraction API is issue #203.
+pub fn port_input_impedance(
+    mesh: &TetMesh,
+    port: &LumpedPort<'_>,
+    edges: &[[u32; 2]],
+    e_edges: &[c64],
+) -> c64 {
+    let v = port_voltage(mesh, port, edges, e_edges);
+    let i = port_current(port, v);
+    v / i
+}
+
+#[inline]
+fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+fn norm3(a: [f64; 3]) -> f64 {
+    (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt()
+}
+
+#[inline]
+fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn scale3(a: [f64; 3], s: f64) -> [f64; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::silvermuller::assemble_silver_muller_surface;
+    use crate::{cube_tet_mesh, TetMesh};
+    use std::collections::BTreeMap;
+
+    fn unit_triangle_mesh() -> (TetMesh, Vec<[u32; 3]>) {
+        let nodes = vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ];
+        let tets = vec![[0u32, 1, 2, 3]];
+        let mesh = TetMesh {
+            nodes,
+            tets,
+            physical_groups: BTreeMap::new(),
+        };
+        let faces = vec![[0u32, 1, 2]];
+        (mesh, faces)
+    }
+
+    /// The triplet-form port surface mass must agree with the dense
+    /// Silver-Müller surface kernel (independent implementation of the
+    /// same integral) on a multi-face boundary patch.
+    #[test]
+    fn port_mass_matches_silver_muller_kernel() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        // Port patch: every boundary face on z = 0.
+        let faces: Vec<[u32; 3]> = mesh
+            .faces()
+            .into_iter()
+            .filter(|f| f.iter().all(|&n| mesh.nodes[n as usize][2].abs() < 1e-12))
+            .collect();
+        assert!(!faces.is_empty());
+
+        let tags = vec![1_i32; faces.len()];
+        let dense = assemble_silver_muller_surface(&mesh, &faces, &tags, 1, &edges);
+
+        let n = edges.len();
+        let mut from_triplets = vec![0.0_f64; n * n];
+        for (r, c, v) in assemble_port_surface_mass(&mesh, &faces, &edges) {
+            from_triplets[r * n + c] += v;
+        }
+
+        let mut max_diff = 0.0_f64;
+        for r in 0..n {
+            for c in 0..n {
+                max_diff = max_diff.max((from_triplets[r * n + c] - dense[(r, c)]).abs());
+            }
+        }
+        assert!(
+            max_diff < 1e-14,
+            "port mass disagrees with Silver-Müller kernel: {max_diff}"
+        );
+    }
+
+    /// The assembled port surface mass must be symmetric (the iω-scaled
+    /// admittance term inherits A(ω)ᵀ = A(ω) from this).
+    #[test]
+    fn port_mass_is_symmetric() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        let faces: Vec<[u32; 3]> = mesh
+            .faces()
+            .into_iter()
+            .filter(|f| f.iter().all(|&n| mesh.nodes[n as usize][2].abs() < 1e-12))
+            .collect();
+        let n = edges.len();
+        let mut s = vec![0.0_f64; n * n];
+        for (r, c, v) in assemble_port_surface_mass(&mesh, &faces, &edges) {
+            s[r * n + c] += v;
+        }
+        let mut max_asym = 0.0_f64;
+        for r in 0..n {
+            for c in 0..n {
+                max_asym = max_asym.max((s[r * n + c] - s[c * n + r]).abs());
+            }
+        }
+        assert!(max_asym < 1e-14, "S_p not symmetric: {max_asym}");
+    }
+
+    /// Closed-form flux on the unit right triangle: with
+    /// `ê = x̂`, `∫_T N_01 · x̂ dA = ∫_T (1 − y) dA = 1/3`,
+    /// `∫_T N_02 · x̂ dA = ∫_T y dA = 1/6` and
+    /// `∫_T N_12 · x̂ dA = ∫_T (−y) dA = −1/6`
+    /// (Whitney traces from the silvermuller.rs analytic test).
+    #[test]
+    fn flux_matches_analytic_on_unit_triangle() {
+        let (mesh, faces) = unit_triangle_mesh();
+        let edges = mesh.edges();
+        let flux = assemble_port_flux(&mesh, &faces, [1.0, 0.0, 0.0], &edges);
+
+        let idx = |a: u32, b: u32| edges.iter().position(|e| e == &[a, b]).unwrap();
+        let tol = 1e-14;
+        assert!((flux[idx(0, 1)] - 1.0 / 3.0).abs() < tol);
+        assert!((flux[idx(0, 2)] - 1.0 / 6.0).abs() < tol);
+        assert!((flux[idx(1, 2)] + 1.0 / 6.0).abs() < tol);
+        // Off-face edges carry no flux.
+        assert_eq!(flux[idx(0, 3)], 0.0);
+        assert_eq!(flux[idx(1, 3)], 0.0);
+        assert_eq!(flux[idx(2, 3)], 0.0);
+    }
+
+    /// A uniform tangential field `E = ê` interpolated on the port
+    /// edges must read back the exact gap voltage: `V = l` (so a port
+    /// with `length = l` sees `V/l = 1`). Whitney elements reproduce
+    /// constants exactly, so this is a round-trip identity.
+    #[test]
+    fn uniform_field_voltage_roundtrip() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        let faces: Vec<[u32; 3]> = mesh
+            .faces()
+            .into_iter()
+            .filter(|f| f.iter().all(|&n| mesh.nodes[n as usize][2].abs() < 1e-12))
+            .collect();
+        // Edge DOFs of the constant field E = ŷ: e_i = ∫_edge ŷ · dl
+        // = (y_b − y_a) for global edge a → b.
+        let e_edges: Vec<c64> = edges
+            .iter()
+            .map(|e| {
+                let dy = mesh.nodes[e[1] as usize][1] - mesh.nodes[e[0] as usize][1];
+                c64::new(dy, 0.0)
+            })
+            .collect();
+        let port = LumpedPort {
+            faces: &faces,
+            e_hat: [0.0, 1.0, 0.0],
+            resistance: 1.0,
+            width: 1.0,
+            length: 1.0,
+            v_inc: c64::new(0.0, 0.0),
+        };
+        let v = port_voltage(&mesh, &port, &edges, &e_edges);
+        assert!(
+            (v - c64::new(1.0, 0.0)).norm() < 1e-13,
+            "uniform-field voltage readback: got {v}, want 1"
+        );
+    }
+
+    /// Surface impedance mapping `Z_s = R·w/l`.
+    #[test]
+    fn surface_impedance_mapping() {
+        let port = LumpedPort {
+            faces: &[],
+            e_hat: [0.0, 1.0, 0.0],
+            resistance: 50.0,
+            width: 2.0,
+            length: 0.5,
+            v_inc: c64::new(0.0, 0.0),
+        };
+        assert_eq!(port.surface_impedance(), 200.0);
+    }
+
+    /// Matched-load circuit identities: V = V_inc ⇒ I = V_inc/R and
+    /// Z_in = R.
+    #[test]
+    fn matched_load_circuit_identities() {
+        let port = LumpedPort {
+            faces: &[],
+            e_hat: [0.0, 1.0, 0.0],
+            resistance: 3.0,
+            width: 1.0,
+            length: 1.0,
+            v_inc: c64::new(2.0, 0.0),
+        };
+        let v = port.v_inc; // matched: no reflection
+        let i = port_current(&port, v);
+        assert!((i - v / 3.0).norm() < 1e-15);
+        let z_in = v / i;
+        assert!((z_in - c64::new(3.0, 0.0)).norm() < 1e-13);
+    }
+}

--- a/crates/geode-core/tests/lumped_port.rs
+++ b/crates/geode-core/tests/lumped_port.rs
@@ -1,0 +1,500 @@
+//! Lumped-port boundary condition + excitation regressions (issue #202).
+//!
+//! 1. **Transmission-line oracle** — a PEC-shorted parallel-plate line
+//!    (PMC side walls = natural BC) driven through a uniform lumped
+//!    port must present the analytic input impedance
+//!    `Z_in = j Z₀ tan(ω d)` (characteristic impedance `Z₀ = l/w`,
+//!    line length `d`; natural units) within mesh-convergence
+//!    tolerance across ≥3 frequencies, with the error shrinking under
+//!    refinement.
+//! 2. **Complex symmetry** — `A(ω)ᵀ = A(ω)` with a port present,
+//!    verified through the solver as Lorentz reciprocity:
+//!    `b₂ᵀ x₁ = b₁ᵀ x₂` for two independent volume sources (the
+//!    unconjugated bilinear identity holds iff `A⁻¹` is symmetric).
+//! 3. **PEC + port composition** — a port on a PEC-backed cavity keeps
+//!    eliminated edges at exact zeros, the direct-solve residual at the
+//!    round-off floor, and finite non-zero V/I bookkeeping.
+//! 4. **No-op composition** — empty port list reproduces
+//!    `driven_solve` exactly; a passive port with zero source stays
+//!    identically zero; invalid port specs error instead of panicking.
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use geode_core::{
+    assemble_nedelec_current_rhs, cube_tet_mesh, driven_solve, driven_solve_with_ports,
+    port_current, port_input_impedance, port_voltage, upload_mesh, CurrentSource, DefaultBackend,
+    DrivenBcs, DrivenError, DrivenMaterials, LumpedPort, TetMesh,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+fn zero_source(mesh: &TetMesh) -> CurrentSource {
+    CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    }
+}
+
+/// Boundary faces of the mesh lying entirely in the plane
+/// `coord[axis] == value`.
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+/// PEC interior-edge mask eliminating every edge whose **both**
+/// endpoints lie on the same listed plane `(axis, value)`.
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+/// Solve the parallel-plate transmission line (unit cube, PEC plates at
+/// y = 0/1, PEC short at z = 1, natural/PMC side walls at x = 0/1, port
+/// across the full z = 0 face with ê = ŷ) and return the input
+/// impedance seen at the port.
+fn parallel_plate_z_in(n: usize, omega: f64, resistance: f64) -> c64 {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    assert!(!port_faces.is_empty(), "port surface must be non-empty");
+
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let sol = driven_solve_with_ports::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        omega,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("port-driven solve");
+    assert!(
+        sol.residual_rel < 1e-10,
+        "direct-solve residual too large: {}",
+        sol.residual_rel
+    );
+    port_input_impedance(&mesh, &port, &edges, &sol.e_edges)
+}
+
+/// Analytic transmission-line oracle: `Z_in = j Z₀ tan(ωd)` with
+/// `Z₀ = l/w = 1`, `d = 1` for the unit-cube line. The extracted
+/// impedance must match within mesh-convergence tolerance across three
+/// frequencies and improve under refinement.
+#[test]
+fn transmission_line_input_impedance_matches_analytic() {
+    // (ω, relative tolerance at n = 8). Tolerances reflect the O((ωh)²)
+    // FEM dispersion error amplified by tan′ near the line resonance;
+    // measured n = 8 errors are well below these bounds (see assert
+    // message output for the actual values).
+    let cases = [(0.5_f64, 2e-3), (1.0, 5e-3), (2.0, 4e-2)];
+    for &(omega, tol) in cases.iter() {
+        let z_ref = c64::new(0.0, omega.tan());
+        let z8 = parallel_plate_z_in(8, omega, 1.0);
+        let err8 = (z8 - z_ref).norm() / z_ref.norm();
+        println!("ω = {omega}: Z_in(n=8) = {z8}, analytic = {z_ref}, rel err = {err8:.3e}");
+        assert!(
+            err8 < tol,
+            "ω = {omega}: Z_in = {z8} vs analytic {z_ref} (rel err {err8:.3e} > tol {tol:.1e})"
+        );
+
+        // Mesh convergence: the coarse mesh must be strictly worse and
+        // the fine mesh better by at least ~the expected O(h²) factor /2
+        // (slack for the tan amplification varying between meshes).
+        let z4 = parallel_plate_z_in(4, omega, 1.0);
+        let err4 = (z4 - z_ref).norm() / z_ref.norm();
+        assert!(
+            err8 < 0.5 * err4,
+            "ω = {omega}: no mesh convergence (err n=4: {err4:.3e}, n=8: {err8:.3e})"
+        );
+    }
+}
+
+/// The extracted input impedance is a property of the structure, not of
+/// the port termination: changing R (the source impedance) must leave
+/// Z_in unchanged up to the uniform-port discretization error (the
+/// distributed admittance term `(jω/Z_s) S_p` is only rank-1-equivalent
+/// to the lumped circuit picture in the uniform-field limit, so a tiny
+/// R-dependence at the mesh-error level remains; measured ~6e-6 at
+/// n = 4).
+#[test]
+fn input_impedance_is_independent_of_port_resistance() {
+    let omega = 1.0;
+    let z_r1 = parallel_plate_z_in(4, omega, 1.0);
+    let z_r5 = parallel_plate_z_in(4, omega, 5.0);
+    let rel = (z_r1 - z_r5).norm() / z_r1.norm();
+    assert!(
+        rel < 1e-4,
+        "Z_in depends on port R: {z_r1} (R=1) vs {z_r5} (R=5), rel diff {rel:.3e}"
+    );
+}
+
+/// Complex-symmetry regression with a port present (acceptance
+/// criterion): Lorentz reciprocity `b₂ᵀ x₁ = b₁ᵀ x₂` through the
+/// solver. The unconjugated identity holds iff the interior system
+/// matrix (including the iω-scaled port admittance term) satisfies
+/// `A(ω)ᵀ = A(ω)`.
+#[test]
+fn reciprocity_holds_with_port_present() {
+    let n = 3;
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    // Passive port (pure resistive termination): the admittance term is
+    // in A(ω), the drive is the volume current.
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 2.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(0.0, 0.0),
+    };
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let omega = 1.3;
+
+    // Two independent localized volume sources (real-valued so the
+    // real-part RHS readback below captures them exactly).
+    let j1 = CurrentSource::from_centroids(&mesh, |c| {
+        if c[2] < 0.4 {
+            [c64::new(0.0, 0.0), c64::new(1.0, 0.0), c64::new(0.0, 0.0)]
+        } else {
+            [c64::new(0.0, 0.0); 3]
+        }
+    });
+    let j2 = CurrentSource::from_centroids(&mesh, |c| {
+        if c[2] > 0.6 {
+            [c64::new(0.3, 0.0), c64::new(0.5, 0.0), c64::new(0.0, 0.0)]
+        } else {
+            [c64::new(0.0, 0.0); 3]
+        }
+    });
+
+    let solve = |src: &CurrentSource| {
+        driven_solve_with_ports::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &bcs,
+            std::slice::from_ref(&port),
+            omega,
+            src,
+            &device(),
+        )
+        .expect("port reciprocity solve")
+    };
+    let x1 = solve(&j1).e_edges;
+    let x2 = solve(&j2).e_edges;
+
+    // Raw RHS vectors b_i ∝ ∫ N_i · J dV (the iω scale cancels in the
+    // bilinear identity).
+    let (tet_idx, tet_sign): (Vec<[u32; 6]>, Vec<[i8; 6]>) = {
+        let te = mesh.tet_edges();
+        (
+            te.iter()
+                .map(|row| std::array::from_fn(|i| row[i].0))
+                .collect(),
+            te.iter()
+                .map(|row| std::array::from_fn(|i| row[i].1))
+                .collect(),
+        )
+    };
+    let (nodes_t, tets_t) = upload_mesh::<B>(&mesh, &device());
+    let rhs_of = |src: &CurrentSource| -> Vec<f64> {
+        let j_re: Vec<[f64; 3]> = src
+            .j_tet
+            .iter()
+            .map(|j| [j[0].re, j[1].re, j[2].re])
+            .collect();
+        assemble_nedelec_current_rhs(
+            nodes_t.clone(),
+            tets_t.clone(),
+            &tet_idx,
+            &tet_sign,
+            n_edges,
+            &j_re,
+        )
+        .into_data()
+        .iter::<f64>()
+        .collect()
+    };
+    let b1 = rhs_of(&j1);
+    let b2 = rhs_of(&j2);
+
+    // Unconjugated bilinear forms (complex symmetry, not Hermitian).
+    let dot = |b: &[f64], x: &[c64]| -> c64 {
+        b.iter()
+            .zip(x.iter())
+            .fold(c64::new(0.0, 0.0), |acc, (&bi, &xi)| acc + xi * bi)
+    };
+    let lhs = dot(&b2, &x1);
+    let rhs = dot(&b1, &x2);
+    let scale = lhs.norm().max(rhs.norm());
+    assert!(scale > 0.0, "degenerate reciprocity test: zero responses");
+    assert!(
+        (lhs - rhs).norm() < 1e-10 * scale,
+        "reciprocity violated with port present: b₂ᵀx₁ = {lhs}, b₁ᵀx₂ = {rhs}"
+    );
+}
+
+/// PEC + port composition: a port on a fully PEC-backed cavity (every
+/// wall PEC except the port surface). Eliminated edges must stay exact
+/// zeros, the residual at the round-off floor, and the port V/I finite
+/// and non-zero.
+#[test]
+fn pec_backed_cavity_with_port_composes() {
+    let n = 4;
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    // PEC everywhere except the port face z = 0.
+    let mask = pec_mask_for_planes(
+        &mesh,
+        &edges,
+        &[(0, 0.0), (0, 1.0), (1, 0.0), (1, 1.0), (2, 1.0)],
+    );
+    let eps = vacuum(&mesh);
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let sol = driven_solve_with_ports::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        1.3,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("PEC + port solve");
+
+    assert!(
+        sol.residual_rel < 1e-10,
+        "residual too large: {}",
+        sol.residual_rel
+    );
+    for (i, &keep) in mask.iter().enumerate() {
+        if !keep {
+            assert_eq!(
+                sol.e_edges[i],
+                c64::new(0.0, 0.0),
+                "PEC edge {i} not exactly zero with port present"
+            );
+        }
+    }
+    assert!(sol
+        .e_edges
+        .iter()
+        .all(|e| e.re.is_finite() && e.im.is_finite()));
+
+    let v = port_voltage(&mesh, &port, &edges, &sol.e_edges);
+    let i = port_current(&port, v);
+    assert!(v.re.is_finite() && v.im.is_finite());
+    assert!(i.re.is_finite() && i.im.is_finite());
+    assert!(v.norm() > 0.0, "port-driven cavity must develop a voltage");
+    assert!(i.norm() > 0.0, "port-driven cavity must draw a current");
+}
+
+/// An empty port list must reproduce `driven_solve` exactly (bit-for-bit
+/// at the linear-system level — same assembly, same factorization).
+#[test]
+fn empty_port_list_matches_driven_solve() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(0.0, 0.0),
+            c64::new((std::f64::consts::PI * c[2]).sin(), 0.0),
+            c64::new(0.0, 0.0),
+        ]
+    });
+    let omega = 1.1;
+    let sol_p = driven_solve_with_ports::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[],
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("empty-ports solve");
+    let sol_0 = driven_solve::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        &bcs,
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("plain solve");
+    assert_eq!(sol_p.n_interior, sol_0.n_interior);
+    for (a, b) in sol_p.e_edges.iter().zip(sol_0.e_edges.iter()) {
+        assert_eq!(a, b, "empty port list changed the solution");
+    }
+}
+
+/// A passive port (V_inc = 0) with a zero volume source must keep the
+/// field exactly zero.
+#[test]
+fn passive_port_with_zero_source_gives_zero_field() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(0.0, 0.0),
+    };
+    let sol = driven_solve_with_ports::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        1.0,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("passive port solve");
+    assert!(sol.e_edges.iter().all(|e| e.re == 0.0 && e.im == 0.0));
+}
+
+/// Invalid port specifications must error, not panic.
+#[test]
+fn invalid_port_specs_error() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let source = zero_source(&mesh);
+
+    let base = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let solve_with = |port: LumpedPort<'_>| {
+        driven_solve_with_ports::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &bcs,
+            &[port],
+            1.0,
+            &source,
+            &device(),
+        )
+    };
+
+    let bad_faces = LumpedPort {
+        faces: &[],
+        ..base.clone()
+    };
+    assert!(matches!(
+        solve_with(bad_faces).unwrap_err(),
+        DrivenError::InvalidPort { .. }
+    ));
+
+    let bad_r = LumpedPort {
+        resistance: 0.0,
+        ..base.clone()
+    };
+    assert!(matches!(
+        solve_with(bad_r).unwrap_err(),
+        DrivenError::InvalidPort { .. }
+    ));
+
+    let bad_e_hat = LumpedPort {
+        e_hat: [0.0, 2.0, 0.0],
+        ..base.clone()
+    };
+    assert!(matches!(
+        solve_with(bad_e_hat).unwrap_err(),
+        DrivenError::InvalidPort { .. }
+    ));
+
+    let bad_len = LumpedPort {
+        length: -1.0,
+        ..base.clone()
+    };
+    assert!(matches!(
+        solve_with(bad_len).unwrap_err(),
+        DrivenError::InvalidPort { .. }
+    ));
+
+    let bad_node = LumpedPort {
+        faces: &[[0, 1, 9999]],
+        ..base
+    };
+    assert!(matches!(
+        solve_with(bad_node).unwrap_err(),
+        DrivenError::InvalidPort { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

Adds a Palace-style **uniform lumped port** to the driven frequency-domain solver (Epic #193 Phase 2): a boundary surface bridging two conductors that both excites the structure and terminates it resistively. With the codebase's `exp(+jωt)` convention, the matched-source port Robin BC `n×(∇×E) + (jω/Z_s) n×(n×E) = −(2jω/Z_s) E_inc` (with `Z_s = R·w/l`, `E_inc = (V_inc/l)ê`) contributes in the weak form:

- **Termination**: `A(ω) += (jω/Z_s)·S_p` with the real-symmetric tangential surface mass `S_p = ∮(n×N_i)·(n×N_j) dS` — same Whitney triangle kernel as the Silver-Müller surface term (3-point edge-midpoint quadrature, degree-2 exact), so `A(ω)ᵀ = A(ω)` is preserved.
- **Excitation**: `b_i += (2jω/Z_s)(V_inc/l)·∮N_i·ê dS` — the boundary analogue of the volumetric current drive. The flux vector `f_i = ∮N_i·ê dS` doubles as the voltage-readout functional (adjoint-consistent drive/measure pair).

V/I bookkeeping for circuit extraction (kept minimal — full `Z(ω)→L/R/Q/S` API is #203's scope): `V = (1/w)∮E·ê dS` (field projection), `I = (2V_inc − V)/R` (admittance relation), `Z_in = V/I`.

## Changes

- `crates/geode-core/src/lumped_port.rs` (new): `LumpedPort` spec (explicit face list + ê, R, w, l, V_inc; gmsh physical groups arrive with Phase 3), host-side triplet assembly `assemble_port_surface_mass` / `assemble_port_flux`, bookkeeping helpers `port_voltage` / `port_current` / `port_input_impedance`; full derivation in module docs. Self-contained kernel (cross-validated against the Silver-Müller one in unit tests) to avoid touching `silvermuller.rs`.
- `crates/geode-core/src/driven.rs`: new entry point `driven_solve_with_ports` (port spec alongside materials/σ/bcs/source); port validation (`DrivenError::InvalidPort`); admittance triplets merged into the interior `A(ω)` (faer sums duplicate triplets; port pairs are a subset of the volume sparsity pattern); port drive added to `b`; existing entry points unchanged (`ports = &[]`).
- `crates/geode-core/src/lib.rs`: module + re-exports.
- `crates/geode-core/tests/lumped_port.rs` (new): oracle, symmetry, and composition regressions (below).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Port excitation + R-termination expressible in `driven_solve` (port spec alongside bcs/source) | ✅ | `driven_solve_with_ports(mesh, materials, sigma, bcs, ports, omega, source, device)`; `empty_port_list_matches_driven_solve` shows exact no-op composition |
| Complex-symmetry regression with port present | ✅ | `reciprocity_holds_with_port_present`: solver-level Lorentz reciprocity `b₂ᵀx₁ = b₁ᵀx₂` (holds iff `A(ω)ᵀ = A(ω)` incl. the port term) to 1e-10; plus direct `S_p` symmetry unit test (`< 1e-14`) |
| Analytic transmission-line Z_in oracle, ≥3 frequencies, mesh-convergence tolerance | ✅ | PEC-shorted parallel-plate line (PMC sides), `Z_in = j·tan(ω)`: rel err **3.4e-4 (ω=0.5), 1.6e-3 (ω=1.0), 4.9e-4 (ω=2.0)** at n=8, each `< 0.5×` the n=4 error; `Re(Z_in)` at the lossless floor; Z_in independent of port R to 6e-6 |
| PEC + port composition regression | ✅ | `pec_backed_cavity_with_port_composes`: PEC edges exact zeros, residual `< 1e-10`, finite non-zero V/I; oracle test also composes PEC plates + short with the port |
| Tests pass for new functionality | ✅ | 6 unit + 7 integration tests; full workspace suite below |

## Test Plan

- `cargo test --workspace --release`: **213 passed, 0 failed, 33 ignored** (pre-existing ignores), exit 0
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `cargo fmt --check`: clean

Closes #202