### PR TITLE
feat: true mesh height-step waveguide fixture + S-parameter validation (#248)

### DIFF
--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -137,8 +137,9 @@ pub use silvermuller_self_consistent::{
 };
 pub use sparse::{global_system_to_sparse, SparseError, SparseSystem};
 pub use wave_port::{
-    extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh, solve_wave_port_sweep,
-    waveguide_mode_reduce, ExtrudedWaveguideMesh, WavePort, WavePortSweepPoint,
+    extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
+    map_mode_profile_to_full_mesh, solve_wave_port_sweep, waveguide_mode_reduce,
+    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, WavePort, WavePortSweepPoint,
 };
 pub use waveguide_modes::{
     apply_pec_2d, assemble_2d_nedelec, rect_pec_interior_edges, rect_pec_interior_nodes,

--- a/crates/geode-core/src/wave_port.rs
+++ b/crates/geode-core/src/wave_port.rs
@@ -781,6 +781,292 @@ impl ExtrudedWaveguideMesh {
     }
 }
 
+// =====================================================================
+// Programmatic 3-D height-step waveguide fixture (issue #248)
+// =====================================================================
+
+/// Generate a tetrahedralized **height-step** rectangular waveguide:
+/// section A `[0,a] × [0,b1] × [0,L1]` joined at `z = L1` to section B
+/// `[0,a] × [0,b2] × [L1, L1 + L2]`. The two sections share the bottom
+/// wall `y = 0` and the side walls `x ∈ {0, a}`; section B has
+/// `b2 < b1`, so at `z = L1` the annular strip `y ∈ [b2, b1]` becomes a
+/// new PEC backwall (the "step face"). Section A's top wall `y = b1`
+/// and section B's top wall `y = b2` are PEC. Wave ports live on the
+/// end faces `z = 0` (cross-section `a × b1`) and `z = L1 + L2`
+/// (cross-section `a × b2`).
+///
+/// To keep the two sub-meshes node-conforming at the interface
+/// `z = L1`, both halves share the **same horizontal discretization**:
+/// `nx` cells across `[0, a]` and a single `hy` chosen so that `b1` and
+/// `b2` are both integer multiples of `hy`. The caller passes
+/// `(nx, ny1, ny2)` with the implicit invariant `b1 * ny2 == b2 * ny1`
+/// (the same `hy = b1/ny1 = b2/ny2`); the function asserts this. The
+/// `(nz1, nz2)` cell counts control the z resolution of each half
+/// independently.
+///
+/// The cross-section of port 1 at `z = 0` is the 2-D mesh produced by
+/// `rect_tri_mesh(nx, ny1, a, b1)`; the cross-section of port 2 at
+/// `z = L1 + L2` is the 2-D mesh produced by
+/// `rect_tri_mesh(nx, ny2, a, b2)`. This matches the assumption in the
+/// wave-port BC machinery: per-port modal solves run independently on
+/// each port's own 2-D mesh (different `b` → different modal basis),
+/// and [`map_mode_profile_to_full_mesh`] stitches each profile into the
+/// 3-D edge table by node-tag matching against this fixture's nodes.
+///
+/// # Panics
+///
+/// - if `nx, ny1, ny2, nz1, nz2 < 1`,
+/// - if `b1 * ny2 != b2 * ny1` (the implicit `hy` invariant).
+#[allow(clippy::too_many_arguments)]
+pub fn extruded_height_step_waveguide_mesh(
+    nx: usize,
+    ny1: usize,
+    ny2: usize,
+    nz1: usize,
+    nz2: usize,
+    a: f64,
+    b1: f64,
+    b2: f64,
+    l1: f64,
+    l2: f64,
+) -> ExtrudedHeightStepMesh {
+    assert!(
+        nx >= 1 && ny1 >= 1 && ny2 >= 1 && nz1 >= 1 && nz2 >= 1,
+        "height-step waveguide requires nx, ny1, ny2, nz1, nz2 ≥ 1"
+    );
+    // Shared hy invariant.
+    let hy_a = b1 / ny1 as f64;
+    let hy_b = b2 / ny2 as f64;
+    assert!(
+        (hy_a - hy_b).abs() < 1e-12 * hy_a.max(hy_b).max(1.0),
+        "height-step waveguide needs b1/ny1 == b2/ny2 (b1={b1}, ny1={ny1}, b2={b2}, ny2={ny2})"
+    );
+    assert!(
+        ny2 <= ny1,
+        "height-step waveguide expects the smaller section B (ny2 ≤ ny1); got ny1={ny1}, ny2={ny2}"
+    );
+
+    use std::collections::BTreeMap;
+    let npx = nx + 1;
+    let npy_a = ny1 + 1;
+    let npy_b = ny2 + 1;
+    let npz_a = nz1 + 1;
+    let npz_b = nz2 + 1;
+    let hx = a / nx as f64;
+    let hy = hy_a;
+    let hz_a = l1 / nz1 as f64;
+    let hz_b = l2 / nz2 as f64;
+
+    // --- Section A nodes: full lattice [0..npx] × [0..npy_a] × [0..npz_a]
+    // indexed lex-order (i, j, k) → i + j*npx + k*npx*npy_a.
+    let n_a = npx * npy_a * npz_a;
+    let node_a = |i: usize, j: usize, k: usize| -> u32 { (i + j * npx + k * npx * npy_a) as u32 };
+
+    // --- Section B nodes live in a separate index range. Their k=0
+    // slice (z = L1) must reuse section A's k=nz1 nodes for j ∈ [0, ny2]
+    // — same (x, y) coordinates. We do this by *not allocating* new
+    // nodes for B's k=0 layer; we'll point B's k=0 indices at A's
+    // k=nz1, j∈[0,ny2] nodes through a translation table.
+    let b_layer_size = npx * npy_b;
+    let n_b_new = b_layer_size * nz2; // layers k = 1..=nz2 are new
+    let node_b = |i: usize, j: usize, k: usize| -> u32 {
+        // k = 0: alias into section A at k = nz1, j ∈ [0, ny2].
+        if k == 0 {
+            node_a(i, j, nz1)
+        } else {
+            (n_a + i + j * npx + (k - 1) * b_layer_size) as u32
+        }
+    };
+
+    let mut nodes = Vec::with_capacity(n_a + n_b_new);
+    for k in 0..npz_a {
+        for j in 0..npy_a {
+            for i in 0..npx {
+                nodes.push([i as f64 * hx, j as f64 * hy, k as f64 * hz_a]);
+            }
+        }
+    }
+    for k in 1..npz_b {
+        for j in 0..npy_b {
+            for i in 0..npx {
+                nodes.push([i as f64 * hx, j as f64 * hy, l1 + k as f64 * hz_b]);
+            }
+        }
+    }
+    debug_assert_eq!(nodes.len(), n_a + n_b_new);
+
+    // --- Section A tets (same 6-tet split as extruded_rect_waveguide_mesh).
+    let mut tets = Vec::with_capacity(6 * nx * ny1 * nz1 + 6 * nx * ny2 * nz2);
+    for k in 0..nz1 {
+        for j in 0..ny1 {
+            for i in 0..nx {
+                let c = [
+                    node_a(i, j, k),
+                    node_a(i + 1, j, k),
+                    node_a(i + 1, j + 1, k),
+                    node_a(i, j + 1, k),
+                    node_a(i, j, k + 1),
+                    node_a(i + 1, j, k + 1),
+                    node_a(i + 1, j + 1, k + 1),
+                    node_a(i, j + 1, k + 1),
+                ];
+                tets.push([c[0], c[1], c[2], c[6]]);
+                tets.push([c[0], c[2], c[3], c[6]]);
+                tets.push([c[0], c[3], c[7], c[6]]);
+                tets.push([c[0], c[7], c[4], c[6]]);
+                tets.push([c[0], c[4], c[5], c[6]]);
+                tets.push([c[0], c[5], c[1], c[6]]);
+            }
+        }
+    }
+    // --- Section B tets.
+    for k in 0..nz2 {
+        for j in 0..ny2 {
+            for i in 0..nx {
+                let c = [
+                    node_b(i, j, k),
+                    node_b(i + 1, j, k),
+                    node_b(i + 1, j + 1, k),
+                    node_b(i, j + 1, k),
+                    node_b(i, j, k + 1),
+                    node_b(i + 1, j, k + 1),
+                    node_b(i + 1, j + 1, k + 1),
+                    node_b(i, j + 1, k + 1),
+                ];
+                tets.push([c[0], c[1], c[2], c[6]]);
+                tets.push([c[0], c[2], c[3], c[6]]);
+                tets.push([c[0], c[3], c[7], c[6]]);
+                tets.push([c[0], c[7], c[4], c[6]]);
+                tets.push([c[0], c[4], c[5], c[6]]);
+                tets.push([c[0], c[5], c[1], c[6]]);
+            }
+        }
+    }
+
+    let mesh = TetMesh {
+        nodes,
+        tets,
+        physical_groups: BTreeMap::new(),
+    };
+
+    // --- Port 1 face triangles (z = 0, full section A cross-section).
+    let mut port1_faces: Vec<[u32; 3]> = Vec::with_capacity(2 * nx * ny1);
+    for j in 0..ny1 {
+        for i in 0..nx {
+            let c00 = node_a(i, j, 0);
+            let c10 = node_a(i + 1, j, 0);
+            let c11 = node_a(i + 1, j + 1, 0);
+            let c01 = node_a(i, j + 1, 0);
+            port1_faces.push([c00, c10, c11]);
+            port1_faces.push([c00, c11, c01]);
+        }
+    }
+    // --- Port 2 face triangles (z = L1 + L2, section B cross-section).
+    let mut port2_faces: Vec<[u32; 3]> = Vec::with_capacity(2 * nx * ny2);
+    for j in 0..ny2 {
+        for i in 0..nx {
+            let c00 = node_b(i, j, nz2);
+            let c10 = node_b(i + 1, j, nz2);
+            let c11 = node_b(i + 1, j + 1, nz2);
+            let c01 = node_b(i, j + 1, nz2);
+            port2_faces.push([c00, c10, c11]);
+            port2_faces.push([c00, c11, c01]);
+        }
+    }
+
+    // --- Sidewall PEC faces. Walk every tet face; a face is a PEC
+    // sidewall iff all three vertices share one of:
+    //   (1) `x = 0` plane,
+    //   (2) `x = a` plane,
+    //   (3) `y = 0` plane (shared floor),
+    //   (4) section A top: `y = b1` AND `z ∈ [0, L1]`,
+    //   (5) section B top: `y = b2` AND `z ∈ [L1, L1 + L2]`,
+    //   (6) **the step backwall**: `z = L1` AND `y ∈ [b2, b1]` (i.e.
+    //       the annular face that closes the volume where section B
+    //       narrowed).
+    // We exclude the two port planes (handled separately as wave ports).
+    let tol_xyz = 1e-9 * a.max(b1.max(b2)).max(l1.max(l2)).max(1.0);
+    let mut sidewall_faces: Vec<[u32; 3]> = Vec::new();
+    for tet in &mesh.tets {
+        let coords: [[f64; 3]; 4] = std::array::from_fn(|v| mesh.nodes[tet[v] as usize]);
+        for lf in &crate::mesh::TET_LOCAL_FACES {
+            let tri_pts = [coords[lf[0]], coords[lf[1]], coords[lf[2]]];
+            // Exclude port planes.
+            let on_port1 = tri_pts.iter().all(|p| p[2].abs() < tol_xyz);
+            let on_port2 = tri_pts.iter().all(|p| (p[2] - (l1 + l2)).abs() < tol_xyz);
+            if on_port1 || on_port2 {
+                continue;
+            }
+            let same_x0 = tri_pts.iter().all(|p| p[0].abs() < tol_xyz);
+            let same_xa = tri_pts.iter().all(|p| (p[0] - a).abs() < tol_xyz);
+            let same_y0 = tri_pts.iter().all(|p| p[1].abs() < tol_xyz);
+            // Section A top: y = b1 AND z ∈ [0, L1].
+            let on_a_top = tri_pts
+                .iter()
+                .all(|p| (p[1] - b1).abs() < tol_xyz && p[2] <= l1 + tol_xyz);
+            // Section B top: y = b2 AND z ∈ [L1, L1 + L2].
+            let on_b_top = tri_pts
+                .iter()
+                .all(|p| (p[1] - b2).abs() < tol_xyz && p[2] >= l1 - tol_xyz);
+            // Step backwall: z = L1 AND y ∈ [b2, b1].
+            let on_step = tri_pts.iter().all(|p| {
+                (p[2] - l1).abs() < tol_xyz && p[1] >= b2 - tol_xyz && p[1] <= b1 + tol_xyz
+            });
+            if same_x0 || same_xa || same_y0 || on_a_top || on_b_top || on_step {
+                let tri = [tet[lf[0]], tet[lf[1]], tet[lf[2]]];
+                sidewall_faces.push(tri);
+            }
+        }
+    }
+
+    ExtrudedHeightStepMesh {
+        mesh,
+        port1_faces,
+        port2_faces,
+        sidewall_faces,
+        a,
+        b1,
+        b2,
+        l1,
+        l2,
+    }
+}
+
+/// Output of [`extruded_height_step_waveguide_mesh`]: the volume mesh
+/// plus the boundary face lists needed to build the two wave-port BCs
+/// (different cross-sections) and the PEC elimination over the combined
+/// sidewall + step-backwall surface.
+#[derive(Debug, Clone)]
+pub struct ExtrudedHeightStepMesh {
+    pub mesh: TetMesh,
+    /// Port-1 face triangles on `z = 0`, section A cross-section
+    /// `a × b1`.
+    pub port1_faces: Vec<[u32; 3]>,
+    /// Port-2 face triangles on `z = L1 + L2`, section B cross-section
+    /// `a × b2`.
+    pub port2_faces: Vec<[u32; 3]>,
+    /// PEC face triangles on the four side walls + section A top
+    /// (`y = b1`, `z ∈ [0, L1]`) + section B top (`y = b2`,
+    /// `z ∈ [L1, L1 + L2]`) + step backwall (`z = L1`, `y ∈ [b2, b1]`).
+    pub sidewall_faces: Vec<[u32; 3]>,
+    pub a: f64,
+    pub b1: f64,
+    pub b2: f64,
+    pub l1: f64,
+    pub l2: f64,
+}
+
+impl ExtrudedHeightStepMesh {
+    /// PEC interior-edge mask: edges are kept (interior) unless they
+    /// lie on a sidewall / step backwall — port-face edges are kept
+    /// (the wave port substitutes for the PEC there). Same contract as
+    /// [`ExtrudedWaveguideMesh::pec_interior_mask`].
+    pub fn pec_interior_mask(&self) -> Vec<bool> {
+        let edges = self.mesh.edges();
+        crate::mesh::pec_interior_mask_from_triangles(&edges, &[self.sidewall_faces.as_slice()])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -868,5 +1154,74 @@ mod tests {
     fn trimesh_2d_smoke() {
         let m: TriMesh = rect_tri_mesh(2, 2, 1.0, 1.0);
         assert_eq!(m.n_tris(), 8);
+    }
+
+    #[test]
+    fn height_step_mesh_node_and_tet_counts() {
+        // a × b1 × L1 joined to a × b2 × L2, with shared hy.
+        // b1 = 1.0, ny1 = 4 → hy = 0.25; b2 = 0.5, ny2 = 2 → hy = 0.25.
+        let (nx, ny1, ny2, nz1, nz2) = (4, 4, 2, 3, 3);
+        let (a, b1, b2, l1, l2) = (2.0, 1.0, 0.5, 1.0, 1.0);
+        let g = extruded_height_step_waveguide_mesh(nx, ny1, ny2, nz1, nz2, a, b1, b2, l1, l2);
+        // Section A: (nx+1)(ny1+1)(nz1+1) nodes; section B contributes
+        // (nx+1)(ny2+1)(nz2) NEW nodes (k=0 layer is aliased).
+        let expected_nodes = (nx + 1) * (ny1 + 1) * (nz1 + 1) + (nx + 1) * (ny2 + 1) * nz2;
+        assert_eq!(g.mesh.n_nodes(), expected_nodes);
+        // Tets: 6 per hex × hex count per section.
+        let expected_tets = 6 * (nx * ny1 * nz1 + nx * ny2 * nz2);
+        assert_eq!(g.mesh.n_tets(), expected_tets);
+        assert_eq!(g.port1_faces.len(), 2 * nx * ny1);
+        assert_eq!(g.port2_faces.len(), 2 * nx * ny2);
+    }
+
+    #[test]
+    fn height_step_mesh_interface_is_node_conforming() {
+        // The shared interface at z = L1 should have section A's
+        // bottom-portion nodes (j ∈ [0, ny2]) re-used as section B's
+        // k = 0 nodes (same node index, same coords). We verify by
+        // checking that any face at z = L1 with y ∈ [0, b2] is referenced
+        // by both section A and section B tets and is NOT a sidewall.
+        let (nx, ny1, ny2, nz1, nz2) = (4, 4, 2, 2, 2);
+        let (a, b1, b2, l1, l2) = (2.0, 1.0, 0.5, 0.8, 0.6);
+        let g = extruded_height_step_waveguide_mesh(nx, ny1, ny2, nz1, nz2, a, b1, b2, l1, l2);
+        let tol = 1e-9;
+        // The step backwall (z = L1, y ∈ [b2, b1]) should be PEC.
+        // Count: it has nx cells across x and (ny1 - ny2) cells across
+        // y → 2 triangles per quad.
+        let expected_step_tris = 2 * nx * (ny1 - ny2);
+        let mut step_count = 0;
+        for tri in &g.sidewall_faces {
+            let pts = [
+                g.mesh.nodes[tri[0] as usize],
+                g.mesh.nodes[tri[1] as usize],
+                g.mesh.nodes[tri[2] as usize],
+            ];
+            let on_step = pts
+                .iter()
+                .all(|p| (p[2] - l1).abs() < tol && p[1] >= b2 - tol && p[1] <= b1 + tol);
+            if on_step {
+                step_count += 1;
+            }
+        }
+        assert_eq!(
+            step_count, expected_step_tris,
+            "step backwall: expected {expected_step_tris} triangles, got {step_count}"
+        );
+        // No sidewall face on the open interface z = L1, y ∈ [0, b2].
+        for tri in &g.sidewall_faces {
+            let pts = [
+                g.mesh.nodes[tri[0] as usize],
+                g.mesh.nodes[tri[1] as usize],
+                g.mesh.nodes[tri[2] as usize],
+            ];
+            let on_open = pts
+                .iter()
+                .all(|p| (p[2] - l1).abs() < tol && p[1] <= b2 - tol);
+            assert!(
+                !on_open,
+                "open interface face wrongly tagged as PEC: {:?}",
+                pts
+            );
+        }
     }
 }

--- a/crates/geode-core/tests/wave_port.rs
+++ b/crates/geode-core/tests/wave_port.rs
@@ -35,9 +35,9 @@
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
-    extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh,
-    solve_rect_waveguide_modes_with_vectors, solve_wave_port_sweep, DefaultBackend, DrivenBcs,
-    DrivenMaterials, TetMesh, WavePort,
+    extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
+    map_mode_profile_to_full_mesh, solve_rect_waveguide_modes_with_vectors, solve_wave_port_sweep,
+    DefaultBackend, DrivenBcs, DrivenMaterials, TetMesh, WavePort,
 };
 
 type B = DefaultBackend;
@@ -385,5 +385,269 @@ fn height_step_discontinuity_produces_nontrivial_s11() {
         recip_err < 0.15,
         "reciprocity violated for iris: |S21 − S12|/|S21| = {:.3}",
         recip_err
+    );
+}
+
+/// **True mesh height-step discontinuity** (issue #248): two waveguide
+/// sections of different cross-sections, joined at `z = L1`. Section A
+/// is `a × b1 × L1` (port 1 at `z = 0`); section B is `a × b2 × L2`
+/// (port 2 at `z = L1 + L2`), with `b2 < b1` and a shared bottom wall
+/// at `y = 0`. The annular strip `z = L1, y ∈ [b2, b1]` is the PEC
+/// step backwall (the natural discontinuity).
+///
+/// Each port runs its own 2-D modal solve over its own `(nx, ny)`
+/// cross-section mesh (`rect_tri_mesh(nx, ny1, a, b1)` for port 1,
+/// `rect_tri_mesh(nx, ny2, a, b2)` for port 2) — the per-port modal
+/// bases are different. The wave-port machinery from PR #245 handles
+/// independent per-port modes already (one mode per port, SMW rank
+/// equal to the port count), so the validation here is end-to-end with
+/// the existing single-mode infrastructure.
+///
+/// # Operating frequency
+///
+/// Section A's `TE₁₀` cutoff is `π/a` and `TE₂₀` cutoff is `2π/a`.
+/// Section B has the same `a`, so the same TE_n0 cutoffs in `x`. The
+/// next family is `TE_{m,n}` with `n ≥ 1`: section A's `TE₀₁` cutoff
+/// is `π/b1`, section B's is `π/b2`. With `b1 = 1.0, b2 = 0.5,
+/// a = 2.0`:
+/// - `TE₁₀ (A) = TE₁₀ (B) = π/2 ≈ 1.5708`,
+/// - `TE₂₀ (A) = TE₂₀ (B) = π ≈ 3.1416`,
+/// - `TE₀₁ (A) = π ≈ 3.1416`,
+/// - `TE₀₁ (B) = 2π ≈ 6.2832`.
+///
+/// Pick `ω = 2.4` (above `TE₁₀` for both, below the next mode on
+/// either section), so single-mode wave ports on each end face capture
+/// the propagating physics. The dominant-mode TE₁₀ profile is the same
+/// transverse shape (∝ sin(πx/a)) on both sections, only the
+/// `b`-integral changes.
+///
+/// # Validation
+///
+/// **Single-mode self-consistency** (the issue lists this as an
+/// acceptable bar when no external oracle is available for this
+/// fixture):
+/// - Energy conservation: `|S₁₁|² + |S₂₁|² ≈ 1` (PEC walls, lossless
+///   vacuum, propagating modes only).
+/// - Reciprocity: `|S₁₂ − S₂₁| ≪ |S₂₁|`.
+/// - Non-trivial reflection: `|S₁₁|` well above the matched-section
+///   floor — the height step from `b1 = 1.0` to `b2 = 0.5` reflects a
+///   substantial fraction of the TE₁₀ mode (modal impedance ratio
+///   `Z_TE(A)/Z_TE(B) = b1/b2 = 2`, by transmission-line analogy a
+///   thin-junction reflection of order `|S₁₁| ≈ |Γ| = |(Z_B − Z_A) /
+///   (Z_B + Z_A)| = 1/3` to leading order; the FEM result includes
+///   finite-section coupling that shifts this).
+///
+/// External-oracle note: a rigorous mode-matching reference (e.g.
+/// Pozar §3.10) requires more than one mode per port — section A's
+/// reflection couples to its `TE_{m,n}` family (in particular `TE₀₁`
+/// is evanescent at ω = 2.4 but contributes to the junction
+/// admittance). The single-mode wave-port path here ignores those
+/// evanescent contributions; the reported S-parameters are the
+/// single-mode projection. We file the analytic mode-matching cross-
+/// check as the natural follow-up to multi-mode wave-port support
+/// (#250).
+#[allow(clippy::too_many_arguments)]
+fn build_te10_port_step(
+    mesh: &TetMesh,
+    faces_3d: &[[u32; 3]],
+    a: f64,
+    b_port: f64,
+    nx: usize,
+    ny_port: usize,
+    z_plane: f64,
+    a_inc: c64,
+) -> WavePort {
+    use geode_core::rect_tri_mesh;
+    let port_mesh = rect_tri_mesh(nx, ny_port, a, b_port);
+
+    let tol = 1e-9 * a.max(b_port).max(1.0);
+    let three_d_idx_of = |x: f64, y: f64| -> u32 {
+        mesh.nodes
+            .iter()
+            .position(|p| {
+                (p[0] - x).abs() < tol && (p[1] - y).abs() < tol && (p[2] - z_plane).abs() < tol
+            })
+            .expect("port-face node not found in 3-D step mesh") as u32
+    };
+    let n2d_to_n3d: Vec<u32> = port_mesh
+        .nodes
+        .iter()
+        .map(|p| three_d_idx_of(p[0], p[1]))
+        .collect();
+
+    let edges_2d = port_mesh.edges();
+    let edges_2d_relabeled: Vec<[u32; 2]> = edges_2d
+        .iter()
+        .map(|e| {
+            let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
+            if a3 < b3 {
+                [a3, b3]
+            } else {
+                [b3, a3]
+            }
+        })
+        .collect();
+
+    // 2-D modal solve for this port's cross-section. Different `b`
+    // → different modal basis (different k_c — but only the b-dependent
+    // family; the dominant TE₁₀ has k_c = π/a for both ports).
+    let modes = solve_rect_waveguide_modes_with_vectors(&port_mesh, a, b_port, 1)
+        .expect("2-D modal solve (port)");
+    let m = &modes[0];
+    let mode_2d = m.e_edges.clone();
+
+    let edges_3d = mesh.edges();
+    let mode_3d = map_mode_profile_to_full_mesh(&edges_2d_relabeled, &mode_2d, &edges_3d);
+
+    WavePort {
+        faces: faces_3d.to_vec(),
+        mode: mode_3d,
+        k_c: m.k_c,
+        a_inc,
+    }
+}
+
+#[test]
+#[ignore = "heavy: true mesh height-step waveguide; cargo test --release --features ndarray --no-default-features --test wave_port -- --ignored height_step_true"]
+fn height_step_true_mesh_discontinuity_self_consistent() {
+    // a × b1 × L1   joined at z = L1 to   a × b2 × L2.
+    // Shared hy = b1/ny1 = b2/ny2 = 0.25.
+    let (a, b1, b2, l1, l2) = (2.0, 1.0, 0.5, 1.2, 1.0);
+    let (nx, ny1, ny2, nz1, nz2) = (8, 4, 2, 5, 4);
+
+    let g = extruded_height_step_waveguide_mesh(nx, ny1, ny2, nz1, nz2, a, b1, b2, l1, l2);
+    let pec_mask = g.pec_interior_mask();
+    let eps = vacuum(&g.mesh);
+
+    // ω = 2.4: above TE₁₀ cutoff π/a ≈ 1.5708, below the next mode
+    // cutoff on either section (see test docstring).
+    let omega = 2.4_f64;
+
+    let port1 = build_te10_port_step(
+        &g.mesh,
+        &g.port1_faces,
+        a,
+        b1,
+        nx,
+        ny1,
+        0.0,
+        c64::new(1.0, 0.0),
+    );
+    let port2 = build_te10_port_step(
+        &g.mesh,
+        &g.port2_faces,
+        a,
+        b2,
+        nx,
+        ny2,
+        l1 + l2,
+        c64::new(1.0, 0.0),
+    );
+
+    let bcs = DrivenBcs {
+        pec_interior_mask: &pec_mask,
+    };
+    let sweep = solve_wave_port_sweep::<B>(
+        &g.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[port1, port2],
+        &[omega],
+        &device(),
+    )
+    .expect("wave-port sweep on true height-step");
+
+    assert_eq!(sweep.len(), 1);
+    let pt = &sweep[0];
+    let s = &pt.s;
+    let s11 = s[0];
+    let s12 = s[1];
+    let s21 = s[2];
+    let s22 = s[3];
+    eprintln!("Height-step (a={a}, b1={b1}, b2={b2}, L1={l1}, L2={l2}, ω={omega}):");
+    eprintln!(
+        "  |S11| = {:.4}, |S21| = {:.4}, |S12| = {:.4}, |S22| = {:.4}",
+        s11.norm(),
+        s21.norm(),
+        s12.norm(),
+        s22.norm(),
+    );
+    eprintln!(
+        "  β₁ = {:.4} + {:.4}i,  β₂ = {:.4} + {:.4}i",
+        pt.beta[0].re, pt.beta[0].im, pt.beta[1].re, pt.beta[1].im,
+    );
+    eprintln!("  residual_rel = {:.3e}", pt.residual_rel);
+
+    // (1) Both per-port β are real and approximately equal (same
+    //     TE₁₀ k_c = π/a on both cross-sections; the b-discretization
+    //     does not affect the x-dependent dominant mode's β to leading
+    //     order). We don't compare to analytic β here — the modal solver
+    //     already includes its own discretization error documented in
+    //     the straight-section test.
+    assert!(
+        pt.beta[0].im.abs() < 1e-9 && pt.beta[1].im.abs() < 1e-9,
+        "expected propagating β (real), got β₁={:?}, β₂={:?}",
+        pt.beta[0],
+        pt.beta[1]
+    );
+    let beta_rel = (pt.beta[0].re - pt.beta[1].re).abs() / pt.beta[0].re;
+    assert!(
+        beta_rel < 0.05,
+        "TE₁₀ β should be equal on the two cross-sections (same k_c = π/a); got rel diff {beta_rel:.3e}"
+    );
+
+    // (2) Non-trivial reflection: |S₁₁| well above the matched-section
+    //     floor (~0.1 in the straight-section test). The height-step
+    //     reflection of a TE₁₀ mode includes a leading-order
+    //     transmission-line piece |Γ| = |(b2 − b1) / (b2 + b1)| = 1/3.
+    //     The FEM single-mode projection adds finite-section interference
+    //     plus discretization, so we set the lower bar at 0.15.
+    assert!(
+        s11.norm() > 0.15,
+        "height-step |S11| = {:.3} too small (expected > 0.15)",
+        s11.norm()
+    );
+
+    // (3) Reciprocity: |S₂₁ − S₁₂| ≪ |S₂₁|. The wave-port operator is
+    //     complex-symmetric so reciprocity is exact at the level of
+    //     modal projections, modulo solver tolerance.
+    let recip_err = (s21 - s12).norm() / s21.norm().max(1e-12);
+    eprintln!("  reciprocity err (S21 − S12)/|S21| = {:.3e}", recip_err);
+    assert!(
+        recip_err < 0.1,
+        "reciprocity violated: |S₂₁ − S₁₂|/|S₂₁| = {:.3}",
+        recip_err
+    );
+
+    // (4) Energy conservation: |S₁₁|² + |S₂₁|² ≈ 1 (lossless vacuum,
+    //     PEC walls, single propagating mode on each port). Below the
+    //     next modal cutoff there is no propagating channel to leak
+    //     into. Discretization plus the single-mode truncation (which
+    //     ignores reactive evanescent storage near the junction) lift
+    //     this slightly off unity; we set the tolerance at 15% to
+    //     account for both effects on a coarse 8 × {4,2} × {5,4} mesh.
+    let energy_inbound_1 = s11.norm() * s11.norm() + s21.norm() * s21.norm();
+    let energy_inbound_2 = s22.norm() * s22.norm() + s12.norm() * s12.norm();
+    eprintln!(
+        "  energy: |S11|² + |S21|² = {:.4},  |S22|² + |S12|² = {:.4}",
+        energy_inbound_1, energy_inbound_2
+    );
+    assert!(
+        (energy_inbound_1 - 1.0).abs() < 0.15,
+        "energy conservation port 1: |S11|² + |S21|² = {:.4} (expected ≈ 1, tol 15%)",
+        energy_inbound_1
+    );
+    assert!(
+        (energy_inbound_2 - 1.0).abs() < 0.15,
+        "energy conservation port 2: |S22|² + |S12|² = {:.4} (expected ≈ 1, tol 15%)",
+        energy_inbound_2
+    );
+
+    // (5) Residual sanity.
+    assert!(
+        pt.residual_rel < 1e-6,
+        "solver residual_rel = {:.3e} too large",
+        pt.residual_rel
     );
 }


### PR DESCRIPTION
## Summary

Replaces the PEC half-iris proxy from PR #245 with a true mesh **height-step**
discontinuity fixture for wave-port S-parameter validation. Section A
(`a × b1 × L1`) joined at `z = L1` to section B (`a × b2 × L2`) with a
PEC step backwall at the annular strip `y ∈ [b2, b1]`. The two
sub-meshes share a common `hy` so the interface is node-conforming
by construction.

- New `extruded_height_step_waveguide_mesh` + `ExtrudedHeightStepMesh`
  in `crates/geode-core/src/wave_port.rs` (plus 2 unit tests for the
  mesh topology).
- New `#[ignore]`d integration test `height_step_true_mesh_discontinuity_self_consistent`
  in `crates/geode-core/tests/wave_port.rs`: end-to-end single-mode
  S-parameter sweep with **independent per-port modal bases** (port 1
  on `a × b1`, port 2 on `a × b2`).
- The PEC iris fixture from PR #245 is **kept** as a regression test
  at a different operating point.

## Validation (single-mode self-consistency)

The issue lists this as an acceptable bar when no external oracle is
available for the fixture. At `ω = 2.4` (above TE₁₀ cutoff `π/a ≈ 1.571`,
below the next mode cutoff on either section):

| metric                              | value         |
|-------------------------------------|---------------|
| `|S₁₁|`                             | 0.404         |
| `|S₂₁|`                             | 0.915         |
| energy `|S₁₁|² + |S₂₁|²`            | 0.99996 ≈ 1   |
| reciprocity `|S₂₁ − S₁₂| / |S₂₁|`   | 9e-7          |
| `β₁`, `β₂` (TE₁₀ propagation)       | 1.8175, 1.8175|
| solver `residual_rel`               | 2.7e-14       |

The non-trivial reflection (well above the 0.1 matched-section floor)
and exact energy conservation + reciprocity confirm the wave-port
machinery handles **two ports with different cross-sections / different
modal bases** correctly — the existing rank-N SMW path treats each
port's mode independently, no refactor required.

## Why single-mode self-consistency, not analytic mode-matching?

A rigorous mode-matching reference (Pozar §3.10 / Collin) requires the
evanescent `TE₀ₙ` family on section A (cut off at the junction but
contributing to its admittance) — that is the multi-mode wave-port
problem deferred to #250 (architect). The single-mode wave-port path
here ignores those reactive contributions; the reported S-parameters
are the single-mode projection, which the energy + reciprocity bars
validate as internally consistent.

## Test plan

- [x] `cargo build -p geode-core` — clean.
- [x] `cargo clippy -p geode-core --features ndarray --no-default-features --tests --lib` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo test -p geode-core --features ndarray --no-default-features --lib wave_port::tests` — 6/6 pass (2 new mesh unit tests).
- [x] `cargo test -p geode-core --features ndarray --no-default-features --test wave_port -- --ignored height_step_true` — passes (numbers above).
- [x] `cargo test -p geode-core --features ndarray --no-default-features --test wave_port -- straight_section` — existing test still passes (PEC iris path / Phase-2 machinery untouched).

## Out of scope

- Multi-mode wave-port S-parameter extraction (rank-N SMW with N > 1 mode per port) — filed as #250 architect.
- Refactoring `wave_port.rs` or the modal eigensolver.
- Replacing the iris regression test.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)