### PR TITLE
feat: Krylov iterative solver (COCG + Jacobi) for the driven complex-symmetric system

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -640,6 +640,68 @@ fn driven_solve_impl<B: Backend>(
     op.solve_at(omega)
 }
 
+/// Iterative-solver entry point parallel to [`driven_solve`] —
+/// **Krylov path** (issue #238).
+///
+/// Assembles the driven operator exactly as [`driven_solve`] does and
+/// dispatches to [`DrivenOperator::solve_at_iterative`] with the
+/// supplied [`KspSolve`] solver and Jacobi preconditioner. Returns
+/// both the solution and the Krylov [`KspReport`] (iteration count,
+/// final relative residual) — the report is what issue #238's
+/// acceptance criteria call out as "iteration counts reported".
+///
+/// The returned `DrivenSolution` is shape-identical to the direct
+/// path's: PEC-eliminated edges carry exact zeros, `residual_rel` is
+/// `‖A x − b‖₂ / ‖b‖₂` with the same definition. On a small driven
+/// fixture the two paths agree to the documented Krylov tolerance
+/// (see the regression test `iterative_matches_direct_lu` in this
+/// module).
+///
+/// # Solver / preconditioner choice
+///
+/// The default `KspSolve` for the complex-symmetric driven pencil is
+/// [`crate::ksp_solve::Cocg`] (conjugate orthogonal CG, the natural
+/// choice for `A^T = A` without conjugation; see the module docs).
+/// The default preconditioner is
+/// [`crate::ksp_solve::JacobiPreconditioner`] — diagonal scaling,
+/// cheap, and sufficient for the driven curl-curl pencil at the
+/// frequencies the patch / parallel-plate fixtures exercise. Pass
+/// [`crate::ksp_solve::IdentityPreconditioner::new`] via
+/// [`DrivenOperator::solve_at_iterative`] directly for the
+/// unpreconditioned baseline.
+///
+/// # Errors
+///
+/// Returns the assembly errors of [`driven_solve`] plus
+/// [`DrivenError::Solve`] wrapping any [`crate::ksp_solve::KspError`]
+/// (breakdown, non-convergence, dimension mismatch).
+pub fn driven_solve_iterative<B: Backend, K>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    source: &CurrentSource,
+    ksp: &K,
+    device: &B::Device,
+) -> Result<(DrivenSolution, crate::ksp_solve::KspReport), DrivenError>
+where
+    K: crate::ksp_solve::KspSolve,
+{
+    let op = DrivenOperator::assemble_impl::<B>(
+        mesh,
+        materials,
+        None,
+        bcs,
+        &[],
+        &[],
+        RhsSamples::Constant(&source.j_tet),
+        device,
+    )?;
+    op.solve_at_iterative(omega, ksp, |a| {
+        crate::ksp_solve::JacobiPreconditioner::new(a.as_ref())
+    })
+}
+
 /// One lumped port of a [`DrivenOperator`]: the ω-independent pieces of
 /// the port's system / RHS / readout contributions, cached at assembly
 /// time.
@@ -1250,6 +1312,30 @@ impl DrivenOperator {
     /// evaluates to a zero/non-finite `Z_s(ω)`, plus the sparse
     /// assembly / factorization failures of [`driven_solve`].
     pub fn factor_at(&self, omega: f64) -> Result<FactoredDrivenOperator<'_>, DrivenError> {
+        let a_int = self.assemble_a_at(omega)?;
+
+        // --- Factor once (same machinery as complex Lanczos) ----------------
+        let lu = a_int
+            .as_ref()
+            .sp_lu()
+            .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+
+        Ok(FactoredDrivenOperator {
+            op: self,
+            omega,
+            a_int,
+            lu,
+        })
+    }
+
+    /// Re-form the interior `A(ω) = K + iωC − ω²M + Σ coeff·S + (jω/Z_s) S_p`
+    /// as a sparse CSC matrix at frequency `omega`, by linear
+    /// combination of the ω-independent value tensors cached at
+    /// assembly time. Shared between [`DrivenOperator::factor_at`]
+    /// (direct path) and [`DrivenOperator::solve_at_iterative`] (Krylov
+    /// path) so the two solver families see bit-for-bit the same
+    /// matrix.
+    fn assemble_a_at(&self, omega: f64) -> Result<SparseColMat<usize, c64>, DrivenError> {
         // Leontovich coefficients iω/Z_s(ω) — ω-dependent, re-evaluated
         // here at every frequency (issue #204 sweep caveat).
         let surface_coeffs: Vec<c64> = self
@@ -1285,25 +1371,167 @@ impl DrivenOperator {
             }
         }
 
-        let a_int = SparseColMat::<usize, c64>::try_new_from_triplets(
+        SparseColMat::<usize, c64>::try_new_from_triplets(
             self.n_interior,
             self.n_interior,
             &triplets,
         )
-        .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+        .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))
+    }
 
-        // --- Factor once (same machinery as complex Lanczos) ----------------
-        let lu = a_int
-            .as_ref()
-            .sp_lu()
-            .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+    /// Build the interior RHS `b(ω) = iω ∫ N · J dV (+ port drives)` at
+    /// frequency `omega`. `excited`, when `Some(p)`, restricts the
+    /// port drive contributions to port `p` (the matched-source /
+    /// S-parameter convention of
+    /// [`FactoredDrivenOperator::solve_excited`]). Returns the
+    /// interior-filtered vector ready for either an LU back-solve or
+    /// a Krylov iteration.
+    fn assemble_b_at(&self, omega: f64, excited: Option<usize>) -> Vec<c64> {
+        // b = iωμ₀ ∫ N · J dV with μ₀ = 1:  iω (re + i·im) = ω(−im + i·re).
+        let mut b_full: Vec<c64> = self
+            .rhs_re
+            .iter()
+            .zip(self.rhs_im.iter())
+            .map(|(&re, &im)| c64::new(-omega * im, omega * re))
+            .collect();
 
-        Ok(FactoredDrivenOperator {
-            op: self,
-            omega,
-            a_int,
-            lu,
-        })
+        // Matched-source port drive: b_i += (2jω/Z_s)(V_inc/l) f_i —
+        // restricted to the excited port when one is selected.
+        for (p, port) in self.ports.iter().enumerate() {
+            if excited.is_some_and(|j| j != p) {
+                continue;
+            }
+            if port.v_inc == c64::new(0.0, 0.0) {
+                continue;
+            }
+            let e_inc = port.v_inc * (1.0 / port.length);
+            let drive = c64::new(0.0, 2.0 * omega / port.z_s) * e_inc;
+            for (b, f) in b_full.iter_mut().zip(port.flux.iter()) {
+                *b += drive * *f;
+            }
+        }
+
+        // Interior-filter through the PEC mask.
+        self.pec_interior_mask
+            .iter()
+            .zip(b_full.iter())
+            .filter_map(|(&keep, &b)| if keep { Some(b) } else { None })
+            .collect()
+    }
+
+    /// Scatter an interior-DOF solution `x_int` back into the
+    /// full-length `[n_edges]` complex edge vector (zeros on PEC-
+    /// eliminated edges).
+    fn scatter_to_full(&self, x_int: &[c64]) -> Vec<c64> {
+        let mut e_edges = vec![c64::new(0.0, 0.0); self.n_edges];
+        for (full_idx, &ri) in self.remap.iter().enumerate() {
+            if ri >= 0 {
+                e_edges[full_idx] = x_int[ri as usize];
+            }
+        }
+        e_edges
+    }
+
+    /// Solve `A(ω) x = b` at one frequency through a **Krylov
+    /// iterative** solver instead of the direct LU factorization
+    /// (issue #238). The iterative analog of
+    /// [`DrivenOperator::solve_at`]: assembles the same interior
+    /// `A(ω)` and `b(ω)` as the direct path (sharing
+    /// [`DrivenOperator::assemble_a_at`] and
+    /// [`DrivenOperator::assemble_b_at`]) and hands the pair off to
+    /// `ksp` with `precond` as a left-preconditioner.
+    ///
+    /// The returned [`DrivenSolution`] has the same shape and
+    /// invariants as the direct-path output (full-length edge vector,
+    /// PEC zeros, post-solve residual `‖A x − b‖ / ‖b‖` — computed by
+    /// the Krylov solver in this case, but using the same definition,
+    /// so [`DrivenSolution::residual_rel`] is directly comparable
+    /// across solvers). The Krylov iteration count is reported
+    /// separately in the second tuple slot — issue #238 calls this
+    /// figure out explicitly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DrivenError::SurfaceImpedanceSingular`] if a
+    /// Leontovich model evaluates to a singular `Z_s(ω)`,
+    /// [`DrivenError::SparseAssembly`] on triplet assembly failure,
+    /// and [`DrivenError::Solve`] (wrapping the Krylov error) for
+    /// iteration breakdown or non-convergence. A zero RHS is treated
+    /// as a trivial all-zero solution (one iteration recorded) rather
+    /// than an error — to match the direct path's
+    /// [`zero_source_gives_zero_field`] semantics.
+    pub fn solve_at_iterative<K, P>(
+        &self,
+        omega: f64,
+        ksp: &K,
+        precond_factory: impl FnOnce(&SparseColMat<usize, c64>) -> Result<P, crate::ksp_solve::KspError>,
+    ) -> Result<(DrivenSolution, crate::ksp_solve::KspReport), DrivenError>
+    where
+        K: crate::ksp_solve::KspSolve,
+        P: crate::ksp_solve::Preconditioner,
+    {
+        use crate::complex_lanczos::spmv;
+
+        let a_int = self.assemble_a_at(omega)?;
+        let b_int = self.assemble_b_at(omega, None);
+
+        // Build the preconditioner from the assembled A(ω).
+        let precond = precond_factory(&a_int)
+            .map_err(|e| DrivenError::Solve(format!("preconditioner setup: {e}")))?;
+
+        let mut x_int = vec![c64::new(0.0, 0.0); self.n_interior];
+
+        // Zero RHS: trivially x = 0. Report zero iterations and a
+        // healthy "residual" (0 / 0 collapses to 0 in our metric).
+        let b_norm2: f64 = b_int.iter().map(|b| b.re * b.re + b.im * b.im).sum();
+        if b_norm2 == 0.0 {
+            return Ok((
+                DrivenSolution {
+                    e_edges: vec![c64::new(0.0, 0.0); self.n_edges],
+                    n_interior: self.n_interior,
+                    residual_rel: 0.0,
+                },
+                crate::ksp_solve::KspReport {
+                    iters: 0,
+                    residual_rel: 0.0,
+                    converged: true,
+                },
+            ));
+        }
+
+        let report = ksp
+            .solve(a_int.as_ref(), &b_int, &mut x_int, &precond)
+            .map_err(|e| DrivenError::Solve(format!("Krylov solve: {e}")))?;
+
+        // Post-solve residual check (same definition as the direct
+        // path; the Krylov reporter already computes this, but we
+        // recompute explicitly here so the DrivenSolution exposes the
+        // same residual_rel field across solver paths).
+        let mut ax = vec![c64::new(0.0, 0.0); self.n_interior];
+        spmv(a_int.as_ref(), &x_int, &mut ax);
+        let mut res2 = 0.0_f64;
+        let mut b2 = 0.0_f64;
+        for i in 0..self.n_interior {
+            let r = ax[i] - b_int[i];
+            res2 += r.re * r.re + r.im * r.im;
+            b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+        }
+        let residual_rel = if b2 > 0.0 {
+            (res2 / b2).sqrt()
+        } else {
+            res2.sqrt()
+        };
+
+        let e_edges = self.scatter_to_full(&x_int);
+
+        Ok((
+            DrivenSolution {
+                e_edges,
+                n_interior: self.n_interior,
+                residual_rel,
+            },
+            report,
+        ))
     }
 }
 
@@ -1815,5 +2043,337 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, DrivenError::MaterialDimMismatch { .. }));
+    }
+
+    // ---------------------------------------------------------------------
+    // Iterative-solver regression (issue #238)
+    // ---------------------------------------------------------------------
+
+    /// **Issue #238 regression**: the COCG iterative path must agree
+    /// with the direct sparse LU to a documented tolerance on a small
+    /// driven fixture (cube cavity, scalar ε, real volumetric source).
+    /// The Krylov solver is preconditioned-COCG with Jacobi; iteration
+    /// counts are reported through [`KspReport`].
+    #[test]
+    fn iterative_matches_direct_lu() {
+        use crate::ksp_solve::Cocg;
+
+        // Small cube cavity (same fixture the residual / linearity
+        // tests use). PEC walls, vacuum interior, smooth real source.
+        let mesh = cube_tet_mesh(3, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let source = CurrentSource::from_centroids(&mesh, |c| {
+            [
+                c64::new(0.0, 0.0),
+                c64::new(0.0, 0.0),
+                c64::new((std::f64::consts::PI * c[0]).sin(), 0.0),
+            ]
+        });
+        let omega = 1.5;
+
+        // Direct sparse LU path (the existing solver).
+        let sol_lu = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("direct LU solve");
+
+        // COCG iterative path (issue #238). Jacobi preconditioner is
+        // wired in by `driven_solve_iterative`. A tight Krylov tol
+        // ensures the iterative residual is at the same floor as the
+        // direct path's.
+        let ksp = Cocg::new(1e-12, 5000);
+        let (sol_ksp, report) = super::driven_solve_iterative::<B, _>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &source,
+            &ksp,
+            &device(),
+        )
+        .expect("COCG iterative solve");
+
+        // The iterative path's own residual must clear the requested
+        // tolerance, and so must the post-solve residual reported on
+        // the DrivenSolution (the two are the same definition).
+        assert!(report.converged, "COCG did not converge: {:?}", report);
+        assert!(
+            report.residual_rel < 1e-10,
+            "COCG residual too large: {}",
+            report.residual_rel
+        );
+        assert!(
+            sol_ksp.residual_rel < 1e-10,
+            "iterative DrivenSolution residual too large: {}",
+            sol_ksp.residual_rel
+        );
+
+        // Iteration count must be reported (the acceptance criterion).
+        assert!(report.iters > 0, "no iterations recorded");
+        // Issue-#238 tolerance contract: iterative vs direct LU agree
+        // to 1e-8 (relative, in the L2 norm) on this fixture. The
+        // direct path floors at machine epsilon and Krylov tolerance
+        // we asked for is 1e-12, so 1e-8 is a documented safety
+        // margin that survives both solvers' round-off.
+        let norm_lu: f64 = sol_lu
+            .e_edges
+            .iter()
+            .map(|e| e.re * e.re + e.im * e.im)
+            .sum::<f64>()
+            .sqrt();
+        assert!(norm_lu > 0.0, "direct solution must be non-trivial");
+        let mut diff2 = 0.0_f64;
+        for (a, b) in sol_lu.e_edges.iter().zip(sol_ksp.e_edges.iter()) {
+            let d = *a - *b;
+            diff2 += d.re * d.re + d.im * d.im;
+        }
+        let rel_diff = diff2.sqrt() / norm_lu;
+        const ITERATIVE_DIRECT_TOL: f64 = 1e-8;
+        assert!(
+            rel_diff < ITERATIVE_DIRECT_TOL,
+            "iterative vs LU solutions disagree: rel_diff = {} (tol {}) over {} edges, COCG report = {:?}",
+            rel_diff,
+            ITERATIVE_DIRECT_TOL,
+            sol_lu.e_edges.len(),
+            report,
+        );
+
+        // PEC-eliminated edges must be exactly zero in both paths.
+        for (i, &keep) in interior.iter().enumerate() {
+            if !keep {
+                assert_eq!(sol_ksp.e_edges[i], c64::new(0.0, 0.0));
+            }
+        }
+
+        // Iteration-count + cost report for the issue's acceptance
+        // criteria. Printed at INFO level (cargo test --nocapture).
+        eprintln!(
+            "[issue #238] cube cavity grid=3, n_interior={}, COCG iters={}, residual_rel={:.3e}, rel_diff_vs_LU={:.3e}",
+            sol_ksp.n_interior,
+            report.iters,
+            report.residual_rel,
+            rel_diff,
+        );
+    }
+
+    /// **Issue #238 supporting**: identity preconditioner produces
+    /// the same solution as Jacobi on the regression fixture (just
+    /// more iterations). Cross-checks that the iterative path works
+    /// even without preconditioning, so the preconditioner is
+    /// genuinely a separate concern from the Krylov core.
+    #[test]
+    fn identity_preconditioner_also_converges() {
+        use crate::ksp_solve::{Cocg, IdentityPreconditioner};
+
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let source = CurrentSource::from_centroids(&mesh, |c| {
+            [
+                c64::new(0.0, 0.0),
+                c64::new(0.0, 0.0),
+                c64::new((std::f64::consts::PI * c[0]).sin(), 0.0),
+            ]
+        });
+        let omega = 1.2;
+
+        let sol_lu = driven_solve::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("direct LU solve");
+
+        // Use the operator-level entry point with an explicit identity
+        // preconditioner factory — the per-solver-path lever the issue
+        // calls for.
+        let op = DrivenOperator::assemble::<B>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &bcs,
+            &[],
+            &[],
+            &source,
+            &device(),
+        )
+        .expect("operator assembly");
+        let ksp = Cocg::new(1e-12, 5000);
+        let (sol_ksp, report) = op
+            .solve_at_iterative(omega, &ksp, |a| {
+                Ok::<_, crate::ksp_solve::KspError>(IdentityPreconditioner::new(a.nrows()))
+            })
+            .expect("identity-preconditioned COCG");
+        assert!(report.converged);
+
+        let norm_lu: f64 = sol_lu
+            .e_edges
+            .iter()
+            .map(|e| e.re * e.re + e.im * e.im)
+            .sum::<f64>()
+            .sqrt();
+        let mut diff2 = 0.0_f64;
+        for (a, b) in sol_lu.e_edges.iter().zip(sol_ksp.e_edges.iter()) {
+            let d = *a - *b;
+            diff2 += d.re * d.re + d.im * d.im;
+        }
+        let rel_diff = diff2.sqrt() / norm_lu;
+        assert!(
+            rel_diff < 1e-8,
+            "identity-preconditioned COCG disagrees with LU: rel_diff = {}",
+            rel_diff
+        );
+        eprintln!(
+            "[issue #238] identity preconditioner: COCG iters={}, residual_rel={:.3e}",
+            report.iters, report.residual_rel
+        );
+    }
+
+    /// A zero current source through the iterative path must produce
+    /// the exact-zero field — matches the direct path's
+    /// `zero_source_gives_zero_field` semantics.
+    #[test]
+    fn iterative_zero_source_gives_zero_field() {
+        use crate::ksp_solve::Cocg;
+
+        let mesh = cube_tet_mesh(2, 1.0);
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        let eps = vacuum(&mesh);
+        let source = CurrentSource {
+            j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+        };
+        let ksp = Cocg::default();
+        let (sol, report) = super::driven_solve_iterative::<B, _>(
+            &mesh,
+            DrivenMaterials::Scalar(&eps),
+            &DrivenBcs {
+                pec_interior_mask: &interior,
+            },
+            1.0,
+            &source,
+            &ksp,
+            &device(),
+        )
+        .expect("iterative driven solve with zero source");
+        assert!(sol.e_edges.iter().all(|e| e.re == 0.0 && e.im == 0.0));
+        assert_eq!(report.iters, 0);
+        assert!(report.converged);
+    }
+
+    /// **Issue #238 heavy benchmark**: the iterative path must scale
+    /// to the patch fixture (~30k interior edges) and converge to a
+    /// documented tolerance vs the direct LU. `#[ignore]`d because
+    /// it requires the patch fixture and is expensive — run with
+    /// `cargo test --release -- --ignored iterative_patch_benchmark`.
+    #[test]
+    #[ignore = "heavy fixture; opt-in with `cargo test --release -- --ignored iterative_patch_benchmark`"]
+    fn iterative_patch_benchmark() {
+        use crate::ksp_solve::Cocg;
+        use crate::mesh::{pec_interior_mask_from_triangles, read_patch_smoke_fixture};
+
+        let fixture = read_patch_smoke_fixture().expect("patch fixture");
+        let patch_tris = fixture.patch_triangles();
+        let ground_tris = fixture.ground_triangles();
+        let outer_tris = fixture.outer_boundary_triangles();
+        let edges = fixture.mesh.edges();
+        let interior = pec_interior_mask_from_triangles(
+            &edges,
+            &[
+                patch_tris.as_slice(),
+                ground_tris.as_slice(),
+                outer_tris.as_slice(),
+            ],
+        );
+        let mesh = &fixture.mesh;
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let eps = fixture.epsilon_r_default();
+        let source = CurrentSource::from_centroids(mesh, |c| {
+            [
+                c64::new(0.0, 0.0),
+                c64::new(0.0, 0.0),
+                c64::new(c[0].sin(), 0.0),
+            ]
+        });
+        // Patch smoke fixture: pick a representative ω near the
+        // operating band's normalized frequency (the smoke fixture is
+        // small and tolerant of any moderate ω).
+        let omega = 0.1;
+
+        let t_lu = std::time::Instant::now();
+        let sol_lu = driven_solve::<B>(
+            mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("direct LU patch solve");
+        let lu_secs = t_lu.elapsed().as_secs_f64();
+
+        let ksp = Cocg::new(1e-8, 20_000);
+        let t_it = std::time::Instant::now();
+        let (sol_ksp, report) = super::driven_solve_iterative::<B, _>(
+            mesh,
+            DrivenMaterials::Scalar(&eps),
+            &bcs,
+            omega,
+            &source,
+            &ksp,
+            &device(),
+        )
+        .expect("COCG patch solve");
+        let it_secs = t_it.elapsed().as_secs_f64();
+
+        let norm_lu: f64 = sol_lu
+            .e_edges
+            .iter()
+            .map(|e| e.re * e.re + e.im * e.im)
+            .sum::<f64>()
+            .sqrt();
+        let mut diff2 = 0.0_f64;
+        for (a, b) in sol_lu.e_edges.iter().zip(sol_ksp.e_edges.iter()) {
+            let d = *a - *b;
+            diff2 += d.re * d.re + d.im * d.im;
+        }
+        let rel_diff = diff2.sqrt() / norm_lu;
+
+        eprintln!(
+            "[issue #238 / patch] n_interior={}, COCG iters={}, residual_rel={:.3e}, \
+             rel_diff_vs_LU={:.3e}, LU_secs={:.3}, COCG_secs={:.3}, speedup={:.2}x",
+            sol_ksp.n_interior,
+            report.iters,
+            report.residual_rel,
+            rel_diff,
+            lu_secs,
+            it_secs,
+            lu_secs / it_secs.max(1e-12),
+        );
+        assert!(report.converged);
+        // Loose tol for the heavy fixture — the direct LU residual
+        // floor + Krylov tol stack up — but COCG must reach the same
+        // solution to a few-digit agreement.
+        assert!(
+            rel_diff < 1e-4,
+            "patch iterative vs LU rel_diff = {}",
+            rel_diff
+        );
     }
 }

--- a/crates/geode-core/src/ksp_solve.rs
+++ b/crates/geode-core/src/ksp_solve.rs
@@ -1,0 +1,706 @@
+//! **Krylov iterative solvers** for the complex-symmetric driven system
+//! `A(ω) x = b` (issue #238).
+//!
+//! All driven and eigen solves currently exit to a direct sparse LU
+//! ([`faer::sparse::linalg::solvers::Lu`]) at the solve boundary
+//! ([`crate::driven::FactoredDrivenOperator`],
+//! [`crate::complex_lanczos`]). Direct factorization caps the problem
+//! size at what fill-in can afford; for larger structures (the
+//! ~30k-edge patch fixture, future 3-D stacks) the next ceiling is the
+//! solve itself.
+//!
+//! This module realizes the `ksp_solve` / `krylov_step` /
+//! `preconditioning-framework` L4 surfaces of the operator tracker
+//! (#5) — the iterative-solve corner of `ksp_solve` complementing the
+//! existing direct-solve corner. It exposes:
+//!
+//! - The [`KspSolve`] trait — the iterative analog of the LU "solve at
+//!   ω" boundary. Implementors take the assembled sparse `A` and RHS
+//!   `b` and produce the solution + a [`KspReport`] of iteration count
+//!   / final residual.
+//! - A **complex-symmetric COCG** solver ([`Cocg`]), the natural
+//!   Krylov choice when `A^T = A` without conjugation (the assembled
+//!   driven pencil's invariant — see [`crate::driven`] and PR #55).
+//!   Real-CG carries over verbatim by replacing the Hermitian
+//!   `(r, z) = r^H z` inner product with the bilinear `r^T z`. The
+//!   same complex-symmetric structure powers the bilinear-form
+//!   Lanczos in [`crate::complex_lanczos`].
+//! - A [`Preconditioner`] trait with two concrete preconditioners:
+//!   [`IdentityPreconditioner`] (the no-op) and [`JacobiPreconditioner`]
+//!   (diagonal scaling — `M = diag(A)`, the simplest and cheapest
+//!   left-preconditioner).
+//!
+//! # Algorithm — preconditioned COCG
+//!
+//! For complex-symmetric `A` (`A^T = A`, **bilinear**, no conjugation)
+//! and SPD-ish preconditioner `M` (we only require `M^{-1}` applicable
+//! and the bilinear `r^T M^{-1} r` to not vanish), the preconditioned
+//! COCG iteration is:
+//!
+//! ```text
+//! x_0 given (we use 0),  r_0 = b - A x_0,  z_0 = M^{-1} r_0,  p_0 = z_0
+//! ρ_0 = r_0^T z_0                     (bilinear, no conjugation)
+//! for k = 0, 1, …:
+//!     q = A p_k
+//!     α = ρ_k / (p_k^T q)             (bilinear)
+//!     x_{k+1} = x_k + α p_k
+//!     r_{k+1} = r_k - α q
+//!     if ‖r_{k+1}‖₂ ≤ tol · ‖b‖₂: stop
+//!     z_{k+1} = M^{-1} r_{k+1}
+//!     ρ_{k+1} = r_{k+1}^T z_{k+1}
+//!     β = ρ_{k+1} / ρ_k
+//!     p_{k+1} = z_{k+1} + β p_k
+//! ```
+//!
+//! See e.g. van der Vorst & Mellisen (1990), Bai et al. *Templates*
+//! §6.8. COCG can in principle break down (the bilinear form is not
+//! positive definite, so `ρ_k` or `p^T q` can vanish), but for the
+//! lossy / PML driven pencils we care about — where `A` is close to a
+//! real SPD with a small absorbing imaginary part — breakdown is
+//! extremely unlikely on the grid sizes the test suite covers. The
+//! solver guards against this by returning a [`KspError::Breakdown`]
+//! rather than producing NaNs.
+//!
+//! # Convergence reporting
+//!
+//! Every solve returns a [`KspReport`] with the iteration count,
+//! final relative residual `‖A x − b‖₂ / ‖b‖₂`, and a flag indicating
+//! whether the tolerance was reached. The acceptance criteria for
+//! issue #238 require iteration counts to be reported on the patch
+//! benchmark fixture; this is the channel.
+
+use faer::c64;
+use faer::sparse::SparseColMatRef;
+
+use crate::complex_lanczos::spmv;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the Krylov solver path.
+#[derive(Debug, thiserror::Error)]
+pub enum KspError {
+    /// The Krylov iteration broke down — a bilinear inner product
+    /// (`r^T z` or `p^T A p`) vanished or went non-finite before
+    /// convergence. COCG is not unconditionally robust; if this
+    /// happens, switch to a stronger preconditioner (Jacobi → ILU →
+    /// direct) or back off to the direct path.
+    #[error(
+        "COCG breakdown at iteration {iter}: bilinear inner product {kind} = {value_re}+{value_im}i \
+         is zero or non-finite (the complex-symmetric Krylov form is not unconditionally robust; \
+         a stronger preconditioner or the direct solver is required)"
+    )]
+    Breakdown {
+        /// Iteration index at which the breakdown was detected.
+        iter: usize,
+        /// Which bilinear quantity failed (`"r^T z"` or `"p^T A p"`).
+        kind: &'static str,
+        /// Real and imaginary parts of the offending scalar.
+        value_re: f64,
+        value_im: f64,
+    },
+    /// The iteration ran out of steps without reaching the requested
+    /// tolerance. Bumping [`Cocg::max_iters`] or using a stronger
+    /// preconditioner usually fixes this; in the worst case fall back
+    /// to direct LU.
+    #[error(
+        "COCG did not converge in {iter} iterations: relative residual {residual_rel} > tol {tol}"
+    )]
+    NotConverged {
+        iter: usize,
+        residual_rel: f64,
+        tol: f64,
+    },
+    /// The right-hand side is identically zero (after the optional
+    /// scaling). The solution is trivially zero, but callers that
+    /// asked for a Krylov solve probably want to know.
+    #[error("right-hand side has ‖b‖₂ = 0 (trivial solution); no iteration to run")]
+    ZeroRhs,
+    /// Dimension mismatch between the operator and the RHS / output
+    /// buffer.
+    #[error("Krylov dimension mismatch: A is {n}×{n}, but {what} has length {got}")]
+    DimMismatch {
+        n: usize,
+        what: &'static str,
+        got: usize,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// KspReport
+// ---------------------------------------------------------------------------
+
+/// Outcome of a Krylov solve.
+///
+/// Returned by every [`KspSolve::solve`] call. The relative residual
+/// is `‖A x − b‖₂ / ‖b‖₂`, computed with an explicit spmv on the
+/// final iterate — the **same** residual definition the direct path
+/// reports in [`crate::driven::DrivenSolution::residual_rel`], so the
+/// two are directly comparable.
+#[derive(Debug, Clone, Copy)]
+pub struct KspReport {
+    /// Number of Krylov iterations that actually ran.
+    pub iters: usize,
+    /// Final relative residual `‖A x − b‖₂ / ‖b‖₂`.
+    pub residual_rel: f64,
+    /// `true` if the tolerance was met within the iteration budget,
+    /// `false` if the iteration was cut off (callers should treat the
+    /// returned `x` as an approximation in that case — the iterative
+    /// entry points return [`KspError::NotConverged`] before reaching
+    /// the caller, but this flag is preserved for diagnostics).
+    pub converged: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Preconditioner trait + implementations
+// ---------------------------------------------------------------------------
+
+/// Left-preconditioner for the Krylov solver: applies `z = M^{-1} r`.
+///
+/// The preconditioner does not need to be explicitly stored — only
+/// the application matters. Implementations are responsible for
+/// their own setup (e.g. extracting the diagonal of `A` at
+/// construction time).
+///
+/// All concrete preconditioners in this module are **complex**,
+/// matching the driven-system arithmetic.
+pub trait Preconditioner {
+    /// Apply `z = M^{-1} r`. `z` and `r` are the same length as the
+    /// system. Implementations may panic on length mismatch; the
+    /// [`Cocg`] driver checks lengths once up front.
+    fn apply(&self, r: &[c64], z: &mut [c64]);
+
+    /// Size `n` the preconditioner was built for (the system
+    /// dimension). Used for sanity checks.
+    fn dim(&self) -> usize;
+}
+
+/// Identity preconditioner — applies `z = r`. Useful as a baseline
+/// (unpreconditioned COCG) and for testing the iteration core in
+/// isolation.
+#[derive(Debug, Clone, Copy)]
+pub struct IdentityPreconditioner {
+    n: usize,
+}
+
+impl IdentityPreconditioner {
+    /// Build the identity preconditioner for a system of size `n`.
+    pub fn new(n: usize) -> Self {
+        Self { n }
+    }
+}
+
+impl Preconditioner for IdentityPreconditioner {
+    fn apply(&self, r: &[c64], z: &mut [c64]) {
+        debug_assert_eq!(r.len(), self.n);
+        debug_assert_eq!(z.len(), self.n);
+        z.copy_from_slice(r);
+    }
+    fn dim(&self) -> usize {
+        self.n
+    }
+}
+
+/// Jacobi (diagonal) preconditioner — `M = diag(A)`, so the
+/// application is `z_i = r_i / A_{ii}`. The cheapest non-trivial
+/// preconditioner; effective whenever `A` is diagonally dominant or
+/// close to it (the driven curl-curl pencil at moderate frequencies
+/// usually is).
+///
+/// Construction caches the reciprocal of each diagonal entry up
+/// front, so each apply is one complex multiply per DOF.
+///
+/// # Errors at construction
+///
+/// Returns [`KspError::Breakdown`] (with `kind = "diag(A)"`) if any
+/// diagonal entry is zero or non-finite — the Jacobi preconditioner
+/// is not defined in that case.
+#[derive(Debug, Clone)]
+pub struct JacobiPreconditioner {
+    inv_diag: Vec<c64>,
+}
+
+impl JacobiPreconditioner {
+    /// Extract `diag(A)` from a complex sparse CSC matrix and store
+    /// its reciprocal. The matrix must be square.
+    pub fn new(a: SparseColMatRef<'_, usize, c64>) -> Result<Self, KspError> {
+        let n = a.nrows();
+        assert_eq!(a.ncols(), n, "JacobiPreconditioner requires square A");
+        let col_ptr = a.col_ptr();
+        let row_idx = a.row_idx();
+        let val = a.val();
+        let mut diag = vec![c64::new(0.0, 0.0); n];
+        for j in 0..n {
+            for k in col_ptr[j]..col_ptr[j + 1] {
+                let i = row_idx[k];
+                if i == j {
+                    diag[j] += val[k];
+                }
+            }
+        }
+        let mut inv_diag = vec![c64::new(0.0, 0.0); n];
+        for (j, d) in diag.iter().enumerate() {
+            if !(d.re.is_finite() && d.im.is_finite()) {
+                return Err(KspError::Breakdown {
+                    iter: 0,
+                    kind: "diag(A)",
+                    value_re: d.re,
+                    value_im: d.im,
+                });
+            }
+            let mag2 = d.re * d.re + d.im * d.im;
+            if mag2 == 0.0 {
+                return Err(KspError::Breakdown {
+                    iter: 0,
+                    kind: "diag(A)",
+                    value_re: d.re,
+                    value_im: d.im,
+                });
+            }
+            // 1 / (a + bi) = (a − bi) / (a² + b²).
+            inv_diag[j] = c64::new(d.re / mag2, -d.im / mag2);
+        }
+        Ok(Self { inv_diag })
+    }
+}
+
+impl Preconditioner for JacobiPreconditioner {
+    fn apply(&self, r: &[c64], z: &mut [c64]) {
+        debug_assert_eq!(r.len(), self.inv_diag.len());
+        debug_assert_eq!(z.len(), self.inv_diag.len());
+        for i in 0..r.len() {
+            z[i] = r[i] * self.inv_diag[i];
+        }
+    }
+    fn dim(&self) -> usize {
+        self.inv_diag.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KspSolve trait
+// ---------------------------------------------------------------------------
+
+/// Krylov-solver boundary — the iterative analog of the direct LU
+/// factor+solve path. Mirrors the role of
+/// [`faer::sparse::linalg::solvers::Lu`] in
+/// [`crate::driven::FactoredDrivenOperator`]: takes the assembled
+/// sparse `A` and RHS `b` and produces the solution + a convergence
+/// report.
+///
+/// The trait is intentionally narrow — no per-frequency caching, no
+/// material plumbing. The driven layer assembles `A(ω)` and `b(ω)`
+/// using its existing machinery and hands the pair off; switching
+/// solvers in `driven_solve_iterative` is a matter of swapping which
+/// `KspSolve` implementation is passed.
+pub trait KspSolve {
+    /// Solve `A x = b` for `x` (overwriting `x` with the solution,
+    /// which is also returned implicitly by reference). The caller
+    /// initializes `x` (typically to zero — COCG's starting guess
+    /// `x_0 = 0` makes `r_0 = b`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KspError::DimMismatch`] on shape mismatch,
+    /// [`KspError::ZeroRhs`] if `b ≡ 0`,
+    /// [`KspError::Breakdown`] on bilinear-form failure, and
+    /// [`KspError::NotConverged`] when the iteration budget is
+    /// exhausted before reaching tolerance.
+    fn solve<P: Preconditioner>(
+        &self,
+        a: SparseColMatRef<'_, usize, c64>,
+        b: &[c64],
+        x: &mut [c64],
+        precond: &P,
+    ) -> Result<KspReport, KspError>;
+}
+
+// ---------------------------------------------------------------------------
+// COCG
+// ---------------------------------------------------------------------------
+
+/// **Conjugate Orthogonal Conjugate Gradient** for complex-symmetric
+/// `A` (`A^T = A`, bilinear / no conjugation — the driven pencil
+/// invariant, see PR #55). Real-CG carries over verbatim with the
+/// Hermitian inner product replaced by the bilinear `u^T v` — same
+/// substitution the complex-symmetric Lanczos in
+/// [`crate::complex_lanczos`] uses.
+///
+/// # Configuration
+///
+/// - `tol` — relative-residual stopping criterion `‖r‖₂ ≤ tol·‖b‖₂`.
+/// - `max_iters` — iteration budget; `KspError::NotConverged` if
+///   exhausted.
+/// - `breakdown_tol` — magnitude below which a bilinear inner
+///   product is considered zero (breakdown). Default `1e-300` —
+///   essentially "underflowed to zero".
+///
+/// `KspReport::iters` is the iteration count actually executed and
+/// is the figure of merit issue #238 asks for in the regression test.
+#[derive(Debug, Clone, Copy)]
+pub struct Cocg {
+    /// Convergence tolerance on the relative residual.
+    pub tol: f64,
+    /// Maximum number of iterations.
+    pub max_iters: usize,
+    /// Threshold below which `|r^T z|` or `|p^T A p|` is treated as a
+    /// breakdown.
+    pub breakdown_tol: f64,
+}
+
+impl Default for Cocg {
+    fn default() -> Self {
+        Self {
+            tol: 1e-10,
+            max_iters: 2000,
+            breakdown_tol: 1e-300,
+        }
+    }
+}
+
+impl Cocg {
+    /// Convenience constructor — `tol` and `max_iters` only, with
+    /// the default breakdown threshold.
+    pub fn new(tol: f64, max_iters: usize) -> Self {
+        Self {
+            tol,
+            max_iters,
+            ..Default::default()
+        }
+    }
+}
+
+/// `acc = u^T v` (**bilinear**, no conjugation) — the complex-symmetric
+/// Krylov inner product. Mirrors the bilinear form
+/// [`crate::complex_lanczos`] uses for the Lanczos pencil.
+fn bilinear_dot(u: &[c64], v: &[c64]) -> c64 {
+    debug_assert_eq!(u.len(), v.len());
+    let mut acc = c64::new(0.0, 0.0);
+    for i in 0..u.len() {
+        acc += u[i] * v[i];
+    }
+    acc
+}
+
+/// `‖v‖₂` (Euclidean norm) — for the residual stopping criterion the
+/// natural choice is the standard Hermitian norm: it is what the
+/// direct path reports as `residual_rel`, and what users expect
+/// "‖A x − b‖" to mean.
+fn euclid_norm(v: &[c64]) -> f64 {
+    let mut acc = 0.0_f64;
+    for x in v {
+        acc += x.re * x.re + x.im * x.im;
+    }
+    acc.sqrt()
+}
+
+impl KspSolve for Cocg {
+    fn solve<P: Preconditioner>(
+        &self,
+        a: SparseColMatRef<'_, usize, c64>,
+        b: &[c64],
+        x: &mut [c64],
+        precond: &P,
+    ) -> Result<KspReport, KspError> {
+        let n = a.nrows();
+        if a.ncols() != n {
+            return Err(KspError::DimMismatch {
+                n,
+                what: "A.ncols",
+                got: a.ncols(),
+            });
+        }
+        if b.len() != n {
+            return Err(KspError::DimMismatch {
+                n,
+                what: "b",
+                got: b.len(),
+            });
+        }
+        if x.len() != n {
+            return Err(KspError::DimMismatch {
+                n,
+                what: "x",
+                got: x.len(),
+            });
+        }
+        if precond.dim() != n {
+            return Err(KspError::DimMismatch {
+                n,
+                what: "preconditioner",
+                got: precond.dim(),
+            });
+        }
+
+        let b_norm = euclid_norm(b);
+        if b_norm == 0.0 {
+            return Err(KspError::ZeroRhs);
+        }
+        let target = self.tol * b_norm;
+
+        // r = b - A x  (x typically starts at 0, in which case r = b).
+        let mut r = vec![c64::new(0.0, 0.0); n];
+        spmv(a, x, &mut r); // r = A x
+        for i in 0..n {
+            r[i] = b[i] - r[i];
+        }
+
+        // Early exit if the initial guess already satisfies the tolerance.
+        let r_norm = euclid_norm(&r);
+        if r_norm <= target {
+            return Ok(KspReport {
+                iters: 0,
+                residual_rel: r_norm / b_norm,
+                converged: true,
+            });
+        }
+
+        // z = M^{-1} r, p = z, ρ = r^T z.
+        let mut z = vec![c64::new(0.0, 0.0); n];
+        precond.apply(&r, &mut z);
+        let mut p = z.clone();
+        let mut rho = bilinear_dot(&r, &z);
+        let bd_check =
+            |val: c64, iter: usize, kind: &'static str, tol: f64| -> Result<(), KspError> {
+                let mag2 = val.re * val.re + val.im * val.im;
+                if !val.re.is_finite() || !val.im.is_finite() || mag2 < tol * tol {
+                    Err(KspError::Breakdown {
+                        iter,
+                        kind,
+                        value_re: val.re,
+                        value_im: val.im,
+                    })
+                } else {
+                    Ok(())
+                }
+            };
+        bd_check(rho, 0, "r^T z", self.breakdown_tol)?;
+
+        let mut q = vec![c64::new(0.0, 0.0); n];
+
+        for k in 0..self.max_iters {
+            // q = A p
+            spmv(a, &p, &mut q);
+
+            // α = ρ / (p^T q)
+            let pq = bilinear_dot(&p, &q);
+            bd_check(pq, k, "p^T A p", self.breakdown_tol)?;
+            let alpha = rho / pq;
+
+            // x += α p; r -= α q
+            for i in 0..n {
+                x[i] += alpha * p[i];
+                r[i] -= alpha * q[i];
+            }
+
+            // Tolerance check on the recursively maintained residual.
+            let r_norm = euclid_norm(&r);
+            if r_norm <= target {
+                // Recompute the true residual to report a reliable
+                // figure (the recursively maintained `r` can drift on
+                // ill-conditioned systems; the explicit spmv matches
+                // what the direct path reports).
+                let mut ax = vec![c64::new(0.0, 0.0); n];
+                spmv(a, x, &mut ax);
+                let mut true_r = 0.0_f64;
+                for i in 0..n {
+                    let d = ax[i] - b[i];
+                    true_r += d.re * d.re + d.im * d.im;
+                }
+                let residual_rel = true_r.sqrt() / b_norm;
+                return Ok(KspReport {
+                    iters: k + 1,
+                    residual_rel,
+                    converged: residual_rel <= self.tol,
+                });
+            }
+
+            // z = M^{-1} r, ρ_new = r^T z, β = ρ_new / ρ
+            precond.apply(&r, &mut z);
+            let rho_new = bilinear_dot(&r, &z);
+            bd_check(rho_new, k + 1, "r^T z", self.breakdown_tol)?;
+            let beta = rho_new / rho;
+            rho = rho_new;
+
+            // p = z + β p
+            for i in 0..n {
+                p[i] = z[i] + beta * p[i];
+            }
+        }
+
+        // Out of iterations — compute the true residual for the report.
+        let mut ax = vec![c64::new(0.0, 0.0); n];
+        spmv(a, x, &mut ax);
+        let mut true_r = 0.0_f64;
+        for i in 0..n {
+            let d = ax[i] - b[i];
+            true_r += d.re * d.re + d.im * d.im;
+        }
+        let residual_rel = true_r.sqrt() / b_norm;
+        Err(KspError::NotConverged {
+            iter: self.max_iters,
+            residual_rel,
+            tol: self.tol,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faer::sparse::{SparseColMat, Triplet};
+
+    /// Build a small **real-symmetric positive-definite** complex
+    /// matrix (Im ≡ 0) and check COCG converges. The bilinear `u^T v`
+    /// reduces to the real dot product on real vectors, so COCG
+    /// degenerates to ordinary CG and must converge in ≤ n iterations.
+    #[test]
+    fn cocg_recovers_cg_on_real_spd_system() {
+        // 3x3 SPD: [[4,1,0],[1,3,1],[0,1,2]]
+        let n = 3;
+        let trips = vec![
+            Triplet::new(0_usize, 0, c64::new(4.0, 0.0)),
+            Triplet::new(0, 1, c64::new(1.0, 0.0)),
+            Triplet::new(1, 0, c64::new(1.0, 0.0)),
+            Triplet::new(1, 1, c64::new(3.0, 0.0)),
+            Triplet::new(1, 2, c64::new(1.0, 0.0)),
+            Triplet::new(2, 1, c64::new(1.0, 0.0)),
+            Triplet::new(2, 2, c64::new(2.0, 0.0)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(n, n, &trips).unwrap();
+        let b: Vec<c64> = vec![c64::new(1.0, 0.0), c64::new(2.0, 0.0), c64::new(3.0, 0.0)];
+
+        let mut x = vec![c64::new(0.0, 0.0); n];
+        let pc = IdentityPreconditioner::new(n);
+        let cocg = Cocg::new(1e-12, 100);
+        let report = cocg
+            .solve(a.as_ref(), &b, &mut x, &pc)
+            .expect("COCG converges on a 3×3 SPD system");
+        assert!(report.converged);
+        assert!(report.iters <= n, "CG hits SPD in ≤ n iters");
+        // Check the residual.
+        let mut ax = vec![c64::new(0.0, 0.0); n];
+        spmv(a.as_ref(), &x, &mut ax);
+        let mut res2 = 0.0;
+        for i in 0..n {
+            let d = ax[i] - b[i];
+            res2 += d.re * d.re + d.im * d.im;
+        }
+        assert!(res2.sqrt() < 1e-9);
+    }
+
+    /// COCG must solve a small **complex-symmetric** (`A^T = A`, no
+    /// conjugation) lossy system to round-off.
+    #[test]
+    fn cocg_solves_complex_symmetric_lossy_system() {
+        // A = [[4+0.1i, 1+0.05i, 0],
+        //      [1+0.05i, 3+0.2i, 1],
+        //      [0,        1,      2+0.1i]]
+        // Symmetric (A[i,j] = A[j,i]) but with non-trivial imaginary parts.
+        let n = 3;
+        let trips = vec![
+            Triplet::new(0_usize, 0, c64::new(4.0, 0.1)),
+            Triplet::new(0, 1, c64::new(1.0, 0.05)),
+            Triplet::new(1, 0, c64::new(1.0, 0.05)),
+            Triplet::new(1, 1, c64::new(3.0, 0.2)),
+            Triplet::new(1, 2, c64::new(1.0, 0.0)),
+            Triplet::new(2, 1, c64::new(1.0, 0.0)),
+            Triplet::new(2, 2, c64::new(2.0, 0.1)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(n, n, &trips).unwrap();
+        let b: Vec<c64> = vec![c64::new(1.0, -0.2), c64::new(2.0, 0.1), c64::new(0.5, 0.3)];
+
+        let mut x = vec![c64::new(0.0, 0.0); n];
+        let pc = JacobiPreconditioner::new(a.as_ref()).expect("nonzero diagonal");
+        let cocg = Cocg::new(1e-12, 100);
+        let report = cocg
+            .solve(a.as_ref(), &b, &mut x, &pc)
+            .expect("COCG converges");
+        assert!(report.converged);
+        assert!(report.residual_rel < 1e-10, "{:?}", report);
+    }
+
+    /// Jacobi preconditioner must reject a zero-diagonal matrix.
+    #[test]
+    fn jacobi_rejects_zero_diagonal() {
+        let trips = vec![
+            Triplet::new(0_usize, 1, c64::new(1.0, 0.0)),
+            Triplet::new(1, 0, c64::new(1.0, 0.0)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(2, 2, &trips).unwrap();
+        let err = JacobiPreconditioner::new(a.as_ref()).unwrap_err();
+        assert!(matches!(err, KspError::Breakdown { .. }));
+    }
+
+    /// A zero RHS must be reported, not silently consumed.
+    #[test]
+    fn zero_rhs_is_an_error() {
+        let trips = vec![
+            Triplet::new(0_usize, 0, c64::new(2.0, 0.0)),
+            Triplet::new(1, 1, c64::new(3.0, 0.0)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(2, 2, &trips).unwrap();
+        let b = vec![c64::new(0.0, 0.0); 2];
+        let mut x = vec![c64::new(0.0, 0.0); 2];
+        let pc = IdentityPreconditioner::new(2);
+        let err = Cocg::default()
+            .solve(a.as_ref(), &b, &mut x, &pc)
+            .unwrap_err();
+        assert!(matches!(err, KspError::ZeroRhs));
+    }
+
+    /// Identity preconditioner is exactly the no-op.
+    #[test]
+    fn identity_preconditioner_is_noop() {
+        let r = vec![c64::new(1.0, -2.0), c64::new(3.0, 4.0)];
+        let mut z = vec![c64::new(0.0, 0.0); 2];
+        IdentityPreconditioner::new(2).apply(&r, &mut z);
+        assert_eq!(z, r);
+    }
+
+    /// Jacobi preconditioner inverts each diagonal entry.
+    #[test]
+    fn jacobi_inverts_each_diagonal_entry() {
+        let trips = vec![
+            Triplet::new(0_usize, 0, c64::new(2.0, 0.0)),
+            Triplet::new(1, 1, c64::new(0.0, 4.0)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(2, 2, &trips).unwrap();
+        let pc = JacobiPreconditioner::new(a.as_ref()).unwrap();
+        let r = vec![c64::new(4.0, 0.0), c64::new(8.0, 0.0)];
+        let mut z = vec![c64::new(0.0, 0.0); 2];
+        pc.apply(&r, &mut z);
+        // 4 / 2 = 2; 8 / (4i) = -2i
+        assert!((z[0].re - 2.0).abs() < 1e-15 && z[0].im.abs() < 1e-15);
+        assert!(z[1].re.abs() < 1e-15 && (z[1].im - (-2.0)).abs() < 1e-15);
+    }
+
+    /// `NotConverged` is returned (not silent garbage) when the
+    /// budget is exhausted.
+    #[test]
+    fn budget_exhaustion_returns_not_converged() {
+        // Reuse the SPD 3×3 from the first test but allow only 1 iter.
+        let n = 3;
+        let trips = vec![
+            Triplet::new(0_usize, 0, c64::new(4.0, 0.0)),
+            Triplet::new(0, 1, c64::new(1.0, 0.0)),
+            Triplet::new(1, 0, c64::new(1.0, 0.0)),
+            Triplet::new(1, 1, c64::new(3.0, 0.0)),
+            Triplet::new(1, 2, c64::new(1.0, 0.0)),
+            Triplet::new(2, 1, c64::new(1.0, 0.0)),
+            Triplet::new(2, 2, c64::new(2.0, 0.0)),
+        ];
+        let a = SparseColMat::<usize, c64>::try_new_from_triplets(n, n, &trips).unwrap();
+        let b: Vec<c64> = vec![c64::new(1.0, 0.0), c64::new(2.0, 0.0), c64::new(3.0, 0.0)];
+        let mut x = vec![c64::new(0.0, 0.0); n];
+        let pc = IdentityPreconditioner::new(n);
+        let cocg = Cocg::new(1e-15, 1); // tight tol + 1-iter budget
+        let err = cocg.solve(a.as_ref(), &b, &mut x, &pc).unwrap_err();
+        assert!(matches!(err, KspError::NotConverged { .. }));
+    }
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod driven;
 pub mod eigen;
 pub mod extraction;
 pub mod fe_assemble;
+pub mod ksp_solve;
 pub mod lanczos;
 pub mod lumped_port;
 pub mod mesh;
@@ -42,10 +43,10 @@ pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{SparseComplexEigenSolver, SparseComplexShiftInvertLanczos};
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
 pub use driven::{
-    driven_solve, driven_solve_quad, driven_solve_with_ports, driven_solve_with_sigma,
-    driven_solve_with_sigma_quad, driven_solve_with_surface_impedance, CurrentSource, DrivenBcs,
-    DrivenError, DrivenMaterials, DrivenOperator, DrivenSolution, FactoredDrivenOperator,
-    QuadCurrentSource, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    driven_solve, driven_solve_iterative, driven_solve_quad, driven_solve_with_ports,
+    driven_solve_with_sigma, driven_solve_with_sigma_quad, driven_solve_with_surface_impedance,
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, DrivenSolution,
+    FactoredDrivenOperator, QuadCurrentSource, SurfaceImpedanceBc, SurfaceImpedanceModel,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenSolver,
@@ -57,6 +58,10 @@ pub use extraction::{
     SweepPoint,
 };
 pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
+pub use ksp_solve::{
+    Cocg, IdentityPreconditioner, JacobiPreconditioner, KspError, KspReport, KspSolve,
+    Preconditioner,
+};
 pub use lanczos::{SparseEigenSolver, SparseShiftInvertLanczos};
 pub use lumped_port::{
     assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,


### PR DESCRIPTION
## Summary

Realizes the `ksp_solve` / `krylov_step` / `preconditioning-framework` L4 surfaces of the operator tracker (#5) — the iterative-solve corner of `ksp_solve` complementing the existing direct sparse LU. `driven_solve_iterative` is the new switchable entry point.

- **`crates/geode-core/src/ksp_solve.rs`** — new module:
  - `KspSolve` trait paralleling the LU "solve at ω" boundary.
  - `Cocg` — **Conjugate Orthogonal Conjugate Gradient** for the complex-symmetric pencil `A^T = A` (the driven invariant from PR #55); bilinear `u^T v` Krylov inner product, configurable `tol` / `max_iters` / `breakdown_tol`.
  - `Preconditioner` trait with `IdentityPreconditioner` (baseline) and `JacobiPreconditioner` (cached `1/diag(A)`).
  - `KspReport` returns iteration count + final relative residual.
- **`crates/geode-core/src/driven.rs`** — integration:
  - Factored `factor_at` into `assemble_a_at` / `assemble_b_at` / `scatter_to_full` helpers so direct and iterative paths see bit-for-bit the same `A(ω)` and `b(ω)`.
  - `DrivenOperator::solve_at_iterative(omega, ksp, precond_factory)` — operator-level entry point; the caller picks KSP solver and preconditioner.
  - `driven_solve_iterative` — free function paralleling `driven_solve`, defaults to COCG + Jacobi, returns `(DrivenSolution, KspReport)`.

## Acceptance criteria (issue #238)

- [x] `KspSolve` / iterative path **selectable in driven solve** (`driven_solve_iterative` + `DrivenOperator::solve_at_iterative`).
- [x] Complex-symmetric Krylov solver (`Cocg`) + at least one preconditioner (`JacobiPreconditioner`, `IdentityPreconditioner`).
- [x] Iterative-vs-direct agreement within documented tolerance — `iterative_matches_direct_lu`: cube cavity 3³, **rel_diff = 2.3e-12 vs LU**, COCG converges in **66 iters**, residual 8.4e-13.
- [x] Iteration-count / convergence reporting via `KspReport { iters, residual_rel, converged }`.
- [x] Works on the patch benchmark fixture as a heavy `#[ignore]`d test (`iterative_patch_benchmark`): **4616 interior DOFs, COCG 2238 iters, rel_diff = 1.6e-9 vs LU**, COCG 0.73s vs LU 0.63s (release).
- [x] Tests pass; clippy/fmt clean.

## Numerical results

| Fixture | n_interior | COCG iters | residual_rel | rel_diff vs LU | LU sec | COCG sec |
|---|---|---|---|---|---|---|
| cube 3³ (debug) | 93 | 66 | 8.4e-13 | 2.3e-12 | — | — |
| cube 2³ identity (debug) | small | 5 | 4.7e-16 | <1e-8 | — | — |
| patch smoke (release) | 4616 | 2238 | 6.9e-9 | 1.6e-9 | 0.63 | 0.73 |

LU and COCG are roughly tied at ~5 k DOFs on the patch fixture; COCG scales linearly in nnz vs LU's super-linear fill-in, so the iterative path wins at larger sizes — which was the binding constraint #238 calls out.

## Test plan

- [x] `cargo test -p geode-core --lib ksp_solve` — 7 unit tests (real-SPD CG recovery, complex-symmetric lossy solve, Jacobi correctness, zero-RHS, budget exhaustion, breakdown detection).
- [x] `cargo test -p geode-core --lib driven::` — 12 tests including 3 new iterative regressions.
- [x] `cargo test -p geode-core --release --lib iterative_patch_benchmark -- --ignored --nocapture` — heavy fixture, reports iteration counts + speed comparison.
- [x] `cargo clippy -p geode-core --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Notes / pre-existing failure

`waveguide_modes::tests::rect_waveguide_te10_matches_analytic` fails on this branch — and on `origin/main` — due to an `attempt to subtract with overflow` inside `faer-0.24.0/src/linalg/gevd/qz_real/mod.rs:2287`. Pre-existing; not touched by this PR.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)