### PR TITLE
fix: faer-0.24 QZ overflow panic in rect_waveguide_modes (debug profile)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Faer 0.24's `gevd::qz_real` performs intentional wrap-around
+# subtractions; with rustc's default behavior they panic under
+# overflow checks. Cargo's `[profile.<n>.package."*"]` override does
+# not reliably emit `-C overflow-checks=off` (verified on cargo 1.96)
+# so we set RUSTFLAGS for every build instead. Release already
+# disables overflow checks by default; this makes `cargo test`
+# (default debug profile) work without an explicit `--release`.
+[build]
+rustflags = ["-C", "overflow-checks=off"]

--- a/.github/workflows/rect-waveguide-modes-debug.yml
+++ b/.github/workflows/rect-waveguide-modes-debug.yml
@@ -1,0 +1,92 @@
+name: rect-waveguide-modes (debug profile)
+
+# Issue #244 — debug-profile CI lane for the rectangular-waveguide
+# modal eigensolver tests.
+#
+# Why this exists separately from the (release-only) `arpack.yml`:
+# faer 0.24's `gevd::qz_real` performs subtractions that legitimately
+# wrap during the QZ iteration. Under the default `cargo test` (debug
+# profile, overflow checks on) those wraps panic with
+# `attempt to subtract with overflow`, even though the release-build
+# math is correct. The workspace ships a `.cargo/config.toml` with
+# `rustflags = ["-C", "overflow-checks=off"]` to mask the panic, and
+# this CI lane is the regression guard: if anyone (a contributor, a
+# Doctor cycle, or a faer bump) breaks the workaround we want CI to
+# fail loudly on the next push instead of waiting for a workstation
+# `cargo test` run to trip.
+#
+# The runner is headless ubuntu-latest, so we drop the default `wgpu`
+# backend (no Vulkan adapter on CI) and run the `ndarray` CPU backend
+# instead. The eigensolver only touches `faer::MatRef<f64>` data, so
+# the backend choice is irrelevant to the assertion we want to make.
+# No `--release` — that is the whole point: this lane exists to catch
+# the faer overflow regression in the default debug profile that
+# `arpack.yml` and the release-only workflows mask.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/geode-core/src/waveguide_modes.rs'
+      - 'crates/geode-core/src/eigen.rs'
+      - 'crates/geode-core/src/nedelec_assembly.rs'
+      - 'crates/geode-core/src/mesh/**'
+      - 'crates/geode-core/tests/rect_waveguide_modes.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/config.toml'
+      - '.github/workflows/rect-waveguide-modes-debug.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/geode-core/src/waveguide_modes.rs'
+      - 'crates/geode-core/src/eigen.rs'
+      - 'crates/geode-core/src/nedelec_assembly.rs'
+      - 'crates/geode-core/src/mesh/**'
+      - 'crates/geode-core/tests/rect_waveguide_modes.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/config.toml'
+      - '.github/workflows/rect-waveguide-modes-debug.yml'
+  workflow_dispatch: {}
+
+jobs:
+  rect-waveguide-modes-debug:
+    name: cargo test rect_waveguide_modes (debug, ndarray)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: short
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-rect-waveguide-debug-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Print toolchain info
+        run: |
+          uname -a
+          rustc --version
+          cargo --version
+          echo "Workspace .cargo/config.toml:"
+          cat .cargo/config.toml || echo "(no .cargo/config.toml)"
+
+      # Default cargo test — debug profile, no --release. The
+      # `.cargo/config.toml` rustflags must keep this green; if it
+      # panics inside faer's `qz_real`, the workaround has regressed
+      # and either faer needs a new pin or the rustflags need to
+      # propagate to the GA runner the same way they do locally.
+      - name: cargo test -p geode-core --test rect_waveguide_modes (debug)
+        run: |
+          cargo test --no-default-features --features geode-core/ndarray \
+            -p geode-core --test rect_waveguide_modes \
+            -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,12 @@ codegen-units = 1
 # `debug-assertions = false` + `overflow-checks = false` are required for
 # faer 0.24: its `gevd::qz_real` performs subtractions that legitimately
 # wrap under debug-assertions, producing `attempt to subtract with
-# overflow` panics even though the release math is correct. Caught by
-# the PR #19 judge round.
+# overflow` panics even though the release math is correct. The
+# `[profile.<n>.package."*"]` block alone is not enough to suppress the
+# overflow panic in faer under cargo 1.96 (cargo does not reliably emit
+# `-C overflow-checks=off` for the override pattern; see
+# `.cargo/config.toml` for the workspace-wide RUSTFLAGS fallback that
+# actually disables the check). Issue #244.
 [profile.dev.package."*"]
 opt-level = 3
 debug = false

--- a/crates/geode-core/tests/rect_waveguide_modes.rs
+++ b/crates/geode-core/tests/rect_waveguide_modes.rs
@@ -27,13 +27,17 @@
 //! Running:
 //!
 //! ```sh
-//! cargo test -p geode-core --release --test rect_waveguide_modes
+//! cargo test -p geode-core --test rect_waveguide_modes
 //! ```
 //!
-//! (Same `--release` recipe as the sphere PEC eigenmode test — faer
-//! 0.24's `gevd::qz_real` panics under `debug-assertions`, so the
-//! workspace `[profile.test.package.faer]` override + release profile is
-//! the supported invocation.)
+//! Both the default debug profile and `--release` are supported. faer
+//! 0.24's `gevd::qz_real` performs subtractions that legitimately wrap
+//! during the QZ iteration and would panic with `attempt to subtract
+//! with overflow` under rustc's default overflow checks; the
+//! workspace `.cargo/config.toml` masks this with
+//! `rustflags = ["-C", "overflow-checks=off"]` so the default
+//! `cargo test` invocation works on both contributor workstations and
+//! CI. See issue #244 for details.
 
 use geode_core::{
     apply_pec_2d, assemble_2d_nedelec, rect_pec_interior_edges, rect_pec_interior_nodes,


### PR DESCRIPTION
## Summary

Fixes #244 — `cargo test -p geode-core --test rect_waveguide_modes` panicked under the default debug profile inside `faer-0.24.0/src/linalg/gevd/qz_real/mod.rs:2287` (`attempt to subtract with overflow`). Release tests were green because release builds disable overflow checks; the QZ kernel intentionally wraps, but rustc's default overflow check turns the wrap into a panic.

## Fix path taken

**Workspace `.cargo/config.toml` with `rustflags = ["-C", "overflow-checks=off"]`** — a Path-2 holding pattern.

Triage of the three priority paths from the issue:

| Path | Verdict |
|------|---------|
| 1. Faer upgrade | Not available: 0.24.0 is already the latest on crates.io (2026-01-26). The next release down is 0.23.2 (2025-09-23). |
| 2. Faer pin to 0.23.x | Loses ~3 months of upstream fixes for one wrap-overflow assertion. Workspace-level rustflags is the lighter-touch holding pattern with the same effect. |
| 3. Switch to Arpack sparse path | Out of scope. Would pivot the Phase-1 dense-faer methodology that landed in PR #240 ~24h ago. Documented as a future option in the issue comment if faer 0.25 still has the bug. |

### Why this works and the existing `[profile.test.package."*"]` override didn't

The pre-existing `[profile.test.package."*"]` block in `Cargo.toml` already set `overflow-checks = false`, but **cargo 1.96 does not in fact emit `-C overflow-checks=off`** for that override pattern — verified by inspecting the rustc invocation, which contains only `-C opt-level=3`. Without the flag, rustc's compiled-in default panics on overflow. `RUSTFLAGS`-based `.cargo/config.toml` is the only mechanism that reliably propagates the flag to all dependency builds (including faer) on stable cargo.

## Before / after numbers

Identical between debug (with the rustflags workaround) and `--release` — confirming the prior release "pass" was correct math, not wrap-luck:

```
TE10  0.05%   (vs analytic π/a)
TE20  0.22%
TE01  0.21%
TM11  0.01%
```

Same accuracy band as the documented Phase-1 numbers in #235 (0.01% - 0.22%).

## Changes

- **`.cargo/config.toml`** (new): `rustflags = ["-C", "overflow-checks=off"]` workspace-wide. Release builds already disable overflow checks, so this is a no-op for them.
- **`Cargo.toml`**: comment update on `[profile.<n>.package."*"]` documenting why the override alone is insufficient and pointing at the rustflags fallback. Links #244.
- **`crates/geode-core/tests/rect_waveguide_modes.rs`**: module doc-comment drops the `--release`-only invocation and documents the new debug-profile path.
- **`.github/workflows/rect-waveguide-modes-debug.yml`** (new): CI lane that runs the rect_waveguide_modes tests in the default debug profile on `ubuntu-latest` with the `ndarray` CPU backend. This is the regression guard the issue's acceptance criteria asked for — if anyone (Doctor cycle, faer bump, profile refactor) breaks the workaround, this workflow fails on the next push instead of waiting for a workstation `cargo test`.

## Test plan

- [x] `cargo test -p geode-core --test rect_waveguide_modes` (default debug profile, wgpu backend) — 5/5 pass
- [x] `cargo test --no-default-features --features geode-core/ndarray -p geode-core --test rect_waveguide_modes` (CI invocation, ndarray backend) — 5/5 pass
- [x] `cargo test --no-default-features --features geode-core/ndarray -p geode-core --release --test rect_waveguide_modes` — 5/5 pass with the same numbers
- [x] `cargo clippy --tests -p geode-core --no-default-features --features ndarray -- -D warnings` — clean
- [ ] New `rect-waveguide-modes-debug.yml` workflow turns green on this PR (CI is the test)

## Notes

- The rustflags change applies globally to every build (cargo build / test / check, debug and release). Release builds already disabled overflow checks, so this is observably a no-op there. For debug builds of our own crates this does lose overflow-check coverage as a defensive-programming tool — that is the documented trade-off for keeping `cargo test` working without `--release`. A future cargo release (or a faer 0.25 with the QZ wrap fixed) should let us narrow the scope.
- Upstream faer 0.24 line of interest: `faer-0.24.0/src/linalg/gevd/qz_real/mod.rs:2287` — `let nd = &ihi - &kwbot;` where the iteration legitimately allows `kwbot > ihi`.

Refs #244 (keep open as holding-pattern marker — revisit when faer 0.25 ships a QZ fix, or if a second overflow surfaces elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
