### PR TITLE
refactor: unify Whitney triangle surface-mass kernels in shared whitney_face module

### DIFF
--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod scattering;
 pub mod silvermuller;
 pub mod silvermuller_self_consistent;
 pub mod sparse;
+pub(crate) mod whitney_face;
 
 #[cfg(feature = "arpack")]
 pub mod arpack;

--- a/crates/geode-core/src/lumped_port.rs
+++ b/crates/geode-core/src/lumped_port.rs
@@ -75,10 +75,9 @@
 //! terms are frequency-independent real matrices/vectors scaled by
 //! `jω/Z_s` at solve time inside [`crate::driven`].
 
-use std::collections::HashMap;
-
 use faer::c64;
 
+use crate::whitney_face::{self, dot3, edge_lookup, face_geometry, scale3, sub3, TRI_LOCAL_EDGES};
 use crate::TetMesh;
 
 /// Palace-style uniform lumped port specification.
@@ -116,78 +115,6 @@ impl LumpedPort<'_> {
     }
 }
 
-/// Per-face Whitney geometry shared by the mass and flux kernels.
-struct FaceGeometry {
-    /// Triangle area.
-    area: f64,
-    /// In-plane gradients of the three barycentric coordinates.
-    grad_lambda: [[f64; 3]; 3],
-    /// `(global_edge_index, orientation_sign)` for the three local
-    /// edges in [`TRI_LOCAL_EDGES`] order.
-    edge_info: [(u32, i8); 3],
-}
-
-/// Local edge order on a triangle face (lower local index first),
-/// matching `silvermuller.rs`.
-const TRI_LOCAL_EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
-
-fn face_geometry(
-    tri: &[u32; 3],
-    v: &[[f64; 3]; 3],
-    edge_lookup: &HashMap<(u32, u32), u32>,
-) -> FaceGeometry {
-    let e10 = sub3(v[1], v[0]);
-    let e20 = sub3(v[2], v[0]);
-    let cross = cross3(e10, e20);
-    let two_area = norm3(cross);
-    let area = 0.5 * two_area;
-    let n_hat = [
-        cross[0] / two_area,
-        cross[1] / two_area,
-        cross[2] / two_area,
-    ];
-
-    // In-plane gradients of triangle barycentric coords:
-    //   ∇λ_k = (n_hat × edge_opposite_k) / (2 area).
-    let opp = [sub3(v[2], v[1]), sub3(v[0], v[2]), sub3(v[1], v[0])];
-    let grad_lambda: [[f64; 3]; 3] = [
-        scale3(cross3(n_hat, opp[0]), 1.0 / two_area),
-        scale3(cross3(n_hat, opp[1]), 1.0 / two_area),
-        scale3(cross3(n_hat, opp[2]), 1.0 / two_area),
-    ];
-
-    // Global-edge mapping + orientation sign (lower-tag-first), same
-    // convention as the volume assembly and silvermuller.rs.
-    let mut edge_info: [(u32, i8); 3] = [(0, 1); 3];
-    for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
-        let ga = tri[la];
-        let gb = tri[lb];
-        let (lo, hi, sign) = if ga < gb {
-            (ga, gb, 1i8)
-        } else {
-            (gb, ga, -1i8)
-        };
-        let gidx = *edge_lookup
-            .get(&(lo, hi))
-            .expect("port face edge must appear in global edge table");
-        edge_info[k] = (gidx, sign);
-    }
-
-    FaceGeometry {
-        area,
-        grad_lambda,
-        edge_info,
-    }
-}
-
-fn edge_lookup(edges: &[[u32; 2]]) -> HashMap<(u32, u32), u32> {
-    let mut lookup = HashMap::with_capacity(edges.len());
-    for (idx, e) in edges.iter().enumerate() {
-        lookup.insert((e[0], e[1]), idx as u32);
-    }
-    lookup
-}
-
 /// Assemble the **tangential surface mass** of a port surface as signed
 /// global triplets:
 ///
@@ -202,9 +129,12 @@ fn edge_lookup(edges: &[[u32; 2]]) -> HashMap<(u32, u32), u32> {
 /// `A(ω)ᵀ = A(ω)`.
 ///
 /// Same kernel as
-/// [`crate::silvermuller::assemble_silver_muller_surface`] (3-point
-/// edge-midpoint quadrature, degree-2 exact) in sparse triplet form —
-/// the unit tests cross-validate the two implementations.
+/// [`crate::silvermuller::assemble_surface_mass_triplets`] — both are
+/// thin delegates to the shared [`crate::whitney_face`] module (3-point
+/// edge-midpoint quadrature, degree-2 exact; issue #208), so the two
+/// entry points produce bit-identical triplet streams. The unit tests
+/// cross-validate this path against the dense Silver-Müller assembly as
+/// a regression on the unified kernel.
 ///
 /// # Panics
 ///
@@ -215,49 +145,7 @@ pub fn assemble_port_surface_mass(
     faces: &[[u32; 3]],
     edges: &[[u32; 2]],
 ) -> Vec<(usize, usize, f64)> {
-    let lookup = edge_lookup(edges);
-    let mut triplets = Vec::with_capacity(faces.len() * 9);
-
-    // λ values at the three edge midpoints (degree-2 exact rule).
-    const BARYCENTRIC_MIDPOINTS: [[f64; 3]; 3] = [
-        [0.5, 0.5, 0.0], // m_01
-        [0.5, 0.0, 0.5], // m_02
-        [0.0, 0.5, 0.5], // m_12
-    ];
-
-    for tri in faces {
-        let v: [[f64; 3]; 3] = [
-            mesh.nodes[tri[0] as usize],
-            mesh.nodes[tri[1] as usize],
-            mesh.nodes[tri[2] as usize],
-        ];
-        let geo = face_geometry(tri, &v, &lookup);
-
-        let weight = geo.area / 3.0;
-        let mut block = [[0.0_f64; 3]; 3];
-        for lam in BARYCENTRIC_MIDPOINTS.iter() {
-            // Whitney trace N_e(λ) = λ_la ∇λ_lb − λ_lb ∇λ_la.
-            let mut basis_q: [[f64; 3]; 3] = [[0.0; 3]; 3];
-            for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
-                let term_a = scale3(geo.grad_lambda[lb], lam[la]);
-                let term_b = scale3(geo.grad_lambda[la], lam[lb]);
-                basis_q[k] = sub3(term_a, term_b);
-            }
-            for i in 0..3 {
-                for j in 0..3 {
-                    block[i][j] += weight * dot3(basis_q[i], basis_q[j]);
-                }
-            }
-        }
-
-        for (row, &(gi, si)) in block.iter().zip(geo.edge_info.iter()) {
-            for (&val, &(gj, sj)) in row.iter().zip(geo.edge_info.iter()) {
-                triplets.push((gi as usize, gj as usize, val * (si as f64) * (sj as f64)));
-            }
-        }
-    }
-
-    triplets
+    whitney_face::assemble_surface_mass_triplets(mesh, faces, edges)
 }
 
 /// Assemble the **port flux vector**
@@ -374,35 +262,6 @@ pub fn port_input_impedance(
     v / i
 }
 
-#[inline]
-fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
-}
-
-#[inline]
-fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    [
-        a[1] * b[2] - a[2] * b[1],
-        a[2] * b[0] - a[0] * b[2],
-        a[0] * b[1] - a[1] * b[0],
-    ]
-}
-
-#[inline]
-fn norm3(a: [f64; 3]) -> f64 {
-    (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt()
-}
-
-#[inline]
-fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
-    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
-}
-
-#[inline]
-fn scale3(a: [f64; 3], s: f64) -> [f64; 3] {
-    [a[0] * s, a[1] * s, a[2] * s]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -461,6 +320,31 @@ mod tests {
             max_diff < 1e-14,
             "port mass disagrees with Silver-Müller kernel: {max_diff}"
         );
+    }
+
+    /// The two public triplet entry points must produce **bit-identical**
+    /// triplet streams (same face order, same duplicate-unsummed
+    /// convention) — issue #208 acceptance criterion: both delegate to
+    /// the single kernel in `whitney_face`.
+    #[test]
+    fn port_mass_triplets_bit_identical_to_silver_muller_triplets() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        let faces: Vec<[u32; 3]> = mesh
+            .faces()
+            .into_iter()
+            .filter(|f| f.iter().all(|&n| mesh.nodes[n as usize][2].abs() < 1e-12))
+            .collect();
+        assert!(!faces.is_empty());
+
+        let port = assemble_port_surface_mass(&mesh, &faces, &edges);
+        let sm = crate::silvermuller::assemble_surface_mass_triplets(&mesh, &faces, &edges);
+        assert_eq!(port.len(), sm.len());
+        for (a, b) in port.iter().zip(sm.iter()) {
+            assert_eq!(a.0, b.0);
+            assert_eq!(a.1, b.1);
+            assert_eq!(a.2.to_bits(), b.2.to_bits(), "triplet values differ");
+        }
     }
 
     /// The assembled port surface mass must be symmetric (the iω-scaled

--- a/crates/geode-core/src/silvermuller.rs
+++ b/crates/geode-core/src/silvermuller.rs
@@ -60,6 +60,10 @@
 //! triangle to f64 precision; see the `face_mass_matches_analytic`
 //! unit test below.
 //!
+//! The per-face geometry and quadrature kernel live in the shared
+//! [`crate::whitney_face`] module (issue #208), which this module and
+//! [`crate::lumped_port`] both delegate to.
+//!
 //! # Why the BAC-CAB rank reduction is valid here
 //!
 //! For first-order Nédélec on a **flat** triangle, the basis traces
@@ -82,11 +86,10 @@
 //! entry `(i, j)` is multiplied by `s_i · s_j` before adding to the
 //! global `S`.
 
-use std::collections::HashMap;
-
 use faer::Mat;
 
 use crate::mesh::TetMesh;
+use crate::whitney_face;
 
 /// Assemble the dense Silver-Müller surface matrix `S` on the outer
 /// boundary triangles.
@@ -198,7 +201,10 @@ pub fn assemble_surface_mass(
 /// [`crate::driven::DrivenOperator`]). Triplets appear in face order,
 /// so summing them reproduces the dense accumulation order exactly.
 /// Same convention as
-/// [`crate::lumped_port::assemble_port_surface_mass`].
+/// [`crate::lumped_port::assemble_port_surface_mass`], which is the
+/// **same kernel** — both delegate to the shared
+/// [`crate::whitney_face`] module (issue #208), so the two entry points
+/// produce bit-identical triplet streams.
 ///
 /// # Panics
 ///
@@ -209,166 +215,7 @@ pub fn assemble_surface_mass_triplets(
     triangles: &[[u32; 3]],
     edges: &[[u32; 2]],
 ) -> Vec<(usize, usize, f64)> {
-    // Build edge lookup: (lo, hi) -> global edge index.
-    let mut edge_lookup: HashMap<(u32, u32), u32> = HashMap::with_capacity(edges.len());
-    for (idx, e) in edges.iter().enumerate() {
-        edge_lookup.insert((e[0], e[1]), idx as u32);
-    }
-
-    let mut triplets = Vec::with_capacity(triangles.len() * 9);
-    for tri in triangles.iter() {
-        let v: [[f64; 3]; 3] = [
-            mesh.nodes[tri[0] as usize],
-            mesh.nodes[tri[1] as usize],
-            mesh.nodes[tri[2] as usize],
-        ];
-        let (face_s, edge_info) = face_silver_muller_block(tri, &v, &edge_lookup);
-
-        for i in 0..3 {
-            let (gi, si) = edge_info[i];
-            for j in 0..3 {
-                let (gj, sj) = edge_info[j];
-                let val = face_s[i][j] * (si as f64) * (sj as f64);
-                triplets.push((gi as usize, gj as usize, val));
-            }
-        }
-    }
-
-    triplets
-}
-
-/// Local edge order on a triangle face. Mirrors `TET_LOCAL_EDGES` for
-/// tets: lower local index first.
-const TRI_LOCAL_EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
-
-/// Build the 3×3 face contribution `S^face_{ij} = ∫_T N_i · N_j dA`
-/// using the 3-point edge-midpoint quadrature (Hammer-Stroud, degree-2
-/// exact) on the first-order Whitney 1-form basis of a flat triangle,
-/// and the matching `(global_edge_idx, sign)` for each of the three
-/// local edges.
-///
-/// The integrand `N_i · N_j` is exactly quadratic in barycentric
-/// coordinates, so the 3-point edge-midpoint rule reproduces the
-/// analytic face mass to floating-point precision. See the
-/// `face_mass_matches_analytic` unit test.
-fn face_silver_muller_block(
-    tri: &[u32; 3],
-    v: &[[f64; 3]; 3],
-    edge_lookup: &HashMap<(u32, u32), u32>,
-) -> ([[f64; 3]; 3], [(u32, i8); 3]) {
-    // Triangle edges in 3D and the unit outward normal direction (raw
-    // cross product gives 2·area * n_hat). We never need the actual n
-    // for the integrand (rank-reducing identity `(n × u) · (n × v) = u · v`
-    // for in-plane u, v) but we DO need the area.
-    let e10 = sub3(v[1], v[0]);
-    let e20 = sub3(v[2], v[0]);
-    let cross = cross3(e10, e20);
-    let two_area = norm3(cross);
-    let area = 0.5 * two_area;
-    // Unit normal — direction is the right-hand-rule one from vertex
-    // ordering. Sign does not matter because the integrand only sees
-    // the in-plane components of the basis.
-    let n_hat = [
-        cross[0] / two_area,
-        cross[1] / two_area,
-        cross[2] / two_area,
-    ];
-
-    // In-plane gradients of triangle barycentric coords:
-    //   ∇λ_k = (n_hat × edge_opposite_k) / (2 area)
-    // where edge_opposite_k goes from v_{(k+1)%3} to v_{(k+2)%3}.
-    // This formula puts ∇λ_k perpendicular to the opposite edge, in the
-    // triangle plane, with the right magnitude (1 / height_from_k).
-    let opp = [sub3(v[2], v[1]), sub3(v[0], v[2]), sub3(v[1], v[0])];
-    let grad_lambda: [[f64; 3]; 3] = [
-        scale3(cross3(n_hat, opp[0]), 1.0 / two_area),
-        scale3(cross3(n_hat, opp[1]), 1.0 / two_area),
-        scale3(cross3(n_hat, opp[2]), 1.0 / two_area),
-    ];
-
-    // Compute the global-edge mapping and orientation sign for each
-    // local triangle edge. Sign + global-edge mapping comes from
-    // comparing the global node tags of the local edge endpoints
-    // (lower-tag first), matching the volume assembly convention.
-    let mut edge_info: [(u32, i8); 3] = [(0, 1); 3];
-    for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
-        let ga = tri[la];
-        let gb = tri[lb];
-        let (lo, hi, sign) = if ga < gb {
-            (ga, gb, 1i8)
-        } else {
-            (gb, ga, -1i8)
-        };
-        let gidx = *edge_lookup
-            .get(&(lo, hi))
-            .expect("triangle edge must appear in global edge table");
-        edge_info[k] = (gidx, sign);
-    }
-
-    // 3-point edge-midpoint quadrature (Hammer-Stroud, degree-2 exact):
-    //   ∫_T f dA ≈ (area/3) · [f(m_01) + f(m_02) + f(m_12)]
-    // where m_ab is the midpoint of local edge (la, lb). In barycentric
-    // coords this is λ_la = λ_lb = 1/2, λ_other = 0.
-    //
-    // We evaluate the 3 Whitney basis functions at each of the 3 edge
-    // midpoints, then sum the outer products.
-    //
-    // BARYCENTRIC_MIDPOINTS[q][k] = value of λ_k at quadrature point q.
-    // q=0 → midpoint of edge (0,1), q=1 → edge (0,2), q=2 → edge (1,2).
-    const BARYCENTRIC_MIDPOINTS: [[f64; 3]; 3] = [
-        [0.5, 0.5, 0.0], // m_01
-        [0.5, 0.0, 0.5], // m_02
-        [0.0, 0.5, 0.5], // m_12
-    ];
-
-    let weight = area / 3.0;
-    let mut block = [[0.0_f64; 3]; 3];
-    for lam in BARYCENTRIC_MIDPOINTS.iter() {
-        // Evaluate the three Whitney basis vectors at this midpoint.
-        // N_e(λ) = λ_la · ∇λ_lb − λ_lb · ∇λ_la for local edge (la, lb).
-        let mut basis_q: [[f64; 3]; 3] = [[0.0; 3]; 3];
-        for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
-            let term_a = scale3(grad_lambda[lb], lam[la]);
-            let term_b = scale3(grad_lambda[la], lam[lb]);
-            basis_q[k] = sub3(term_a, term_b);
-        }
-        for i in 0..3 {
-            for j in 0..3 {
-                block[i][j] += weight * dot3(basis_q[i], basis_q[j]);
-            }
-        }
-    }
-
-    (block, edge_info)
-}
-
-#[inline]
-fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
-}
-
-#[inline]
-fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
-    [
-        a[1] * b[2] - a[2] * b[1],
-        a[2] * b[0] - a[0] * b[2],
-        a[0] * b[1] - a[1] * b[0],
-    ]
-}
-
-#[inline]
-fn norm3(a: [f64; 3]) -> f64 {
-    (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt()
-}
-
-#[inline]
-fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
-    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
-}
-
-#[inline]
-fn scale3(a: [f64; 3], s: f64) -> [f64; 3] {
-    [a[0] * s, a[1] * s, a[2] * s]
+    whitney_face::assemble_surface_mass_triplets(mesh, triangles, edges)
 }
 
 #[cfg(test)]

--- a/crates/geode-core/src/whitney_face.rs
+++ b/crates/geode-core/src/whitney_face.rs
@@ -1,0 +1,248 @@
+//! Shared Whitney 1-form triangle-face kernel (issue #208).
+//!
+//! Both the Silver-Müller / Leontovich impedance boundary conditions
+//! ([`crate::silvermuller`]) and the uniform lumped port
+//! ([`crate::lumped_port`]) integrate first-order (Whitney) Nédélec
+//! edge-element traces over flat boundary triangles. Before this module
+//! existed the per-face geometry (area, in-plane barycentric gradients,
+//! lower-tag-first edge orientation signs) and the tangential
+//! surface-mass quadrature were duplicated in both files — see issue
+//! #208. This `pub(crate)` module hosts the single implementation; the
+//! public assembly entry points (`assemble_surface_mass*`,
+//! `assemble_port_surface_mass`, `assemble_port_flux`) stay where they
+//! were and delegate here.
+//!
+//! # Discretization (see `silvermuller.rs` module docs for the full
+//! derivation)
+//!
+//! On a **flat** triangle the Whitney trace `N_e = λ_a ∇λ_b − λ_b ∇λ_a`
+//! lies in the face plane, so the BAC-CAB identity rank-reduces the
+//! tangential integrand: `(n × N_i) · (n × N_j) = N_i · N_j`. The mass
+//! integrand is degree-2 in barycentric coordinates and is integrated
+//! exactly with the 3-point edge-midpoint rule (Hammer-Stroud,
+//! degree-2 exact):
+//!
+//! ```text
+//! ∫_T f dA ≈ (area / 3) · [f(m_01) + f(m_02) + f(m_12)]
+//! ```
+//!
+//! # Sign convention
+//!
+//! Edge DOFs use the same lower-tag-first global orientation as
+//! [`crate::nedelec_assembly`]: for a global edge `(va, vb)` with
+//! `va < vb` the basis direction is `va → vb` (sign +1); a local face
+//! edge contributes with sign `+1` if its local direction produces
+//! global tags in ascending order and `-1` otherwise. Face entry
+//! `(i, j)` is multiplied by `s_i · s_j` before scattering into the
+//! global matrix — the same rule as the volume assembly.
+
+use std::collections::HashMap;
+
+use crate::mesh::TetMesh;
+
+/// Local edge order on a triangle face. Mirrors `TET_LOCAL_EDGES` for
+/// tets: lower local index first.
+pub(crate) const TRI_LOCAL_EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
+
+/// `BARYCENTRIC_MIDPOINTS[q][k]` = value of `λ_k` at quadrature point
+/// `q` of the 3-point edge-midpoint rule. `q=0` → midpoint of edge
+/// `(0,1)`, `q=1` → edge `(0,2)`, `q=2` → edge `(1,2)`.
+pub(crate) const BARYCENTRIC_MIDPOINTS: [[f64; 3]; 3] = [
+    [0.5, 0.5, 0.0], // m_01
+    [0.5, 0.0, 0.5], // m_02
+    [0.0, 0.5, 0.5], // m_12
+];
+
+/// Per-face Whitney geometry shared by the mass and flux kernels.
+pub(crate) struct FaceGeometry {
+    /// Triangle area.
+    pub(crate) area: f64,
+    /// In-plane gradients of the three barycentric coordinates.
+    pub(crate) grad_lambda: [[f64; 3]; 3],
+    /// `(global_edge_index, orientation_sign)` for the three local
+    /// edges in [`TRI_LOCAL_EDGES`] order.
+    pub(crate) edge_info: [(u32, i8); 3],
+}
+
+/// Build the `(lo, hi) → global edge index` lookup from the global
+/// edge table (`mesh.edges()` order, lower tag first).
+pub(crate) fn edge_lookup(edges: &[[u32; 2]]) -> HashMap<(u32, u32), u32> {
+    let mut lookup = HashMap::with_capacity(edges.len());
+    for (idx, e) in edges.iter().enumerate() {
+        lookup.insert((e[0], e[1]), idx as u32);
+    }
+    lookup
+}
+
+/// Compute the per-face Whitney geometry: area, in-plane barycentric
+/// gradients, and the `(global_edge_index, sign)` mapping for the three
+/// local edges.
+///
+/// The triangle's unit normal direction (right-hand rule on the vertex
+/// order) only enters through the in-plane gradient formula
+/// `∇λ_k = (n̂ × edge_opposite_k) / (2·area)`; its sign does not affect
+/// any of the integrals built on top (the mass integrand only sees
+/// in-plane components, the flux integrand is linear in `∇λ`
+/// differences), so winding order does not matter for callers.
+///
+/// # Panics
+///
+/// Panics if a triangle edge does not appear in `edge_lookup` — i.e. if
+/// the triangle is not a face of the tet mesh whose edge table was used
+/// to build the lookup.
+pub(crate) fn face_geometry(
+    tri: &[u32; 3],
+    v: &[[f64; 3]; 3],
+    edge_lookup: &HashMap<(u32, u32), u32>,
+) -> FaceGeometry {
+    let e10 = sub3(v[1], v[0]);
+    let e20 = sub3(v[2], v[0]);
+    let cross = cross3(e10, e20);
+    let two_area = norm3(cross);
+    let area = 0.5 * two_area;
+    // Unit normal — direction is the right-hand-rule one from vertex
+    // ordering. Sign does not matter (see doc comment above).
+    let n_hat = [
+        cross[0] / two_area,
+        cross[1] / two_area,
+        cross[2] / two_area,
+    ];
+
+    // In-plane gradients of triangle barycentric coords:
+    //   ∇λ_k = (n_hat × edge_opposite_k) / (2 area)
+    // where edge_opposite_k goes from v_{(k+1)%3} to v_{(k+2)%3}.
+    // This formula puts ∇λ_k perpendicular to the opposite edge, in the
+    // triangle plane, with the right magnitude (1 / height_from_k).
+    let opp = [sub3(v[2], v[1]), sub3(v[0], v[2]), sub3(v[1], v[0])];
+    let grad_lambda: [[f64; 3]; 3] = [
+        scale3(cross3(n_hat, opp[0]), 1.0 / two_area),
+        scale3(cross3(n_hat, opp[1]), 1.0 / two_area),
+        scale3(cross3(n_hat, opp[2]), 1.0 / two_area),
+    ];
+
+    // Global-edge mapping + orientation sign for each local triangle
+    // edge: compare the global node tags of the endpoints (lower tag
+    // first), matching the volume assembly convention.
+    let mut edge_info: [(u32, i8); 3] = [(0, 1); 3];
+    for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+        let ga = tri[la];
+        let gb = tri[lb];
+        let (lo, hi, sign) = if ga < gb {
+            (ga, gb, 1i8)
+        } else {
+            (gb, ga, -1i8)
+        };
+        let gidx = *edge_lookup
+            .get(&(lo, hi))
+            .expect("triangle edge must appear in global edge table");
+        edge_info[k] = (gidx, sign);
+    }
+
+    FaceGeometry {
+        area,
+        grad_lambda,
+        edge_info,
+    }
+}
+
+/// Build the 3×3 face contribution `S^face_{ij} = ∫_T N_i · N_j dA`
+/// (unsigned, local-edge order [`TRI_LOCAL_EDGES`]) with the 3-point
+/// edge-midpoint quadrature on the Whitney 1-form trace basis.
+///
+/// The integrand is exactly quadratic in barycentric coordinates, so
+/// the rule reproduces the analytic face mass to floating-point
+/// precision — see `silvermuller::tests::face_mass_matches_analytic`.
+pub(crate) fn face_mass_block(geo: &FaceGeometry) -> [[f64; 3]; 3] {
+    let weight = geo.area / 3.0;
+    let mut block = [[0.0_f64; 3]; 3];
+    for lam in BARYCENTRIC_MIDPOINTS.iter() {
+        // Evaluate the three Whitney basis vectors at this midpoint:
+        // N_e(λ) = λ_la · ∇λ_lb − λ_lb · ∇λ_la for local edge (la, lb).
+        let mut basis_q: [[f64; 3]; 3] = [[0.0; 3]; 3];
+        for (k, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+            let term_a = scale3(geo.grad_lambda[lb], lam[la]);
+            let term_b = scale3(geo.grad_lambda[la], lam[lb]);
+            basis_q[k] = sub3(term_a, term_b);
+        }
+        for i in 0..3 {
+            for j in 0..3 {
+                block[i][j] += weight * dot3(basis_q[i], basis_q[j]);
+            }
+        }
+    }
+    block
+}
+
+/// Assemble the tangential-trace surface mass
+/// `S_{ij} = ∮_Γ (n × N_i) · (n × N_j) dS = ∮_Γ N_i · N_j dS`
+/// over an explicit triangle list as signed `(row, col, value)` triplets
+/// over global edge indices.
+///
+/// Duplicate `(row, col)` entries (edges shared by adjacent faces) are
+/// **not** summed — the caller accumulates them. Triplets appear in
+/// face order, then row-major within each 3×3 face block, so summing
+/// them reproduces the dense accumulation order exactly.
+///
+/// This is the single kernel behind both
+/// [`crate::silvermuller::assemble_surface_mass_triplets`] and
+/// [`crate::lumped_port::assemble_port_surface_mass`] (issue #208).
+///
+/// # Panics
+///
+/// Panics if a triangle edge does not appear in `edges` — i.e. if the
+/// triangles are not faces of the tet mesh whose edge table was passed.
+pub(crate) fn assemble_surface_mass_triplets(
+    mesh: &TetMesh,
+    triangles: &[[u32; 3]],
+    edges: &[[u32; 2]],
+) -> Vec<(usize, usize, f64)> {
+    let lookup = edge_lookup(edges);
+
+    let mut triplets = Vec::with_capacity(triangles.len() * 9);
+    for tri in triangles.iter() {
+        let v: [[f64; 3]; 3] = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let geo = face_geometry(tri, &v, &lookup);
+        let block = face_mass_block(&geo);
+
+        for (row, &(gi, si)) in block.iter().zip(geo.edge_info.iter()) {
+            for (&val, &(gj, sj)) in row.iter().zip(geo.edge_info.iter()) {
+                triplets.push((gi as usize, gj as usize, val * (si as f64) * (sj as f64)));
+            }
+        }
+    }
+
+    triplets
+}
+
+#[inline]
+pub(crate) fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+pub(crate) fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+pub(crate) fn norm3(a: [f64; 3]) -> f64 {
+    (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt()
+}
+
+#[inline]
+pub(crate) fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+pub(crate) fn scale3(a: [f64; 3], s: f64) -> [f64; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated Whitney face surface-mass triplet kernel and its supporting geometry (`face_geometry`, `TRI_LOCAL_EDGES`/`BARYCENTRIC_MIDPOINTS`, `edge_lookup`, vec3 helpers) from `silvermuller.rs` and `lumped_port.rs` into a shared `whitney_face` module; both callers delegate to it.
- Net −20 lines with all duplication removed (292 insertions / 312 deletions); pure refactor, no numerical changes.
- Scope per curator: PR #220 already made `assemble_surface_mass_triplets` the triplet core in silvermuller.rs; this PR removes the remaining semantic duplicate in `lumped_port::assemble_port_surface_mass` and the shared helper copies.

## Test plan

- [x] `cargo test --workspace --release` — all pass (cross-validation test between the two surface-mass paths retained)
- [x] `cargo clippy --workspace --all-targets --release` — clean
- [x] `cargo fmt --check` — clean

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)