### PR TITLE
feat: sparse [nnz] pattern-slot Nédélec assembly — lifts the 46k-edge dense-scatter cap

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -108,12 +108,13 @@ use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, Triplet};
 
 use crate::complex_lanczos::{solve_with_lu, spmv};
-use crate::eigen::burn_matrix_to_faer;
 use crate::lumped_port::{assemble_port_flux, assemble_port_surface_mass, LumpedPort};
 use crate::nedelec_assembly::{
-    assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
-    assemble_global_nedelec_with_full_tensors, assemble_nedelec_current_rhs,
-    assemble_nedelec_current_rhs_quad4, burn_complex_mass_to_faer, tet_centroids,
+    assemble_global_nedelec_with_anisotropic_epsilon_sparse,
+    assemble_global_nedelec_with_complex_epsilon_sparse,
+    assemble_global_nedelec_with_full_tensors_sparse, assemble_nedelec_current_rhs,
+    assemble_nedelec_current_rhs_quad4, assemble_nedelec_sigma_damping_sparse, tet_centroids,
+    NedelecScatterMap,
 };
 use crate::TetMesh;
 
@@ -521,7 +522,7 @@ pub fn driven_solve_with_ports<B: Backend>(
 /// ```
 ///
 /// with `S_Γ` the real-symmetric tangential surface mass
-/// ([`crate::silvermuller::assemble_surface_mass`]) over the surface's
+/// ([`crate::silvermuller::assemble_surface_mass_triplets`]) over the surface's
 /// triangles. The complex weight is a *scalar* per surface, so the
 /// complex-symmetry invariant `A(ω)ᵀ = A(ω)` is preserved.
 ///
@@ -854,22 +855,6 @@ impl DrivenOperator {
             }
         }
 
-        // --- Leontovich impedance surfaces (issue #204) -------------------------
-        // The real surface mass S_Γ is ω-independent and cached; its weak
-        // coefficient iω/Z_s(ω) is ω-dependent (∝ √ω·(1+i) for the
-        // good-conductor model), so it is re-evaluated inside `solve_at` at
-        // every frequency. Every (i, j) pair S_Γ couples lies within the
-        // 6×6 edge block of the tet owning the boundary face, so the
-        // surface entries are a subset of the recorded volume sparsity
-        // pattern and the value-caching loop below picks them all up.
-        let surface_masses: Vec<(faer::Mat<f64>, SurfaceImpedanceModel)> = surfaces
-            .iter()
-            .map(|bc| {
-                let s = crate::silvermuller::assemble_surface_mass(mesh, bc.triangles, &edges);
-                (s, bc.model)
-            })
-            .collect();
-
         // --- Edge tables ------------------------------------------------------
         let tet_edges = mesh.tet_edges();
         let tet_idx: Vec<[u32; 6]> = tet_edges
@@ -881,62 +866,97 @@ impl DrivenOperator {
             .map(|row| std::array::from_fn(|i| row[i].1))
             .collect();
 
+        // --- Pattern-slot scatter map (issue #218) ------------------------------
+        // All volume assembly below scatters into flat [nnz] value tensors
+        // aligned with this sorted sparsity pattern: O(nnz) peak memory
+        // instead of O(n_edges²), and no i32 linear-index overflow for
+        // n_edges > 46_340 (the 54k-edge spiral benchmark fixture).
+        let scatter = NedelecScatterMap::new(&tet_idx);
+        let nnz = scatter.nnz();
+
+        // --- Leontovich impedance surfaces (issue #204) -------------------------
+        // The real surface mass S_Γ is ω-independent and cached; its weak
+        // coefficient iω/Z_s(ω) is ω-dependent (∝ √ω·(1+i) for the
+        // good-conductor model), so it is re-evaluated inside `solve_at` at
+        // every frequency. Every (i, j) pair S_Γ couples lies within the
+        // 6×6 edge block of the tet owning the boundary face, so the
+        // surface entries are a subset of the volume sparsity pattern —
+        // accumulate the face-block triplets straight into [nnz] vectors
+        // aligned with the pattern (no dense [n_edges²] matrix, issue #218).
+        let surface_masses: Vec<(Vec<f64>, SurfaceImpedanceModel)> = surfaces
+            .iter()
+            .map(|bc| {
+                let mut vals = vec![0.0_f64; nnz];
+                for (r, c, v) in
+                    crate::silvermuller::assemble_surface_mass_triplets(mesh, bc.triangles, &edges)
+                {
+                    let slot = scatter
+                        .slot_of(r as u32, c as u32)
+                        .expect("surface-mass entry must lie within the volume sparsity pattern");
+                    vals[slot] += v;
+                }
+                (vals, bc.model)
+            })
+            .collect();
+
         // --- Assemble K, M(ε) on the Burn backend ------------------------------
         // The stiffness imaginary part is `None` for the ε-only material
         // models (K is real there); the matched UPML stretches μ too, so
-        // its `K(Λ⁻¹)` carries an imaginary part.
+        // its `K(Λ⁻¹)` carries an imaginary part. Everything lands in flat
+        // [nnz] pattern-aligned value tensors.
         let (nodes_t, tets_t) = crate::assembly::upload_mesh::<B>(mesh, device);
-        let (k_re_t, k_im_t, m_re_t, m_im_t, sparsity) = match materials {
+        let (k_re_t, k_im_t, m_re_t, m_im_t) = match materials {
             DrivenMaterials::Scalar(eps) => {
-                let sys = assemble_global_nedelec_with_complex_epsilon(
+                let sys = assemble_global_nedelec_with_complex_epsilon_sparse(
                     nodes_t.clone(),
                     tets_t.clone(),
-                    &tet_idx,
                     &tet_sign,
-                    n_edges,
+                    &scatter,
                     eps,
                 );
-                (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+                (sys.k_vals, None, sys.m_re_vals, sys.m_im_vals)
             }
             DrivenMaterials::DiagTensor(eps) => {
-                let sys = assemble_global_nedelec_with_anisotropic_epsilon(
+                let sys = assemble_global_nedelec_with_anisotropic_epsilon_sparse(
                     nodes_t.clone(),
                     tets_t.clone(),
-                    &tet_idx,
                     &tet_sign,
-                    n_edges,
+                    &scatter,
                     eps,
                 );
-                (sys.k, None, sys.m_re, sys.m_im, sys.sparsity)
+                (sys.k_vals, None, sys.m_re_vals, sys.m_im_vals)
             }
             DrivenMaterials::MatchedUpml {
                 epsilon_tensor,
                 nu_tensor,
             } => {
-                let sys = assemble_global_nedelec_with_full_tensors(
+                let sys = assemble_global_nedelec_with_full_tensors_sparse(
                     nodes_t.clone(),
                     tets_t.clone(),
-                    &tet_idx,
                     &tet_sign,
-                    n_edges,
+                    &scatter,
                     epsilon_tensor,
                     nu_tensor,
                 );
-                (sys.k_re, Some(sys.k_im), sys.m_re, sys.m_im, sys.sparsity)
+                (
+                    sys.k_re_vals,
+                    Some(sys.k_im_vals),
+                    sys.m_re_vals,
+                    sys.m_im_vals,
+                )
             }
         };
 
         // --- Assemble the conductivity damping matrix C(σ), if any -------------
         // C shares the (K, M) sparsity pattern — it is a σ-weighted mass
-        // assembled over the same tet→edge scatter indices — so the triplet
-        // loop below can read it through the recorded pattern directly.
+        // assembled over the same tet→edge scatter slots — so its values
+        // align with the pattern directly.
         let c_burn = sigma_tet.map(|sigma| {
-            crate::nedelec_assembly::assemble_nedelec_sigma_damping::<B>(
+            assemble_nedelec_sigma_damping_sparse::<B>(
                 nodes_t.clone(),
                 tets_t.clone(),
-                &tet_idx,
                 &tet_sign,
-                n_edges,
+                &scatter,
                 sigma,
             )
         });
@@ -999,11 +1019,15 @@ impl DrivenOperator {
             .map(|port| assemble_port_flux(mesh, port.faces, port.e_hat, &edges))
             .collect();
 
-        // --- Host transfer + PEC reduction -------------------------------------
-        let k_full = burn_matrix_to_faer(k_re_t);
-        let k_im_full = k_im_t.map(burn_matrix_to_faer);
-        let m_full = burn_complex_mass_to_faer(m_re_t, m_im_t);
-        let c_full = c_burn.map(burn_matrix_to_faer);
+        // --- Host transfer ------------------------------------------------------
+        // [nnz] pattern-aligned value vectors — no dense [n_edges²] faer
+        // intermediates (issue #218). `iter::<f64>` upcasts losslessly from
+        // whatever float dtype the backend stores.
+        let k_re_host: Vec<f64> = k_re_t.into_data().iter::<f64>().collect();
+        let k_im_host: Option<Vec<f64>> = k_im_t.map(|t| t.into_data().iter::<f64>().collect());
+        let m_re_host: Vec<f64> = m_re_t.into_data().iter::<f64>().collect();
+        let m_im_host: Vec<f64> = m_im_t.into_data().iter::<f64>().collect();
+        let c_host: Option<Vec<f64>> = c_burn.map(|t| t.into_data().iter::<f64>().collect());
 
         // Remap full edge indices → contiguous interior indices.
         let mut remap = vec![-1_i64; n_edges];
@@ -1022,17 +1046,18 @@ impl DrivenOperator {
         // One aligned value per kept (interior, interior) entry, in pattern
         // order, so `solve_at` re-forms A(ω) = K + iωC − ω²M + Σ coeff·S by
         // pure linear combination — no re-assembly.
-        let n_entries = sparsity.rows.len();
+        let pattern = scatter.pattern();
+        let n_entries = pattern.nnz();
         let mut rows = Vec::with_capacity(n_entries);
         let mut cols = Vec::with_capacity(n_entries);
         let mut k_vals = Vec::with_capacity(n_entries);
         let mut m_vals = Vec::with_capacity(n_entries);
-        let mut c_vals = c_full.as_ref().map(|_| Vec::with_capacity(n_entries));
+        let mut c_vals = c_host.as_ref().map(|_| Vec::with_capacity(n_entries));
         let mut surface_vals: Vec<Vec<f64>> = surface_masses
             .iter()
             .map(|_| Vec::with_capacity(n_entries))
             .collect();
-        for (&r_u32, &c_u32) in sparsity.rows.iter().zip(sparsity.cols.iter()) {
+        for (idx, (&r_u32, &c_u32)) in pattern.rows.iter().zip(pattern.cols.iter()).enumerate() {
             let (r, c) = (r_u32 as usize, c_u32 as usize);
             let (rr, cc) = (remap[r], remap[c]);
             if rr < 0 || cc < 0 {
@@ -1040,14 +1065,14 @@ impl DrivenOperator {
             }
             rows.push(rr as usize);
             cols.push(cc as usize);
-            let k_im_val = k_im_full.as_ref().map_or(0.0, |m| m[(r, c)]);
-            k_vals.push(c64::new(k_full[(r, c)], k_im_val));
-            m_vals.push(m_full[(r, c)]);
-            if let (Some(vals), Some(cm)) = (c_vals.as_mut(), c_full.as_ref()) {
-                vals.push(cm[(r, c)]);
+            let k_im_val = k_im_host.as_ref().map_or(0.0, |v| v[idx]);
+            k_vals.push(c64::new(k_re_host[idx], k_im_val));
+            m_vals.push(c64::new(m_re_host[idx], m_im_host[idx]));
+            if let (Some(vals), Some(ch)) = (c_vals.as_mut(), c_host.as_ref()) {
+                vals.push(ch[idx]);
             }
             for (vals, (s, _)) in surface_vals.iter_mut().zip(surface_masses.iter()) {
-                vals.push(s[(r, c)]);
+                vals.push(s[idx]);
             }
         }
 

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -87,15 +87,19 @@ pub use nedelec::{
 };
 pub use nedelec_assembly::{
     assemble_global_nedelec, assemble_global_nedelec_with_anisotropic_epsilon,
-    assemble_global_nedelec_with_complex_epsilon, assemble_global_nedelec_with_epsilon,
-    assemble_global_nedelec_with_full_tensors, assemble_nedelec_current_rhs,
-    assemble_nedelec_current_rhs_quad4, assemble_nedelec_sigma_damping,
+    assemble_global_nedelec_with_anisotropic_epsilon_sparse,
+    assemble_global_nedelec_with_complex_epsilon,
+    assemble_global_nedelec_with_complex_epsilon_sparse, assemble_global_nedelec_with_epsilon,
+    assemble_global_nedelec_with_full_tensors, assemble_global_nedelec_with_full_tensors_sparse,
+    assemble_nedelec_current_rhs, assemble_nedelec_current_rhs_quad4,
+    assemble_nedelec_sigma_damping, assemble_nedelec_sigma_damping_sparse,
     build_anisotropic_pml_tensor_diag, build_complex_epsilon_eff, build_complex_epsilon_r_pml,
     build_epsilon_r, burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
-    rank_via_svd, restrict_gradient_dense, sphere_n_interior_nodes, sphere_pec_interior_edges,
-    sphere_pec_node_interior_mask, spurious_dim_from_derham, tet_centroid_radii, tet_centroids,
-    NedelecComplexGlobalSystem, NedelecFullTensorGlobalSystem, NedelecGlobalSystem,
-    DERHAM_RANK_THRESHOLD_REL,
+    rank_via_svd, restrict_gradient_dense, sparsity_pattern_from_tet_edges,
+    sphere_n_interior_nodes, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
+    spurious_dim_from_derham, tet_centroid_radii, tet_centroids, NedelecComplexGlobalSystem,
+    NedelecFullTensorGlobalSystem, NedelecGlobalSystem, NedelecScatterMap,
+    NedelecSparseComplexSystem, NedelecSparseFullTensorSystem, DERHAM_RANK_THRESHOLD_REL,
 };
 pub use p1::{batched_p1_local_matrices, P1LocalMatrices};
 pub use scattering::{
@@ -103,7 +107,9 @@ pub use scattering::{
     plane_wave_polarization_current, q_from_power, scattered_flux_power,
     solve_scattered_field_matched_upml, upml_matched_tensors,
 };
-pub use silvermuller::{assemble_silver_muller_surface, assemble_surface_mass};
+pub use silvermuller::{
+    assemble_silver_muller_surface, assemble_surface_mass, assemble_surface_mass_triplets,
+};
 pub use silvermuller_self_consistent::{
     self_consistent_k, self_consistent_k_vector_tracked, SelfConsistentResult,
 };

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -173,7 +173,13 @@ pub fn assemble_global_nedelec<B: Backend>(
     NedelecGlobalSystem { k, m, sparsity }
 }
 
-fn sparsity_pattern_from_tet_edges(tet_edge_idx: &[[u32; 6]]) -> SparsityPattern {
+/// Build the Nédélec edge-DOF [`SparsityPattern`] from the host-side
+/// per-tet global edge indices: every `(tet_edge_idx[e][i],
+/// tet_edge_idx[e][j])` pair contributes one entry, duplicates
+/// collapsed. Entries are **sorted lexicographically** by `(row, col)`
+/// (BTreeSet iteration order) — the invariant the slot binary search of
+/// [`NedelecScatterMap`] relies on.
+pub fn sparsity_pattern_from_tet_edges(tet_edge_idx: &[[u32; 6]]) -> SparsityPattern {
     let mut set: BTreeSet<(u32, u32)> = BTreeSet::new();
     for row in tet_edge_idx {
         for i in 0..6 {
@@ -189,6 +195,182 @@ fn sparsity_pattern_from_tet_edges(tet_edge_idx: &[[u32; 6]]) -> SparsityPattern
         cols.push(c);
     }
     SparsityPattern { rows, cols }
+}
+
+/// Binary search a `(row, col)` pair in the lexicographically sorted
+/// pattern produced by [`sparsity_pattern_from_tet_edges`]. Returns the
+/// slot index, or `None` if the entry is not in the pattern.
+fn pattern_slot(pattern: &SparsityPattern, row: u32, col: u32) -> Option<usize> {
+    let key = (row, col);
+    let mut lo = 0usize;
+    let mut hi = pattern.rows.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if (pattern.rows[mid], pattern.cols[mid]) < key {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    if lo < pattern.rows.len() && (pattern.rows[lo], pattern.cols[lo]) == key {
+        Some(lo)
+    } else {
+        None
+    }
+}
+
+/// Host-side scatter map from per-element local 6×6 entries to slots of
+/// the sorted global [`SparsityPattern`] (issue #218).
+///
+/// The dense assemblers in this module scatter into a flat
+/// `[n_edges * n_edges]` tensor with `row * n_edges + col` linear
+/// indices, which (a) overflows Burn's i32 Int index for
+/// `n_edges > 46_340` and (b) costs O(n_edges²) memory. This map
+/// precomputes, for every `(element, i, j)` local entry, the index of
+/// its `(row, col)` pair in the sorted pattern, so the same
+/// autodiff-preserving 1-D `scatter(0, …, Add)` can target a flat
+/// `[nnz]` tensor instead. For a tet mesh `nnz ≈ 15–20 × n_edges`
+/// (~1 M entries at the 54 k-edge spiral benchmark fixture, vs ~3 G
+/// dense), and i32 slot indices stay safe to ~2.1 B non-zeros —
+/// comfortably past the 100 k-edge direct-sparse-LU budget.
+///
+/// Construction is O(36 · n_elem · log nnz) host work. The indices are
+/// pure integers (no autodiff flows through them); gradients flow
+/// through the scattered *values* exactly as on the dense path.
+#[derive(Debug, Clone)]
+pub struct NedelecScatterMap {
+    pattern: SparsityPattern,
+    /// Pattern-slot index of every `(e, i, j)` local entry, `[n_elem * 36]`.
+    slot_idx: Vec<i32>,
+}
+
+impl NedelecScatterMap {
+    /// Build the map from the per-tet global edge indices
+    /// (`tet_edge_idx` from [`TetMesh::tet_edges`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the pattern's `nnz` exceeds `i32::MAX` (the Burn Int
+    /// tensor index limit — ~2.1 B non-zeros).
+    pub fn new(tet_edge_idx: &[[u32; 6]]) -> Self {
+        let pattern = sparsity_pattern_from_tet_edges(tet_edge_idx);
+        assert!(
+            pattern.nnz() <= i32::MAX as usize,
+            "sparsity pattern nnz {} exceeds the i32 Burn Int index range",
+            pattern.nnz()
+        );
+        let mut slot_idx = Vec::with_capacity(tet_edge_idx.len() * 36);
+        for row in tet_edge_idx {
+            for i in 0..6 {
+                for j in 0..6 {
+                    let slot = pattern_slot(&pattern, row[i], row[j])
+                        .expect("every (e, i, j) entry is in the pattern by construction");
+                    slot_idx.push(slot as i32);
+                }
+            }
+        }
+        Self { pattern, slot_idx }
+    }
+
+    /// The sorted sparsity pattern the slot indices point into.
+    pub fn pattern(&self) -> &SparsityPattern {
+        &self.pattern
+    }
+
+    /// Number of unique non-zero entries — the length of every `[nnz]`
+    /// value tensor assembled through this map.
+    pub fn nnz(&self) -> usize {
+        self.pattern.nnz()
+    }
+
+    /// Number of elements the map was built from.
+    pub fn n_elem(&self) -> usize {
+        self.slot_idx.len() / 36
+    }
+
+    /// Pattern slot of a global `(row, col)` entry, if present
+    /// (O(log nnz) binary search). Lets host-side surface assemblies
+    /// (port / Leontovich masses, whose entries are subsets of the
+    /// volume pattern) align their values with the `[nnz]` layout.
+    pub fn slot_of(&self, row: u32, col: u32) -> Option<usize> {
+        pattern_slot(&self.pattern, row, col)
+    }
+
+    /// Upload the per-`(e, i, j)` slot indices as a Burn Int tensor
+    /// `[n_elem * 36]` for the 1-D scatter.
+    fn slot_tensor<B: Backend>(&self, device: &B::Device) -> Tensor<B, 1, Int> {
+        Tensor::<B, 1, Int>::from_data(
+            TensorData::new(self.slot_idx.clone(), [self.slot_idx.len()]),
+            device,
+        )
+    }
+}
+
+/// Per-element orientation-sign outer product `[n_elem, 6, 6]` —
+/// `sign[e, i] * sign[e, j]` — shared by the sparse assemblers. Same
+/// arithmetic (f32 upload, broadcasted multiply) as the inline code of
+/// the dense assemblers, so the two paths agree bitwise.
+fn sign_outer_tensor<B: Backend>(tet_edge_sign: &[[i8; 6]], device: &B::Device) -> Tensor<B, 3> {
+    let n_elem = tet_edge_sign.len();
+    let sign_flat: Vec<f32> = tet_edge_sign
+        .iter()
+        .flat_map(|row| row.iter().map(|&s| s as f32))
+        .collect();
+    let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), device);
+    let sign_row = sign_2d.clone().unsqueeze_dim::<3>(2); // [n_elem, 6, 1]
+    let sign_col = sign_2d.unsqueeze_dim::<3>(1); // [n_elem, 1, 6]
+    sign_row.mul(sign_col)
+}
+
+/// Scatter one signed `[n_elem, 6, 6]` local tensor into a flat `[nnz]`
+/// value tensor through the precomputed pattern-slot indices. Autodiff
+/// flows through the values via `IndexingUpdateOp::Add`, exactly as on
+/// the dense `[n_edges²]` path.
+fn scatter_to_pattern_vals<B: Backend>(
+    signed_local: Tensor<B, 3>,
+    slot_indices: &Tensor<B, 1, Int>,
+    nnz: usize,
+    device: &B::Device,
+) -> Tensor<B, 1> {
+    let [n_elem, _, _] = signed_local.dims();
+    Tensor::<B, 1>::zeros([nnz], device).scatter(
+        0,
+        slot_indices.clone(),
+        signed_local.reshape([n_elem * 36]),
+        IndexingUpdateOp::Add,
+    )
+}
+
+/// Sparse-values counterpart of [`NedelecComplexGlobalSystem`]
+/// (issue #218): the same assembly arithmetic, but each matrix is a
+/// flat `[nnz]` Burn value tensor aligned with the sorted
+/// [`SparsityPattern`] of the [`NedelecScatterMap`] it was assembled
+/// through, instead of a dense `[n_edges, n_edges]` matrix. Peak memory
+/// is O(nnz), and no i32 linear-index overflow occurs for
+/// `n_edges > 46_340`.
+#[derive(Debug, Clone)]
+pub struct NedelecSparseComplexSystem<B: Backend> {
+    /// Curl-curl stiffness values (real), `[nnz]` in pattern order.
+    pub k_vals: Tensor<B, 1>,
+    /// Real part of the ε-weighted mass values, `[nnz]`.
+    pub m_re_vals: Tensor<B, 1>,
+    /// Imaginary part of the ε-weighted mass values, `[nnz]`.
+    pub m_im_vals: Tensor<B, 1>,
+}
+
+/// Sparse-values counterpart of [`NedelecFullTensorGlobalSystem`]
+/// (matched UPML, issue #199) — see [`NedelecSparseComplexSystem`] for
+/// the layout convention.
+#[derive(Debug, Clone)]
+pub struct NedelecSparseFullTensorSystem<B: Backend> {
+    /// Real part of the ν-weighted curl-curl stiffness values, `[nnz]`.
+    pub k_re_vals: Tensor<B, 1>,
+    /// Imaginary part of the ν-weighted curl-curl stiffness values.
+    pub k_im_vals: Tensor<B, 1>,
+    /// Real part of the ε-weighted mass values, `[nnz]`.
+    pub m_re_vals: Tensor<B, 1>,
+    /// Imaginary part of the ε-weighted mass values, `[nnz]`.
+    pub m_im_vals: Tensor<B, 1>,
 }
 
 /// Build a boolean mask `[n_edges]` marking each global edge as either
@@ -846,6 +1028,116 @@ pub fn assemble_global_nedelec_with_complex_epsilon<B: Backend>(
     }
 }
 
+/// Sparse (`[nnz]` pattern-aligned) variant of
+/// [`assemble_global_nedelec_with_complex_epsilon`] (issue #218).
+///
+/// Same element-local kernels, same f32 weight upload, same orientation
+/// signs and the same autodiff-preserving 1-D `scatter(0, …, Add)` —
+/// only the scatter target changes from the dense flat `[n_edges²]`
+/// tensor to a flat `[nnz]` tensor indexed by the precomputed
+/// pattern-slot map. Per pattern entry, the summands accumulate in the
+/// same `(e, i, j)` order as on the dense path, so the values agree
+/// with the dense matrices read over the same pattern to bit precision
+/// on a deterministic backend. Unlike the dense complex path (two full
+/// passes through the scalar-ε assembler), the local matrices are
+/// computed **once** and the stiffness is scattered once.
+///
+/// `scatter` must be built from the same `tet_edge_idx` used for
+/// `tet_edge_sign` (see [`NedelecScatterMap::new`]).
+pub fn assemble_global_nedelec_with_complex_epsilon_sparse<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_sign: &[[i8; 6]],
+    scatter: &NedelecScatterMap,
+    epsilon_r_complex: &[faer::c64],
+) -> NedelecSparseComplexSystem<B> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        scatter.n_elem(),
+        n_elem,
+        "scatter map element count mismatch"
+    );
+    assert_eq!(
+        epsilon_r_complex.len(),
+        n_elem,
+        "complex epsilon_r length mismatch"
+    );
+
+    // 1. Element-local stiffness and mass — computed once (the dense
+    //    complex path runs the scalar assembler twice and discards a
+    //    duplicate K).
+    let coords = gather_tet_coords(nodes, tets);
+    let local = batched_nedelec_local_matrices(coords);
+
+    // 1b. Scale per-element mass by Re(ε) / Im(ε) via broadcasting —
+    //     same f32 upload as the dense scalar-ε path.
+    let eps_re_flat: Vec<f32> = epsilon_r_complex.iter().map(|c| c.re as f32).collect();
+    let eps_im_flat: Vec<f32> = epsilon_r_complex.iter().map(|c| c.im as f32).collect();
+    let eps_re_3d = Tensor::<B, 1>::from_data(TensorData::new(eps_re_flat, [n_elem]), &device)
+        .unsqueeze_dim::<2>(1)
+        .unsqueeze_dim::<3>(2); // [n_elem, 1, 1]
+    let eps_im_3d = Tensor::<B, 1>::from_data(TensorData::new(eps_im_flat, [n_elem]), &device)
+        .unsqueeze_dim::<2>(1)
+        .unsqueeze_dim::<3>(2);
+    let m_re_local = local.m_local.clone().mul(eps_re_3d);
+    let m_im_local = local.m_local.mul(eps_im_3d);
+
+    // 2. Orientation-sign outer product.
+    let sign_outer = sign_outer_tensor::<B>(tet_edge_sign, &device);
+    let k_signed = local.k_local.mul(sign_outer.clone());
+    let m_re_signed = m_re_local.mul(sign_outer.clone());
+    let m_im_signed = m_im_local.mul(sign_outer);
+
+    // 3. Scatter-add into flat [nnz] value tensors.
+    let slot_indices = scatter.slot_tensor::<B>(&device);
+    let nnz = scatter.nnz();
+    NedelecSparseComplexSystem {
+        k_vals: scatter_to_pattern_vals(k_signed, &slot_indices, nnz, &device),
+        m_re_vals: scatter_to_pattern_vals(m_re_signed, &slot_indices, nnz, &device),
+        m_im_vals: scatter_to_pattern_vals(m_im_signed, &slot_indices, nnz, &device),
+    }
+}
+
+/// Sparse (`[nnz]` pattern-aligned) variant of
+/// [`assemble_nedelec_sigma_damping`] (issue #218): the σ-weighted
+/// damping values `C_ij = ∫ N_i · N_j σ dV` in pattern order. Same
+/// kernels, f32 weight upload, signs and values-side autodiff as the
+/// dense path — only the scatter target changes.
+pub fn assemble_nedelec_sigma_damping_sparse<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_sign: &[[i8; 6]],
+    scatter: &NedelecScatterMap,
+    sigma_tet: &[f64],
+) -> Tensor<B, 1> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        scatter.n_elem(),
+        n_elem,
+        "scatter map element count mismatch"
+    );
+    assert_eq!(sigma_tet.len(), n_elem, "sigma_tet length mismatch");
+
+    let coords = gather_tet_coords(nodes, tets);
+    let local = batched_nedelec_local_matrices(coords);
+
+    let sigma_flat: Vec<f32> = sigma_tet.iter().map(|&s| s as f32).collect();
+    let sigma_3d = Tensor::<B, 1>::from_data(TensorData::new(sigma_flat, [n_elem]), &device)
+        .unsqueeze_dim::<2>(1)
+        .unsqueeze_dim::<3>(2); // [n_elem, 1, 1]
+    let c_local = local.m_local.mul(sigma_3d);
+
+    let sign_outer = sign_outer_tensor::<B>(tet_edge_sign, &device);
+    let c_signed = c_local.mul(sign_outer);
+
+    let slot_indices = scatter.slot_tensor::<B>(&device);
+    scatter_to_pattern_vals(c_signed, &slot_indices, scatter.nnz(), &device)
+}
+
 /// Build a per-tet **diagonal anisotropic** complex permittivity tensor
 /// in the global Cartesian basis for the bundled sphere fixture's PML
 /// shell (issue #54).
@@ -1088,6 +1380,69 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
     }
 }
 
+/// Sparse (`[nnz]` pattern-aligned) variant of
+/// [`assemble_global_nedelec_with_anisotropic_epsilon`] (issue #218).
+/// Same kernels (Re-pass + Im-pass through
+/// [`batched_nedelec_local_mass_anisotropic_diag`]), signs and
+/// values-side autodiff as the dense path — only the scatter target
+/// changes. See [`assemble_global_nedelec_with_complex_epsilon_sparse`]
+/// for the layout convention.
+pub fn assemble_global_nedelec_with_anisotropic_epsilon_sparse<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_sign: &[[i8; 6]],
+    scatter: &NedelecScatterMap,
+    epsilon_tensor_diag: &[[faer::c64; 3]],
+) -> NedelecSparseComplexSystem<B> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        scatter.n_elem(),
+        n_elem,
+        "scatter map element count mismatch"
+    );
+    assert_eq!(
+        epsilon_tensor_diag.len(),
+        n_elem,
+        "epsilon_tensor_diag length mismatch"
+    );
+
+    // 1. Element-local stiffness (real) + anisotropic mass (Re/Im pass).
+    let coords = gather_tet_coords(nodes, tets);
+    let local = batched_nedelec_local_matrices(coords.clone());
+
+    let eps_re_flat: Vec<f32> = epsilon_tensor_diag
+        .iter()
+        .flat_map(|row| row.iter().map(|c| c.re as f32))
+        .collect();
+    let eps_im_flat: Vec<f32> = epsilon_tensor_diag
+        .iter()
+        .flat_map(|row| row.iter().map(|c| c.im as f32))
+        .collect();
+    let eps_re_tensor =
+        Tensor::<B, 2>::from_data(TensorData::new(eps_re_flat, [n_elem, 3]), &device);
+    let eps_im_tensor =
+        Tensor::<B, 2>::from_data(TensorData::new(eps_im_flat, [n_elem, 3]), &device);
+
+    let m_local_re = batched_nedelec_local_mass_anisotropic_diag(coords.clone(), eps_re_tensor);
+    let m_local_im = batched_nedelec_local_mass_anisotropic_diag(coords, eps_im_tensor);
+
+    // 2. Signs + 3. flat [nnz] scatters.
+    let sign_outer = sign_outer_tensor::<B>(tet_edge_sign, &device);
+    let k_signed = local.k_local.mul(sign_outer.clone());
+    let m_re_signed = m_local_re.mul(sign_outer.clone());
+    let m_im_signed = m_local_im.mul(sign_outer);
+
+    let slot_indices = scatter.slot_tensor::<B>(&device);
+    let nnz = scatter.nnz();
+    NedelecSparseComplexSystem {
+        k_vals: scatter_to_pattern_vals(k_signed, &slot_indices, nnz, &device),
+        m_re_vals: scatter_to_pattern_vals(m_re_signed, &slot_indices, nnz, &device),
+        m_im_vals: scatter_to_pattern_vals(m_im_signed, &slot_indices, nnz, &device),
+    }
+}
+
 /// Upload one real component (Re or Im) of a per-tet 3×3 complex
 /// tensor field as a `[n_elem, 3, 3]` Burn tensor at the backend's
 /// full float precision (`B::FloatElem` — f64 on the ndarray CPU
@@ -1222,6 +1577,63 @@ pub fn assemble_global_nedelec_with_full_tensors<B: Backend>(
         m_re,
         m_im,
         sparsity,
+    }
+}
+
+/// Sparse (`[nnz]` pattern-aligned) variant of
+/// [`assemble_global_nedelec_with_full_tensors`] (matched UPML,
+/// issues #199/#218). Same four weighted kernel invocations, signs and
+/// values-side autodiff as the dense path — only the scatter target
+/// changes. See [`assemble_global_nedelec_with_complex_epsilon_sparse`]
+/// for the layout convention.
+pub fn assemble_global_nedelec_with_full_tensors_sparse<B: Backend>(
+    nodes: Tensor<B, 2>,
+    tets: Tensor<B, 2, Int>,
+    tet_edge_sign: &[[i8; 6]],
+    scatter: &NedelecScatterMap,
+    epsilon_tensor: &[[[faer::c64; 3]; 3]],
+    nu_tensor: &[[[faer::c64; 3]; 3]],
+) -> NedelecSparseFullTensorSystem<B> {
+    let device = nodes.device();
+    let [n_elem, _] = tets.dims();
+    assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+    assert_eq!(
+        scatter.n_elem(),
+        n_elem,
+        "scatter map element count mismatch"
+    );
+    assert_eq!(
+        epsilon_tensor.len(),
+        n_elem,
+        "epsilon_tensor length mismatch"
+    );
+    assert_eq!(nu_tensor.len(), n_elem, "nu_tensor length mismatch");
+
+    // 1. Element-local weighted matrices: Re/Im pass per weight.
+    let coords = gather_tet_coords(nodes, tets);
+    let eps_re = upload_tensor33_component::<B>(epsilon_tensor, |c| c.re, &device);
+    let eps_im = upload_tensor33_component::<B>(epsilon_tensor, |c| c.im, &device);
+    let nu_re = upload_tensor33_component::<B>(nu_tensor, |c| c.re, &device);
+    let nu_im = upload_tensor33_component::<B>(nu_tensor, |c| c.im, &device);
+
+    let k_local_re = batched_nedelec_local_stiffness_weighted(coords.clone(), nu_re);
+    let k_local_im = batched_nedelec_local_stiffness_weighted(coords.clone(), nu_im);
+    let m_local_re = batched_nedelec_local_mass_anisotropic_full(coords.clone(), eps_re);
+    let m_local_im = batched_nedelec_local_mass_anisotropic_full(coords, eps_im);
+
+    // 2. Signs + 3. flat [nnz] scatters (shared slot indices).
+    let sign_outer = sign_outer_tensor::<B>(tet_edge_sign, &device);
+    let slot_indices = scatter.slot_tensor::<B>(&device);
+    let nnz = scatter.nnz();
+    let scatter_one = |local: Tensor<B, 3>| -> Tensor<B, 1> {
+        scatter_to_pattern_vals(local.mul(sign_outer.clone()), &slot_indices, nnz, &device)
+    };
+
+    NedelecSparseFullTensorSystem {
+        k_re_vals: scatter_one(k_local_re),
+        k_im_vals: scatter_one(k_local_im),
+        m_re_vals: scatter_one(m_local_re),
+        m_im_vals: scatter_one(m_local_im),
     }
 }
 

--- a/crates/geode-core/src/silvermuller.rs
+++ b/crates/geode-core/src/silvermuller.rs
@@ -180,13 +180,42 @@ pub fn assemble_surface_mass(
 ) -> Mat<f64> {
     let n_edges = edges.len();
     let mut s = Mat::<f64>::zeros(n_edges, n_edges);
+    for (r, c, v) in assemble_surface_mass_triplets(mesh, triangles, edges) {
+        s[(r, c)] += v;
+    }
+    s
+}
 
+/// Sparse-triplet core of [`assemble_surface_mass`] (issue #218): the
+/// same face-block-wise kernel, returned as signed `(row, col, value)`
+/// triplets over global edge indices instead of a dense
+/// `[n_edges, n_edges]` matrix (which costs O(n_edges²) memory —
+/// ~23.7 GB at the 54 k-edge spiral benchmark fixture).
+///
+/// Duplicate `(row, col)` entries (edges shared by adjacent faces) are
+/// **not** summed — the caller accumulates them (e.g. faer's
+/// `try_new_from_triplets`, or a pattern-slot scatter as in
+/// [`crate::driven::DrivenOperator`]). Triplets appear in face order,
+/// so summing them reproduces the dense accumulation order exactly.
+/// Same convention as
+/// [`crate::lumped_port::assemble_port_surface_mass`].
+///
+/// # Panics
+///
+/// Panics if a triangle edge does not appear in `edges` — i.e. if the
+/// triangles are not faces of the tet mesh whose edge table was passed.
+pub fn assemble_surface_mass_triplets(
+    mesh: &TetMesh,
+    triangles: &[[u32; 3]],
+    edges: &[[u32; 2]],
+) -> Vec<(usize, usize, f64)> {
     // Build edge lookup: (lo, hi) -> global edge index.
-    let mut edge_lookup: HashMap<(u32, u32), u32> = HashMap::with_capacity(n_edges);
+    let mut edge_lookup: HashMap<(u32, u32), u32> = HashMap::with_capacity(edges.len());
     for (idx, e) in edges.iter().enumerate() {
         edge_lookup.insert((e[0], e[1]), idx as u32);
     }
 
+    let mut triplets = Vec::with_capacity(triangles.len() * 9);
     for tri in triangles.iter() {
         let v: [[f64; 3]; 3] = [
             mesh.nodes[tri[0] as usize],
@@ -200,13 +229,12 @@ pub fn assemble_surface_mass(
             for j in 0..3 {
                 let (gj, sj) = edge_info[j];
                 let val = face_s[i][j] * (si as f64) * (sj as f64);
-                let cur = s[(gi as usize, gj as usize)];
-                s[(gi as usize, gj as usize)] = cur + val;
+                triplets.push((gi as usize, gj as usize, val));
             }
         }
     }
 
-    s
+    triplets
 }
 
 /// Local edge order on a triangle face. Mirrors `TET_LOCAL_EDGES` for

--- a/crates/geode-core/tests/nedelec_sparse.rs
+++ b/crates/geode-core/tests/nedelec_sparse.rs
@@ -1,0 +1,377 @@
+//! Sparse `[nnz]` pattern-aligned Nédélec assembly vs the dense
+//! `[n_edges²]` path (issue #218).
+//!
+//! The sparse assemblers run the *same* element-local kernels, signs
+//! and 1-D `scatter(0, …, Add)` as the dense ones — only the scatter
+//! target changes from a flat `[n_edges * n_edges]` tensor (i32
+//! linear-index overflow at n_edges > 46_340, O(n²) memory) to a flat
+//! `[nnz]` tensor indexed by precomputed pattern slots. Per pattern
+//! entry the summands accumulate in the same `(e, i, j)` order, so on
+//! the deterministic CPU backend the two paths must agree **bitwise**.
+//!
+//! Coverage:
+//!
+//! 1. dense-vs-sparse value equality over the recorded pattern for all
+//!    three driven-path material assemblers (scalar complex ε,
+//!    diagonal-anisotropic ε, matched-UPML full tensors) plus the
+//!    σ damping matrix;
+//! 2. pattern-slot map sanity (`slot_of` hits every recorded entry,
+//!    misses off-pattern pairs);
+//! 3. autodiff smoke through the `[nnz]` scatter (gradients w.r.t.
+//!    node coordinates exist, finite, non-zero — mirrors the dense-path
+//!    test at `tests/sigma_conductivity.rs`).
+
+use burn::tensor::backend::BackendTypes;
+use burn::tensor::{Int, Tensor, TensorData};
+use faer::c64;
+use geode_core::{
+    assemble_global_nedelec_with_anisotropic_epsilon,
+    assemble_global_nedelec_with_anisotropic_epsilon_sparse,
+    assemble_global_nedelec_with_complex_epsilon,
+    assemble_global_nedelec_with_complex_epsilon_sparse, assemble_global_nedelec_with_full_tensors,
+    assemble_global_nedelec_with_full_tensors_sparse, assemble_nedelec_sigma_damping,
+    assemble_nedelec_sigma_damping_sparse, cube_tet_mesh, upload_mesh, DefaultBackend,
+    NedelecScatterMap, SparsityPattern, TetMesh,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+    let te = mesh.tet_edges();
+    (
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect(),
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect(),
+    )
+}
+
+/// Read a dense `[n, n]` Burn matrix to a host row-major Vec<f64>.
+fn dense_to_host(t: Tensor<B, 2>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+/// Read a `[nnz]` Burn value tensor to a host Vec<f64>.
+fn vals_to_host(t: Tensor<B, 1>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+/// Assert that the sparse `[nnz]` values equal the dense matrix read
+/// over the same (sorted) pattern, bit-for-bit.
+fn assert_pattern_equal(
+    label: &str,
+    pattern: &SparsityPattern,
+    n_edges: usize,
+    dense: &[f64],
+    sparse: &[f64],
+) {
+    assert_eq!(sparse.len(), pattern.nnz(), "{label}: value length");
+    for (idx, (&r, &c)) in pattern.rows.iter().zip(pattern.cols.iter()).enumerate() {
+        let d = dense[r as usize * n_edges + c as usize];
+        let s = sparse[idx];
+        assert_eq!(
+            d.to_bits(),
+            s.to_bits(),
+            "{label}: entry ({r}, {c}) dense {d:e} != sparse {s:e}"
+        );
+    }
+}
+
+/// Spatially varying complex scalar ε (lossy dielectric ramp).
+fn varying_eps(mesh: &TetMesh) -> Vec<c64> {
+    (0..mesh.n_tets())
+        .map(|t| c64::new(1.0 + 0.07 * t as f64, -0.01 * (t % 5) as f64))
+        .collect()
+}
+
+#[test]
+fn sparse_complex_epsilon_matches_dense_bitwise() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps = varying_eps(&mesh);
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let dense = assemble_global_nedelec_with_complex_epsilon::<B>(
+        nodes.clone(),
+        tets.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps,
+    );
+
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let sparse = assemble_global_nedelec_with_complex_epsilon_sparse::<B>(
+        nodes, tets, &tet_sign, &scatter, &eps,
+    );
+
+    let pattern = scatter.pattern();
+    assert_eq!(pattern.nnz(), dense.sparsity.nnz(), "pattern nnz mismatch");
+    assert_pattern_equal(
+        "K",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.k),
+        &vals_to_host(sparse.k_vals),
+    );
+    assert_pattern_equal(
+        "M_re",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.m_re),
+        &vals_to_host(sparse.m_re_vals),
+    );
+    assert_pattern_equal(
+        "M_im",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.m_im),
+        &vals_to_host(sparse.m_im_vals),
+    );
+}
+
+#[test]
+fn sparse_anisotropic_epsilon_matches_dense_bitwise() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps_diag: Vec<[c64; 3]> = (0..mesh.n_tets())
+        .map(|t| {
+            [
+                c64::new(1.0 + 0.05 * t as f64, -0.02),
+                c64::new(1.3, -0.001 * t as f64),
+                c64::new(0.9 + 0.01 * t as f64, 0.0),
+            ]
+        })
+        .collect();
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let dense = assemble_global_nedelec_with_anisotropic_epsilon::<B>(
+        nodes.clone(),
+        tets.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_diag,
+    );
+
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let sparse = assemble_global_nedelec_with_anisotropic_epsilon_sparse::<B>(
+        nodes, tets, &tet_sign, &scatter, &eps_diag,
+    );
+
+    let pattern = scatter.pattern();
+    assert_pattern_equal(
+        "K",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.k),
+        &vals_to_host(sparse.k_vals),
+    );
+    assert_pattern_equal(
+        "M_re",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.m_re),
+        &vals_to_host(sparse.m_re_vals),
+    );
+    assert_pattern_equal(
+        "M_im",
+        pattern,
+        n_edges,
+        &dense_to_host(dense.m_im),
+        &vals_to_host(sparse.m_im_vals),
+    );
+}
+
+#[test]
+fn sparse_full_tensors_matches_dense_bitwise() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    // Symmetric complex 3×3 tensors with off-diagonal coupling.
+    let eps_t: Vec<[[c64; 3]; 3]> = (0..mesh.n_tets())
+        .map(|t| {
+            let a = 1.0 + 0.03 * t as f64;
+            [
+                [c64::new(a, -0.02), c64::new(0.1, 0.01), c64::new(0.0, 0.0)],
+                [
+                    c64::new(0.1, 0.01),
+                    c64::new(1.2, -0.05),
+                    c64::new(0.05, 0.0),
+                ],
+                [
+                    c64::new(0.0, 0.0),
+                    c64::new(0.05, 0.0),
+                    c64::new(0.8, -0.01),
+                ],
+            ]
+        })
+        .collect();
+    let nu_t: Vec<[[c64; 3]; 3]> = (0..mesh.n_tets())
+        .map(|t| {
+            let a = 0.9 + 0.02 * t as f64;
+            [
+                [c64::new(a, 0.04), c64::new(0.0, 0.0), c64::new(-0.07, 0.02)],
+                [c64::new(0.0, 0.0), c64::new(1.1, 0.01), c64::new(0.0, 0.0)],
+                [
+                    c64::new(-0.07, 0.02),
+                    c64::new(0.0, 0.0),
+                    c64::new(1.0, 0.03),
+                ],
+            ]
+        })
+        .collect();
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let dense = assemble_global_nedelec_with_full_tensors::<B>(
+        nodes.clone(),
+        tets.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_t,
+        &nu_t,
+    );
+
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let sparse = assemble_global_nedelec_with_full_tensors_sparse::<B>(
+        nodes, tets, &tet_sign, &scatter, &eps_t, &nu_t,
+    );
+
+    let pattern = scatter.pattern();
+    for (label, d, s) in [
+        ("K_re", dense.k_re, sparse.k_re_vals),
+        ("K_im", dense.k_im, sparse.k_im_vals),
+        ("M_re", dense.m_re, sparse.m_re_vals),
+        ("M_im", dense.m_im, sparse.m_im_vals),
+    ] {
+        assert_pattern_equal(label, pattern, n_edges, &dense_to_host(d), &vals_to_host(s));
+    }
+}
+
+#[test]
+fn sparse_sigma_damping_matches_dense_bitwise() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let sigma: Vec<f64> = (0..mesh.n_tets()).map(|t| 0.5 + 0.11 * t as f64).collect();
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let dense = assemble_nedelec_sigma_damping::<B>(
+        nodes.clone(),
+        tets.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &sigma,
+    );
+
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let sparse =
+        assemble_nedelec_sigma_damping_sparse::<B>(nodes, tets, &tet_sign, &scatter, &sigma);
+
+    assert_pattern_equal(
+        "C",
+        scatter.pattern(),
+        n_edges,
+        &dense_to_host(dense),
+        &vals_to_host(sparse),
+    );
+}
+
+/// `slot_of` must locate every recorded `(row, col)` pair at its own
+/// slot index and return `None` for pairs outside the pattern.
+#[test]
+fn scatter_map_slot_lookup_is_consistent() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let (tet_idx, _) = edge_tables(&mesh);
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let pattern = scatter.pattern();
+
+    for (idx, (&r, &c)) in pattern.rows.iter().zip(pattern.cols.iter()).enumerate() {
+        assert_eq!(scatter.slot_of(r, c), Some(idx));
+    }
+
+    // The cube mesh is far from fully coupled: edge 0 cannot couple to
+    // every other edge. Find one absent pair and check it misses.
+    let n_edges = mesh.edges().len() as u32;
+    let coupled_to_zero: std::collections::BTreeSet<u32> = pattern
+        .rows
+        .iter()
+        .zip(pattern.cols.iter())
+        .filter(|(&r, _)| r == 0)
+        .map(|(_, &c)| c)
+        .collect();
+    let absent = (0..n_edges)
+        .find(|c| !coupled_to_zero.contains(c))
+        .expect("edge 0 must not couple to all edges on the 2-cube mesh");
+    assert_eq!(scatter.slot_of(0, absent), None);
+}
+
+/// Autodiff smoke through the `[nnz]` scatter (mirrors the dense-path
+/// test `sigma_damping_assembly_preserves_autodiff` in
+/// `tests/sigma_conductivity.rs`): gradients w.r.t. node coordinates
+/// must exist, be finite, and be non-zero somewhere.
+#[test]
+fn sparse_assembly_preserves_autodiff() {
+    use burn::backend::Autodiff;
+    type Ad = Autodiff<B>;
+
+    let mesh = cube_tet_mesh(2, 1.0);
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let sigma: Vec<f64> = (0..mesh.n_tets()).map(|t| 0.5 + 0.11 * t as f64).collect();
+    let scatter = NedelecScatterMap::new(&tet_idx);
+
+    let n = mesh.n_nodes();
+    let n_elem = mesh.n_tets();
+    let ad_dev = <Ad as BackendTypes>::Device::default();
+    let node_flat: Vec<f32> = mesh
+        .nodes
+        .iter()
+        .flat_map(|p| p.iter().map(|&x| x as f32))
+        .collect();
+    let tet_flat: Vec<i32> = mesh
+        .tets
+        .iter()
+        .flat_map(|t| t.iter().map(|&i| i as i32))
+        .collect();
+    let nodes =
+        Tensor::<Ad, 2>::from_data(TensorData::new(node_flat, [n, 3]), &ad_dev).require_grad();
+    let tets = Tensor::<Ad, 2, Int>::from_data(TensorData::new(tet_flat, [n_elem, 4]), &ad_dev);
+
+    let c_vals = assemble_nedelec_sigma_damping_sparse::<Ad>(
+        nodes.clone(),
+        tets,
+        &tet_sign,
+        &scatter,
+        &sigma,
+    );
+    assert_eq!(c_vals.dims(), [scatter.nnz()]);
+
+    let loss = c_vals.powf_scalar(2.0).sum();
+    let grads = loss.backward();
+    let dnodes = nodes
+        .grad(&grads)
+        .expect("gradient w.r.t. nodes should exist");
+    let dnodes_vec: Vec<f64> = dnodes.into_data().iter::<f64>().collect();
+    assert!(
+        dnodes_vec.iter().all(|g| g.is_finite()),
+        "all gradients must be finite"
+    );
+    assert!(
+        dnodes_vec.iter().any(|g| g.abs() > 1e-6),
+        "gradient should be non-zero somewhere"
+    );
+}

--- a/crates/geode-core/tests/spiral_mesh.rs
+++ b/crates/geode-core/tests/spiral_mesh.rs
@@ -5,10 +5,10 @@
 //! `reference/gmsh/spiral_inductor.geo`:
 //!
 //! - **benchmark** (`spiral_3p5.msh`, ~54 k edges) — the Phase 3
-//!   benchmark mesh for issue #211; too large for the current dense
-//!   Burn scatter assembly, so only mesh-level checks run on it here;
+//!   benchmark mesh for issue #211, assemblable since the sparse
+//!   `[nnz]` Burn scatter landed (issue #218);
 //! - **smoke** (`spiral_3p5_smoke.msh`, ~15 k edges) — same topology,
-//!   coarser, used for the end-to-end solve.
+//!   coarser, used for the fast end-to-end solve.
 //!
 //! Coverage:
 //!
@@ -32,6 +32,12 @@
 //!    outer walls + PEC conductor cavity via the edge-exact mask)
 //!    completes with a healthy direct-solve residual and finite,
 //!    non-zero port V / I / Z_in.
+//! 5. **Benchmark-fixture solve** (issue #218) — [`DrivenOperator`]
+//!    assembly + one `solve_at` on the full 54 k-edge benchmark mesh
+//!    (above the 46 340-edge i32 dense-scatter overflow threshold),
+//!    port-driven with the conductor as a Leontovich (good-conductor)
+//!    impedance surface — exercising both the `[nnz]` volume scatter
+//!    and the triplet-based surface mass at scale.
 
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
@@ -42,7 +48,8 @@ use geode_core::mesh::spiral::{
 use geode_core::{
     driven_solve_with_ports, pec_interior_mask_from_triangles, port_current, port_input_impedance,
     port_voltage, read_spiral_fixture, read_spiral_smoke_fixture, CurrentSource, DefaultBackend,
-    DrivenBcs, DrivenMaterials, SpiralFixture, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    DrivenBcs, DrivenMaterials, DrivenOperator, SpiralFixture, SurfaceImpedanceBc,
+    SurfaceImpedanceModel,
 };
 use std::collections::BTreeSet;
 
@@ -302,6 +309,97 @@ fn driven_solve_with_ports_end_to_end_smoke() {
     // collapsed to 0, not blown up) — a loose physical sanity band, not
     // a benchmark assertion (that is issue #211's job).
     let z_ohms = z * 376.730_313_668;
+    assert!(
+        z_ohms.norm() > 1e-3 && z_ohms.norm() < 1e6,
+        "Z_in = {z_ohms} Ω outside loose sanity band"
+    );
+}
+
+/// Benchmark-fixture solve (issue #218 acceptance): [`DrivenOperator`]
+/// assembly + one `solve_at` on the full 54,428-edge spiral mesh.
+///
+/// This mesh sits **above** the 46,340-edge threshold where the old
+/// dense `[n_edges²]` Burn scatter overflowed its i32 linear index
+/// (debug-build panic) and would have needed ~12 GB per f32 tensor
+/// (~24 GB per dense f64 faer intermediate) — the sparse `[nnz]`
+/// pattern-slot assembly handles it in O(nnz) ≈ 1 M values per matrix.
+///
+/// Setup mirrors the smoke solve, with one upgrade: the conductor
+/// surface is a Leontovich good-conductor impedance BC instead of a
+/// PEC cavity, so the triplet-based surface mass (the second dense
+/// `[n_edges²]` object eliminated by #218) is exercised at scale too.
+/// PEC outer walls, 50 Ω port driven with V_inc = 1 at 10 GHz, no
+/// volume current.
+#[test]
+fn driven_operator_assembles_and_solves_benchmark_fixture() {
+    let f = read_spiral_fixture().expect("benchmark fixture must load");
+    let edges = f.mesh.edges();
+    assert!(
+        edges.len() > 46_340,
+        "benchmark fixture has {} edges — must exceed the i32 dense-scatter \
+         overflow threshold for this regression to bite",
+        edges.len()
+    );
+
+    let eps = f.epsilon_r_default();
+
+    // PEC outer walls only — the conductor surface gets the impedance BC.
+    let outer = f.outer_boundary_triangles();
+    let mask = pec_interior_mask_from_triangles(&edges, &[outer.as_slice()]);
+    assert!(mask.iter().any(|&keep| !keep) && mask.iter().any(|&keep| keep));
+
+    let cond = f.conductor_triangles();
+    let surface = SurfaceImpedanceBc {
+        triangles: &cond,
+        model: SurfaceImpedanceModel::GoodConductor {
+            sigma: CONDUCTOR_SIGMA_NATURAL,
+        },
+    };
+
+    let port = f.port();
+    let r_50 = 50.0 / 376.730_313_668;
+    let lp = port.lumped_port(r_50, c64::new(1.0, 0.0));
+
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; f.mesh.n_tets()],
+    };
+
+    let op = DrivenOperator::assemble::<B>(
+        &f.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&lp),
+        std::slice::from_ref(&surface),
+        &source,
+        &device(),
+    )
+    .expect("sparse assembly on the 54k-edge benchmark fixture must succeed");
+
+    let sol = op
+        .solve_at(OMEGA_10GHZ)
+        .expect("port-driven solve on the benchmark fixture must succeed");
+
+    assert!(
+        sol.residual_rel < 1e-8,
+        "direct-solve residual {} not at round-off floor",
+        sol.residual_rel
+    );
+    assert!(sol
+        .e_edges
+        .iter()
+        .all(|e| e.re.is_finite() && e.im.is_finite()));
+
+    let v = op.port_voltage(0, &sol.e_edges);
+    let i = op.port_current(0, v);
+    assert!(v.re.is_finite() && v.im.is_finite(), "V = {v} not finite");
+    assert!(i.re.is_finite() && i.im.is_finite(), "I = {i} not finite");
+    assert!(v.norm() > 0.0, "port voltage must be non-zero when driven");
+    assert!(i.norm() > 0.0, "port current must be non-zero when driven");
+
+    let z_ohms = (v / i) * 376.730_313_668;
     assert!(
         z_ohms.norm() > 1e-3 && z_ohms.norm() < 1e6,
         "Z_in = {z_ohms} Ω outside loose sanity band"


### PR DESCRIPTION
## Summary

Replaces the dense `[n_edges²]` Burn scatter on the driven path with a sparse `[nnz]` pattern-slot scatter (issue #218), removing both the i32 linear-index overflow at n_edges > 46,340 and the O(n²) memory wall:

- **`NedelecScatterMap`**: host-side precompute mapping each per-element (e,i,j) entry to its sorted-`SparsityPattern` slot (binary search, O(36·n_elem·log nnz)); i32 slot indices safe to ~2.1B nnz.
- **Sparse `[nnz]` variants** of the complex-ε / anisotropic-ε / full-tensor (matched UPML) assemblers + σ damping — identical kernels and signs, values-side autodiff scatter preserved, **bit-identical to the dense path over the pattern** (regression-tested on small meshes).
- **`DrivenOperator::assemble_impl`** consumes the `[nnz]` values directly, dropping the dense Burn tensors and 3–4 dense `[n²]` faer intermediates (~23.7 GB each at 54k edges).
- **`assemble_surface_mass_triplets`**: triplet core of the Leontovich surface mass (the second dense `[n²]` object on the driven path, flagged by the curator); dense version kept as a thin wrapper for eigen-path callers.
- **Benchmark-fixture test**: `DrivenOperator` assembly + port-driven `solve_at` on `spiral_3p5.msh` (54,428 edges, Leontovich conductor) — ~51–61 s, ~2.4 GB peak RSS.

Dense assemblers and their eigen/scattering consumers are untouched.

## Test plan

- [x] `cargo test --workspace --release` — all binaries pass (incl. new `nedelec_sparse` dense-vs-sparse equality regressions and the 54k-edge spiral benchmark-fixture solve)
- [x] `cargo clippy --workspace --all-targets --release` — clean
- [x] `cargo fmt --check` — clean

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)