### PR TITLE
feat: Palace 3D oracle scaffolding — config generator + result ingester + patch benchmark wiring (#239)

### DIFF
--- a/benchmarks/patch_antenna/results.toml
+++ b/benchmarks/patch_antenna/results.toml
@@ -41,8 +41,8 @@ loss_limited_q = 5.000000e1
 fractional_bw_10db = 1.333333e-2
 
 [oracles.palace]
-status = "deferred"
-note = "Palace (or another full-wave reference) not run on the generation machine. Operator-supplied S11/f_res/efficiency values can be recorded here with their own provenance."
+status = "pending_operator_run"
+note = "Palace is not installed on the generation machine (only a Docker build recipe under ~/GitHub/sphere/eda/mom/docker/palace). The geode-fem-side config generator + result ingester (issue #239) live in reference/palace/geode_patch_baseline/ (emits palace_config.json) and crates/geode-core/src/palace.rs (parses Palace's s-parameters.csv into a populated [oracles.palace] block). Operator workflow: (1) emit the config, (2) run Palace, (3) populate this slot via geode_core::palace::PalaceResults with full provenance (palace_version, config_sha256). Same toolchain-gap convention as the FastHenry slot of benchmarks/spiral_inductor/results.toml."
 
 [comparison]
 f_res_fem_ghz = 2.274530e0

--- a/benchmarks/patch_antenna/results_matched.toml
+++ b/benchmarks/patch_antenna/results_matched.toml
@@ -44,8 +44,8 @@ loss_limited_q = 5.000000e1
 fractional_bw_10db = 1.333333e-2
 
 [oracles.palace]
-status = "deferred"
-note = "Palace (or another full-wave reference) not run on the generation machine. Operator-supplied S11/f_res/efficiency values can be recorded here with their own provenance."
+status = "pending_operator_run"
+note = "Palace is not installed on the generation machine (only a Docker build recipe under ~/GitHub/sphere/eda/mom/docker/palace). The geode-fem-side config generator + result ingester (issue #239) live in reference/palace/geode_patch_baseline/ (emits palace_config.json) and crates/geode-core/src/palace.rs (parses Palace's s-parameters.csv into a populated [oracles.palace] block). Operator workflow: (1) emit the config, (2) run Palace, (3) populate this slot via geode_core::palace::PalaceResults with full provenance (palace_version, config_sha256). Same toolchain-gap convention as the FastHenry slot of benchmarks/spiral_inductor/results.toml."
 
 [comparison]
 f_res_fem_ghz = 2.267495e0

--- a/benchmarks/patch_antenna/results_smoke.toml
+++ b/benchmarks/patch_antenna/results_smoke.toml
@@ -41,8 +41,8 @@ loss_limited_q = 5.000000e1
 fractional_bw_10db = 1.333333e-2
 
 [oracles.palace]
-status = "deferred"
-note = "Palace (or another full-wave reference) not run on the generation machine. Operator-supplied S11/f_res/efficiency values can be recorded here with their own provenance."
+status = "pending_operator_run"
+note = "Palace is not installed on the generation machine (only a Docker build recipe under ~/GitHub/sphere/eda/mom/docker/palace). The geode-fem-side config generator + result ingester (issue #239) live in reference/palace/geode_patch_baseline/ (emits palace_config.json) and crates/geode-core/src/palace.rs (parses Palace's s-parameters.csv into a populated [oracles.palace] block). Operator workflow: (1) emit the config, (2) run Palace, (3) populate this slot via geode_core::palace::PalaceResults with full provenance (palace_version, config_sha256). Same toolchain-gap convention as the FastHenry slot of benchmarks/spiral_inductor/results.toml."
 
 [comparison]
 f_res_fem_ghz = 2.600000e0

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -12,6 +12,11 @@ burn = { workspace = true }
 faer = { version = "0.24", default-features = false, features = ["std", "linalg", "sparse-linalg"] }
 mshio = "0.4"
 thiserror = "2"
+# Parses the [oracles.palace] block of the benchmark results TOMLs in
+# `src/palace.rs` (issue #239 — operator-assisted Palace 3D oracle
+# scaffolding). Same major as the existing dev-dep usage in the
+# benchmark tests.
+toml = "0.8"
 
 # Optional: link-time discovery of the system `libarpack` for the `arpack`
 # Cargo feature. Bindings to `dsaupd_c` / `dseupd_c` (the stable ARPACK

--- a/crates/geode-core/examples/patch_antenna.rs
+++ b/crates/geode-core/examples/patch_antenna.rs
@@ -515,8 +515,8 @@ fn write_toml(rows: &[Row], path: &PathBuf, choice: FixtureChoice, pml_thick: f6
     s.push('\n');
 
     s.push_str("[oracles.palace]\n");
-    s.push_str("status = \"deferred\"\n");
-    s.push_str("note = \"Palace (or another full-wave reference) not run on the generation machine. Operator-supplied S11/f_res/efficiency values can be recorded here with their own provenance.\"\n");
+    s.push_str("status = \"pending_operator_run\"\n");
+    s.push_str("note = \"Palace is not installed on the generation machine (only a Docker build recipe under ~/GitHub/sphere/eda/mom/docker/palace). The geode-fem-side config generator + result ingester (issue #239) live in reference/palace/geode_patch_baseline/ (emits palace_config.json) and crates/geode-core/src/palace.rs (parses Palace's s-parameters.csv into a populated [oracles.palace] block). Operator workflow: (1) emit the config, (2) run Palace, (3) populate this slot via geode_core::palace::PalaceResults with full provenance (palace_version, config_sha256). Same toolchain-gap convention as the FastHenry slot of benchmarks/spiral_inductor/results.toml.\"\n");
     s.push('\n');
 
     // Achieved comparison at resonance.

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod nedelec;
 pub mod nedelec_assembly;
 pub mod ntff;
 pub mod p1;
+pub mod palace;
 pub mod patch_cavity;
 pub mod scattering;
 pub mod silvermuller;

--- a/crates/geode-core/src/palace.rs
+++ b/crates/geode-core/src/palace.rs
@@ -1,0 +1,623 @@
+//! Palace oracle ingestion (issue #239).
+//!
+//! Palace (<https://github.com/awslabs/palace>) is the eventual full-3D
+//! gold-standard oracle for the geode-fem driven-port benchmarks. Palace
+//! is not installed on the geode-fem dev machine — its run is
+//! **operator-assisted** — but the *configuration* + *result-ingestion*
+//! glue lives here so a Palace reference can be produced by anyone with
+//! a working Palace install (or the sister-repo Docker recipe at
+//! `~/GitHub/sphere/eda/mom/docker/palace`) and slotted into the
+//! benchmark TOMLs without ad-hoc parsing per benchmark.
+//!
+//! # Two sides of the oracle
+//!
+//! 1. **Config generation** lives in the offline driver
+//!    `reference/palace/geode_patch_baseline/` (cargo binary, outside
+//!    the geode workspace — mirrors the `reference/mom/` offline
+//!    pattern). It emits `reference/fixtures/patch_palace/palace_config.json`,
+//!    which an operator can feed directly to Palace.
+//!
+//! 2. **Result ingestion** — this module — parses Palace's CSV output
+//!    artifacts into a typed [`PalaceResults`] struct that can be:
+//!      - serialized into the `[oracles.palace]` TOML block (via
+//!        [`PalaceOracleSlot`]); or
+//!      - consumed directly by a benchmark test in compare-with-band
+//!        mode when the slot is `populated`, with a clean
+//!        skip-with-note path when the slot is `pending_operator_run`.
+//!
+//! # Honesty about "pending_operator_run"
+//!
+//! The committed `[oracles.palace]` slot in the benchmark TOMLs stays
+//! `pending_operator_run` until a real operator-supplied Palace run is
+//! ingested. **No fabricated Palace numbers** go into a real
+//! `[oracles.palace]` slot. The unit tests in
+//! `crates/geode-core/tests/palace_ingestion.rs` exercise the parser
+//! against a clearly-labeled example fixture under
+//! `crates/geode-core/tests/fixtures/palace/` — that fixture is for
+//! testing the *ingestion code*, not the *oracle*.
+
+use std::fmt;
+use std::path::Path;
+
+/// Reference impedance Palace reports S-parameters against. The Palace
+/// config emitted by `reference/palace/geode_patch_baseline/` uses a
+/// 50 Ω lumped port, matching the geode-fem benchmark drive.
+pub const PALACE_DEFAULT_PORT_OHM: f64 = 50.0;
+
+/// One Palace driven-port sweep point as parsed from the standard
+/// Palace `s-parameters.csv` artifact.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PalaceSweepPoint {
+    /// Drive frequency (GHz). Palace writes Hz; the ingester converts
+    /// to GHz to match the geode-fem benchmark TOMLs.
+    pub f_ghz: f64,
+    /// Complex S11 at the lumped port.
+    pub s11_re: f64,
+    pub s11_im: f64,
+}
+
+impl PalaceSweepPoint {
+    /// |S11|, the linear reflection magnitude (always in [0, 1] for a
+    /// passive one-port).
+    pub fn s11_mag(&self) -> f64 {
+        (self.s11_re * self.s11_re + self.s11_im * self.s11_im).sqrt()
+    }
+
+    /// Return loss in dB: `20 log10 |S11|`.
+    pub fn s11_db(&self) -> f64 {
+        20.0 * self.s11_mag().max(1e-30).log10()
+    }
+
+    /// Re-derive port impedance from S11 and a reference resistance:
+    /// `Z = R · (1 + S11) / (1 - S11)`.
+    ///
+    /// Returns `(re, im)` parts in ohms.
+    pub fn z_from_s11(&self, r_ref_ohm: f64) -> (f64, f64) {
+        // Z = R · (1 + s) / (1 - s) where s = s11_re + i s11_im.
+        let num_re = 1.0 + self.s11_re;
+        let num_im = self.s11_im;
+        let den_re = 1.0 - self.s11_re;
+        let den_im = -self.s11_im;
+        let den_mag2 = den_re * den_re + den_im * den_im;
+        let z_re = (num_re * den_re + num_im * den_im) / den_mag2;
+        let z_im = (num_im * den_re - num_re * den_im) / den_mag2;
+        (r_ref_ohm * z_re, r_ref_ohm * z_im)
+    }
+}
+
+/// All ingested Palace artifacts for one benchmark fixture.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PalaceResults {
+    /// Free-form Palace version string (e.g. `"0.13.0-git"`). Recorded
+    /// in provenance and the `[oracles.palace]` TOML block.
+    pub palace_version: String,
+    /// Hex-encoded SHA256 of the Palace JSON config the run consumed.
+    /// Lets the comparison test confirm Palace ran on the same config
+    /// the geode-fem generator emitted (the "are we comparing the same
+    /// problem?" check).
+    pub config_sha256: String,
+    /// Port reference resistance (Ω) the Palace run used.
+    pub port_resistance_ohm: f64,
+    /// Per-frequency sweep points.
+    pub points: Vec<PalaceSweepPoint>,
+}
+
+impl PalaceResults {
+    /// Parse a Palace `s-parameters.csv` artifact into [`PalaceResults`].
+    ///
+    /// Palace's CSV format (as of 0.13) is a comma-separated table with
+    /// a header line of column names and one row per sweep point. The
+    /// columns relevant to a one-port driven sweep are:
+    ///
+    /// ```text
+    /// f (GHz),               Re(S[1][1]),         Im(S[1][1]),       ...
+    /// ```
+    ///
+    /// The ingester is **lenient**: column names are matched
+    /// case-insensitively with whitespace trimmed, and extra columns
+    /// are ignored. Lines beginning with `#` are treated as comments.
+    /// Frequency is detected as either `f (GHz)` or `f (Hz)`; Hz values
+    /// are converted to GHz on read.
+    pub fn from_palace_csv(
+        csv_text: &str,
+        palace_version: impl Into<String>,
+        config_sha256: impl Into<String>,
+        port_resistance_ohm: f64,
+    ) -> Result<Self, PalaceIngestError> {
+        let mut lines = csv_text
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'));
+
+        let header = lines.next().ok_or(PalaceIngestError::EmptyCsv)?;
+        let headers: Vec<String> = header
+            .split(',')
+            .map(|c| c.trim().to_ascii_lowercase())
+            .collect();
+
+        // Locate the frequency column (Palace varies between `f (GHz)`
+        // and `f (Hz)` across versions; we read either and normalize).
+        let mut f_idx: Option<usize> = None;
+        let mut f_in_hz = false;
+        for (i, h) in headers.iter().enumerate() {
+            // Accept "f (ghz)", "freq (ghz)", "frequency (ghz)", etc.
+            if h.contains("ghz") && (h.starts_with('f') || h.contains("freq")) {
+                f_idx = Some(i);
+                f_in_hz = false;
+                break;
+            }
+            if h.contains("hz") && (h.starts_with('f') || h.contains("freq")) {
+                f_idx = Some(i);
+                f_in_hz = true;
+            }
+        }
+        let f_idx = f_idx.ok_or(PalaceIngestError::MissingColumn("frequency".to_string()))?;
+
+        // Real and imaginary S11 columns. Palace writes them as
+        // `Re(S[1][1])` / `Im(S[1][1])`. After lowercasing + trimming
+        // the patterns we accept are quite loose so different Palace
+        // versions land in the same parser.
+        let re_idx = find_col(&headers, &["re(s[1][1])", "re(s11)", "real(s[1][1])"])
+            .ok_or(PalaceIngestError::MissingColumn("Re(S[1][1])".to_string()))?;
+        let im_idx = find_col(&headers, &["im(s[1][1])", "im(s11)", "imag(s[1][1])"])
+            .ok_or(PalaceIngestError::MissingColumn("Im(S[1][1])".to_string()))?;
+
+        let mut points = Vec::new();
+        for (lineno, row) in lines.enumerate() {
+            let cols: Vec<&str> = row.split(',').map(|c| c.trim()).collect();
+            if cols.len() <= f_idx.max(re_idx).max(im_idx) {
+                return Err(PalaceIngestError::ShortRow {
+                    line: lineno + 2, // header was line 1, rows start at 2
+                    expected: f_idx.max(re_idx).max(im_idx) + 1,
+                    got: cols.len(),
+                });
+            }
+            let parse = |i: usize| -> Result<f64, PalaceIngestError> {
+                cols[i]
+                    .parse::<f64>()
+                    .map_err(|e| PalaceIngestError::ParseFloat {
+                        line: lineno + 2,
+                        column: i,
+                        value: cols[i].to_string(),
+                        err: e.to_string(),
+                    })
+            };
+            let f_raw = parse(f_idx)?;
+            let s11_re = parse(re_idx)?;
+            let s11_im = parse(im_idx)?;
+            let f_ghz = if f_in_hz { f_raw / 1.0e9 } else { f_raw };
+            points.push(PalaceSweepPoint {
+                f_ghz,
+                s11_re,
+                s11_im,
+            });
+        }
+
+        if points.is_empty() {
+            return Err(PalaceIngestError::NoPoints);
+        }
+
+        Ok(PalaceResults {
+            palace_version: palace_version.into(),
+            config_sha256: config_sha256.into(),
+            port_resistance_ohm,
+            points,
+        })
+    }
+
+    /// Convenience wrapper: read CSV from disk and parse via
+    /// [`Self::from_palace_csv`].
+    pub fn from_palace_csv_file(
+        path: &Path,
+        palace_version: impl Into<String>,
+        config_sha256: impl Into<String>,
+        port_resistance_ohm: f64,
+    ) -> Result<Self, PalaceIngestError> {
+        let text = std::fs::read_to_string(path).map_err(|e| PalaceIngestError::Io {
+            path: path.to_string_lossy().into_owned(),
+            err: e.to_string(),
+        })?;
+        Self::from_palace_csv(&text, palace_version, config_sha256, port_resistance_ohm)
+    }
+
+    /// First-resonance estimate: the lowest-frequency point at which
+    /// `Im Z` crosses through zero from positive to negative (or
+    /// negative to positive). Returns `None` if no crossing is found
+    /// in the sweep.
+    pub fn estimate_resonance_ghz(&self) -> Option<f64> {
+        let zs: Vec<(f64, f64)> = self
+            .points
+            .iter()
+            .map(|p| {
+                let (_, z_im) = p.z_from_s11(self.port_resistance_ohm);
+                (p.f_ghz, z_im)
+            })
+            .collect();
+        for w in zs.windows(2) {
+            let (f0, im0) = w[0];
+            let (f1, im1) = w[1];
+            if im0 == 0.0 {
+                return Some(f0);
+            }
+            if (im0 > 0.0) != (im1 > 0.0) {
+                // Linear interpolation to the zero crossing.
+                let t = im0 / (im0 - im1);
+                return Some(f0 + t * (f1 - f0));
+            }
+        }
+        None
+    }
+
+    /// S11 dip (frequency and value in dB). Returns the most-negative
+    /// `s11_db` in the sweep — the strongest match. None for an empty
+    /// sweep.
+    pub fn s11_dip_db(&self) -> Option<(f64, f64)> {
+        self.points
+            .iter()
+            .map(|p| (p.f_ghz, p.s11_db()))
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+    }
+}
+
+fn find_col(headers: &[String], needles: &[&str]) -> Option<usize> {
+    for (i, h) in headers.iter().enumerate() {
+        let normalized: String = h.chars().filter(|c| !c.is_whitespace()).collect();
+        for n in needles {
+            let n_norm: String = n.chars().filter(|c| !c.is_whitespace()).collect();
+            if normalized == n_norm {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Errors emitted by the Palace CSV ingester.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PalaceIngestError {
+    EmptyCsv,
+    MissingColumn(String),
+    ShortRow {
+        line: usize,
+        expected: usize,
+        got: usize,
+    },
+    ParseFloat {
+        line: usize,
+        column: usize,
+        value: String,
+        err: String,
+    },
+    Io {
+        path: String,
+        err: String,
+    },
+    NoPoints,
+}
+
+impl fmt::Display for PalaceIngestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyCsv => write!(f, "Palace CSV is empty"),
+            Self::MissingColumn(c) => write!(f, "missing required column: {c}"),
+            Self::ShortRow {
+                line,
+                expected,
+                got,
+            } => write!(
+                f,
+                "Palace CSV row {line}: expected at least {expected} columns, got {got}"
+            ),
+            Self::ParseFloat {
+                line,
+                column,
+                value,
+                err,
+            } => write!(
+                f,
+                "Palace CSV row {line}, column {column}: cannot parse {value:?} as f64: {err}"
+            ),
+            Self::Io { path, err } => write!(f, "I/O error reading {path}: {err}"),
+            Self::NoPoints => write!(f, "Palace CSV has no data points"),
+        }
+    }
+}
+
+impl std::error::Error for PalaceIngestError {}
+
+/// Lightweight typed view of the `[oracles.palace]` TOML block in a
+/// benchmark `results.toml`.
+///
+/// The block has two valid shapes, matching the two phases of the
+/// operator-assisted lifecycle:
+///
+/// - **`pending_operator_run`**: Palace has not been run for this
+///   benchmark on this fixture. The slot still carries its
+///   provenance-style `note`. Benchmark tests **skip with a note** in
+///   this state — they never silently pass.
+/// - **`populated`**: A real operator-run Palace reference has been
+///   ingested. The block carries `palace_version`, `config_sha256`,
+///   `port_resistance_ohm`, and the parsed `points`. Benchmark tests
+///   compare FEM results against these values within a documented band.
+///
+/// The [`from_toml_table`](Self::from_toml_table) loader is robust
+/// against extra fields (so future schema extensions don't trip the
+/// parser).
+#[derive(Clone, Debug, PartialEq)]
+pub enum PalaceOracleSlot {
+    PendingOperatorRun { note: Option<String> },
+    Populated(Box<PalaceResults>),
+}
+
+impl PalaceOracleSlot {
+    /// True if the slot has been populated with an operator-run
+    /// reference (vs. still `pending_operator_run`).
+    pub fn is_populated(&self) -> bool {
+        matches!(self, Self::Populated(_))
+    }
+
+    /// Return the populated results if present.
+    pub fn as_results(&self) -> Option<&PalaceResults> {
+        match self {
+            Self::Populated(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Parse the `[oracles.palace]` table out of a `toml::Value` (any
+    /// flavor: a `toml::Value::Table` matching the schema below).
+    ///
+    /// Pending shape:
+    /// ```toml
+    /// [oracles.palace]
+    /// status = "pending_operator_run"
+    /// note = "..."
+    /// ```
+    ///
+    /// Populated shape:
+    /// ```toml
+    /// [oracles.palace]
+    /// status = "populated"
+    /// palace_version = "0.13.0-git"
+    /// config_sha256 = "..."
+    /// port_resistance_ohm = 50
+    ///
+    /// [[oracles.palace.points]]
+    /// f_ghz = 2.30
+    /// s11_re = -0.43
+    /// s11_im = -0.26
+    /// ```
+    pub fn from_toml_table(table: &toml::Value) -> Result<Self, PalaceSlotError> {
+        let t = table
+            .as_table()
+            .ok_or_else(|| PalaceSlotError::Schema("[oracles.palace] is not a table".into()))?;
+        let status = t
+            .get("status")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| PalaceSlotError::Schema("missing or non-string `status`".into()))?;
+
+        match status {
+            "pending_operator_run" | "deferred" => {
+                let note = t.get("note").and_then(|v| v.as_str()).map(String::from);
+                Ok(Self::PendingOperatorRun { note })
+            }
+            "populated" => {
+                let palace_version = t
+                    .get("palace_version")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        PalaceSlotError::Schema("populated slot missing `palace_version`".into())
+                    })?
+                    .to_string();
+                let config_sha256 = t
+                    .get("config_sha256")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        PalaceSlotError::Schema("populated slot missing `config_sha256`".into())
+                    })?
+                    .to_string();
+                let port_resistance_ohm = t
+                    .get("port_resistance_ohm")
+                    .and_then(|v| v.as_float().or_else(|| v.as_integer().map(|i| i as f64)))
+                    .ok_or_else(|| {
+                        PalaceSlotError::Schema(
+                            "populated slot missing `port_resistance_ohm`".into(),
+                        )
+                    })?;
+                let points_val = t.get("points").ok_or_else(|| {
+                    PalaceSlotError::Schema("populated slot missing `points` array".into())
+                })?;
+                let points_arr = points_val.as_array().ok_or_else(|| {
+                    PalaceSlotError::Schema("`points` is not an array of tables".into())
+                })?;
+                let mut points = Vec::with_capacity(points_arr.len());
+                for (i, p) in points_arr.iter().enumerate() {
+                    let getf = |k: &str| {
+                        p.get(k).and_then(|v| v.as_float()).ok_or_else(|| {
+                            PalaceSlotError::Schema(format!("points[{i}].{k} missing or not float"))
+                        })
+                    };
+                    points.push(PalaceSweepPoint {
+                        f_ghz: getf("f_ghz")?,
+                        s11_re: getf("s11_re")?,
+                        s11_im: getf("s11_im")?,
+                    });
+                }
+                if points.is_empty() {
+                    return Err(PalaceSlotError::Schema(
+                        "populated slot has empty `points`".into(),
+                    ));
+                }
+                Ok(Self::Populated(Box::new(PalaceResults {
+                    palace_version,
+                    config_sha256,
+                    port_resistance_ohm,
+                    points,
+                })))
+            }
+            other => Err(PalaceSlotError::UnknownStatus(other.to_string())),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PalaceSlotError {
+    Schema(String),
+    UnknownStatus(String),
+}
+
+impl fmt::Display for PalaceSlotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Schema(s) => write!(f, "[oracles.palace] schema error: {s}"),
+            Self::UnknownStatus(s) => write!(
+                f,
+                "[oracles.palace] unknown `status` {s:?} (expected \
+                 \"pending_operator_run\" or \"populated\")"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PalaceSlotError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_palace_csv() {
+        let csv = "\
+# Palace s-parameters (example)
+f (GHz), Re(S[1][1]), Im(S[1][1])
+2.30, -0.43, -0.26
+2.40, -0.88, 0.16
+";
+        let r = PalaceResults::from_palace_csv(csv, "0.13.0-test", "abcd", 50.0).unwrap();
+        assert_eq!(r.points.len(), 2);
+        assert!((r.points[0].f_ghz - 2.30).abs() < 1e-12);
+        assert!((r.points[0].s11_re + 0.43).abs() < 1e-12);
+        assert!((r.points[1].s11_im - 0.16).abs() < 1e-12);
+        assert!((r.points[0].s11_mag() - (0.43_f64 * 0.43 + 0.26 * 0.26).sqrt()).abs() < 1e-12);
+        assert_eq!(r.port_resistance_ohm, 50.0);
+        assert_eq!(r.palace_version, "0.13.0-test");
+    }
+
+    #[test]
+    fn parse_hz_frequency_column() {
+        // Same content but f is in Hz: the ingester normalizes.
+        let csv = "\
+f (Hz), Re(S[1][1]), Im(S[1][1])
+2.30e9, -0.5, 0.0
+";
+        let r = PalaceResults::from_palace_csv(csv, "v", "h", 50.0).unwrap();
+        assert!((r.points[0].f_ghz - 2.30).abs() < 1e-9);
+    }
+
+    #[test]
+    fn missing_column_is_reported() {
+        let csv = "f (GHz), Re(S[1][1])\n2.30, -0.5\n";
+        match PalaceResults::from_palace_csv(csv, "v", "h", 50.0) {
+            Err(PalaceIngestError::MissingColumn(c)) => assert!(c.to_lowercase().contains("im")),
+            other => panic!("expected MissingColumn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn z_round_trip_matched_load() {
+        // S11 = 0 → Z = R = 50 ohm + 0i.
+        let p = PalaceSweepPoint {
+            f_ghz: 2.4,
+            s11_re: 0.0,
+            s11_im: 0.0,
+        };
+        let (re, im) = p.z_from_s11(50.0);
+        assert!((re - 50.0).abs() < 1e-12);
+        assert!(im.abs() < 1e-12);
+    }
+
+    #[test]
+    fn z_round_trip_short_and_open() {
+        // S11 = -1 → Z = 0; S11 = +1 → Z = infinity (denominator zero is
+        // a numerical limit we just check the magnitude blows up for).
+        let short = PalaceSweepPoint {
+            f_ghz: 2.4,
+            s11_re: -1.0,
+            s11_im: 0.0,
+        };
+        let (re, im) = short.z_from_s11(50.0);
+        assert!(re.abs() < 1e-12);
+        assert!(im.abs() < 1e-12);
+
+        let nearly_open = PalaceSweepPoint {
+            f_ghz: 2.4,
+            s11_re: 0.999,
+            s11_im: 0.0,
+        };
+        let (re, _) = nearly_open.z_from_s11(50.0);
+        assert!(
+            re > 1.0e4,
+            "open termination should drive Z to large positive"
+        );
+    }
+
+    #[test]
+    fn pending_slot_round_trip() {
+        let toml_text = r#"
+[oracles.palace]
+status = "pending_operator_run"
+note = "Palace is operator-assisted; ingest via geode_core::palace."
+"#;
+        let doc: toml::Value = toml::from_str(toml_text).unwrap();
+        let block = &doc["oracles"]["palace"];
+        let slot = PalaceOracleSlot::from_toml_table(block).unwrap();
+        assert!(!slot.is_populated());
+        assert!(slot.as_results().is_none());
+    }
+
+    #[test]
+    fn populated_slot_round_trip() {
+        let toml_text = r#"
+[oracles.palace]
+status = "populated"
+palace_version = "0.13.0-git"
+config_sha256 = "deadbeef"
+port_resistance_ohm = 50
+
+[[oracles.palace.points]]
+f_ghz = 2.30
+s11_re = -0.43
+s11_im = -0.26
+
+[[oracles.palace.points]]
+f_ghz = 2.40
+s11_re = -0.88
+s11_im = 0.16
+"#;
+        let doc: toml::Value = toml::from_str(toml_text).unwrap();
+        let slot = PalaceOracleSlot::from_toml_table(&doc["oracles"]["palace"]).unwrap();
+        assert!(slot.is_populated());
+        let r = slot.as_results().unwrap();
+        assert_eq!(r.palace_version, "0.13.0-git");
+        assert_eq!(r.points.len(), 2);
+        let dip = r.s11_dip_db().unwrap();
+        // The deeper dip is at 2.40 GHz (s11_mag ~ 0.894 → ~-0.97 dB);
+        // 2.30 GHz has s11_mag ~ 0.502 → ~ -5.98 dB. The dip is deeper
+        // at 2.30 GHz.
+        assert!((dip.0 - 2.30).abs() < 1e-9);
+        assert!(dip.1 < -5.0 && dip.1 > -7.0);
+    }
+
+    #[test]
+    fn unknown_status_is_reported() {
+        let toml_text = r#"
+[oracles.palace]
+status = "running"
+"#;
+        let doc: toml::Value = toml::from_str(toml_text).unwrap();
+        match PalaceOracleSlot::from_toml_table(&doc["oracles"]["palace"]) {
+            Err(PalaceSlotError::UnknownStatus(s)) => assert_eq!(s, "running"),
+            other => panic!("expected UnknownStatus, got {other:?}"),
+        }
+    }
+}

--- a/crates/geode-core/tests/fixtures/palace/README.md
+++ b/crates/geode-core/tests/fixtures/palace/README.md
@@ -1,0 +1,35 @@
+# `tests/fixtures/palace/` — Palace ingester test fixtures
+
+These files exist to exercise the Palace **ingestion code** in
+`crates/geode-core/src/palace.rs`. They are **NOT** an authoritative
+Palace oracle, and they must **not** be ingested into a real
+`benchmarks/*/results.toml` `[oracles.palace]` slot.
+
+## Files
+
+- `example_s_parameters.csv` — synthetic Palace-format S-parameters
+  sweep for the patch-antenna fixture. The values are *plausible*
+  (interpolated/shrunken from the geode-fem committed FEM sweep at
+  2.0–3.0 GHz so the structure and magnitudes resemble what Palace
+  would actually emit), but they were **not produced by a real Palace
+  run**. The ingester treats this file as opaque text; the test only
+  asserts on parser output shape (column detection, frequency
+  normalization, S11 → Z round-trip).
+- `populated_results.toml` — a `[oracles.palace]` block in the
+  *populated* shape, with three synthetic sweep points. Used to test
+  the `PalaceOracleSlot::from_toml_table` parser, including the
+  schema-error paths.
+
+## Honesty rule (the bright line)
+
+Both files carry an `EXAMPLE / SYNTHETIC` header. The real
+`benchmarks/patch_antenna/results.toml` `[oracles.palace]` slot stays
+`status = "pending_operator_run"` until an actual operator-run Palace
+reference is ingested by a human with provenance (Palace version,
+config SHA, command line, mesh SHA).
+
+The Palace config that an operator runs against the patch fixture is
+emitted by `reference/palace/geode_patch_baseline/` (a Rust offline
+driver outside the geode-fem workspace, mirroring the
+`reference/mom/geode_*_baseline/` pattern), and committed at
+`reference/fixtures/patch_palace/palace_config.json`.

--- a/crates/geode-core/tests/fixtures/palace/example_s_parameters.csv
+++ b/crates/geode-core/tests/fixtures/palace/example_s_parameters.csv
@@ -1,0 +1,14 @@
+# EXAMPLE / SYNTHETIC: not a real Palace run. See README.md.
+# Format mimics Palace 0.13's `s-parameters.csv` artifact for a
+# one-port driven sweep. Values are synthetic but plausible — they
+# follow the shape of the committed FEM benchmark sweep
+# (benchmarks/patch_antenna/results.toml) at a few sample frequencies.
+# Used only to exercise the parser in crates/geode-core/src/palace.rs.
+f (GHz), Re(S[1][1]), Im(S[1][1])
+2.00, -0.7476, 0.5966
+2.20, -0.2087, 0.7017
+2.30, -0.4292, -0.2590
+2.40, -0.8868, 0.1561
+2.60, -0.8159, 0.4440
+2.80, -0.7553, 0.5986
+3.00, -0.6371, 0.7228

--- a/crates/geode-core/tests/fixtures/palace/populated_results.toml
+++ b/crates/geode-core/tests/fixtures/palace/populated_results.toml
@@ -1,0 +1,26 @@
+# EXAMPLE / SYNTHETIC populated [oracles.palace] block. NOT a real
+# Palace reference — see ./README.md. Used to test the
+# `PalaceOracleSlot::from_toml_table` "populated" parser path. The real
+# `benchmarks/patch_antenna/results.toml` slot stays
+# `pending_operator_run` until an operator-run reference is ingested.
+
+[oracles.palace]
+status = "populated"
+palace_version = "0.13.0-test-fixture"
+config_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+port_resistance_ohm = 50
+
+[[oracles.palace.points]]
+f_ghz = 2.20
+s11_re = -0.2087
+s11_im = 0.7017
+
+[[oracles.palace.points]]
+f_ghz = 2.30
+s11_re = -0.4292
+s11_im = -0.2590
+
+[[oracles.palace.points]]
+f_ghz = 2.40
+s11_re = -0.8868
+s11_im = 0.1561

--- a/crates/geode-core/tests/palace_ingestion.rs
+++ b/crates/geode-core/tests/palace_ingestion.rs
@@ -1,0 +1,166 @@
+//! Palace ingestion-glue regression tests (issue #239).
+//!
+//! Tests live here rather than in `src/palace.rs`' `#[cfg(test)]`
+//! module because they consume the **on-disk synthetic fixtures** under
+//! `tests/fixtures/palace/`. The fixtures are clearly marked
+//! `EXAMPLE / SYNTHETIC` (see `tests/fixtures/palace/README.md`) — they
+//! exercise the parser code, not the oracle, and they must not be
+//! confused with an authoritative Palace reference.
+//!
+//! The companion `tests/patch_antenna_benchmark.rs` test wires the
+//! parser into the **real** `benchmarks/patch_antenna/results.toml`
+//! `[oracles.palace]` slot with a skip-with-note path while that slot
+//! is still `pending_operator_run`. This file exercises the parser end
+//! itself on synthetic, plausible-shaped inputs.
+
+use std::path::PathBuf;
+
+use geode_core::palace::{PalaceOracleSlot, PalaceResults, PALACE_DEFAULT_PORT_OHM};
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/palace")
+}
+
+/// Parser reads the synthetic Palace-format CSV cleanly and the parsed
+/// points have the expected shape and pass passivity sanity checks.
+#[test]
+fn example_csv_parses_into_palace_results() {
+    let path = fixtures_dir().join("example_s_parameters.csv");
+    let r = PalaceResults::from_palace_csv_file(
+        &path,
+        "0.13.0-test-fixture",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        PALACE_DEFAULT_PORT_OHM,
+    )
+    .expect("synthetic Palace CSV parses cleanly");
+
+    assert_eq!(r.points.len(), 7, "all 7 example rows are parsed");
+    assert_eq!(r.port_resistance_ohm, PALACE_DEFAULT_PORT_OHM);
+    assert!(r.palace_version.starts_with("0.13"));
+
+    // Frequency ordering is preserved.
+    let fs: Vec<f64> = r.points.iter().map(|p| p.f_ghz).collect();
+    for w in fs.windows(2) {
+        assert!(w[1] > w[0], "frequencies should be increasing: {fs:?}");
+    }
+
+    // Passivity: |S11| <= 1 for every sample point.
+    for p in &r.points {
+        let m = p.s11_mag();
+        assert!(
+            m <= 1.0 + 1e-9,
+            "|S11| = {m} > 1 at {} GHz violates passivity",
+            p.f_ghz
+        );
+        let (z_re, _) = p.z_from_s11(r.port_resistance_ohm);
+        assert!(
+            z_re > -1e-6,
+            "passive Z must have Re Z >= 0, got {z_re} at {} GHz",
+            p.f_ghz
+        );
+    }
+}
+
+/// The CSV → S11 → Z derivation matches a hand calculation. The
+/// strongest-match sample in the synthetic sweep is 2.30 GHz, where
+/// `|S11| = sqrt(0.4292^2 + 0.2590^2) ≈ 0.5015` (≈ −5.99 dB) — the
+/// deepest dip across the 7 frequencies. This matches the geode-fem
+/// committed FEM sweep dip cell at 2.30 GHz (results.toml point_3).
+#[test]
+fn example_csv_dip_matches_hand_calc() {
+    let path = fixtures_dir().join("example_s_parameters.csv");
+    let r = PalaceResults::from_palace_csv_file(&path, "v", "c", 50.0).unwrap();
+    let (f_dip, db_dip) = r.s11_dip_db().unwrap();
+    assert!(
+        (f_dip - 2.30).abs() < 1e-9,
+        "synthetic dip at 2.30 GHz, got {f_dip}"
+    );
+    assert!(
+        db_dip < -5.0 && db_dip > -7.0,
+        "dip dB ~ -6 dB plausible: {db_dip}"
+    );
+
+    // Spot-check the Z conversion at the dip: S11 = -0.4292 - 0.2590i,
+    // R = 50: Z = R · (1 + s)/(1 - s).
+    let dip_pt = r
+        .points
+        .iter()
+        .find(|p| (p.f_ghz - 2.30).abs() < 1e-9)
+        .unwrap();
+    let (z_re, z_im) = dip_pt.z_from_s11(50.0);
+    // Hand calc: numerator = (1 - 0.4292) + (-0.2590)i = 0.5708 - 0.2590i
+    //            denominator = (1 + 0.4292) + 0.2590i = 1.4292 + 0.2590i
+    //            |den|^2 = 2.043 + 0.067 = 2.110
+    //            num · conj(den) = (0.5708)(1.4292) + (-0.2590)(0.2590)
+    //                              + i[(-0.2590)(1.4292) - (0.5708)(0.2590)]
+    //                            = 0.8158 - 0.0671 + i[-0.3702 - 0.1478]
+    //                            = 0.7487 - 0.5180 i
+    //            (z_re, z_im)/R = (0.3548, -0.2455)
+    //            (z_re, z_im)    = (17.74, -12.27) ohm
+    // — which matches the FEM committed `point_3` Z almost exactly: that's
+    // the whole point of the synthetic CSV (mirrors the FEM sweep so the
+    // ingestion test stays self-consistent without a real Palace run).
+    assert!(
+        (z_re - 17.74).abs() < 0.1,
+        "Z_re hand calc: expected ~17.74, got {z_re}"
+    );
+    assert!(
+        (z_im - (-12.27)).abs() < 0.1,
+        "Z_im hand calc: expected ~-12.27, got {z_im}"
+    );
+}
+
+/// Populated `[oracles.palace]` block round-trips through the slot
+/// parser into a [`PalaceResults`] with the same shape as the in-line
+/// CSV parser produces.
+#[test]
+fn populated_toml_slot_parses() {
+    let path = fixtures_dir().join("populated_results.toml");
+    let text = std::fs::read_to_string(&path).expect("read populated_results.toml");
+    let doc: toml::Value = toml::from_str(&text).expect("valid TOML");
+    let slot = PalaceOracleSlot::from_toml_table(&doc["oracles"]["palace"])
+        .expect("populated slot parses");
+    assert!(slot.is_populated());
+    let r = slot.as_results().unwrap();
+    assert_eq!(r.points.len(), 3);
+    assert_eq!(r.port_resistance_ohm, 50.0);
+    assert_eq!(r.palace_version, "0.13.0-test-fixture");
+    // The synthetic populated dip is at 2.30 GHz (|S11| ~ 0.50 → ~-6 dB),
+    // the most-negative s11_db across the 3 sample points.
+    let (f_dip, db_dip) = r.s11_dip_db().unwrap();
+    assert!((f_dip - 2.30).abs() < 1e-9);
+    assert!(db_dip < -3.0 && db_dip > -8.0, "dip dB ~ -6 dB: {db_dip}");
+}
+
+/// Pending-status `[oracles.palace]` block (the on-disk shape in the
+/// committed `benchmarks/*/results.toml` files) parses into a
+/// `PendingOperatorRun` variant — the "skip-with-note" signal benchmark
+/// tests consume.
+#[test]
+fn pending_status_block_round_trips() {
+    let toml_text = r#"
+[oracles.palace]
+status = "pending_operator_run"
+note = "Palace operator-assisted; ingest via geode_core::palace."
+"#;
+    let doc: toml::Value = toml::from_str(toml_text).unwrap();
+    let slot = PalaceOracleSlot::from_toml_table(&doc["oracles"]["palace"]).unwrap();
+    assert!(!slot.is_populated());
+    assert!(slot.as_results().is_none());
+}
+
+/// Older "deferred" status (the existing legacy slot text in the patch
+/// `results.toml` files prior to issue #239) is treated as a synonym
+/// for `pending_operator_run` so the new ingester does not break the
+/// already-committed benchmark TOMLs.
+#[test]
+fn legacy_deferred_status_treated_as_pending() {
+    let toml_text = r#"
+[oracles.palace]
+status = "deferred"
+note = "legacy slot wording"
+"#;
+    let doc: toml::Value = toml::from_str(toml_text).unwrap();
+    let slot = PalaceOracleSlot::from_toml_table(&doc["oracles"]["palace"]).unwrap();
+    assert!(!slot.is_populated());
+}

--- a/crates/geode-core/tests/patch_antenna_extraction.rs
+++ b/crates/geode-core/tests/patch_antenna_extraction.rs
@@ -449,3 +449,145 @@ fn benchmark_fixture_reference_point_matches_committed_results() {
         "f_res {f_res_fem:.4} GHz vs cavity {f_res_cavity:.4} GHz outside the 8% band"
     );
 }
+
+/// Tier 4: **Palace 3D oracle wiring** (issue #239).
+///
+/// Loads the `[oracles.palace]` slot from
+/// `benchmarks/patch_antenna/results.toml` and, if it is populated with
+/// an operator-run Palace reference, compares the committed FEM sweep
+/// against it within a calibrated band. While the slot is still
+/// `pending_operator_run` (the default state — Palace is not installed
+/// on the geode-fem dev machine), the test **skips with a note** so a
+/// missing Palace oracle never silently passes.
+///
+/// The honest contract — same convention as the FastHenry / mom slots
+/// — is: committed FEM artifacts can be cross-checked against the
+/// cavity-model oracle (Balanis, 3-5 % band) plus *whatever
+/// operator-supplied references have been ingested with full
+/// provenance.* No fabricated Palace numbers ever live in the real
+/// `results.toml` slot.
+#[test]
+fn fem_vs_palace_oracle_within_band_or_skip_with_note() {
+    use geode_core::palace::PalaceOracleSlot;
+
+    let path = repo_root().join("benchmarks/patch_antenna/results.toml");
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read committed results {}: {e}", path.display()));
+    let doc: toml::Value = toml::from_str(&raw).expect("results.toml is valid TOML");
+    let palace_block = doc
+        .get("oracles")
+        .and_then(|o| o.get("palace"))
+        .expect("results.toml has [oracles.palace] block");
+
+    let slot = PalaceOracleSlot::from_toml_table(palace_block)
+        .unwrap_or_else(|e| panic!("[oracles.palace] in {} did not parse: {e}", path.display()));
+
+    let Some(palace) = slot.as_results() else {
+        // Honest skip-with-note. Eprintln so the test runner surface
+        // shows it; the test passes (no comparison to do) but never
+        // silently — the operator workflow is documented in
+        // `reference/palace/geode_patch_baseline/` + `src/palace.rs`.
+        eprintln!(
+            "\nSKIP: [oracles.palace] in {} is `pending_operator_run` — \
+             no Palace reference ingested.\n  \
+             To populate: emit the config via `cd reference/palace/\
+             geode_patch_baseline && cargo run --release`, run Palace \
+             on it (`palace -np N reference/fixtures/patch_palace/\
+             palace_config.json`), then ingest the s-parameters.csv via \
+             `geode_core::palace::PalaceResults::from_palace_csv_file` \
+             and write the populated [oracles.palace] block in the \
+             benchmark TOML with full provenance.",
+            path.display()
+        );
+        return;
+    };
+
+    // --- Sanity provenance checks before the numeric comparison ---------
+    assert!(
+        !palace.palace_version.is_empty(),
+        "populated [oracles.palace] must record `palace_version` (provenance)"
+    );
+    assert!(
+        palace.config_sha256.len() == 64,
+        "populated [oracles.palace] must record a hex sha256 of the Palace config \
+         (provenance), got length {}",
+        palace.config_sha256.len()
+    );
+    // Cross-check: the Palace port-impedance should agree with the FEM
+    // benchmark drive (both are 50 ohm by construction).
+    assert!(
+        (palace.port_resistance_ohm - R_PORT_OHM).abs() < 0.5,
+        "Palace port R = {} ohm, FEM benchmark drives at {R_PORT_OHM} ohm — \
+         the two oracles must be on the same reference impedance",
+        palace.port_resistance_ohm
+    );
+
+    // --- Numeric band: S11 dip frequency agreement ----------------------
+    // The FEM and Palace dip frequencies should agree to within a
+    // **calibrated** band wide enough to absorb (a) the FEM matched-UPML
+    // vs Palace first-order absorbing-boundary mismatch and (b) sweep
+    // grid resolution on either side. 5 % is the headline band for the
+    // patch fixture (the cavity-model oracle uses 8 %; Palace solves the
+    // same wave equation as the FEM, so it should agree more tightly).
+    let palace_dip = palace
+        .s11_dip_db()
+        .expect("Palace sweep has a sample with finite |S11|");
+    let fem_committed = committed_results();
+    let fem_dip_f = fem_committed.s11_dip_f_ghz;
+    let dip_drift = (palace_dip.0 - fem_dip_f) / fem_dip_f;
+    eprintln!(
+        "FEM dip: {fem_dip_f:.4} GHz vs Palace dip: {:.4} GHz ({:+.2}%)",
+        palace_dip.0,
+        100.0 * dip_drift
+    );
+    assert!(
+        dip_drift.abs() < 0.05,
+        "S11 dip frequency Palace {:.4} GHz vs FEM {fem_dip_f:.4} GHz: \
+         {:+.2}% drift exceeds the 5 % band (Palace and FEM solve the \
+         same wave equation; if drift > 5 %, suspect the absorbing-\
+         boundary mismatch or a port-direction sign convention).",
+        palace_dip.0,
+        100.0 * dip_drift
+    );
+
+    // --- Numeric band: per-point S11 agreement at shared frequencies ----
+    let mut compared = 0_usize;
+    for fem_row in &fem_committed.rows {
+        let Some(palace_pt) = palace.points.iter().find(|p| {
+            (p.f_ghz - fem_row.f_ghz).abs() < 1e-6
+                || ((p.f_ghz - fem_row.f_ghz).abs() / fem_row.f_ghz) < 1e-4
+        }) else {
+            continue;
+        };
+        let fem_mag = fem_row.s11_mag;
+        let palace_mag = palace_pt.s11_mag();
+        // |S11| comparison band — 0.10 absolute. The two solvers should
+        // be very close on |S11| in the absence of absorber-driven
+        // disagreement; this is a tracking band, calibrate down as
+        // Palace data accumulates.
+        let abs_err = (palace_mag - fem_mag).abs();
+        eprintln!(
+            "  f = {:.3} GHz: FEM |S11| = {fem_mag:.4}, Palace |S11| = {palace_mag:.4} \
+             (|Δ| = {abs_err:.4})",
+            fem_row.f_ghz
+        );
+        assert!(
+            abs_err < 0.10,
+            "|S11| disagreement at {:.3} GHz: FEM {fem_mag:.4} vs Palace \
+             {palace_mag:.4} (|Δ| = {abs_err:.4}) exceeds the 0.10 tracking band",
+            fem_row.f_ghz
+        );
+        compared += 1;
+    }
+    assert!(
+        compared >= 1,
+        "Palace sweep shares no frequency points with the FEM benchmark sweep \
+         (Palace freqs: {:?}, FEM freqs: {:?})",
+        palace.points.iter().map(|p| p.f_ghz).collect::<Vec<_>>(),
+        fem_committed
+            .rows
+            .iter()
+            .map(|r| r.f_ghz)
+            .collect::<Vec<_>>(),
+    );
+}

--- a/reference/fixtures/patch_palace/palace_config.json
+++ b/reference/fixtures/patch_palace/palace_config.json
@@ -1,0 +1,75 @@
+{
+  "Problem": {
+    "Output": "postpro/patch_palace",
+    "Type": "Driven",
+    "Verbose": 2
+  },
+  "Model": {
+    "L0": 0.001,
+    "Mesh": "crates/geode-core/tests/fixtures/patch_2g4.msh",
+    "Refinement": {
+      "UniformLevels": 0
+    }
+  },
+  "Domains": {
+    "Materials": [
+      {
+        "Attributes": [
+          1
+        ],
+        "LossTan": 0.02,
+        "Permittivity": 4.4
+      },
+      {
+        "Attributes": [
+          2,
+          3
+        ],
+        "LossTan": 0.0,
+        "Permittivity": 1.0
+      }
+    ]
+  },
+  "Boundaries": {
+    "Absorbing": {
+      "Attributes": [
+        14
+      ],
+      "Order": 1
+    },
+    "LumpedPort": [
+      {
+        "Attributes": [
+          11
+        ],
+        "Direction": "+Z",
+        "Excitation": true,
+        "Index": 1,
+        "R": 50.0
+      }
+    ],
+    "PEC": {
+      "Attributes": [
+        12,
+        13,
+        14
+      ]
+    }
+  },
+  "Solver": {
+    "Driven": {
+      "FreqStep": 0.1,
+      "MaxFreq": 3.0,
+      "MinFreq": 2.0,
+      "Restart": 1,
+      "SaveStep": 0
+    },
+    "Linear": {
+      "KSPType": "GMRES",
+      "MaxIts": 200,
+      "Tol": 1e-8,
+      "Type": "Default"
+    },
+    "Order": 1
+  }
+}

--- a/reference/fixtures/patch_palace/palace_config.provenance.txt
+++ b/reference/fixtures/patch_palace/palace_config.provenance.txt
@@ -1,0 +1,34 @@
+fixture:        patch_2g4.msh
+mesh_sha256:    01c55cbd359b97d2fdceae9630a86d6fa2342f9a18317c01d61ad41a1df05f83
+generator:      reference/palace/geode_patch_baseline (cargo run --release)
+palace docs:    https://awslabs.github.io/palace/dev/config/
+palace recipe:  ~/GitHub/sphere/eda/mom/docker/palace (sister-repo Docker build)
+
+problem:        Driven (frequency-domain driven solver)
+port:           LumpedPort, R = 50 ohm, +Z direction,
+attribute 11 (matches reference/gmsh/patch_antenna.geo)
+materials:
+substrate:    FR-4, eps_r = 4.4, tan_delta = 0.02
+(attribute 1 — substrate volume)
+air + upml:   vacuum (attributes 2, 3)
+boundaries:
+PEC:          patch (attribute 12) + ground (attribute 13) + outer wall (attribute 14)
+Absorbing:    first-order Sommerfeld on the outer wall (attribute 14)
+— Palace analog of the geode-fem matched-UPML shell
+sweep:          2 GHz to 3 GHz, 0.1 GHz steps (matches the geode benchmark sweep)
+
+operator workflow:
+1. cd <geode-fem repo root>
+2. palace -np <N> reference/fixtures/patch_palace/palace_config.json
+(or via the sister-repo Docker image)
+3. The Palace run writes postpro/patch_palace/{s-parameters.csv,
+port-V.csv, ...}. Ingest these via
+`geode_core::palace::PalaceResults::from_palace_outputs(...)` and
+fill `benchmarks/patch_antenna/results.toml`'s [oracles.palace]
+slot with the parsed values + this provenance file's SHA.
+
+status:         pending_operator_run — Palace is NOT installed on the
+generation machine; the [oracles.palace] slot in
+benchmarks/patch_antenna/results.toml stays
+`pending_operator_run` until an operator-run reference
+is ingested (see crates/geode-core/src/palace.rs).

--- a/reference/palace/README.md
+++ b/reference/palace/README.md
@@ -1,0 +1,125 @@
+# `reference/palace/` — Palace 3D oracle scaffolding (issue #239)
+
+[Palace](https://github.com/awslabs/palace) (Petascale Algorithm for
+Linear And Coupled Electromagnetic Simulation) is an open-source
+MFEM-based 3D full-wave finite-element solver. It is the **eventual
+gold-standard oracle** for the geode-fem driven-port benchmarks (Epic
+#226 patch antenna, Epic #193 spiral inductor) — same wave equation,
+independent implementation, similar Nédélec discretization.
+
+**Status: scaffolded, not run.** Palace itself is *not* installed on
+the geode-fem dev machine — only a Docker build recipe exists in the
+sister monorepo at `~/GitHub/sphere/eda/mom/docker/palace`. This
+directory holds the **glue around** Palace — the config generator and
+the operator workflow — so a Palace reference can be produced by
+anyone with a working install (or the Docker image) and slotted into
+the benchmark TOMLs.
+
+The corresponding **result ingester** (parser that converts Palace's
+output artifacts into the `[oracles.palace]` TOML block the benchmark
+tests consume) is in `crates/geode-core/src/palace.rs`, where it is
+unit-tested against synthetic fixtures under
+`crates/geode-core/tests/fixtures/palace/`.
+
+## Layout
+
+```
+reference/palace/
+├── README.md                            — this file
+└── geode_patch_baseline/
+    ├── Cargo.toml                       — offline-driver workspace
+    └── src/main.rs                      — Palace JSON config emitter for
+                                          the FR-4 patch fixture (#228)
+```
+
+The committed config output lives at
+`reference/fixtures/patch_palace/`:
+
+```
+reference/fixtures/patch_palace/
+├── palace_config.json                   — Palace 0.13 driven-port config
+└── palace_config.provenance.txt         — generator provenance (mesh
+                                          sha256, sweep / boundary
+                                          mapping, operator workflow)
+```
+
+## Generating the config
+
+```sh
+cd reference/palace/geode_patch_baseline
+cargo run --release
+# → reference/fixtures/patch_palace/palace_config.json
+#   reference/fixtures/patch_palace/palace_config.provenance.txt
+```
+
+The generator is **offline** — it does *not* link against Palace; it
+only writes JSON. The sister-repo Docker image
+(`~/GitHub/sphere/eda/mom/docker/palace`) is the suggested runtime.
+
+## Running Palace (operator-assisted)
+
+From the geode-fem repo root, with a working Palace install:
+
+```sh
+palace -np 4 reference/fixtures/patch_palace/palace_config.json
+# Or via the sister-repo Docker image (paths mounted at /work):
+#   docker run --rm -v $(pwd):/work palace:latest \
+#     -np 4 /work/reference/fixtures/patch_palace/palace_config.json
+```
+
+Palace writes the standard driven-solve artifacts (`s-parameters.csv`,
+`port-V.csv`, `port-I.csv`, ...) under `postpro/patch_palace/`.
+
+## Ingesting results
+
+The s-parameters CSV is what the geode-fem `[oracles.palace]` slot
+consumes. From a Rust call site (e.g. a one-shot ingest binary):
+
+```rust
+use geode_core::palace::{PalaceResults, PALACE_DEFAULT_PORT_OHM};
+
+let r = PalaceResults::from_palace_csv_file(
+    std::path::Path::new("postpro/patch_palace/s-parameters.csv"),
+    "0.13.0-git",                                  // Palace version string
+    "<sha256 of palace_config.json>",              // provenance
+    PALACE_DEFAULT_PORT_OHM,
+)?;
+// Then serialize `r` into the `[oracles.palace]` block of
+// `benchmarks/patch_antenna/results.toml` (populated shape — see
+// `PalaceOracleSlot` in `crates/geode-core/src/palace.rs`).
+```
+
+The benchmark test
+(`crates/geode-core/tests/patch_antenna_extraction.rs::
+fem_vs_palace_oracle_within_band_or_skip_with_note`) then compares the
+committed FEM sweep against the populated Palace block within a 5 %
+S11-dip-frequency band and a 0.10 absolute `|S11|` tracking band.
+
+**Until** an operator populates the slot, that test prints a clear
+"SKIP" note (with the operator workflow inlined) and passes — the slot
+in `benchmarks/patch_antenna/results.toml` stays
+`status = "pending_operator_run"`. The test **never silently passes**
+on a missing oracle.
+
+## Why "offline driver" and not a built-in test?
+
+Same reason as `reference/mom/geode_*_baseline/`:
+
+- Palace (and mom) are heavyweight third-party solvers that are not
+  installed everywhere; making the geode workspace depend on either
+  would block every contributor from running `cargo test`.
+- The offline driver pattern keeps the **config generation** path in
+  Rust (so it stays in sync with the geode-fem fixture API), while the
+  **run** stays an explicit operator step.
+- The result ingester (`crates/geode-core/src/palace.rs`) is the only
+  Rust code on the hot path of CI; it's parsed and tested against a
+  clearly-labeled synthetic fixture.
+
+## Parent epics
+
+- **#226** — patch antenna benchmark (Phase 2 #228, matched feed #237)
+- **#193** — spiral inductor benchmark (Phase 3 #211)
+- **#239** — this scaffolding (config generator + ingester + one
+  wired benchmark test)
+- **#5** — operator-only tracker (catches the "the operator has to
+  run X" steps so they don't get lost)

--- a/reference/palace/geode_patch_baseline/.gitignore
+++ b/reference/palace/geode_patch_baseline/.gitignore
@@ -1,0 +1,4 @@
+# Offline sidecar build artifacts (this crate is not part of the
+# geode workspace; see Cargo.toml).
+/target
+/Cargo.lock

--- a/reference/palace/geode_patch_baseline/Cargo.toml
+++ b/reference/palace/geode_patch_baseline/Cargo.toml
@@ -1,0 +1,33 @@
+# Offline Palace config generator for the geode-fem patch-antenna
+# benchmark (issue #239). NOT part of the geode workspace and NOT built
+# in CI — same offline-sidecar convention as `reference/mom/` and
+# `reference/numpy/`.
+#
+# Palace itself is NOT a dependency of this generator: this binary
+# **only emits a Palace JSON configuration file** that an operator
+# (with a working Palace install or a Docker recipe such as the one
+# under `~/GitHub/sphere/eda/mom/docker/palace`) can feed to Palace
+# directly. The run + result-ingestion step lives in
+# `reference/palace/README.md`.
+#
+# Usage:
+#
+#   cd reference/palace/geode_patch_baseline
+#   cargo run --release
+#
+# Writes:
+#   reference/fixtures/patch_palace/palace_config.json
+#   reference/fixtures/patch_palace/palace_config.provenance.txt
+
+[package]
+name = "geode-patch-palace-baseline"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"

--- a/reference/palace/geode_patch_baseline/src/main.rs
+++ b/reference/palace/geode_patch_baseline/src/main.rs
@@ -1,0 +1,277 @@
+//! Palace JSON config generator for the geode-fem patch-antenna
+//! benchmark (issue #239, Epic #226 follow-up).
+//!
+//! Emits a [Palace](https://github.com/awslabs/palace) driven-port
+//! configuration that targets the **same geometry / stack / port /
+//! frequency set** the geode-fem patch benchmark uses
+//! (`benchmarks/patch_antenna/results.toml`,
+//! `tests/fixtures/patch_2g4.msh`).
+//!
+//! # Why "offline"?
+//!
+//! Palace is a heavy MFEM-based 3D full-wave solver and is **not
+//! installed on the geode-fem dev machine** (only a Docker build recipe
+//! exists in the sister monorepo, `~/GitHub/sphere/eda/mom/docker/palace`).
+//! This generator therefore only writes the *configuration file* and a
+//! provenance stub; the actual Palace run and the resulting
+//! `s-parameters.csv` / `port-V.csv` artifacts are operator-assisted
+//! and slotted into `benchmarks/patch_antenna/results.toml`'s
+//! `[oracles.palace]` table via the ingester in
+//! `crates/geode-core/src/palace.rs`.
+//!
+//! # What Palace solves for this fixture
+//!
+//! The patch fixture is a probe-fed FR-4 microstrip antenna with a
+//! matched box-UPML open boundary. In Palace terms:
+//!
+//! - **Problem**: `Driven` (frequency-domain driven solver).
+//! - **Boundaries**: PEC on the patch / ground / probe-shell faces,
+//!   absorbing on the outer air box (Palace's first-order Sommerfeld
+//!   absorber is the closest match to the geode-fem matched-UPML
+//!   shell — the side-by-side comparison **is** part of the oracle
+//!   value).
+//! - **Lumped port**: across the coax-probe gap, 50 Ω reference,
+//!   V_inc = 1 V (matching the geode-fem `LumpedPort` driven sweep).
+//! - **Materials**: FR-4 substrate (eps_r 4.4, tan_delta 0.02), air,
+//!   PEC conductors (Phase-1 convention).
+//! - **Sweep**: 2.0–3.0 GHz in 0.1 GHz steps (mirrors the committed
+//!   `examples/patch_antenna.rs` sweep grid).
+//!
+//! # Output
+//!
+//! `reference/fixtures/patch_palace/palace_config.json` — Palace's
+//! native JSON config, with the fixture-mesh path resolved relative to
+//! the geode-fem repo root.
+//!
+//! Operator workflow (e.g. via the sister-repo Docker recipe):
+//!
+//! ```sh
+//! palace -np 4 reference/fixtures/patch_palace/palace_config.json
+//! # → palace.s-parameters.csv, palace.port-V.csv, ...
+//! ```
+//!
+//! The ingester (see `crates/geode-core/src/palace.rs`) parses those
+//! outputs into the schema the benchmark's `[oracles.palace]` slot
+//! expects.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Patch-fixture frequency sweep (GHz). Mirrors the committed sweep in
+/// `examples/patch_antenna.rs` / `benchmarks/patch_antenna/results.toml`.
+const FREQS_GHZ: &[f64] = &[
+    2.0, 2.1, 2.2, 2.3, 2.35, 2.4, 2.45, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0,
+];
+
+/// FR-4 relative permittivity (matches `mesh::patch::FR4_MATERIALS`).
+const FR4_EPS_R: f64 = 4.4;
+/// FR-4 loss tangent (matches `mesh::patch::FR4_MATERIALS`).
+const FR4_TAN_DELTA: f64 = 0.02;
+
+/// Port reference impedance (Ω). Matches the geode-fem benchmark drive.
+const PORT_RESISTANCE_OHM: f64 = 50.0;
+
+/// Patch-fixture gmsh physical-group tags (must match
+/// `reference/gmsh/patch_antenna.geo`).
+mod phys {
+    pub const SUBSTRATE_VOL: u32 = 1;
+    pub const AIR_VOL: u32 = 2;
+    pub const UPML_VOL: u32 = 3;
+    pub const PORT_SURF: u32 = 11;
+    pub const PATCH_SURF: u32 = 12;
+    pub const GROUND_SURF: u32 = 13;
+    pub const OUTER_SURF: u32 = 14;
+}
+
+/// Repo root, two levels up from this offline driver
+/// (`reference/palace/geode_patch_baseline/`).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+/// Sha256 of the mesh file (recorded in the provenance stub so the
+/// operator can confirm they ran Palace on the committed mesh).
+fn mesh_sha256(path: &Path) -> String {
+    let bytes = fs::read(path).expect("read fixture mesh");
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Build the Palace JSON config tree for the patch-antenna fixture.
+///
+/// Field names follow Palace 0.13's `config` schema (see
+/// <https://awslabs.github.io/palace/dev/config/>). The structure here
+/// is a **canonical driven-port config**; a real operator may need to
+/// adjust solver tolerances / partitioning to the local Palace build.
+#[derive(Serialize)]
+struct PalaceConfig {
+    #[serde(rename = "Problem")]
+    problem: Value,
+    #[serde(rename = "Model")]
+    model: Value,
+    #[serde(rename = "Domains")]
+    domains: Value,
+    #[serde(rename = "Boundaries")]
+    boundaries: Value,
+    #[serde(rename = "Solver")]
+    solver: Value,
+}
+
+fn build_config(mesh_path_str: &str) -> PalaceConfig {
+    PalaceConfig {
+        problem: json!({
+            "Type": "Driven",
+            "Verbose": 2,
+            "Output": "postpro/patch_palace"
+        }),
+        model: json!({
+            "Mesh": mesh_path_str,
+            // Convert mm (the gmsh fixture's authoring units) to meters
+            // for Palace, which works internally in SI.
+            "L0": 1.0e-3,
+            "Refinement": { "UniformLevels": 0 }
+        }),
+        domains: json!({
+            "Materials": [
+                {
+                    "Attributes": [phys::SUBSTRATE_VOL],
+                    "Permittivity": FR4_EPS_R,
+                    "LossTan": FR4_TAN_DELTA
+                },
+                {
+                    "Attributes": [phys::AIR_VOL, phys::UPML_VOL],
+                    "Permittivity": 1.0,
+                    "LossTan": 0.0
+                }
+            ]
+        }),
+        boundaries: json!({
+            "PEC": {
+                "Attributes": [phys::PATCH_SURF, phys::GROUND_SURF, phys::OUTER_SURF]
+            },
+            // Palace's first-order absorbing boundary on the matched-UPML
+            // outer face is the closest available analog to the geode-fem
+            // matched (box-)UPML shell. Comparing Palace's first-order
+            // absorber + matched outer to geode-fem's matched-UPML is
+            // **part of the oracle value** — disagreement here calibrates
+            // both absorbers against the same radiator.
+            "Absorbing": {
+                "Attributes": [phys::OUTER_SURF],
+                "Order": 1
+            },
+            "LumpedPort": [
+                {
+                    "Index": 1,
+                    "R": PORT_RESISTANCE_OHM,
+                    "Excitation": true,
+                    "Attributes": [phys::PORT_SURF],
+                    // Coax-probe gap is along +z (substrate stack
+                    // direction). Palace's `Direction` selects the lumped
+                    // port's polarization.
+                    "Direction": "+Z"
+                }
+            ]
+        }),
+        solver: json!({
+            "Order": 1,
+            "Driven": {
+                "MinFreq": FREQS_GHZ.first().copied().unwrap_or(2.0),
+                "MaxFreq": FREQS_GHZ.last().copied().unwrap_or(3.0),
+                "FreqStep": 0.1,
+                "SaveStep": 0,
+                "Restart": 1
+            },
+            "Linear": {
+                "Type": "Default",
+                "KSPType": "GMRES",
+                "Tol": 1e-8,
+                "MaxIts": 200
+            }
+        }),
+    }
+}
+
+fn main() {
+    let root = repo_root();
+    let mesh_path = root.join("crates/geode-core/tests/fixtures/patch_2g4.msh");
+    assert!(
+        mesh_path.exists(),
+        "patch fixture mesh not found at {}",
+        mesh_path.display()
+    );
+    let mesh_sha = mesh_sha256(&mesh_path);
+    // The Palace mesh path is recorded **relative to the repo root** in
+    // the JSON so the same config works whether the operator runs Palace
+    // from the repo root or from a Docker mount at `/work`.
+    let mesh_path_str = "crates/geode-core/tests/fixtures/patch_2g4.msh";
+
+    let cfg = build_config(mesh_path_str);
+
+    let out_dir = root.join("reference/fixtures/patch_palace");
+    fs::create_dir_all(&out_dir).expect("create patch_palace fixture dir");
+    let cfg_path = out_dir.join("palace_config.json");
+    let cfg_json = serde_json::to_string_pretty(&cfg).expect("serialize palace config");
+    fs::write(&cfg_path, &cfg_json).expect("write palace_config.json");
+    eprintln!("wrote {}", cfg_path.display());
+
+    // Provenance stub: records the exact mesh + parameter values so an
+    // operator-ingested Palace result can be cross-checked against the
+    // committed geode-fem fixture state.
+    let prov_path = out_dir.join("palace_config.provenance.txt");
+    let prov = format!(
+        "fixture:        patch_2g4.msh\n\
+         mesh_sha256:    {mesh_sha}\n\
+         generator:      reference/palace/geode_patch_baseline (cargo run --release)\n\
+         palace docs:    https://awslabs.github.io/palace/dev/config/\n\
+         palace recipe:  ~/GitHub/sphere/eda/mom/docker/palace (sister-repo Docker build)\n\
+         \n\
+         problem:        Driven (frequency-domain driven solver)\n\
+         port:           LumpedPort, R = {PORT_RESISTANCE_OHM} ohm, +Z direction,\n\
+                         attribute {} (matches reference/gmsh/patch_antenna.geo)\n\
+         materials:\n\
+           substrate:    FR-4, eps_r = {FR4_EPS_R}, tan_delta = {FR4_TAN_DELTA}\n\
+                         (attribute {} — substrate volume)\n\
+           air + upml:   vacuum (attributes {}, {})\n\
+         boundaries:\n\
+           PEC:          patch (attribute {}) + ground (attribute {}) + outer wall (attribute {})\n\
+           Absorbing:    first-order Sommerfeld on the outer wall (attribute {})\n\
+                         — Palace analog of the geode-fem matched-UPML shell\n\
+         sweep:          {} GHz to {} GHz, 0.1 GHz steps (matches the geode benchmark sweep)\n\
+         \n\
+         operator workflow:\n\
+           1. cd <geode-fem repo root>\n\
+           2. palace -np <N> reference/fixtures/patch_palace/palace_config.json\n\
+              (or via the sister-repo Docker image)\n\
+           3. The Palace run writes postpro/patch_palace/{{s-parameters.csv,\n\
+              port-V.csv, ...}}. Ingest these via\n\
+              `geode_core::palace::PalaceResults::from_palace_outputs(...)` and\n\
+              fill `benchmarks/patch_antenna/results.toml`'s [oracles.palace]\n\
+              slot with the parsed values + this provenance file's SHA.\n\
+         \n\
+         status:         pending_operator_run — Palace is NOT installed on the\n\
+                         generation machine; the [oracles.palace] slot in\n\
+                         benchmarks/patch_antenna/results.toml stays\n\
+                         `pending_operator_run` until an operator-run reference\n\
+                         is ingested (see crates/geode-core/src/palace.rs).\n\
+        ",
+        phys::PORT_SURF,
+        phys::SUBSTRATE_VOL,
+        phys::AIR_VOL,
+        phys::UPML_VOL,
+        phys::PATCH_SURF,
+        phys::GROUND_SURF,
+        phys::OUTER_SURF,
+        phys::OUTER_SURF,
+        FREQS_GHZ.first().copied().unwrap_or(2.0),
+        FREQS_GHZ.last().copied().unwrap_or(3.0),
+    );
+    fs::write(&prov_path, prov).expect("write palace_config.provenance.txt");
+    eprintln!("wrote {}", prov_path.display());
+}


### PR DESCRIPTION
## Summary

Operator-assisted Palace 3D oracle scaffolding for the geode-fem
driven-port benchmarks (issue #239).

Palace itself is **not installed** on the geode-fem dev machine — only
a Docker build recipe exists in the sister monorepo. This PR ships
the **config generation + result ingestion glue** so an operator (with
a working Palace install or the sister-repo Docker image) can produce
a Palace reference and slot it into the benchmark TOMLs without ad-hoc
parsing per benchmark.

### What lands

- **Config generator** at `reference/palace/geode_patch_baseline/`
  (offline Rust driver, outside the geode workspace — mirrors the
  `reference/mom/geode_*_baseline/` pattern). Emits a Palace 0.13
  driven-port JSON config for the FR-4 patch fixture and a provenance
  stub (mesh sha256, boundary/material mapping, operator workflow).
  Committed at `reference/fixtures/patch_palace/palace_config.json`.
- **Result ingester** in `crates/geode-core/src/palace.rs`:
  - `PalaceResults::from_palace_csv_file(...)` parses Palace's
    `s-parameters.csv` (lenient column matching; Hz/GHz normalization;
    explicit error variants for empty CSV, missing columns, short
    rows, parse failures).
  - `PalaceOracleSlot` is the typed view of the `[oracles.palace]`
    TOML block — two valid shapes: `pending_operator_run` and
    `populated`. Accepts the legacy `deferred` status as a synonym
    for `pending_operator_run` so committed TOMLs keep parsing.
- **Wired benchmark test** at
  `tests/patch_antenna_extraction.rs::fem_vs_palace_oracle_within_band_or_skip_with_note`:
  reads the real `benchmarks/patch_antenna/results.toml`. While the
  slot is `pending_operator_run` (the current state), prints a clear
  skip-with-note documenting the operator workflow. When populated by
  an operator, compares FEM vs Palace on S11 dip frequency (5 % band)
  and per-point `|S11|` (0.10 absolute tracking band).
- **Test fixtures** under `crates/geode-core/tests/fixtures/palace/`:
  clearly labeled `EXAMPLE / SYNTHETIC` files (a Palace-format CSV
  shrunken from the FEM sweep + a populated `[oracles.palace]` TOML
  block) that exercise the parser code without pretending to be an
  authoritative Palace reference. The real benchmark slot stays
  `pending_operator_run`.
- **Status string unification**: all three patch results TOMLs (and
  the example generator) switch from `status = "deferred"` to
  `status = "pending_operator_run"`, matching the SLCFET 3HP wording.

### Honesty contract (the bright line)

- No fabricated Palace numbers in a real `[oracles.palace]` slot.
  The committed slot in `benchmarks/patch_antenna/results.toml`
  stays `pending_operator_run` until an operator runs Palace and
  ingests the result with full provenance.
- The synthetic test fixtures live in a separate, clearly-labeled
  directory with their own README (`tests/fixtures/palace/README.md`)
  explaining they exercise the parser, not the oracle.
- The benchmark test never silently passes on a missing oracle —
  the skip-with-note path is explicit, and emits the operator
  workflow inline.

## Test plan

- [x] `cargo test -p geode-core --lib palace` — 8 passing unit tests
  (CSV parsing, Hz normalization, missing-column errors, S11→Z
  round-trip on matched / short / open terminations, both TOML slot
  shapes, unknown-status error).
- [x] `cargo test -p geode-core --test palace_ingestion` — 5 passing
  integration tests against the synthetic test fixtures (CSV parse,
  hand-calc Z verification at the dip, populated slot round-trip,
  pending-status block, legacy `deferred` synonym).
- [x] `cargo test -p geode-core --test patch_antenna_extraction` —
  4 tests (1 ignored heavy; 3 active including the new
  `fem_vs_palace_oracle_within_band_or_skip_with_note` which prints
  the skip-with-note against the real committed
  `benchmarks/patch_antenna/results.toml`).
- [x] `cargo test -p geode-core --test patch_antenna_matched
  --test patch_antenna_benchmark
  --test spiral_inductor_benchmark` — pre-existing tests still pass
  after the `[oracles.palace]` status-string updates.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cd reference/palace/geode_patch_baseline && cargo run
  --release` emits `palace_config.json` (committed) +
  `palace_config.provenance.txt` (committed).

## Follow-ups (not in this PR)

- Wire a `geode-cli` `palace ingest` subcommand for the operator's
  one-shot "ingest the CSV into the TOML slot" step. Out of scope
  here — the operator can call the library API directly for the
  first run.
- Spiral inductor variant: the same scaffolding (config generator +
  ingester) for the 3.5-turn spiral fixture. Out of scope for the
  one-benchmark target of this issue, but the schema and ingester
  are already reusable.
- Run Palace via the sister-repo Docker recipe and populate the
  real `[oracles.palace]` slot — a separate operator task tracked
  by the slot's `pending_operator_run` status.

Closes #239