### PR TITLE
feat: Z(ω) → L/R/Q/S₁₁ extraction + assembly-reusing frequency sweep over port-driven solves

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -632,348 +632,643 @@ fn driven_solve_impl<B: Backend>(
     rhs: RhsSamples<'_>,
     device: &B::Device,
 ) -> Result<DrivenSolution, DrivenError> {
-    let n_tets = mesh.n_tets();
-    let edges = mesh.edges();
-    let n_edges = edges.len();
+    let op = DrivenOperator::assemble_impl::<B>(
+        mesh, materials, sigma_tet, bcs, ports, surfaces, rhs, device,
+    )?;
+    op.solve_at(omega)
+}
 
-    // --- Input validation -------------------------------------------------
-    if bcs.pec_interior_mask.len() != n_edges {
-        return Err(DrivenError::MaskDimMismatch {
-            got: bcs.pec_interior_mask.len(),
-            want: n_edges,
-        });
+/// One lumped port of a [`DrivenOperator`]: the ω-independent pieces of
+/// the port's system / RHS / readout contributions, cached at assembly
+/// time.
+struct OperatorPort {
+    /// Interior-remapped triplets of the tangential surface mass `S_p`
+    /// (PEC-eliminated pairs already dropped).
+    mass_triplets: Vec<(usize, usize, f64)>,
+    /// Full-length port flux functional `f_i = ∮ N_i · ê dS` — drives
+    /// the excitation and reads back the port voltage.
+    flux: Vec<f64>,
+    /// Surface impedance `Z_s = R·w/l`.
+    z_s: f64,
+    /// Incident (drive) voltage.
+    v_inc: c64,
+    /// Gap length `l`.
+    length: f64,
+    /// Port width `w`.
+    width: f64,
+    /// Lumped resistance `R`.
+    resistance: f64,
+}
+
+/// One Leontovich impedance surface of a [`DrivenOperator`]: the
+/// ω-independent real surface mass values plus the model whose scalar
+/// coefficient `iω/Z_s(ω)` is re-evaluated at every frequency.
+struct OperatorSurface {
+    /// `S_Γ` values aligned with the operator's interior-filtered
+    /// sparsity entries.
+    s_vals: Vec<f64>,
+    /// Surface-impedance model (ω-dependent coefficient).
+    model: SurfaceImpedanceModel,
+}
+
+/// Pre-assembled driven frequency-domain operator for **frequency
+/// sweeps** (Epic #193, issue #203).
+///
+/// `A(ω) = K + iωC − ω²M + Σ_p (iω/Z_s,p) S_p + Σ_Γ (iω/Z_s,Γ(ω)) S_Γ`
+/// re-forms per frequency by linear combination of ω-independent
+/// matrices (the design rationale recorded in PR #198), so a sweep
+/// should run the (expensive) Burn volume assembly **once** and then
+/// re-form + re-factor the sparse system at every ω. This type caches
+/// everything ω-independent:
+///
+/// - the interior-filtered sparsity pattern with aligned `K`, `M`, and
+///   `C(σ)` values,
+/// - per-port surface-mass triplets and flux functionals (the port
+///   scalar `iω/Z_s` and the drive `(2iω/Z_s)(V_inc/l)` are applied per
+///   ω),
+/// - per-surface Leontovich masses `S_Γ` (their scalar `iω/Z_s(ω)` is
+///   **not** a fixed polynomial in ω — e.g. `∝ √ω(1+i)` for the
+///   good-conductor model — so it is re-evaluated at every frequency,
+///   as required by the issue-#204 caveat),
+/// - the raw current-source moments `∫ N_i · J dV` (scaled by `iω` per
+///   frequency).
+///
+/// [`DrivenOperator::solve_at`] then builds and LU-factors `A(ω)` and
+/// solves — *re-factorize per ω, never re-assemble*. A single
+/// `assemble` + `solve_at(ω)` pair reproduces
+/// [`driven_solve_with_ports`] / [`driven_solve_with_surface_impedance`]
+/// exactly (the single-ω entry points are implemented on top of this
+/// type).
+pub struct DrivenOperator {
+    n_edges: usize,
+    n_interior: usize,
+    /// Full edge index → interior index (−1 = PEC-eliminated).
+    remap: Vec<i64>,
+    /// Owned copy of the PEC interior mask (RHS reduction per ω).
+    pec_interior_mask: Vec<bool>,
+    /// Interior-remapped row/col of every kept sparsity entry, in the
+    /// recorded assembly-pattern order.
+    rows: Vec<usize>,
+    cols: Vec<usize>,
+    /// Stiffness values aligned with `rows`/`cols` (complex for the
+    /// matched-UPML material, real otherwise).
+    k_vals: Vec<c64>,
+    /// Mass values `M(ε)` aligned with `rows`/`cols`.
+    m_vals: Vec<c64>,
+    /// Conductivity damping values `C(σ)`, if a σ was supplied.
+    c_vals: Option<Vec<f64>>,
+    /// Leontovich impedance surfaces (issue #204).
+    surfaces: Vec<OperatorSurface>,
+    /// Lumped ports (issue #202).
+    ports: Vec<OperatorPort>,
+    /// Raw current-source moments `∫ N_i · J dV` (real / imaginary
+    /// parts), full edge length; `b(ω) = iω (rhs_re + i·rhs_im)`.
+    rhs_re: Vec<f64>,
+    rhs_im: Vec<f64>,
+}
+
+impl DrivenOperator {
+    /// Assemble the ω-independent operator: Burn volume assembly of
+    /// `K`, `M(ε)`, `C(σ)` and the source moments, host-side port /
+    /// impedance-surface masses and port flux functionals, and the PEC
+    /// interior reduction. Inputs are validated exactly as in
+    /// [`driven_solve_with_ports`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same shape-mismatch / invalid-port / empty-interior
+    /// errors as the single-ω entry points. (Surface-impedance models
+    /// are evaluated per frequency inside [`DrivenOperator::solve_at`],
+    /// so a singular `Z_s(ω)` surfaces there.)
+    #[allow(clippy::too_many_arguments)]
+    pub fn assemble<B: Backend>(
+        mesh: &TetMesh,
+        materials: DrivenMaterials<'_>,
+        sigma_tet: Option<&[f64]>,
+        bcs: &DrivenBcs<'_>,
+        ports: &[LumpedPort<'_>],
+        surfaces: &[SurfaceImpedanceBc<'_>],
+        source: &CurrentSource,
+        device: &B::Device,
+    ) -> Result<Self, DrivenError> {
+        Self::assemble_impl::<B>(
+            mesh,
+            materials,
+            sigma_tet,
+            bcs,
+            ports,
+            surfaces,
+            RhsSamples::Constant(&source.j_tet),
+            device,
+        )
     }
-    if rhs.len() != n_tets {
-        return Err(DrivenError::SourceDimMismatch {
-            got: rhs.len(),
-            want: n_tets,
-        });
-    }
-    let material_len = match materials {
-        DrivenMaterials::Scalar(eps) => eps.len(),
-        DrivenMaterials::DiagTensor(eps) => eps.len(),
-        DrivenMaterials::MatchedUpml {
-            epsilon_tensor,
-            nu_tensor,
-        } => {
-            if nu_tensor.len() != n_tets {
-                return Err(DrivenError::MaterialDimMismatch {
-                    got: nu_tensor.len(),
-                    want: n_tets,
-                });
-            }
-            epsilon_tensor.len()
+
+    #[allow(clippy::too_many_arguments)]
+    fn assemble_impl<B: Backend>(
+        mesh: &TetMesh,
+        materials: DrivenMaterials<'_>,
+        sigma_tet: Option<&[f64]>,
+        bcs: &DrivenBcs<'_>,
+        ports: &[LumpedPort<'_>],
+        surfaces: &[SurfaceImpedanceBc<'_>],
+        rhs: RhsSamples<'_>,
+        device: &B::Device,
+    ) -> Result<Self, DrivenError> {
+        let n_tets = mesh.n_tets();
+        let edges = mesh.edges();
+        let n_edges = edges.len();
+
+        // --- Input validation -------------------------------------------------
+        if bcs.pec_interior_mask.len() != n_edges {
+            return Err(DrivenError::MaskDimMismatch {
+                got: bcs.pec_interior_mask.len(),
+                want: n_edges,
+            });
         }
-    };
-    if material_len != n_tets {
-        return Err(DrivenError::MaterialDimMismatch {
-            got: material_len,
-            want: n_tets,
-        });
-    }
-    if let Some(sigma) = sigma_tet {
-        if sigma.len() != n_tets {
-            return Err(DrivenError::SigmaDimMismatch {
-                got: sigma.len(),
+        if rhs.len() != n_tets {
+            return Err(DrivenError::SourceDimMismatch {
+                got: rhs.len(),
                 want: n_tets,
             });
         }
-    }
-    for (index, port) in ports.iter().enumerate() {
-        let invalid = |reason: &str| DrivenError::InvalidPort {
-            index,
-            reason: reason.to_string(),
-        };
-        if port.faces.is_empty() {
-            return Err(invalid("port has no faces"));
-        }
-        if !(port.resistance.is_finite() && port.resistance > 0.0) {
-            return Err(invalid("resistance must be finite and positive"));
-        }
-        if !(port.width.is_finite() && port.width > 0.0) {
-            return Err(invalid("width must be finite and positive"));
-        }
-        if !(port.length.is_finite() && port.length > 0.0) {
-            return Err(invalid("length must be finite and positive"));
-        }
-        let e_norm = (port.e_hat[0].powi(2) + port.e_hat[1].powi(2) + port.e_hat[2].powi(2)).sqrt();
-        if (e_norm - 1.0).abs() >= 1e-8 || e_norm.is_nan() {
-            return Err(invalid("e_hat must be a unit vector"));
-        }
-        let n_nodes = mesh.n_nodes() as u32;
-        if port
-            .faces
-            .iter()
-            .any(|f| f.iter().any(|&node| node >= n_nodes))
-        {
-            return Err(invalid("face node index out of range"));
-        }
-    }
-
-    // --- Leontovich impedance surfaces (issue #204) -------------------------
-    // Per-surface weak coefficient iω/Z_s(ω) on the real surface mass
-    // S_Γ. The coefficient is ω-dependent (∝ √ω·(1+i) for the
-    // good-conductor model), so this block is re-formed on every call;
-    // S_Γ itself is ω-independent. Every (i, j) pair S_Γ couples lies
-    // within the 6×6 edge block of the tet owning the boundary face, so
-    // the surface entries are a subset of the recorded volume sparsity
-    // pattern and the triplet loop below picks them all up.
-    let surface_blocks: Vec<(faer::Mat<f64>, c64)> = surfaces
-        .iter()
-        .map(|bc| {
-            let coeff = bc.model.weak_coefficient(omega)?;
-            let s = crate::silvermuller::assemble_surface_mass(mesh, bc.triangles, &edges);
-            Ok((s, coeff))
-        })
-        .collect::<Result<_, DrivenError>>()?;
-
-    // --- Edge tables ------------------------------------------------------
-    let tet_edges = mesh.tet_edges();
-    let tet_idx: Vec<[u32; 6]> = tet_edges
-        .iter()
-        .map(|row| std::array::from_fn(|i| row[i].0))
-        .collect();
-    let tet_sign: Vec<[i8; 6]> = tet_edges
-        .iter()
-        .map(|row| std::array::from_fn(|i| row[i].1))
-        .collect();
-
-    // --- Assemble K, M(ε) on the Burn backend ------------------------------
-    // The stiffness imaginary part is `None` for the ε-only material
-    // models (K is real there); the matched UPML stretches μ too, so
-    // its `K(Λ⁻¹)` carries an imaginary part.
-    let (nodes_t, tets_t) = crate::assembly::upload_mesh::<B>(mesh, device);
-    let (k_re_t, k_im_t, m_re_t, m_im_t, sparsity) = match materials {
-        DrivenMaterials::Scalar(eps) => {
-            let sys = assemble_global_nedelec_with_complex_epsilon(
-                nodes_t.clone(),
-                tets_t.clone(),
-                &tet_idx,
-                &tet_sign,
-                n_edges,
-                eps,
-            );
-            (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
-        }
-        DrivenMaterials::DiagTensor(eps) => {
-            let sys = assemble_global_nedelec_with_anisotropic_epsilon(
-                nodes_t.clone(),
-                tets_t.clone(),
-                &tet_idx,
-                &tet_sign,
-                n_edges,
-                eps,
-            );
-            (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
-        }
-        DrivenMaterials::MatchedUpml {
-            epsilon_tensor,
-            nu_tensor,
-        } => {
-            let sys = assemble_global_nedelec_with_full_tensors(
-                nodes_t.clone(),
-                tets_t.clone(),
-                &tet_idx,
-                &tet_sign,
-                n_edges,
+        let material_len = match materials {
+            DrivenMaterials::Scalar(eps) => eps.len(),
+            DrivenMaterials::DiagTensor(eps) => eps.len(),
+            DrivenMaterials::MatchedUpml {
                 epsilon_tensor,
                 nu_tensor,
-            );
-            (sys.k_re, Some(sys.k_im), sys.m_re, sys.m_im, sys.sparsity)
+            } => {
+                if nu_tensor.len() != n_tets {
+                    return Err(DrivenError::MaterialDimMismatch {
+                        got: nu_tensor.len(),
+                        want: n_tets,
+                    });
+                }
+                epsilon_tensor.len()
+            }
+        };
+        if material_len != n_tets {
+            return Err(DrivenError::MaterialDimMismatch {
+                got: material_len,
+                want: n_tets,
+            });
         }
-    };
+        if let Some(sigma) = sigma_tet {
+            if sigma.len() != n_tets {
+                return Err(DrivenError::SigmaDimMismatch {
+                    got: sigma.len(),
+                    want: n_tets,
+                });
+            }
+        }
+        for (index, port) in ports.iter().enumerate() {
+            let invalid = |reason: &str| DrivenError::InvalidPort {
+                index,
+                reason: reason.to_string(),
+            };
+            if port.faces.is_empty() {
+                return Err(invalid("port has no faces"));
+            }
+            if !(port.resistance.is_finite() && port.resistance > 0.0) {
+                return Err(invalid("resistance must be finite and positive"));
+            }
+            if !(port.width.is_finite() && port.width > 0.0) {
+                return Err(invalid("width must be finite and positive"));
+            }
+            if !(port.length.is_finite() && port.length > 0.0) {
+                return Err(invalid("length must be finite and positive"));
+            }
+            let e_norm =
+                (port.e_hat[0].powi(2) + port.e_hat[1].powi(2) + port.e_hat[2].powi(2)).sqrt();
+            if (e_norm - 1.0).abs() >= 1e-8 || e_norm.is_nan() {
+                return Err(invalid("e_hat must be a unit vector"));
+            }
+            let n_nodes = mesh.n_nodes() as u32;
+            if port
+                .faces
+                .iter()
+                .any(|f| f.iter().any(|&node| node >= n_nodes))
+            {
+                return Err(invalid("face node index out of range"));
+            }
+        }
 
-    // --- Assemble the conductivity damping matrix C(σ), if any -------------
-    // C shares the (K, M) sparsity pattern — it is a σ-weighted mass
-    // assembled over the same tet→edge scatter indices — so the triplet
-    // loop below can read it through the recorded pattern directly.
-    let c_burn = sigma_tet.map(|sigma| {
-        crate::nedelec_assembly::assemble_nedelec_sigma_damping::<B>(
-            nodes_t.clone(),
-            tets_t.clone(),
-            &tet_idx,
-            &tet_sign,
-            n_edges,
-            sigma,
-        )
-    });
+        // --- Leontovich impedance surfaces (issue #204) -------------------------
+        // The real surface mass S_Γ is ω-independent and cached; its weak
+        // coefficient iω/Z_s(ω) is ω-dependent (∝ √ω·(1+i) for the
+        // good-conductor model), so it is re-evaluated inside `solve_at` at
+        // every frequency. Every (i, j) pair S_Γ couples lies within the
+        // 6×6 edge block of the tet owning the boundary face, so the
+        // surface entries are a subset of the recorded volume sparsity
+        // pattern and the value-caching loop below picks them all up.
+        let surface_masses: Vec<(faer::Mat<f64>, SurfaceImpedanceModel)> = surfaces
+            .iter()
+            .map(|bc| {
+                let s = crate::silvermuller::assemble_surface_mass(mesh, bc.triangles, &edges);
+                (s, bc.model)
+            })
+            .collect();
 
-    // --- Assemble the current-source RHS -----------------------------------
-    // The Burn RHS kernels are real-valued; a complex J runs as two
-    // passes (Re(J), Im(J)) — same split as the complex-ε mass assembly.
-    let (rhs_re, rhs_im) = match rhs {
-        RhsSamples::Constant(j_tet) => {
-            let j_re: Vec<[f64; 3]> = j_tet.iter().map(|j| [j[0].re, j[1].re, j[2].re]).collect();
-            let j_im: Vec<[f64; 3]> = j_tet.iter().map(|j| [j[0].im, j[1].im, j[2].im]).collect();
-            let rhs_re = assemble_nedelec_current_rhs(
+        // --- Edge tables ------------------------------------------------------
+        let tet_edges = mesh.tet_edges();
+        let tet_idx: Vec<[u32; 6]> = tet_edges
+            .iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect();
+        let tet_sign: Vec<[i8; 6]> = tet_edges
+            .iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect();
+
+        // --- Assemble K, M(ε) on the Burn backend ------------------------------
+        // The stiffness imaginary part is `None` for the ε-only material
+        // models (K is real there); the matched UPML stretches μ too, so
+        // its `K(Λ⁻¹)` carries an imaginary part.
+        let (nodes_t, tets_t) = crate::assembly::upload_mesh::<B>(mesh, device);
+        let (k_re_t, k_im_t, m_re_t, m_im_t, sparsity) = match materials {
+            DrivenMaterials::Scalar(eps) => {
+                let sys = assemble_global_nedelec_with_complex_epsilon(
+                    nodes_t.clone(),
+                    tets_t.clone(),
+                    &tet_idx,
+                    &tet_sign,
+                    n_edges,
+                    eps,
+                );
+                (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+            }
+            DrivenMaterials::DiagTensor(eps) => {
+                let sys = assemble_global_nedelec_with_anisotropic_epsilon(
+                    nodes_t.clone(),
+                    tets_t.clone(),
+                    &tet_idx,
+                    &tet_sign,
+                    n_edges,
+                    eps,
+                );
+                (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+            }
+            DrivenMaterials::MatchedUpml {
+                epsilon_tensor,
+                nu_tensor,
+            } => {
+                let sys = assemble_global_nedelec_with_full_tensors(
+                    nodes_t.clone(),
+                    tets_t.clone(),
+                    &tet_idx,
+                    &tet_sign,
+                    n_edges,
+                    epsilon_tensor,
+                    nu_tensor,
+                );
+                (sys.k_re, Some(sys.k_im), sys.m_re, sys.m_im, sys.sparsity)
+            }
+        };
+
+        // --- Assemble the conductivity damping matrix C(σ), if any -------------
+        // C shares the (K, M) sparsity pattern — it is a σ-weighted mass
+        // assembled over the same tet→edge scatter indices — so the triplet
+        // loop below can read it through the recorded pattern directly.
+        let c_burn = sigma_tet.map(|sigma| {
+            crate::nedelec_assembly::assemble_nedelec_sigma_damping::<B>(
                 nodes_t.clone(),
                 tets_t.clone(),
                 &tet_idx,
                 &tet_sign,
                 n_edges,
-                &j_re,
-            );
-            let rhs_im =
-                assemble_nedelec_current_rhs(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im);
-            (rhs_re, rhs_im)
-        }
-        RhsSamples::Quad(j_quad) => {
-            let j_re: Vec<[[f64; 3]; 4]> = j_quad
-                .iter()
-                .map(|t| t.map(|q| [q[0].re, q[1].re, q[2].re]))
-                .collect();
-            let j_im: Vec<[[f64; 3]; 4]> = j_quad
-                .iter()
-                .map(|t| t.map(|q| [q[0].im, q[1].im, q[2].im]))
-                .collect();
-            let rhs_re = assemble_nedelec_current_rhs_quad4(
-                nodes_t.clone(),
-                tets_t.clone(),
-                &tet_idx,
-                &tet_sign,
-                n_edges,
-                &j_re,
-            );
-            let rhs_im = assemble_nedelec_current_rhs_quad4(
-                nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im,
-            );
-            (rhs_re, rhs_im)
-        }
-    };
-    let rhs_re: Vec<f64> = rhs_re.into_data().iter::<f64>().collect();
-    let rhs_im: Vec<f64> = rhs_im.into_data().iter::<f64>().collect();
+                sigma,
+            )
+        });
 
-    // b = iωμ₀ ∫ N · J dV with μ₀ = 1:  iω (re + i·im) = ω(−im + i·re).
-    let mut b_full: Vec<c64> = rhs_re
-        .iter()
-        .zip(rhs_im.iter())
-        .map(|(&re, &im)| c64::new(-omega * im, omega * re))
-        .collect();
+        // --- Assemble the current-source RHS -----------------------------------
+        // The Burn RHS kernels are real-valued; a complex J runs as two
+        // passes (Re(J), Im(J)) — same split as the complex-ε mass assembly.
+        let (rhs_re, rhs_im) = match rhs {
+            RhsSamples::Constant(j_tet) => {
+                let j_re: Vec<[f64; 3]> =
+                    j_tet.iter().map(|j| [j[0].re, j[1].re, j[2].re]).collect();
+                let j_im: Vec<[f64; 3]> =
+                    j_tet.iter().map(|j| [j[0].im, j[1].im, j[2].im]).collect();
+                let rhs_re = assemble_nedelec_current_rhs(
+                    nodes_t.clone(),
+                    tets_t.clone(),
+                    &tet_idx,
+                    &tet_sign,
+                    n_edges,
+                    &j_re,
+                );
+                let rhs_im = assemble_nedelec_current_rhs(
+                    nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im,
+                );
+                (rhs_re, rhs_im)
+            }
+            RhsSamples::Quad(j_quad) => {
+                let j_re: Vec<[[f64; 3]; 4]> = j_quad
+                    .iter()
+                    .map(|t| t.map(|q| [q[0].re, q[1].re, q[2].re]))
+                    .collect();
+                let j_im: Vec<[[f64; 3]; 4]> = j_quad
+                    .iter()
+                    .map(|t| t.map(|q| [q[0].im, q[1].im, q[2].im]))
+                    .collect();
+                let rhs_re = assemble_nedelec_current_rhs_quad4(
+                    nodes_t.clone(),
+                    tets_t.clone(),
+                    &tet_idx,
+                    &tet_sign,
+                    n_edges,
+                    &j_re,
+                );
+                let rhs_im = assemble_nedelec_current_rhs_quad4(
+                    nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im,
+                );
+                (rhs_re, rhs_im)
+            }
+        };
+        let rhs_re: Vec<f64> = rhs_re.into_data().iter::<f64>().collect();
+        let rhs_im: Vec<f64> = rhs_im.into_data().iter::<f64>().collect();
 
-    // --- Lumped-port excitation (issue #202) --------------------------------
-    // Matched-source port drive: b_i += (2jω/Z_s)(V_inc/l) ∮ N_i · ê dS.
-    // The flux vector f_i = ∮ N_i · ê dS doubles as the port-voltage
-    // readout functional (see lumped_port.rs).
-    for port in ports {
-        if port.v_inc == c64::new(0.0, 0.0) {
-            continue;
-        }
-        let zs = port.surface_impedance();
-        let e_inc = port.v_inc * (1.0 / port.length);
-        let drive = c64::new(0.0, 2.0 * omega / zs) * e_inc;
-        let flux = assemble_port_flux(mesh, port.faces, port.e_hat, &edges);
-        for (b, f) in b_full.iter_mut().zip(flux.iter()) {
-            *b += drive * *f;
-        }
-    }
+        // --- Lumped-port flux + surface mass (issue #202) ------------------------
+        // The flux vector f_i = ∮ N_i · ê dS serves both the per-ω
+        // excitation `b_i += (2jω/Z_s)(V_inc/l) f_i` and the port-voltage
+        // readout (see lumped_port.rs). Both it and the tangential surface
+        // mass S_p are ω-independent.
+        let port_fluxes: Vec<Vec<f64>> = ports
+            .iter()
+            .map(|port| assemble_port_flux(mesh, port.faces, port.e_hat, &edges))
+            .collect();
 
-    // --- Host transfer + PEC reduction -------------------------------------
-    let k_full = burn_matrix_to_faer(k_re_t);
-    let k_im_full = k_im_t.map(burn_matrix_to_faer);
-    let m_full = burn_complex_mass_to_faer(m_re_t, m_im_t);
-    let c_full = c_burn.map(burn_matrix_to_faer);
+        // --- Host transfer + PEC reduction -------------------------------------
+        let k_full = burn_matrix_to_faer(k_re_t);
+        let k_im_full = k_im_t.map(burn_matrix_to_faer);
+        let m_full = burn_complex_mass_to_faer(m_re_t, m_im_t);
+        let c_full = c_burn.map(burn_matrix_to_faer);
 
-    // Remap full edge indices → contiguous interior indices.
-    let mut remap = vec![-1_i64; n_edges];
-    let mut n_interior = 0_usize;
-    for (i, &keep) in bcs.pec_interior_mask.iter().enumerate() {
-        if keep {
-            remap[i] = n_interior as i64;
-            n_interior += 1;
+        // Remap full edge indices → contiguous interior indices.
+        let mut remap = vec![-1_i64; n_edges];
+        let mut n_interior = 0_usize;
+        for (i, &keep) in bcs.pec_interior_mask.iter().enumerate() {
+            if keep {
+                remap[i] = n_interior as i64;
+                n_interior += 1;
+            }
         }
-    }
-    if n_interior == 0 {
-        return Err(DrivenError::EmptyInterior);
-    }
+        if n_interior == 0 {
+            return Err(DrivenError::EmptyInterior);
+        }
 
-    // --- Sparse A(ω) = K + iωC − ω² M over the recorded sparsity pattern ---
-    let omega2 = omega * omega;
-    let mut triplets: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(sparsity.rows.len());
-    for (&r_u32, &c_u32) in sparsity.rows.iter().zip(sparsity.cols.iter()) {
-        let (r, c) = (r_u32 as usize, c_u32 as usize);
-        let (rr, cc) = (remap[r], remap[c]);
-        if rr < 0 || cc < 0 {
-            continue;
-        }
-        let k_im_val = k_im_full.as_ref().map_or(0.0, |m| m[(r, c)]);
-        let mut a_val = c64::new(k_full[(r, c)], k_im_val) - m_full[(r, c)] * omega2;
-        if let Some(cm) = &c_full {
-            // Conduction loss: + iω C (exp(+jωt) convention).
-            a_val += c64::new(0.0, omega * cm[(r, c)]);
-        }
-        for (s, coeff) in &surface_blocks {
-            // Leontovich surface loss: + (iω/Z_s) S_Γ (issue #204).
-            a_val += *coeff * s[(r, c)];
-        }
-        triplets.push(Triplet::new(rr as usize, cc as usize, a_val));
-    }
-
-    // --- Lumped-port admittance terms (issue #202) --------------------------
-    // A(ω) += (jω/Z_s) S_p per port. S_p is real symmetric, so the
-    // complex-symmetry invariant A(ω)ᵀ = A(ω) is preserved. The port
-    // faces are boundary faces of mesh tets, so every (r, c) pair below
-    // already exists in the volume sparsity pattern; faer's
-    // `try_new_from_triplets` sums duplicate entries.
-    for port in ports {
-        let zs = port.surface_impedance();
-        let scale = c64::new(0.0, omega / zs);
-        for (r, c, v) in assemble_port_surface_mass(mesh, port.faces, &edges) {
+        // --- Cache interior-filtered values over the recorded sparsity pattern --
+        // One aligned value per kept (interior, interior) entry, in pattern
+        // order, so `solve_at` re-forms A(ω) = K + iωC − ω²M + Σ coeff·S by
+        // pure linear combination — no re-assembly.
+        let n_entries = sparsity.rows.len();
+        let mut rows = Vec::with_capacity(n_entries);
+        let mut cols = Vec::with_capacity(n_entries);
+        let mut k_vals = Vec::with_capacity(n_entries);
+        let mut m_vals = Vec::with_capacity(n_entries);
+        let mut c_vals = c_full.as_ref().map(|_| Vec::with_capacity(n_entries));
+        let mut surface_vals: Vec<Vec<f64>> = surface_masses
+            .iter()
+            .map(|_| Vec::with_capacity(n_entries))
+            .collect();
+        for (&r_u32, &c_u32) in sparsity.rows.iter().zip(sparsity.cols.iter()) {
+            let (r, c) = (r_u32 as usize, c_u32 as usize);
             let (rr, cc) = (remap[r], remap[c]);
             if rr < 0 || cc < 0 {
                 continue;
             }
-            triplets.push(Triplet::new(rr as usize, cc as usize, scale * v));
+            rows.push(rr as usize);
+            cols.push(cc as usize);
+            let k_im_val = k_im_full.as_ref().map_or(0.0, |m| m[(r, c)]);
+            k_vals.push(c64::new(k_full[(r, c)], k_im_val));
+            m_vals.push(m_full[(r, c)]);
+            if let (Some(vals), Some(cm)) = (c_vals.as_mut(), c_full.as_ref()) {
+                vals.push(cm[(r, c)]);
+            }
+            for (vals, (s, _)) in surface_vals.iter_mut().zip(surface_masses.iter()) {
+                vals.push(s[(r, c)]);
+            }
         }
+
+        // --- Lumped-port admittance masses (issue #202) --------------------------
+        // S_p triplets, interior-remapped. The port faces are boundary faces
+        // of mesh tets, so every (r, c) pair below already exists in the
+        // volume sparsity pattern; faer's `try_new_from_triplets` sums
+        // duplicate entries at solve time.
+        let operator_ports: Vec<OperatorPort> = ports
+            .iter()
+            .zip(port_fluxes)
+            .map(|(port, flux)| {
+                let mass_triplets = assemble_port_surface_mass(mesh, port.faces, &edges)
+                    .into_iter()
+                    .filter_map(|(r, c, v)| {
+                        let (rr, cc) = (remap[r], remap[c]);
+                        if rr < 0 || cc < 0 {
+                            None
+                        } else {
+                            Some((rr as usize, cc as usize, v))
+                        }
+                    })
+                    .collect();
+                OperatorPort {
+                    mass_triplets,
+                    flux,
+                    z_s: port.surface_impedance(),
+                    v_inc: port.v_inc,
+                    length: port.length,
+                    width: port.width,
+                    resistance: port.resistance,
+                }
+            })
+            .collect();
+
+        let operator_surfaces: Vec<OperatorSurface> = surface_vals
+            .into_iter()
+            .zip(surface_masses.iter())
+            .map(|(s_vals, (_, model))| OperatorSurface {
+                s_vals,
+                model: *model,
+            })
+            .collect();
+
+        Ok(DrivenOperator {
+            n_edges,
+            n_interior,
+            remap,
+            pec_interior_mask: bcs.pec_interior_mask.to_vec(),
+            rows,
+            cols,
+            k_vals,
+            m_vals,
+            c_vals,
+            surfaces: operator_surfaces,
+            ports: operator_ports,
+            rhs_re,
+            rhs_im,
+        })
     }
 
-    let a_int =
-        SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
-            .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
-
-    let b_int: Vec<c64> = bcs
-        .pec_interior_mask
-        .iter()
-        .zip(b_full.iter())
-        .filter_map(|(&keep, &b)| if keep { Some(b) } else { None })
-        .collect();
-
-    // --- Factor once + direct solve (same machinery as complex Lanczos) ----
-    let lu = a_int
-        .as_ref()
-        .sp_lu()
-        .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
-    let mut x_int = vec![c64::new(0.0, 0.0); n_interior];
-    solve_with_lu(&lu, &b_int, &mut x_int).map_err(|e| DrivenError::Solve(format!("{e}")))?;
-
-    // --- Post-solve residual check ------------------------------------------
-    let mut ax = vec![c64::new(0.0, 0.0); n_interior];
-    spmv(a_int.as_ref(), &x_int, &mut ax);
-    let mut res2 = 0.0_f64;
-    let mut b2 = 0.0_f64;
-    for i in 0..n_interior {
-        let r = ax[i] - b_int[i];
-        res2 += r.re * r.re + r.im * r.im;
-        b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+    /// Number of lumped ports the operator was assembled with.
+    pub fn n_ports(&self) -> usize {
+        self.ports.len()
     }
-    let residual_rel = if b2 > 0.0 {
-        (res2 / b2).sqrt()
-    } else {
-        res2.sqrt()
-    };
 
-    // --- Scatter back to the full edge vector --------------------------------
-    let mut e_edges = vec![c64::new(0.0, 0.0); n_edges];
-    for (full_idx, &ri) in remap.iter().enumerate() {
-        if ri >= 0 {
-            e_edges[full_idx] = x_int[ri as usize];
+    /// Number of interior (kept) DOFs after PEC elimination.
+    pub fn n_interior(&self) -> usize {
+        self.n_interior
+    }
+
+    /// Port voltage `V = (1/w) ∮ E · ê dS` of port `port` read off a
+    /// solution's full-length edge vector, using the cached flux
+    /// functional — identical to [`crate::lumped_port::port_voltage`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `port ≥ self.n_ports()` or `e_edges` has the wrong
+    /// length.
+    pub fn port_voltage(&self, port: usize, e_edges: &[c64]) -> c64 {
+        let p = &self.ports[port];
+        assert_eq!(e_edges.len(), self.n_edges, "edge vector length mismatch");
+        let mut v = c64::new(0.0, 0.0);
+        for (f, e) in p.flux.iter().zip(e_edges.iter()) {
+            v += *e * *f;
         }
+        v * (1.0 / p.width)
     }
 
-    Ok(DrivenSolution {
-        e_edges,
-        n_interior,
-        residual_rel,
-    })
+    /// Port current from the Thevenin admittance relation
+    /// `I = (2 V_inc − V) / R` of port `port` — identical to
+    /// [`crate::lumped_port::port_current`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `port ≥ self.n_ports()`.
+    pub fn port_current(&self, port: usize, v_port: c64) -> c64 {
+        let p = &self.ports[port];
+        (p.v_inc * 2.0 - v_port) * (1.0 / p.resistance)
+    }
+
+    /// Re-form `A(ω)`, factor it, and solve at one frequency.
+    ///
+    /// This is the sweep workhorse: only per-ω scalar work plus the
+    /// sparse LU happen here — the Burn volume assembly ran once in
+    /// [`DrivenOperator::assemble`]. A single `assemble` + `solve_at`
+    /// pair reproduces the corresponding single-ω entry point exactly
+    /// (same arithmetic, same triplet stream).
+    ///
+    /// # Errors
+    ///
+    /// [`DrivenError::SurfaceImpedanceSingular`] if a Leontovich model
+    /// evaluates to a zero/non-finite `Z_s(ω)`, plus the sparse
+    /// assembly / factorization / solve failures of [`driven_solve`].
+    pub fn solve_at(&self, omega: f64) -> Result<DrivenSolution, DrivenError> {
+        // Leontovich coefficients iω/Z_s(ω) — ω-dependent, re-evaluated
+        // here at every frequency (issue #204 sweep caveat).
+        let surface_coeffs: Vec<c64> = self
+            .surfaces
+            .iter()
+            .map(|s| s.model.weak_coefficient(omega))
+            .collect::<Result<_, DrivenError>>()?;
+
+        // b = iωμ₀ ∫ N · J dV with μ₀ = 1:  iω (re + i·im) = ω(−im + i·re).
+        let mut b_full: Vec<c64> = self
+            .rhs_re
+            .iter()
+            .zip(self.rhs_im.iter())
+            .map(|(&re, &im)| c64::new(-omega * im, omega * re))
+            .collect();
+
+        // Matched-source port drive: b_i += (2jω/Z_s)(V_inc/l) f_i.
+        for port in &self.ports {
+            if port.v_inc == c64::new(0.0, 0.0) {
+                continue;
+            }
+            let e_inc = port.v_inc * (1.0 / port.length);
+            let drive = c64::new(0.0, 2.0 * omega / port.z_s) * e_inc;
+            for (b, f) in b_full.iter_mut().zip(port.flux.iter()) {
+                *b += drive * *f;
+            }
+        }
+
+        // --- Sparse A(ω) = K + iωC − ω²M + Σ coeff·S by linear combination --
+        let omega2 = omega * omega;
+        let n_port_entries: usize = self.ports.iter().map(|p| p.mass_triplets.len()).sum();
+        let mut triplets: Vec<Triplet<usize, usize, c64>> =
+            Vec::with_capacity(self.rows.len() + n_port_entries);
+        for idx in 0..self.rows.len() {
+            let mut a_val = self.k_vals[idx] - self.m_vals[idx] * omega2;
+            if let Some(c_vals) = &self.c_vals {
+                // Conduction loss: + iω C (exp(+jωt) convention).
+                a_val += c64::new(0.0, omega * c_vals[idx]);
+            }
+            for (s, coeff) in self.surfaces.iter().zip(surface_coeffs.iter()) {
+                // Leontovich surface loss: + (iω/Z_s) S_Γ (issue #204).
+                a_val += *coeff * s.s_vals[idx];
+            }
+            triplets.push(Triplet::new(self.rows[idx], self.cols[idx], a_val));
+        }
+
+        // Port admittance: A(ω) += (jω/Z_s) S_p per port (issue #202).
+        // S_p is real symmetric, so A(ω)ᵀ = A(ω) is preserved.
+        for port in &self.ports {
+            let scale = c64::new(0.0, omega / port.z_s);
+            for &(rr, cc, v) in &port.mass_triplets {
+                triplets.push(Triplet::new(rr, cc, scale * v));
+            }
+        }
+
+        let a_int = SparseColMat::<usize, c64>::try_new_from_triplets(
+            self.n_interior,
+            self.n_interior,
+            &triplets,
+        )
+        .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+
+        let b_int: Vec<c64> = self
+            .pec_interior_mask
+            .iter()
+            .zip(b_full.iter())
+            .filter_map(|(&keep, &b)| if keep { Some(b) } else { None })
+            .collect();
+
+        // --- Factor once + direct solve (same machinery as complex Lanczos) -
+        let lu = a_int
+            .as_ref()
+            .sp_lu()
+            .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+        let mut x_int = vec![c64::new(0.0, 0.0); self.n_interior];
+        solve_with_lu(&lu, &b_int, &mut x_int).map_err(|e| DrivenError::Solve(format!("{e}")))?;
+
+        // --- Post-solve residual check --------------------------------------
+        let mut ax = vec![c64::new(0.0, 0.0); self.n_interior];
+        spmv(a_int.as_ref(), &x_int, &mut ax);
+        let mut res2 = 0.0_f64;
+        let mut b2 = 0.0_f64;
+        for i in 0..self.n_interior {
+            let r = ax[i] - b_int[i];
+            res2 += r.re * r.re + r.im * r.im;
+            b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+        }
+        let residual_rel = if b2 > 0.0 {
+            (res2 / b2).sqrt()
+        } else {
+            res2.sqrt()
+        };
+
+        // --- Scatter back to the full edge vector ---------------------------
+        let mut e_edges = vec![c64::new(0.0, 0.0); self.n_edges];
+        for (full_idx, &ri) in self.remap.iter().enumerate() {
+            if ri >= 0 {
+                e_edges[full_idx] = x_int[ri as usize];
+            }
+        }
+
+        Ok(DrivenSolution {
+            e_edges,
+            n_interior: self.n_interior,
+            residual_rel,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/geode-core/src/extraction.rs
+++ b/crates/geode-core/src/extraction.rs
@@ -1,0 +1,374 @@
+//! Impedance-extraction post-processing: `Z(ω) → L(ω), R(ω), Q(ω),
+//! S-parameters` over port-driven solves (Epic #193, issue #203).
+//!
+//! Given a driven solve excited through a lumped port
+//! ([`crate::lumped_port::LumpedPort`], issue #202), this module
+//! reduces the field solution to the circuit quantities that are the
+//! epic's actual deliverable:
+//!
+//! ```text
+//! Z(ω)  = V / I                 (port input impedance; V from the
+//!                                port-field projection, I from the
+//!                                Thevenin admittance relation)
+//! R(ω)  = Re Z(ω)               (series resistance)
+//! L(ω)  = Im Z(ω) / ω           (series inductance)
+//! Q(ω)  = Im Z(ω) / Re Z(ω)     (quality factor)
+//! S₁₁(ω) = (Z − Z₀) / (Z + Z₀)  (reflection vs real reference Z₀)
+//! ```
+//!
+//! plus self-resonance detection from the `Im Z(ω)` zero crossing when
+//! a sweep brackets it.
+//!
+//! Everything here is **post-processing over [`DrivenSolution`]** — no
+//! new assembly physics. The field-to-circuit reduction reuses the
+//! lumped-port flux functional `f_i = ∮ N_i · ê dS` (the same discrete
+//! functional that drives the port, so the drive/measure pair is
+//! adjoint-consistent; see `lumped_port.rs`).
+//!
+//! # Frequency sweeps
+//!
+//! `A(ω) = K + iωC − ω²M` re-forms per frequency by linear combination
+//! of ω-independent matrices (the design rationale recorded in
+//! PR #198), so the sweep driver [`driven_frequency_sweep`] assembles
+//! once through [`DrivenOperator`] and then *re-factors per ω, never
+//! re-assembles*. The ω-dependent complex coefficients of the port and
+//! Leontovich surface terms (issue #204) are cheap host-side scalar
+//! rescales applied inside [`DrivenOperator::solve_at`].
+//!
+//! # Multi-port S-parameters
+//!
+//! [`SMatrix`] carries the n-port structure, but only the single-port
+//! constructor ([`SMatrix::from_single_port_z`]) is implemented in this
+//! phase — the multi-port S-matrix needs one driven solve per excited
+//! port and lands with the Phase 3 spiral work (Epic #193).
+
+use burn::tensor::backend::Backend;
+use faer::c64;
+
+use crate::driven::{
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SurfaceImpedanceBc,
+};
+use crate::lumped_port::{port_current, port_voltage, LumpedPort};
+use crate::TetMesh;
+
+/// Circuit quantities of one port at one frequency, read off a driven
+/// solution.
+#[derive(Debug, Clone, Copy)]
+pub struct PortCircuit {
+    /// Port voltage `V = (1/w) ∮ E · ê dS`.
+    pub v: c64,
+    /// Port current `I = (2 V_inc − V) / R`.
+    pub i: c64,
+    /// Input impedance `Z = V / I`.
+    pub z: c64,
+}
+
+impl PortCircuit {
+    /// Series resistance `R(ω) = Re Z`.
+    pub fn resistance(&self) -> f64 {
+        self.z.re
+    }
+
+    /// Series inductance `L(ω) = Im Z / ω`.
+    pub fn inductance(&self, omega: f64) -> f64 {
+        inductance(self.z, omega)
+    }
+
+    /// Quality factor `Q(ω) = Im Z / Re Z`.
+    pub fn quality_factor(&self) -> f64 {
+        quality_factor(self.z)
+    }
+
+    /// Single-port reflection coefficient `S₁₁` vs the real reference
+    /// impedance `z0`.
+    pub fn s11(&self, z0: f64) -> c64 {
+        s11(self.z, z0)
+    }
+}
+
+/// Extract the port circuit quantities `V`, `I`, `Z` from a single
+/// driven solution (`e_edges` in `mesh.edges()` order, e.g.
+/// [`crate::driven::DrivenSolution::e_edges`]).
+///
+/// Thin composition of [`crate::lumped_port::port_voltage`] and
+/// [`crate::lumped_port::port_current`]; sweeps should prefer
+/// [`driven_frequency_sweep`], which reuses the assembled operator and
+/// the cached port flux across frequencies.
+pub fn extract_port_circuit(
+    mesh: &TetMesh,
+    port: &LumpedPort<'_>,
+    edges: &[[u32; 2]],
+    e_edges: &[c64],
+) -> PortCircuit {
+    let v = port_voltage(mesh, port, edges, e_edges);
+    let i = port_current(port, v);
+    PortCircuit { v, i, z: v / i }
+}
+
+/// Series inductance `L(ω) = Im Z / ω`.
+pub fn inductance(z: c64, omega: f64) -> f64 {
+    z.im / omega
+}
+
+/// Quality factor `Q(ω) = Im Z / Re Z` (±∞ for a lossless reactance).
+pub fn quality_factor(z: c64) -> f64 {
+    z.im / z.re
+}
+
+/// Single-port reflection coefficient vs a **real** reference impedance:
+///
+/// ```text
+/// S₁₁ = (Z − Z₀) / (Z + Z₀).
+/// ```
+///
+/// Limits: `Z = Z₀` (matched) → 0; `Z → 0` (short) → −1;
+/// `|Z| → ∞` (open) → +1.
+pub fn s11(z: c64, z0: f64) -> c64 {
+    (z - z0) / (z + z0)
+}
+
+/// Single-frequency S-parameter matrix vs a real reference impedance
+/// `Z₀` (n-port structure; Phase 2 implements the single-port path).
+///
+/// The multi-port constructor requires one driven solve per excited
+/// port (column `j` of `S` comes from driving port `j` with all other
+/// ports passively terminated) and is deferred to the Phase 3 spiral
+/// work of Epic #193 — only [`SMatrix::from_single_port_z`] exists
+/// here, and it is exact.
+#[derive(Debug, Clone)]
+pub struct SMatrix {
+    /// Real reference impedance `Z₀`.
+    pub z0: f64,
+    /// Number of ports `n`.
+    pub n_ports: usize,
+    /// Row-major `n × n` entries.
+    pub s: Vec<c64>,
+}
+
+impl SMatrix {
+    /// Exact single-port S-matrix from the port input impedance:
+    /// `S = [S₁₁]` with `S₁₁ = (Z − Z₀)/(Z + Z₀)`.
+    pub fn from_single_port_z(z: c64, z0: f64) -> Self {
+        Self {
+            z0,
+            n_ports: 1,
+            s: vec![s11(z, z0)],
+        }
+    }
+
+    /// Entry `S[i][j]` (0-based).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` or `j` is out of range.
+    pub fn entry(&self, i: usize, j: usize) -> c64 {
+        assert!(i < self.n_ports && j < self.n_ports, "S-matrix index");
+        self.s[i * self.n_ports + j]
+    }
+}
+
+/// One frequency point of a port-driven sweep.
+#[derive(Debug, Clone)]
+pub struct SweepPoint {
+    /// Frequency `ω ≡ k₀` (natural units, as in [`crate::driven`]).
+    pub omega: f64,
+    /// Direct-solve relative residual at this frequency.
+    pub residual_rel: f64,
+    /// Per-port circuit quantities, in the order the ports were passed
+    /// to the sweep.
+    pub ports: Vec<PortCircuit>,
+}
+
+/// Frequency-sweep driver over a port-driven structure: assemble the
+/// ω-independent operator **once** ([`DrivenOperator::assemble`]), then
+/// re-form + re-factor `A(ω)` and extract `V`, `I`, `Z` at every
+/// requested frequency.
+///
+/// The expensive Burn volume assembly of `K`, `M(ε)`, `C(σ)` and the
+/// source moments runs once for the whole sweep; per frequency only
+/// scalar recombination, the sparse LU, and the port readouts remain.
+/// One sweep point reproduces the corresponding single-ω
+/// [`crate::driven::driven_solve_with_ports`] /
+/// [`crate::driven::driven_solve_with_surface_impedance`] call exactly
+/// (same arithmetic, same triplet stream).
+///
+/// `surfaces` composes Leontovich impedance walls (issue #204) into the
+/// sweep; their ω-dependent scalar coefficient is re-evaluated at every
+/// frequency, as that issue's sweep caveat requires. Pass `&[]` for
+/// none.
+///
+/// # Errors
+///
+/// Any [`DrivenError`] from assembly or from the per-ω solves; the
+/// sweep stops at the first failing frequency.
+#[allow(clippy::too_many_arguments)]
+pub fn driven_frequency_sweep<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
+    surfaces: &[SurfaceImpedanceBc<'_>],
+    omegas: &[f64],
+    source: &CurrentSource,
+    device: &B::Device,
+) -> Result<Vec<SweepPoint>, DrivenError> {
+    let op = DrivenOperator::assemble::<B>(
+        mesh, materials, sigma_tet, bcs, ports, surfaces, source, device,
+    )?;
+    omegas
+        .iter()
+        .map(|&omega| {
+            let sol = op.solve_at(omega)?;
+            let ports = (0..op.n_ports())
+                .map(|p| {
+                    let v = op.port_voltage(p, &sol.e_edges);
+                    let i = op.port_current(p, v);
+                    PortCircuit { v, i, z: v / i }
+                })
+                .collect();
+            Ok(SweepPoint {
+                omega,
+                residual_rel: sol.residual_rel,
+                ports,
+            })
+        })
+        .collect()
+}
+
+/// All `Im Z(ω)` sign changes of a sampled impedance curve, located by
+/// linear interpolation between consecutive samples (an exact-zero
+/// sample reports its own ω).
+///
+/// A sign change marks either a **series-type resonance** (a true zero
+/// of `Im Z` — for an inductor the inductive→capacitive `+ → −`
+/// crossing is the self-resonant frequency) or a sign flip **through a
+/// pole** (parallel anti-resonance, where `|Im Z|` blows up at the
+/// bracketing samples instead of shrinking). Distinguishing the two
+/// requires inspecting `|Im Z|` near the crossing or sweeping the
+/// admittance instead; callers with lossy structures (finite `Re Z`)
+/// see finite peaks in both cases and the interpolated ω remains a
+/// useful bracket.
+///
+/// `omegas` and `zs` must have equal length and `omegas` must be
+/// strictly increasing; non-finite samples are skipped.
+pub fn im_z_zero_crossings(omegas: &[f64], zs: &[c64]) -> Vec<f64> {
+    assert_eq!(omegas.len(), zs.len(), "omegas/zs length mismatch");
+    let mut crossings = Vec::new();
+    let mut prev: Option<(f64, f64)> = None; // (ω, Im Z)
+    for (&omega, &z) in omegas.iter().zip(zs.iter()) {
+        if !z.im.is_finite() {
+            prev = None;
+            continue;
+        }
+        if z.im == 0.0 {
+            crossings.push(omega);
+            prev = Some((omega, z.im));
+            continue;
+        }
+        if let Some((w1, im1)) = prev {
+            if im1 != 0.0 && im1.signum() != z.im.signum() {
+                // Linear interpolation of the bracketed zero.
+                crossings.push(w1 + (omega - w1) * im1 / (im1 - z.im));
+            }
+        }
+        prev = Some((omega, z.im));
+    }
+    crossings
+}
+
+/// Self-resonant frequency estimate: the first `Im Z(ω)` zero crossing
+/// the sweep brackets ([`im_z_zero_crossings`]), or `None` if the sweep
+/// does not bracket one.
+pub fn detect_srf(omegas: &[f64], zs: &[c64]) -> Option<f64> {
+    im_z_zero_crossings(omegas, zs).into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(re: f64, im: f64) -> c64 {
+        c64::new(re, im)
+    }
+
+    /// R/L/Q definitions on a synthetic impedance.
+    #[test]
+    fn circuit_quantities_match_definitions() {
+        let omega = 2.0;
+        let z = c(0.5, 3.0);
+        let pc = PortCircuit {
+            v: c(1.0, 0.0),
+            i: c(1.0, 0.0),
+            z,
+        };
+        assert_eq!(pc.resistance(), 0.5);
+        assert_eq!(pc.inductance(omega), 1.5);
+        assert_eq!(pc.quality_factor(), 6.0);
+        assert_eq!(inductance(z, omega), 1.5);
+        assert_eq!(quality_factor(z), 6.0);
+    }
+
+    /// S₁₁ limits: matched → 0, short → −1, open → +1.
+    #[test]
+    fn s11_limits() {
+        let z0 = 50.0;
+        assert!(s11(c(50.0, 0.0), z0).norm() < 1e-15);
+        assert!((s11(c(0.0, 0.0), z0) - c(-1.0, 0.0)).norm() < 1e-15);
+        let open = s11(c(1e12, 0.0), z0);
+        assert!((open - c(1.0, 0.0)).norm() < 1e-9);
+        // Lossless reactance reflects with unit magnitude.
+        let reactive = s11(c(0.0, 17.0), z0);
+        assert!((reactive.norm() - 1.0).abs() < 1e-15);
+    }
+
+    /// Single-port S-matrix is the scalar S₁₁.
+    #[test]
+    fn single_port_s_matrix() {
+        let z = c(25.0, 10.0);
+        let m = SMatrix::from_single_port_z(z, 50.0);
+        assert_eq!(m.n_ports, 1);
+        assert_eq!(m.entry(0, 0), s11(z, 50.0));
+    }
+
+    /// SRF detection on a series-LC impedance `Im Z = ωL − 1/(ωC)`:
+    /// the analytic resonance `ω₀ = 1/√(LC)` is bracketed and located
+    /// to interpolation accuracy.
+    #[test]
+    fn detects_series_resonance_zero_crossing() {
+        let (l, cap) = (2.0_f64, 0.125_f64);
+        let omega0 = 1.0 / (l * cap).sqrt(); // = 2.0
+        let omegas: Vec<f64> = (1..=12).map(|k| 0.3 * k as f64).collect();
+        let zs: Vec<c64> = omegas
+            .iter()
+            .map(|&w| c(0.01, l * w - 1.0 / (cap * w)))
+            .collect();
+        let srf = detect_srf(&omegas, &zs).expect("sweep brackets the resonance");
+        assert!(
+            (srf - omega0).abs() < 0.05,
+            "series-LC SRF: got {srf}, want {omega0}"
+        );
+    }
+
+    /// A monotone inductive curve has no crossing; a sweep that does
+    /// not bracket the resonance returns `None`.
+    #[test]
+    fn no_crossing_returns_none() {
+        let omegas = [1.0, 2.0, 3.0];
+        let zs = [c(0.1, 1.0), c(0.1, 2.0), c(0.1, 3.0)];
+        assert!(detect_srf(&omegas, &zs).is_none());
+        assert!(im_z_zero_crossings(&omegas, &zs).is_empty());
+    }
+
+    /// An exact-zero sample reports its own ω; multiple crossings are
+    /// all reported in order.
+    #[test]
+    fn exact_zero_and_multiple_crossings() {
+        let omegas = [1.0, 2.0, 3.0, 4.0];
+        let zs = [c(0.1, -1.0), c(0.1, 0.0), c(0.1, 1.0), c(0.1, -1.0)];
+        let crossings = im_z_zero_crossings(&omegas, &zs);
+        assert_eq!(crossings.len(), 2);
+        assert_eq!(crossings[0], 2.0);
+        assert!((crossings[1] - 3.5).abs() < 1e-15);
+    }
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod complex_lanczos;
 pub mod derham;
 pub mod driven;
 pub mod eigen;
+pub mod extraction;
 pub mod fe_assemble;
 pub mod lanczos;
 pub mod lumped_port;
@@ -38,12 +39,16 @@ pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gra
 pub use driven::{
     driven_solve, driven_solve_quad, driven_solve_with_ports, driven_solve_with_sigma,
     driven_solve_with_sigma_quad, driven_solve_with_surface_impedance, CurrentSource, DrivenBcs,
-    DrivenError, DrivenMaterials, DrivenSolution, QuadCurrentSource, SurfaceImpedanceBc,
-    SurfaceImpedanceModel,
+    DrivenError, DrivenMaterials, DrivenOperator, DrivenSolution, QuadCurrentSource,
+    SurfaceImpedanceBc, SurfaceImpedanceModel,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
     FaerDenseEigensolver,
+};
+pub use extraction::{
+    detect_srf, driven_frequency_sweep, extract_port_circuit, im_z_zero_crossings, inductance,
+    quality_factor, s11, PortCircuit, SMatrix, SweepPoint,
 };
 pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
 pub use lanczos::{SparseEigenSolver, SparseShiftInvertLanczos};

--- a/crates/geode-core/src/lumped_port.rs
+++ b/crates/geode-core/src/lumped_port.rs
@@ -361,7 +361,8 @@ pub fn port_current(port: &LumpedPort<'_>, v_port: c64) -> c64 {
 /// This is the structure's input impedance **excluding** the port's own
 /// resistance `R` (the source impedance) — the quantity the
 /// transmission-line oracle compares against `j Z₀ tan(ωd)`. The
-/// full `Z(ω) → L/R/Q/S` extraction API is issue #203.
+/// full `Z(ω) → L/R/Q/S` extraction API and the assembly-reusing
+/// frequency-sweep driver live in [`crate::extraction`] (issue #203).
 pub fn port_input_impedance(
     mesh: &TetMesh,
     port: &LumpedPort<'_>,

--- a/crates/geode-core/tests/extraction.rs
+++ b/crates/geode-core/tests/extraction.rs
@@ -1,0 +1,695 @@
+//! Impedance-extraction regressions (Epic #193, issue #203):
+//! `Z(ω) → L(ω), R(ω), Q(ω), S₁₁(ω)` over port-driven solves, plus the
+//! assembly-reusing frequency-sweep driver.
+//!
+//! 1. **Wire-loop inductance oracle** — a single-turn shielded loop
+//!    inductor with rectangular cross-section (the coaxial / toroidal
+//!    loop: current down the inner conductor, along the bottom plate,
+//!    up the outer shield, back along the top plate) has the exact
+//!    closed-form magnetostatic inductance
+//!
+//!    ```text
+//!    L = (μ₀ h / 2π) ln(b/a)
+//!    ```
+//!
+//!    (Grover, *Inductance Calculations*; any EM text — the
+//!    rectangular-cross-section toroid). Unlike thin-round-wire loop
+//!    formulas it is exact for any aspect ratio and *includes* the
+//!    return shield, so the FEM comparison carries no equivalent-radius
+//!    or open-boundary fudge. We model one azimuthal wedge of angle Φ
+//!    (the φ-planes are exact magnetic-symmetry planes of the TEM
+//!    field, i.e. the natural BC), drive it through a lumped port on a
+//!    circumferential slit in the inner conductor (ê = ẑ exactly), and
+//!    expect `L_wedge = (h/Φ) ln(b/a)` at low frequency. Remaining
+//!    model errors: O(h²) FEM discretization, the polygonal
+//!    approximation of the circular arcs (O((Φ/n_φ)²)), and the finite
+//!    frequency (O((ωh)²) transmission-line correction) — all small and
+//!    shrinking under refinement.
+//! 2. **R(ω) ↔ σ DC-resistance consistency** (issue #196 path) — a
+//!    σ-filled parallel-plate resistor recovers `R_DC = 1/σ` at low ω.
+//! 3. **S₁₁ sanity** — matched load → S₁₁ ≈ 0; PEC-shorted stub →
+//!    S₁₁ ≈ −1 with inductive (positive) phase; open stub → S₁₁ ≈ +1
+//!    with capacitive (negative) phase.
+//! 4. **SRF detection** — sweeping the shorted stub through its
+//!    half-wave resonance brackets the Im Z zero crossing at ωd ≈ π.
+//! 5. **Sweep ≡ single-solve** — the assemble-once
+//!    `DrivenOperator`/sweep path reproduces the per-ω
+//!    `driven_solve_with_ports` / `driven_solve_with_surface_impedance`
+//!    solutions exactly (bit-for-bit: same arithmetic, same triplet
+//!    stream).
+
+use std::collections::BTreeMap;
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use geode_core::{
+    detect_srf, driven_frequency_sweep, driven_solve_with_ports,
+    driven_solve_with_surface_impedance, extract_port_circuit, port_input_impedance, s11,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, DrivenOperator, LumpedPort,
+    SurfaceImpedanceBc, SurfaceImpedanceModel, TetMesh,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+fn zero_source(mesh: &TetMesh) -> CurrentSource {
+    CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    }
+}
+
+/// Boundary faces of the mesh lying entirely in the plane
+/// `coord[axis] == value`.
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+/// PEC interior-edge mask eliminating every edge whose **both**
+/// endpoints lie on the same listed plane `(axis, value)`.
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Wire-loop oracle geometry: annular wedge mesh
+// ---------------------------------------------------------------------------
+
+/// Structured tet mesh of an annular wedge: radii `a..b` (n_r cells),
+/// azimuth `0..phi` (n_phi cells), height `0..h` (n_z cells). Same
+/// 6-tet Kuhn split as `cube_tet_mesh` over the structured
+/// (radial, azimuthal, axial) grid, so the mesh is conforming; the
+/// circular arcs become n_phi-segment polygons (nodes exactly on the
+/// circles).
+#[allow(clippy::too_many_arguments)]
+fn annular_wedge_mesh(
+    a: f64,
+    b: f64,
+    phi: f64,
+    h: f64,
+    n_r: usize,
+    n_phi: usize,
+    n_z: usize,
+) -> TetMesh {
+    let (npr, npp, npz) = (n_r + 1, n_phi + 1, n_z + 1);
+    let node_idx = |i: usize, j: usize, k: usize| -> u32 { (i + j * npr + k * npr * npp) as u32 };
+
+    let mut nodes = Vec::with_capacity(npr * npp * npz);
+    for k in 0..npz {
+        for j in 0..npp {
+            for i in 0..npr {
+                let rho = a + (b - a) * (i as f64) / (n_r as f64);
+                let ang = phi * (j as f64) / (n_phi as f64);
+                let z = h * (k as f64) / (n_z as f64);
+                nodes.push([rho * ang.cos(), rho * ang.sin(), z]);
+            }
+        }
+    }
+
+    let mut tets = Vec::with_capacity(6 * n_r * n_phi * n_z);
+    for k in 0..n_z {
+        for j in 0..n_phi {
+            for i in 0..n_r {
+                let c = [
+                    node_idx(i, j, k),
+                    node_idx(i + 1, j, k),
+                    node_idx(i + 1, j + 1, k),
+                    node_idx(i, j + 1, k),
+                    node_idx(i, j, k + 1),
+                    node_idx(i + 1, j, k + 1),
+                    node_idx(i + 1, j + 1, k + 1),
+                    node_idx(i, j + 1, k + 1),
+                ];
+                tets.push([c[0], c[1], c[2], c[6]]);
+                tets.push([c[0], c[2], c[3], c[6]]);
+                tets.push([c[0], c[3], c[7], c[6]]);
+                tets.push([c[0], c[7], c[4], c[6]]);
+                tets.push([c[0], c[4], c[5], c[6]]);
+                tets.push([c[0], c[5], c[1], c[6]]);
+            }
+        }
+    }
+
+    let mesh = TetMesh {
+        nodes,
+        tets,
+        physical_groups: BTreeMap::new(),
+    };
+    // The cylindrical map is orientation-preserving; assert all tets
+    // stayed right-handed under the curvature.
+    for tet in &mesh.tets {
+        let v: [[f64; 3]; 4] = std::array::from_fn(|m| mesh.nodes[tet[m] as usize]);
+        let d = |p: [f64; 3], q: [f64; 3]| [p[0] - q[0], p[1] - q[1], p[2] - q[2]];
+        let (e1, e2, e3) = (d(v[1], v[0]), d(v[2], v[0]), d(v[3], v[0]));
+        let det = e1[0] * (e2[1] * e3[2] - e2[2] * e3[1]) - e1[1] * (e2[0] * e3[2] - e2[2] * e3[0])
+            + e1[2] * (e2[0] * e3[1] - e2[1] * e3[0]);
+        assert!(det > 0.0, "inverted tet in annular wedge mesh");
+    }
+    mesh
+}
+
+/// Node radius in the xy-plane.
+fn node_rho(p: [f64; 3]) -> f64 {
+    p[0].hypot(p[1])
+}
+
+/// Solve the single-turn shielded loop (annular wedge, PEC inner /
+/// outer / top / bottom walls, circumferential port slit of one axial
+/// cell in the inner conductor at mid-height) over `omegas` and return
+/// the extracted `L(ω) = Im Z / ω` per frequency plus the exact
+/// reference `L_wedge = (h/Φ) ln(b/a)`.
+fn loop_inductance_sweep(
+    n_r: usize,
+    n_phi: usize,
+    n_z: usize,
+    omegas: &[f64],
+) -> (Vec<f64>, f64, Vec<c64>) {
+    let (a, b, phi, h) = (1.0, 2.0, std::f64::consts::PI / 6.0, 2.0);
+    let mesh = annular_wedge_mesh(a, b, phi, h, n_r, n_phi, n_z);
+    let edges = mesh.edges();
+    let tol = 1e-9;
+
+    // Slit: one axial cell starting at mid-height.
+    let z1 = h * ((n_z / 2) as f64) / (n_z as f64);
+    let z2 = h * ((n_z / 2 + 1) as f64) / (n_z as f64);
+
+    // PEC mask: outer shield, bottom and top plates, and the inner
+    // conductor outside the slit band.
+    let mask: Vec<bool> = edges
+        .iter()
+        .map(|e| {
+            let p = mesh.nodes[e[0] as usize];
+            let q = mesh.nodes[e[1] as usize];
+            let (rp, rq) = (node_rho(p), node_rho(q));
+            let on_outer = (rp - b).abs() < tol && (rq - b).abs() < tol;
+            let on_bottom = p[2].abs() < tol && q[2].abs() < tol;
+            let on_top = (p[2] - h).abs() < tol && (q[2] - h).abs() < tol;
+            let on_inner = (rp - a).abs() < tol && (rq - a).abs() < tol;
+            let below_slit = p[2] <= z1 + tol && q[2] <= z1 + tol;
+            let above_slit = p[2] >= z2 - tol && q[2] >= z2 - tol;
+            let inner_pec = on_inner && (below_slit || above_slit);
+            !(on_outer || on_bottom || on_top || inner_pec)
+        })
+        .collect();
+
+    // Port: the slit band on the inner surface, ê = ẑ (exactly
+    // tangential to every polygonal facet of the inner cylinder).
+    let port_faces: Vec<[u32; 3]> = mesh
+        .faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter().all(|&n| {
+                let p = mesh.nodes[n as usize];
+                (node_rho(p) - a).abs() < tol && p[2] >= z1 - tol && p[2] <= z2 + tol
+            })
+        })
+        .collect();
+    assert_eq!(
+        port_faces.len(),
+        2 * n_phi,
+        "slit band must be two triangles per azimuthal cell"
+    );
+
+    // Port width = total azimuthal extent of the polygonal band (sum of
+    // chords), so V = (1/w)∮E·ê dS is the exact per-line gap voltage.
+    let width = (n_phi as f64) * 2.0 * a * (phi / (2.0 * n_phi as f64)).sin();
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 0.0, 1.0],
+        resistance: 1.0,
+        width,
+        length: z2 - z1,
+        v_inc: c64::new(1.0, 0.0),
+    };
+
+    let eps = vacuum(&mesh);
+    let points = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("loop sweep");
+
+    let mut l_extracted = Vec::with_capacity(points.len());
+    let mut z_values = Vec::with_capacity(points.len());
+    for p in &points {
+        assert!(
+            p.residual_rel < 1e-8,
+            "direct-solve residual too large at ω = {}: {}",
+            p.omega,
+            p.residual_rel
+        );
+        l_extracted.push(p.ports[0].inductance(p.omega));
+        z_values.push(p.ports[0].z);
+    }
+    let l_ref = (h / phi) * (b / a).ln();
+    (l_extracted, l_ref, z_values)
+}
+
+/// Static-limit inductance via Richardson extrapolation in ω: the
+/// extracted curve follows `L(ω) = L₀ (1 + c ω²)` (the leading
+/// transmission-line correction of the shorted loop), so two
+/// frequencies give `L₀ = L(ω) − (L(2ω) − L(ω)) / 3`.
+fn extrapolate_l0(l_at_omega: f64, l_at_2omega: f64) -> f64 {
+    l_at_omega - (l_at_2omega - l_at_omega) / 3.0
+}
+
+/// Acceptance oracle: the wedge loop recovers the closed-form
+/// magnetostatic inductance `L = (h/Φ) ln(b/a)` within
+/// mesh-convergence tolerance, improving under refinement.
+///
+/// The raw L(ω) at any single low ω mixes the static FEM/polygon
+/// discretization error with the +O(ω²) transmission-line correction
+/// (which can partially cancel it), so the comparison is made in the
+/// ω → 0 limit via two-frequency Richardson extrapolation.
+///
+/// Measured static-limit errors (printed below): ~5.3e-3 on the
+/// coarse 3×3×8 mesh, ~2.0e-3 on the fine 5×5×12 mesh.
+#[test]
+fn wire_loop_recovers_closed_form_inductance() {
+    let omegas = [0.05, 0.1];
+
+    let (l_coarse, l_ref, z_coarse) = loop_inductance_sweep(3, 3, 8, &omegas);
+    let l0_coarse = extrapolate_l0(l_coarse[0], l_coarse[1]);
+    let err_coarse = (l0_coarse - l_ref).abs() / l_ref;
+    println!(
+        "loop L₀ (coarse 3×3×8): {l0_coarse} vs analytic {l_ref} (rel err {err_coarse:.3e}); \
+         L(0.05) = {}, L(0.1) = {}, Z(0.05) = {}",
+        l_coarse[0], l_coarse[1], z_coarse[0]
+    );
+
+    let (l_fine, _, z_fine) = loop_inductance_sweep(5, 5, 12, &omegas);
+    let l0_fine = extrapolate_l0(l_fine[0], l_fine[1]);
+    let err_fine = (l0_fine - l_ref).abs() / l_ref;
+    println!(
+        "loop L₀ (fine 5×5×12): {l0_fine} vs analytic {l_ref} (rel err {err_fine:.3e}); \
+         L(0.05) = {}, L(0.1) = {}, Z(0.05) = {}",
+        l_fine[0], l_fine[1], z_fine[0]
+    );
+
+    assert!(
+        err_coarse < 2e-2,
+        "coarse-mesh loop inductance error too large: {err_coarse:.3e}"
+    );
+    assert!(
+        err_fine < 1e-2,
+        "fine-mesh loop inductance error too large: {err_fine:.3e}"
+    );
+    assert!(
+        err_fine < err_coarse,
+        "no mesh convergence: coarse {err_coarse:.3e}, fine {err_fine:.3e}"
+    );
+
+    // The PEC loop is (numerically) lossless: the extracted series
+    // resistance is negligible against the reactance.
+    assert!(
+        z_fine[0].re.abs() < 1e-3 * z_fine[0].im.abs(),
+        "PEC loop developed spurious resistance: Z = {}",
+        z_fine[0]
+    );
+}
+
+/// The deviation from the static limit scales as ω² (the leading
+/// transmission-line correction): successive doublings of ω from
+/// 0.025 to 0.1 quadruple the increment `L(2ω) − L(ω)`.
+#[test]
+fn wire_loop_inductance_correction_scales_as_omega_squared() {
+    let (l, l_ref, _) = loop_inductance_sweep(3, 3, 8, &[0.025, 0.05, 0.1]);
+    let d1 = l[1] - l[0]; // c (0.05² − 0.025²)  = 3 c 0.025²
+    let d2 = l[2] - l[1]; // c (0.1²  − 0.05²)   = 12 c 0.025²
+    let ratio = d2 / d1;
+    println!(
+        "loop L(0.025) = {}, L(0.05) = {}, L(0.1) = {} (ref {l_ref}); increment ratio {ratio:.3}",
+        l[0], l[1], l[2]
+    );
+    assert!(
+        d1 > 0.0 && d2 > 0.0,
+        "L(ω) must grow toward the loop resonance"
+    );
+    assert!(
+        (ratio - 4.0).abs() < 1.0,
+        "L(ω) − L₀ must scale as ω²: increment ratio {ratio:.3} (want ≈ 4)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R(ω) ↔ σ DC resistance, matched-load S11
+// ---------------------------------------------------------------------------
+
+/// σ-filled parallel-plate resistor: unit cube, PEC plates at
+/// y = 0 / 1, all other walls natural, port across the z = 0 face,
+/// uniform conductivity σ. DC limit: R = (plate gap)/(σ · area) = 1/σ.
+fn resistor_sweep(n: usize, sigma: f64, omegas: &[f64]) -> Vec<c64> {
+    let mesh = geode_core::cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let sigma_tet = vec![sigma; mesh.n_tets()];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let points = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("resistor sweep");
+    points.iter().map(|p| p.ports[0].z).collect()
+}
+
+/// R(ω) consistency with the volumetric-σ path (issue #196): the
+/// resistive structure recovers its DC resistance 1/σ at low ω, and
+/// Q = Im Z / Re Z is small (the structure is resistance-dominated).
+#[test]
+fn resistor_recovers_dc_resistance_at_low_omega() {
+    let sigma = 2.0;
+    let r_dc = 1.0 / sigma;
+    let zs = resistor_sweep(4, sigma, &[0.02, 0.05]);
+    for (&omega, z) in [0.02, 0.05].iter().zip(zs.iter()) {
+        let err = (z.re - r_dc).abs() / r_dc;
+        println!("resistor Z({omega}) = {z}, R_DC = {r_dc}, Re rel err = {err:.3e}");
+        assert!(
+            err < 1e-2,
+            "ω = {omega}: Re Z = {} vs R_DC = {r_dc} (rel err {err:.3e})",
+            z.re
+        );
+        // Resistance-dominated: |Q| ≪ 1 at low ω.
+        let q = geode_core::quality_factor(*z);
+        assert!(
+            q.abs() < 0.3,
+            "ω = {omega}: resistor Q = {q} not resistance-dominated"
+        );
+    }
+}
+
+/// Matched load: referencing S₁₁ to the structure's own input
+/// resistance gives |S₁₁| ≈ 0 at low ω.
+#[test]
+fn matched_load_s11_is_near_zero() {
+    let sigma = 2.0;
+    let zs = resistor_sweep(4, sigma, &[0.02]);
+    let gamma = s11(zs[0], 1.0 / sigma);
+    println!("matched-load S11 = {gamma} (|S11| = {:.3e})", gamma.norm());
+    assert!(
+        gamma.norm() < 0.05,
+        "matched load must be reflectionless: |S11| = {}",
+        gamma.norm()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Short / open S11 phase limits, SRF detection
+// ---------------------------------------------------------------------------
+
+/// Parallel-plate stub of the issue-#202 oracle: PEC plates at
+/// y = 0 / 1, port across z = 0, PEC short at z = 1 when `shorted`
+/// (open / natural otherwise). Returns Z(ω).
+fn stub_z(n: usize, omega: f64, shorted: bool) -> c64 {
+    let mesh = geode_core::cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mut planes = vec![(1usize, 0.0f64), (1, 1.0)];
+    if shorted {
+        planes.push((2, 1.0));
+    }
+    let mask = pec_mask_for_planes(&mesh, &edges, &planes);
+    let eps = vacuum(&mesh);
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let sol = driven_solve_with_ports::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        omega,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("stub solve");
+    extract_port_circuit(&mesh, &port, &edges, &sol.e_edges).z
+}
+
+/// Short / open S₁₁ phase limits at low ω vs Z₀ = 1:
+/// shorted stub (Z ≈ jωZ₀d, small inductive) → S₁₁ ≈ −1 with
+/// Im S₁₁ > 0; open stub (Z ≈ −jZ₀cot(ωd), large capacitive) →
+/// S₁₁ ≈ +1 with Im S₁₁ < 0. Lossless ⇒ |S₁₁| ≈ 1 in both cases.
+#[test]
+fn short_and_open_s11_have_correct_phase() {
+    let omega = 0.1;
+
+    let z_short = stub_z(4, omega, true);
+    let g_short = s11(z_short, 1.0);
+    println!("short: Z = {z_short}, S11 = {g_short}");
+    assert!((g_short.norm() - 1.0).abs() < 1e-3, "short |S11| ≈ 1");
+    assert!(g_short.re < -0.9, "short S11 must sit near −1");
+    assert!(g_short.im > 0.0, "short S11 phase must be inductive");
+
+    let z_open = stub_z(4, omega, false);
+    let g_open = s11(z_open, 1.0);
+    println!("open: Z = {z_open}, S11 = {g_open}");
+    assert!((g_open.norm() - 1.0).abs() < 1e-3, "open |S11| ≈ 1");
+    assert!(g_open.re > 0.9, "open S11 must sit near +1");
+    assert!(g_open.im < 0.0, "open S11 phase must be capacitive");
+}
+
+/// SRF detection: sweeping the shorted stub (Im Z = Z₀ tan ωd) through
+/// its half-wave resonance brackets the Im Z zero crossing at
+/// ωd ≈ π (up to FEM dispersion at this mesh, a few %).
+#[test]
+fn srf_detected_at_stub_half_wave_resonance() {
+    let n = 6;
+    let mesh = geode_core::cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps = vacuum(&mesh);
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas: Vec<f64> = vec![2.9, 3.0, 3.1, 3.2, 3.3];
+    let points = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("SRF sweep");
+    let zs: Vec<c64> = points.iter().map(|p| p.ports[0].z).collect();
+    let srf = detect_srf(&omegas, &zs).expect("sweep must bracket the resonance");
+    let rel = (srf - std::f64::consts::PI).abs() / std::f64::consts::PI;
+    println!("stub SRF: {srf} vs π (rel err {rel:.3e}); Z samples: {zs:?}");
+    assert!(
+        rel < 0.05,
+        "SRF {srf} too far from analytic π (rel err {rel:.3e})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sweep ≡ single-solve consistency (assembly reuse is exact)
+// ---------------------------------------------------------------------------
+
+/// The assemble-once `DrivenOperator` reproduces
+/// `driven_solve_with_ports` (σ + port + drive) bit-for-bit at every
+/// sweep frequency, and the sweep's circuit readouts match the
+/// single-solve extraction helpers.
+#[test]
+fn operator_sweep_matches_single_solves_with_ports() {
+    let mesh = geode_core::cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+    let eps: Vec<c64> = vec![c64::new(1.5, -0.02); mesh.n_tets()];
+    let sigma_tet = vec![0.3; mesh.n_tets()];
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 2.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.5),
+    };
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(0.0, 0.0),
+            c64::new(c[2], -0.25),
+            c64::new((std::f64::consts::PI * c[0]).sin(), 0.0),
+        ]
+    });
+
+    let omegas = [0.8, 1.3, 2.1];
+    let op = DrivenOperator::assemble::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &bcs,
+        std::slice::from_ref(&port),
+        &[],
+        &source,
+        &device(),
+    )
+    .expect("operator assembly");
+    let points = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &bcs,
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &source,
+        &device(),
+    )
+    .expect("sweep");
+
+    for (&omega, point) in omegas.iter().zip(points.iter()) {
+        let sol_op = op.solve_at(omega).expect("operator solve");
+        let sol_ref = driven_solve_with_ports::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            Some(&sigma_tet),
+            &bcs,
+            std::slice::from_ref(&port),
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("single solve");
+        assert_eq!(sol_op.n_interior, sol_ref.n_interior);
+        for (a, b) in sol_op.e_edges.iter().zip(sol_ref.e_edges.iter()) {
+            assert_eq!(
+                a, b,
+                "operator solve diverged from single solve at ω={omega}"
+            );
+        }
+        // Circuit readouts agree with the single-solve helpers.
+        let pc = extract_port_circuit(&mesh, &port, &edges, &sol_ref.e_edges);
+        let z_ref = port_input_impedance(&mesh, &port, &edges, &sol_ref.e_edges);
+        assert_eq!(point.ports[0].v, pc.v);
+        assert_eq!(point.ports[0].i, pc.i);
+        assert_eq!(point.ports[0].z, z_ref);
+    }
+}
+
+/// The operator path also reproduces
+/// `driven_solve_with_surface_impedance` exactly across frequencies —
+/// the ω-dependent Leontovich coefficient (`∝ √ω(1+i)` for the
+/// good-conductor model) is re-applied per ω on the cached `S_Γ`.
+#[test]
+fn operator_sweep_matches_single_solves_with_leontovich_surface() {
+    let mesh = geode_core::cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let wall = plane_faces(&mesh, 2, 1.0);
+    let surfaces = [SurfaceImpedanceBc {
+        triangles: &wall,
+        model: SurfaceImpedanceModel::GoodConductor { sigma: 40.0 },
+    }];
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(0.0, 0.0),
+            c64::new((std::f64::consts::PI * c[2]).sin(), 0.0),
+            c64::new(0.1, 0.0),
+        ]
+    });
+
+    let op = DrivenOperator::assemble::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[],
+        &surfaces,
+        &source,
+        &device(),
+    )
+    .expect("operator assembly");
+
+    for omega in [0.9, 1.7] {
+        let sol_op = op.solve_at(omega).expect("operator solve");
+        let sol_ref = driven_solve_with_surface_impedance::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &bcs,
+            &surfaces,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("single solve");
+        for (a, b) in sol_op.e_edges.iter().zip(sol_ref.e_edges.iter()) {
+            assert_eq!(a, b, "Leontovich operator solve diverged at ω={omega}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the impedance-extraction post-processing of Epic #193 Phase 2: given a driven solve excited through a lumped port (#202), extract `Z(ω) = V/I` and the derived circuit quantities `L(ω) = Im Z/ω`, `R(ω) = Re Z`, `Q(ω) = Im Z/Re Z`, single-port `S₁₁` vs a real reference `Z₀`, and SRF detection from the `Im Z(ω)` zero crossing — plus a frequency-sweep driver that assembles once and re-factors per ω.

## Changes

- **`crates/geode-core/src/extraction.rs` (new)** — `PortCircuit` (V/I/Z per port per ω), `extract_port_circuit` over a single `DrivenSolution`, free functions `inductance` / `quality_factor` / `s11`, n-port `SMatrix` structure with the exact single-port constructor (multi-port deferred to Phase 3, documented), `im_z_zero_crossings` + `detect_srf` (linear-interpolated bracketing, pole caveat documented), and the sweep driver `driven_frequency_sweep`.
- **`crates/geode-core/src/driven.rs`** — `driven_solve_impl` factored into `DrivenOperator::assemble` (ω-independent: Burn volume assembly of K/M(ε)/C(σ), source moments, port masses + flux functionals, Leontovich `S_Γ`, PEC reduction, interior-filtered sparsity-aligned value caches) + `DrivenOperator::solve_at(ω)` (per-ω scalar recombination, port drive, sparse LU, residual). All existing single-ω entry points now delegate to it — same arithmetic, same triplet stream, so behavior is preserved bit-for-bit (verified by exact-equality tests). The ω-dependent Leontovich coefficient (`∝ √ω(1+i)`) is re-evaluated per frequency on the cached `S_Γ`, per the #204 sweep caveat.
- **`crates/geode-core/tests/extraction.rs` (new)** — wire-loop L oracle, DC-R consistency, S₁₁ sanity, SRF detection, sweep≡single-solve exactness (details below).
- **`crates/geode-core/src/lib.rs`**, **`lumped_port.rs`** — exports + doc cross-reference.

## Wire-loop oracle (geometry + formula choice)

A single-turn shielded loop inductor of rectangular cross-section — the coaxial/toroidal loop (current down the inner conductor, along the bottom plate, up the outer shield, back along the top plate) — has the **exact** closed-form magnetostatic inductance `L = (μ₀h/2π)·ln(b/a)`. Unlike thin-round-wire (Grover) square-loop formulas it is exact for any aspect ratio and *includes* the return shield, so the comparison carries no equivalent-radius or open-boundary fudge. The test meshes one azimuthal wedge of angle Φ = π/6 (the φ-planes are exact magnetic-symmetry planes → natural BC) with a structured annular-wedge tet mesh (same 6-tet Kuhn split as `cube_tet_mesh`), drives it through a lumped port on a circumferential slit in the inner conductor (`ê = ẑ` exactly tangential to the polygonal facets), and compares against `L_wedge = (h/Φ)ln(b/a)`. The raw L(ω) mixes the static discretization error with the +O(ω²) transmission-line correction, so the oracle compares the two-frequency ω→0 Richardson extrapolation; a separate test verifies the ω² scaling of the correction (measured increment ratio 4.07 vs 4 exact).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `Z/L/R/Q/S11` extraction API + sweep driver reusing assembly across ω | ✅ | `extraction.rs` API; `DrivenOperator` assembles once, `solve_at` re-factors per ω; `operator_sweep_matches_single_solves_with_ports` / `..._leontovich_surface` prove exact (`assert_eq` on `c64`) agreement with the single-ω paths |
| Closed-form wire-loop L oracle at low frequency, error documented | ✅ | `wire_loop_recovers_closed_form_inductance`: rel err **5.27e-3** (3×3×8 mesh) → **1.95e-3** (5×5×12 mesh), convergent; PEC loop spurious resistance < 1e-3·Im Z |
| R(ω) consistency with σ path (#196): DC resistance at low ω | ✅ | `resistor_recovers_dc_resistance_at_low_omega`: σ-filled parallel plate, `Re Z` vs `1/σ` rel err **6.1e-5** (ω=0.02), **3.8e-4** (ω=0.05); Q ≪ 1 |
| S₁₁ sanity: matched ≈ 0; open/short phase limits | ✅ | matched (Z₀ = 1/σ): \|S₁₁\| = **1.6e-3**; short: S₁₁ = −0.980+0.199j (\|S₁₁\|≈1, inductive phase); open: S₁₁ = 0.980−0.199j (capacitive phase) |
| SRF reported when sweep brackets it | ✅ | `srf_detected_at_stub_half_wave_resonance`: shorted-stub sweep brackets Im Z zero crossing at ω = 3.1289 vs π (rel err **4.0e-3**); unit tests cover series-LC bracketing, exact-zero samples, no-bracket → `None` |
| Tests pass for new functionality | ✅ | 8 new integration tests + 6 unit tests pass; full suite below |

## Test Plan

- `cargo test --workspace --release` — full suite passes (exit 0, no failures)
- `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo fmt --check` — clean
- New: `cargo test -p geode-core --release --test extraction` (8 tests), `extraction::tests` unit tests (6)

Closes #203