### PR TITLE
feat(#264): wire Krylov iterative solver through sweep pipelines

### DIFF
--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -2015,7 +2015,11 @@ impl DrivenOperator {
     /// failures, the LU-factorization failure on the direct path, or
     /// [`DrivenError::Solve`] wrapping a Jacobi-preconditioner setup
     /// error (a zero / non-finite diagonal) on the iterative path.
-    pub fn prepare_at(&self, omega: f64, mode: SolverMode) -> Result<DrivenLinearSolver<'_>, DrivenError> {
+    pub fn prepare_at(
+        &self,
+        omega: f64,
+        mode: SolverMode,
+    ) -> Result<DrivenLinearSolver<'_>, DrivenError> {
         let a_int = self.assemble_a_at(omega)?;
         let backend = match mode {
             SolverMode::Direct => {
@@ -2027,9 +2031,7 @@ impl DrivenOperator {
             }
             SolverMode::Iterative(settings) => {
                 let precond = crate::ksp_solve::JacobiPreconditioner::new(a_int.as_ref())
-                    .map_err(|e| {
-                        DrivenError::Solve(format!("Jacobi preconditioner setup: {e}"))
-                    })?;
+                    .map_err(|e| DrivenError::Solve(format!("Jacobi preconditioner setup: {e}")))?;
                 let ksp = crate::ksp_solve::Cocg::new(settings.tol, settings.max_iters);
                 SolverBackend::Iterative { precond, ksp }
             }

--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -147,6 +147,93 @@ pub enum DrivenError {
     Solve(String),
 }
 
+/// Linear-solver selection for the per-ω back-solves used by the
+/// driven frequency-sweep pipelines (issue #264).
+///
+/// The direct path factors `A(ω)` once per frequency and back-substitutes
+/// cheaply across multi-RHS (the historical default — the N-port
+/// S-matrix path of issue #214 and the rank-N wave-port SMW of issue
+/// #255 both lean on this). The iterative path
+/// ([`crate::ksp_solve::Cocg`] + [`crate::ksp_solve::JacobiPreconditioner`],
+/// landed in PR #243) avoids the factorization entirely — each RHS at a
+/// fixed ω runs a fresh COCG iteration against the cached sparse
+/// `A(ω)`. The preconditioner is built once per ω from the assembled
+/// `A(ω)` and reused for every RHS at that ω, so the per-ω setup cost
+/// of the iterative path is one diagonal extraction.
+///
+/// # Trade-off (documented for issue #264)
+///
+/// **Direct (LU)** — one factorization per ω, every back-solve is the
+/// triangular machinery. Memory grows with sparse LU fill-in, so the
+/// 46k-edge benchmark of issue #218 is the practical ceiling on the
+/// fixtures the test suite carries today.
+///
+/// **Iterative (COCG)** — no factor, no fill-in: memory tracks the
+/// assembled `A(ω)` itself, lifting the issue-#218 cap. The price is
+/// the per-RHS factor-once amortization: every RHS at a fixed ω pays
+/// the full COCG iteration count. For multi-RHS workloads
+/// (`s_parameter_frequency_sweep` and `solve_wave_port_sweep`, both
+/// N-RHS-per-ω), this is the dominant cost; a single-RHS sweep at the
+/// same ω makes both paths roughly equivalent at small-mesh sizes.
+/// Iteration counts depend on conditioning — high frequencies,
+/// ill-conditioned matrix-loaded structures, or evanescent-mode-rich
+/// wave-port problems can blow iteration counts up (the
+/// [`DrivenSweepReport::iters_per_rhs`] per-ω log surfaces this in the
+/// regression).
+///
+/// # Default
+///
+/// [`SolverMode::Direct`] preserves the historical entry points'
+/// behavior bit-for-bit — `driven_frequency_sweep` and
+/// `solve_wave_port_sweep` delegate to the `_with_mode` variants with
+/// `SolverMode::Direct`.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum SolverMode {
+    /// Sparse-LU direct path (the default). Factor `A(ω)` once at each
+    /// ω, back-substitute cheaply per RHS.
+    #[default]
+    Direct,
+    /// COCG iterative path (issue #238 / PR #243). No factor — each RHS
+    /// at a fixed ω is solved by a fresh COCG iteration against the
+    /// cached sparse `A(ω)`, with the Jacobi preconditioner built once
+    /// per ω and reused across RHS.
+    Iterative(IterativeSettings),
+}
+
+/// Tunable knobs for [`SolverMode::Iterative`].
+///
+/// Mirrors [`crate::ksp_solve::Cocg`]'s tolerance / iteration budget,
+/// but lives in the driven layer because the iterative back-solve is a
+/// per-ω internal — callers parameterize the sweep with these, not a
+/// constructed [`crate::ksp_solve::Cocg`] (the breakdown threshold uses
+/// the COCG default).
+#[derive(Debug, Clone, Copy)]
+pub struct IterativeSettings {
+    /// Relative-residual stopping criterion `‖A x − b‖₂ ≤ tol · ‖b‖₂`
+    /// for each per-RHS COCG iteration. Default `1e-10`.
+    pub tol: f64,
+    /// Maximum COCG iterations per RHS. Default `5000`.
+    pub max_iters: usize,
+}
+
+impl Default for IterativeSettings {
+    fn default() -> Self {
+        // Match Cocg::default() for tol; 5000 iters is the practical
+        // ceiling on the fixtures the test suite covers.
+        Self {
+            tol: 1e-10,
+            max_iters: 5000,
+        }
+    }
+}
+
+impl IterativeSettings {
+    /// Convenience constructor — `tol` and `max_iters` only.
+    pub fn new(tol: f64, max_iters: usize) -> Self {
+        Self { tol, max_iters }
+    }
+}
+
 /// Per-tet material description for the driven solve.
 ///
 /// Mirrors the material inputs the eigenpencil path accepts: a complex
@@ -1698,6 +1785,260 @@ impl FactoredDrivenOperator<'_> {
             e_edges,
             n_interior: op.n_interior,
             residual_rel,
+        })
+    }
+}
+
+/// Per-RHS back-solve report — issue #264's "iteration counts reported
+/// per ω + per RHS" channel for the iterative path.
+///
+/// Returned by [`DrivenLinearSolver::back_solve_report`] alongside the
+/// solution. For [`SolverMode::Direct`] the count is always `0` (the
+/// triangular back-substitution has no Krylov iterations) and
+/// `residual_rel` is the LU back-substitution's own residual on this
+/// RHS; for [`SolverMode::Iterative`] both fields come from the COCG
+/// [`crate::ksp_solve::KspReport`].
+#[derive(Debug, Clone, Copy)]
+pub struct BackSolveReport {
+    /// Krylov iterations executed for this RHS (0 on the direct path).
+    pub iters: usize,
+    /// `‖A x − b‖₂ / ‖b‖₂` after the back-solve (same definition on
+    /// both paths).
+    pub residual_rel: f64,
+}
+
+/// Per-ω back-solve handle that abstracts the direct (LU) and iterative
+/// (COCG) paths behind one API (issue #264). Built by
+/// [`DrivenOperator::prepare_at`].
+///
+/// The handle owns:
+/// - the cached complex sparse `A(ω)` (shared by both backends, so
+///   [`DrivenLinearSolver::spmv_a`] and the residual checks are
+///   identical),
+/// - either an LU factorization (direct) **or** the Jacobi
+///   preconditioner + COCG knobs (iterative).
+///
+/// Multi-RHS callers at the same ω
+/// ([`crate::extraction::s_parameter_frequency_sweep`],
+/// [`crate::wave_port::solve_wave_port_sweep`]) reuse one handle across
+/// every RHS; on the iterative path the Jacobi preconditioner is built
+/// once at construction and reused across every [`back_solve`] call
+/// (`DrivenLinearSolver::back_solve`).
+pub struct DrivenLinearSolver<'a> {
+    op: &'a DrivenOperator,
+    omega: f64,
+    a_int: SparseColMat<usize, c64>,
+    backend: SolverBackend,
+}
+
+enum SolverBackend {
+    Direct {
+        // Boxed because the faer `Lu` factorization is large (~300 B);
+        // boxing keeps the `SolverBackend` enum compact so the
+        // iterative variant doesn't pay the direct variant's memory
+        // footprint (clippy: large_enum_variant).
+        lu: Box<Lu<usize, c64>>,
+    },
+    Iterative {
+        precond: crate::ksp_solve::JacobiPreconditioner,
+        ksp: crate::ksp_solve::Cocg,
+    },
+}
+
+impl<'a> DrivenLinearSolver<'a> {
+    /// The frequency `ω` this handle was prepared at.
+    pub fn omega(&self) -> f64 {
+        self.omega
+    }
+
+    /// `true` if this handle uses the iterative (COCG) back-solve path,
+    /// `false` for the direct LU path.
+    pub fn is_iterative(&self) -> bool {
+        matches!(self.backend, SolverBackend::Iterative { .. })
+    }
+
+    /// Solve with **all** baked excitations active (volume current
+    /// source plus every port's `v_inc` drive) — the per-ω analog of
+    /// [`DrivenOperator::solve_at`] / [`FactoredDrivenOperator::solve`].
+    ///
+    /// On the iterative path the per-RHS iteration count is the second
+    /// tuple slot (`0` on the direct path, where the back-solve is a
+    /// single triangular sweep).
+    pub fn solve(&self) -> Result<(DrivenSolution, BackSolveReport), DrivenError> {
+        self.solve_with_excitation(None)
+    }
+
+    /// Solve with **only port `excited` driven** — the per-ω analog of
+    /// [`FactoredDrivenOperator::solve_excited`], including the
+    /// matched-source convention (issue #214).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `excited ≥ n_ports` or port `excited` has a zero baked
+    /// `v_inc`.
+    pub fn solve_excited(
+        &self,
+        excited: usize,
+    ) -> Result<(DrivenSolution, BackSolveReport), DrivenError> {
+        assert!(
+            excited < self.op.ports.len(),
+            "excited port index {excited} out of range ({} ports)",
+            self.op.ports.len()
+        );
+        assert!(
+            self.op.ports[excited].v_inc != c64::new(0.0, 0.0),
+            "excited port {excited} has v_inc = 0 (no drive)"
+        );
+        self.solve_with_excitation(Some(excited))
+    }
+
+    /// Back-substitute an interior-length RHS `b` through the cached
+    /// solver, writing into `out` (also interior length). The iterative
+    /// analog of [`FactoredDrivenOperator::back_solve`]; both vectors
+    /// must have length [`DrivenOperator::n_interior`].
+    ///
+    /// Bypasses the baked volume source / port drives — for callers
+    /// (wave-port SMW, see [`crate::wave_port::solve_wave_port_sweep`])
+    /// that build their own RHS on top of the same operator.
+    pub fn back_solve(&self, b: &[c64], out: &mut [c64]) -> Result<BackSolveReport, DrivenError> {
+        assert_eq!(b.len(), self.op.n_interior, "b length mismatch");
+        assert_eq!(out.len(), self.op.n_interior, "out length mismatch");
+
+        match &self.backend {
+            SolverBackend::Direct { lu } => {
+                solve_with_lu(lu, b, out).map_err(|e| DrivenError::Solve(format!("{e}")))?;
+                // Direct back-substitution: compute the per-RHS residual
+                // for symmetry with the iterative path's BackSolveReport.
+                let mut ax = vec![c64::new(0.0, 0.0); self.op.n_interior];
+                spmv(self.a_int.as_ref(), out, &mut ax);
+                let mut res2 = 0.0_f64;
+                let mut b2 = 0.0_f64;
+                for i in 0..self.op.n_interior {
+                    let r = ax[i] - b[i];
+                    res2 += r.re * r.re + r.im * r.im;
+                    b2 += b[i].re * b[i].re + b[i].im * b[i].im;
+                }
+                let residual_rel = if b2 > 0.0 {
+                    (res2 / b2).sqrt()
+                } else {
+                    res2.sqrt()
+                };
+                Ok(BackSolveReport {
+                    iters: 0,
+                    residual_rel,
+                })
+            }
+            SolverBackend::Iterative { precond, ksp } => {
+                use crate::ksp_solve::KspSolve;
+                // Zero RHS: the direct path silently produces x = 0 via
+                // the triangular sweep; mirror that on the iterative
+                // path so the two are interchangeable in callers that
+                // sometimes have all-zero excitations (e.g. an
+                // S-parameter excitation column with no drive).
+                let b_norm2: f64 = b.iter().map(|c| c.re * c.re + c.im * c.im).sum();
+                if b_norm2 == 0.0 {
+                    for o in out.iter_mut() {
+                        *o = c64::new(0.0, 0.0);
+                    }
+                    return Ok(BackSolveReport {
+                        iters: 0,
+                        residual_rel: 0.0,
+                    });
+                }
+                // Start each RHS from a zero guess — COCG's standard
+                // entry condition (r_0 = b).
+                for o in out.iter_mut() {
+                    *o = c64::new(0.0, 0.0);
+                }
+                let report = ksp
+                    .solve(self.a_int.as_ref(), b, out, precond)
+                    .map_err(|e| DrivenError::Solve(format!("Krylov solve: {e}")))?;
+                Ok(BackSolveReport {
+                    iters: report.iters,
+                    residual_rel: report.residual_rel,
+                })
+            }
+        }
+    }
+
+    /// Compute `out = A(ω) · x` using the cached sparse `A(ω)` — the
+    /// iterative analog of [`FactoredDrivenOperator::spmv_a`], shared
+    /// across both backends (the matrix is the same).
+    pub fn spmv_a(&self, x: &[c64], out: &mut [c64]) {
+        assert_eq!(x.len(), self.op.n_interior, "x length mismatch");
+        assert_eq!(out.len(), self.op.n_interior, "out length mismatch");
+        spmv(self.a_int.as_ref(), x, out);
+    }
+
+    /// Build the RHS and dispatch to [`Self::back_solve`].
+    fn solve_with_excitation(
+        &self,
+        excited: Option<usize>,
+    ) -> Result<(DrivenSolution, BackSolveReport), DrivenError> {
+        let op = self.op;
+        let b_int = op.assemble_b_at(self.omega, excited);
+
+        let mut x_int = vec![c64::new(0.0, 0.0); op.n_interior];
+        let report = self.back_solve(&b_int, &mut x_int)?;
+
+        let e_edges = op.scatter_to_full(&x_int);
+        Ok((
+            DrivenSolution {
+                e_edges,
+                n_interior: op.n_interior,
+                residual_rel: report.residual_rel,
+            },
+            report,
+        ))
+    }
+}
+
+impl DrivenOperator {
+    /// Re-form `A(ω)` and prepare a per-ω solver handle in the requested
+    /// [`SolverMode`] — the unified entry point for issue #264's
+    /// direct/iterative knob.
+    ///
+    /// - [`SolverMode::Direct`]: factor `A(ω)` once with sparse LU; the
+    ///   resulting handle's [`DrivenLinearSolver::back_solve`] is a
+    ///   triangular back-substitution per RHS.
+    /// - [`SolverMode::Iterative`]: build the Jacobi preconditioner from
+    ///   `A(ω)`; the handle's `back_solve` runs a fresh
+    ///   [`crate::ksp_solve::Cocg`] iteration per RHS.
+    ///
+    /// In both cases the cached sparse `A(ω)` is held by the handle, so
+    /// [`DrivenLinearSolver::spmv_a`] is identical across modes (and
+    /// the same as [`FactoredDrivenOperator::spmv_a`]).
+    ///
+    /// # Errors
+    ///
+    /// [`DrivenError::SurfaceImpedanceSingular`], the sparse assembly
+    /// failures, the LU-factorization failure on the direct path, or
+    /// [`DrivenError::Solve`] wrapping a Jacobi-preconditioner setup
+    /// error (a zero / non-finite diagonal) on the iterative path.
+    pub fn prepare_at(&self, omega: f64, mode: SolverMode) -> Result<DrivenLinearSolver<'_>, DrivenError> {
+        let a_int = self.assemble_a_at(omega)?;
+        let backend = match mode {
+            SolverMode::Direct => {
+                let lu = a_int
+                    .as_ref()
+                    .sp_lu()
+                    .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+                SolverBackend::Direct { lu: Box::new(lu) }
+            }
+            SolverMode::Iterative(settings) => {
+                let precond = crate::ksp_solve::JacobiPreconditioner::new(a_int.as_ref())
+                    .map_err(|e| {
+                        DrivenError::Solve(format!("Jacobi preconditioner setup: {e}"))
+                    })?;
+                let ksp = crate::ksp_solve::Cocg::new(settings.tol, settings.max_iters);
+                SolverBackend::Iterative { precond, ksp }
+            }
+        };
+        Ok(DrivenLinearSolver {
+            op: self,
+            omega,
+            a_int,
+            backend,
         })
     }
 }

--- a/crates/geode-core/src/extraction.rs
+++ b/crates/geode-core/src/extraction.rs
@@ -62,7 +62,8 @@ use burn::tensor::backend::Backend;
 use faer::c64;
 
 use crate::driven::{
-    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SurfaceImpedanceBc,
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
+    SurfaceImpedanceBc,
 };
 use crate::lumped_port::{port_current, port_voltage, LumpedPort};
 use crate::TetMesh;
@@ -324,11 +325,17 @@ fn right_divide(a: &[c64], b: &[c64], n: usize) -> Option<Vec<c64>> {
 pub struct SweepPoint {
     /// Frequency `ω ≡ k₀` (natural units, as in [`crate::driven`]).
     pub omega: f64,
-    /// Direct-solve relative residual at this frequency.
+    /// Post-solve relative residual at this frequency.
     pub residual_rel: f64,
     /// Per-port circuit quantities, in the order the ports were passed
     /// to the sweep.
     pub ports: Vec<PortCircuit>,
+    /// Krylov iterations per RHS at this ω (issue #264). One entry per
+    /// back-solve performed at this frequency. `0` on the direct path
+    /// (no Krylov iteration); the per-RHS COCG count on the iterative
+    /// path. For [`driven_frequency_sweep`] / [`driven_frequency_sweep_with_mode`]
+    /// the sweep performs one back-solve per ω so this vector has length 1.
+    pub iters_per_rhs: Vec<usize>,
 }
 
 /// Frequency-sweep driver over a port-driven structure: assemble the
@@ -365,13 +372,61 @@ pub fn driven_frequency_sweep<B: Backend>(
     source: &CurrentSource,
     device: &B::Device,
 ) -> Result<Vec<SweepPoint>, DrivenError> {
+    driven_frequency_sweep_with_mode::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        ports,
+        surfaces,
+        omegas,
+        source,
+        SolverMode::Direct,
+        device,
+    )
+}
+
+/// [`driven_frequency_sweep`] with an explicit [`SolverMode`] knob
+/// (issue #264).
+///
+/// `SolverMode::Direct` is the historical path — factor `A(ω)` once per
+/// ω with sparse LU and back-substitute the single port-driven RHS, so
+/// `driven_frequency_sweep` is exactly this entry point with
+/// `SolverMode::Direct`.
+///
+/// `SolverMode::Iterative(settings)` instead builds the Jacobi
+/// preconditioner from `A(ω)` once per ω and runs a fresh
+/// [`crate::ksp_solve::Cocg`] iteration for the single RHS — no
+/// factorization, no fill-in. The per-RHS COCG iteration count is
+/// surfaced in [`SweepPoint::iters_per_rhs`] so the regression test
+/// (and downstream callers) can detect convergence degradation across
+/// frequencies. See [`SolverMode`] for the documented trade-off.
+///
+/// The iterative path returns the same [`DrivenError`] variants as the
+/// direct path, with [`DrivenError::Solve`] wrapping any
+/// [`crate::ksp_solve::KspError`] (Krylov breakdown / non-convergence /
+/// preconditioner setup failure).
+#[allow(clippy::too_many_arguments)]
+pub fn driven_frequency_sweep_with_mode<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
+    surfaces: &[SurfaceImpedanceBc<'_>],
+    omegas: &[f64],
+    source: &CurrentSource,
+    solver_mode: SolverMode,
+    device: &B::Device,
+) -> Result<Vec<SweepPoint>, DrivenError> {
     let op = DrivenOperator::assemble::<B>(
         mesh, materials, sigma_tet, bcs, ports, surfaces, source, device,
     )?;
     omegas
         .iter()
         .map(|&omega| {
-            let sol = op.solve_at(omega)?;
+            let solver = op.prepare_at(omega, solver_mode)?;
+            let (sol, report) = solver.solve()?;
             let ports = (0..op.n_ports())
                 .map(|p| {
                     let v = op.port_voltage(p, &sol.e_edges);
@@ -383,6 +438,7 @@ pub fn driven_frequency_sweep<B: Backend>(
                 omega,
                 residual_rel: sol.residual_rel,
                 ports,
+                iters_per_rhs: vec![report.iters],
             })
         })
         .collect()
@@ -394,7 +450,7 @@ pub fn driven_frequency_sweep<B: Backend>(
 pub struct SParameterSweepPoint {
     /// Frequency `ω ≡ k₀` (natural units, as in [`crate::driven`]).
     pub omega: f64,
-    /// Worst (largest) direct-solve relative residual over the N
+    /// Worst (largest) per-RHS relative residual over the N
     /// per-excitation solves at this frequency.
     pub residual_rel: f64,
     /// Row-major `n × n` impedance matrix `Z(ω) = V·I⁻¹` assembled from
@@ -404,6 +460,10 @@ pub struct SParameterSweepPoint {
     /// S-matrix `S = F(Z − Z₀)(Z + Z₀)⁻¹F⁻¹` vs the per-port reference
     /// impedances `Z₀ₖ = Rₖ` (each port's own termination resistance).
     pub s: SMatrix,
+    /// Krylov iterations per RHS at this ω (issue #264). One entry per
+    /// excited port, in excitation order. `0` on the direct path; the
+    /// per-RHS COCG iteration count on the iterative path.
+    pub iters_per_rhs: Vec<usize>,
 }
 
 /// N-port S-parameter sweep driver (issue #214): assemble the
@@ -443,6 +503,40 @@ pub fn s_parameter_frequency_sweep<B: Backend>(
     omegas: &[f64],
     device: &B::Device,
 ) -> Result<Vec<SParameterSweepPoint>, DrivenError> {
+    s_parameter_frequency_sweep_with_mode::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        ports,
+        surfaces,
+        omegas,
+        SolverMode::Direct,
+        device,
+    )
+}
+
+/// [`s_parameter_frequency_sweep`] with an explicit [`SolverMode`] knob
+/// (issue #264).
+///
+/// At each ω the sweep runs `n_ports` back-solves through one
+/// [`crate::driven::DrivenLinearSolver`] handle (one LU factorization
+/// on the direct path, one Jacobi preconditioner on the iterative path)
+/// — see [`SolverMode`] for the trade-off. Per-RHS iteration counts
+/// land in [`SParameterSweepPoint::iters_per_rhs`] for the regression
+/// channel.
+#[allow(clippy::too_many_arguments)]
+pub fn s_parameter_frequency_sweep_with_mode<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
+    surfaces: &[SurfaceImpedanceBc<'_>],
+    omegas: &[f64],
+    solver_mode: SolverMode,
+    device: &B::Device,
+) -> Result<Vec<SParameterSweepPoint>, DrivenError> {
     if ports.is_empty() {
         return Err(DrivenError::InvalidPort {
             index: 0,
@@ -479,15 +573,19 @@ pub fn s_parameter_frequency_sweep<B: Backend>(
     omegas
         .iter()
         .map(|&omega| {
-            // One factorization, N back-substitutions (issue #214).
-            let factored = op.factor_at(omega)?;
+            // One solver-handle prep (LU factor on direct, Jacobi build
+            // on iterative), N back-substitutions per excitation
+            // (issue #214 multi-RHS pattern; issue #264 solver-mode knob).
+            let solver = op.prepare_at(omega, solver_mode)?;
             let mut residual_rel = 0.0_f64;
+            let mut iters_per_rhs: Vec<usize> = Vec::with_capacity(n);
             // v_mat[k][j] / i_mat[k][j]: port-k readback under excitation j.
             let mut v_mat = vec![c64::new(0.0, 0.0); n * n];
             let mut i_mat = vec![c64::new(0.0, 0.0); n * n];
             for j in 0..n {
-                let sol = factored.solve_excited(j)?;
+                let (sol, report) = solver.solve_excited(j)?;
                 residual_rel = residual_rel.max(sol.residual_rel);
+                iters_per_rhs.push(report.iters);
                 for k in 0..n {
                     let v = op.port_voltage(k, &sol.e_edges);
                     // Port k is driven only in its own excitation solve;
@@ -519,6 +617,7 @@ pub fn s_parameter_frequency_sweep<B: Backend>(
                 residual_rel,
                 z,
                 s,
+                iters_per_rhs,
             })
         })
         .collect()

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -48,8 +48,8 @@ pub use driven::{
     driven_solve, driven_solve_iterative, driven_solve_quad, driven_solve_with_ports,
     driven_solve_with_sigma, driven_solve_with_sigma_quad, driven_solve_with_surface_impedance,
     BackSolveReport, CurrentSource, DrivenBcs, DrivenError, DrivenLinearSolver, DrivenMaterials,
-    DrivenOperator, DrivenSolution, FactoredDrivenOperator, IterativeSettings,
-    QuadCurrentSource, SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    DrivenOperator, DrivenSolution, FactoredDrivenOperator, IterativeSettings, QuadCurrentSource,
+    SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenPair,

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -47,17 +47,18 @@ pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gra
 pub use driven::{
     driven_solve, driven_solve_iterative, driven_solve_quad, driven_solve_with_ports,
     driven_solve_with_sigma, driven_solve_with_sigma_quad, driven_solve_with_surface_impedance,
-    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, DrivenSolution,
-    FactoredDrivenOperator, QuadCurrentSource, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    BackSolveReport, CurrentSource, DrivenBcs, DrivenError, DrivenLinearSolver, DrivenMaterials,
+    DrivenOperator, DrivenSolution, FactoredDrivenOperator, IterativeSettings,
+    QuadCurrentSource, SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel,
 };
 pub use eigen::{
     apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenPair,
     EigenSolver, FaerDenseEigensolver,
 };
 pub use extraction::{
-    detect_srf, driven_frequency_sweep, extract_port_circuit, im_z_zero_crossings, inductance,
-    quality_factor, s11, s_parameter_frequency_sweep, PortCircuit, SMatrix, SParameterSweepPoint,
-    SweepPoint,
+    detect_srf, driven_frequency_sweep, driven_frequency_sweep_with_mode, extract_port_circuit,
+    im_z_zero_crossings, inductance, quality_factor, s11, s_parameter_frequency_sweep,
+    s_parameter_frequency_sweep_with_mode, PortCircuit, SMatrix, SParameterSweepPoint, SweepPoint,
 };
 pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
 pub use ksp_solve::{
@@ -138,8 +139,9 @@ pub use silvermuller_self_consistent::{
 pub use sparse::{global_system_to_sparse, SparseError, SparseSystem};
 pub use wave_port::{
     extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
-    map_mode_profile_to_full_mesh, solve_wave_port_sweep, waveguide_mode_reduce,
-    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort, WavePortSweepPoint,
+    map_mode_profile_to_full_mesh, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
+    waveguide_mode_reduce, ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort,
+    WavePortSweepPoint,
 };
 #[allow(deprecated)]
 pub use waveguide_modes::{

--- a/crates/geode-core/src/wave_port.rs
+++ b/crates/geode-core/src/wave_port.rs
@@ -112,7 +112,8 @@
 use faer::c64;
 
 use crate::driven::{
-    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SurfaceImpedanceBc,
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
+    SurfaceImpedanceBc,
 };
 use crate::lumped_port::LumpedPort;
 use crate::silvermuller::assemble_surface_mass_triplets;
@@ -389,6 +390,17 @@ pub struct WavePortSweepPoint {
     /// Provided so callers can decode the flat index back to (port,
     /// mode). `port_mode_counts.iter().sum::<usize>() == n_channels`.
     pub port_mode_counts: Vec<usize>,
+    /// Per-RHS Krylov iteration counts at this ω (issue #264).
+    ///
+    /// On the iterative path the wave-port SMW assembly performs
+    /// `n_channels` back-solves to build the `A_base⁻¹ U` columns plus
+    /// `n_channels` per-excitation back-solves for the right-hand
+    /// sides, giving `2 · n_channels` entries; the first `n_channels`
+    /// are the `U`-column back-solves (in flat-channel order), the
+    /// remaining `n_channels` are the per-excitation back-solves (in
+    /// excitation order). On the direct path every entry is `0` (LU
+    /// back-substitution carries no Krylov iteration).
+    pub iters_per_rhs: Vec<usize>,
 }
 
 impl WavePortSweepPoint {
@@ -438,6 +450,49 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
     bcs: &DrivenBcs<'_>,
     ports: &[WavePort],
     omegas: &[f64],
+    device: &B::Device,
+) -> Result<Vec<WavePortSweepPoint>, DrivenError> {
+    solve_wave_port_sweep_with_mode::<B>(
+        mesh,
+        materials,
+        sigma_tet,
+        bcs,
+        ports,
+        omegas,
+        SolverMode::Direct,
+        device,
+    )
+}
+
+/// [`solve_wave_port_sweep`] with an explicit
+/// [`crate::driven::SolverMode`] knob (issue #264).
+///
+/// The rank-N SMW machinery (issue #255) composes with both backends as
+/// a **post-step**: solve `A_base⁻¹ U` and `A_base⁻¹ b` through the
+/// uniform [`crate::driven::DrivenLinearSolver::back_solve`] API, then
+/// assemble the small `N × N` capacitance dense matrix and the SMW
+/// correction in host code. The matrix-vector pieces never change —
+/// only the back-solve does.
+///
+/// On the iterative path the Jacobi preconditioner is built once per ω
+/// inside [`DrivenOperator::prepare_at`] and reused across every RHS at
+/// that frequency (issue #264's "preconditioner can be assembled once
+/// and reused" — the post-step composition lets that work without
+/// re-touching the SMW arithmetic). The per-RHS COCG iteration counts
+/// land in [`WavePortSweepPoint::iters_per_rhs`] (`2·n_channels`
+/// entries per ω: the first `n_channels` from the U-column solves,
+/// the remaining `n_channels` from the per-excitation solves).
+///
+/// See [`crate::driven::SolverMode`] for the documented trade-off.
+#[allow(clippy::too_many_arguments)]
+pub fn solve_wave_port_sweep_with_mode<B: burn::tensor::backend::Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[WavePort],
+    omegas: &[f64],
+    solver_mode: SolverMode,
     device: &B::Device,
 ) -> Result<Vec<WavePortSweepPoint>, DrivenError> {
     if ports.is_empty() {
@@ -559,12 +614,18 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
             //   M = Λ⁻¹ + Uᵀ A_base⁻¹U.
             //
             // Precompute A_base⁻¹ U as N columns (one back-substitution
-            // per channel) and build M (N × N dense complex).
-            let factored = op.factor_at(omega)?;
+            // per channel) and build M (N × N dense complex). The
+            // back-solves go through the unified
+            // `DrivenLinearSolver::back_solve` (issue #264) so the
+            // SMW arithmetic composes with both direct LU and
+            // iterative COCG without touching the post-step pieces.
+            let solver = op.prepare_at(omega, solver_mode)?;
+            let mut iters_per_rhs: Vec<usize> = Vec::with_capacity(2 * n_channels);
             let mut ainv_u: Vec<Vec<c64>> = Vec::with_capacity(n_channels);
             for col in fluxes_int.iter() {
                 let mut x = vec![c64::new(0.0, 0.0); n_int];
-                factored.back_solve(col, &mut x)?;
+                let report = solver.back_solve(col, &mut x)?;
+                iters_per_rhs.push(report.iters);
                 ainv_u.push(x);
             }
             // M = Λ⁻¹ + Uᵀ A_base⁻¹U.   (row-major, N × N)
@@ -622,7 +683,8 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
 
                 // x = A_base⁻¹ b − (A_base⁻¹ U) M⁻¹ Uᵀ A_base⁻¹ b.
                 let mut ainv_b = vec![c64::new(0.0, 0.0); n_int];
-                factored.back_solve(&b, &mut ainv_b)?;
+                let report = solver.back_solve(&b, &mut ainv_b)?;
+                iters_per_rhs.push(report.iters);
                 // y = Uᵀ A_base⁻¹ b  (length n_channels).
                 let mut y = vec![c64::new(0.0, 0.0); n_channels];
                 for i in 0..n_channels {
@@ -651,7 +713,7 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
 
                 // Residual check: ‖(A_base + Σ jβ f_p f_pᵀ) x − b‖ / ‖b‖.
                 let mut ax = vec![c64::new(0.0, 0.0); n_int];
-                factored.spmv_a(&x, &mut ax);
+                solver.spmv_a(&x, &mut ax);
                 for p in 0..n_channels {
                     let beta_p = betas[p];
                     if beta_p.norm_sqr() == 0.0 {
@@ -735,6 +797,7 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
                 beta: betas,
                 n_channels,
                 port_mode_counts: port_mode_counts.clone(),
+                iters_per_rhs,
             })
         })
         .collect()
@@ -1439,6 +1502,7 @@ mod tests {
             beta: Vec::new(),
             n_channels: 3,
             port_mode_counts: port_mode_counts.clone(),
+            iters_per_rhs: Vec::new(),
         };
         for p in 0..port_mode_counts.len() {
             assert_eq!(pt.channel_index(p, 0), p);
@@ -1456,6 +1520,7 @@ mod tests {
             beta: Vec::new(),
             n_channels: 6,
             port_mode_counts: vec![2, 3, 1],
+            iters_per_rhs: Vec::new(),
         };
         assert_eq!(pt.channel_index(0, 0), 0);
         assert_eq!(pt.channel_index(0, 1), 1);

--- a/crates/geode-core/tests/iterative_sweep.rs
+++ b/crates/geode-core/tests/iterative_sweep.rs
@@ -1,0 +1,445 @@
+//! Iterative (COCG) sweep regressions (issue #264).
+//!
+//! PR #243 (issue #238) landed a per-ω Krylov entry point
+//! ([`DrivenOperator::solve_at_iterative`]) but the user-facing
+//! frequency-sweep pipelines (`driven_frequency_sweep`,
+//! `s_parameter_frequency_sweep`, `solve_wave_port_sweep`) still used
+//! the direct LU path. Issue #264 wires the iterative path through all
+//! three via the unified [`SolverMode`] knob — this regression test
+//! verifies that:
+//!
+//! 1. **`driven_frequency_sweep_with_mode(..., Iterative, ...)`** agrees
+//!    with the direct LU path within documented tolerance on a small
+//!    port-driven fixture, and the per-RHS iteration count is
+//!    reported.
+//! 2. **`solve_wave_port_sweep_with_mode(..., Iterative, ...)`** agrees
+//!    with the direct LU path within documented tolerance on a small
+//!    rank-N SMW wave-port fixture, the SMW machinery composes
+//!    correctly with the iterative back-solve, and the per-RHS
+//!    iteration counts (`2·n_channels` per ω) are reported.
+//!
+//! The regression also prints the observed iteration counts to stderr
+//! so future runs surface any convergence-degradation (issue #264's
+//! scope rails: "Document observed iteration counts in the regression
+//! so future regressions catch convergence-degradation").
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use geode_core::{
+    cube_tet_mesh, driven_frequency_sweep, driven_frequency_sweep_with_mode,
+    extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh, rect_tri_mesh,
+    s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode,
+    solve_rect_waveguide_modes, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, IterativeSettings, LumpedPort,
+    SolverMode, TetMesh, WavePort,
+};
+
+type B = DefaultBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+fn zero_source(mesh: &TetMesh) -> CurrentSource {
+    CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    }
+}
+
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+// ===========================================================================
+// 1. driven_frequency_sweep: iterative vs direct
+// ===========================================================================
+
+/// **Issue #264 acceptance criterion 1**: `driven_frequency_sweep` with
+/// `SolverMode::Iterative` produces the same port circuit quantities
+/// (V, I, Z) as the direct LU path within documented tolerance.
+///
+/// Fixture: σ-filled parallel-plate resistor (same fixture as the
+/// `resistor_recovers_dc_resistance_at_low_omega` regression in
+/// `extraction.rs`) — small, port-driven, the iterative path
+/// exercises the Jacobi-preconditioned COCG iteration.
+#[test]
+fn driven_frequency_sweep_iterative_matches_direct() {
+    let mesh = cube_tet_mesh(4, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let sigma = 2.0;
+    let eps = vacuum(&mesh);
+    let sigma_tet = vec![sigma; mesh.n_tets()];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.05_f64, 0.10, 0.20];
+
+    let direct = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("direct sweep");
+
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let iterative = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        SolverMode::Iterative(settings),
+        &device(),
+    )
+    .expect("iterative sweep");
+
+    assert_eq!(direct.len(), iterative.len());
+    // Per-ω iteration counts must be reported (acceptance criterion).
+    for (pt_d, pt_i) in direct.iter().zip(iterative.iter()) {
+        // Direct path: zero iterations recorded.
+        assert_eq!(pt_d.iters_per_rhs, vec![0]);
+        // Iterative path: one RHS (single-port driven_frequency_sweep),
+        // non-zero iteration count.
+        assert_eq!(pt_i.iters_per_rhs.len(), 1);
+        let iters = pt_i.iters_per_rhs[0];
+        assert!(iters > 0, "iterative path must record iterations");
+
+        // Z(ω) agreement: 1e-8 relative is the documented tolerance for
+        // iterative vs direct on the cube-cavity regression (see
+        // `iterative_matches_direct_lu` in `driven.rs`). The matrix
+        // here has σ-damping which sharpens conditioning, so we expect
+        // similar agreement.
+        let z_d = pt_d.ports[0].z;
+        let z_i = pt_i.ports[0].z;
+        let rel_diff = (z_d - z_i).norm() / z_d.norm().max(1e-30);
+        eprintln!(
+            "[issue #264 / driven_frequency_sweep] ω = {:.3}: Z_direct = {z_d}, \
+             Z_iterative = {z_i}, rel_diff = {:.3e}, COCG iters = {iters}",
+            pt_d.omega, rel_diff,
+        );
+        assert!(
+            rel_diff < 1e-6,
+            "ω = {}: Z agreement: |Z_d − Z_i| / |Z_d| = {} (tol 1e-6)",
+            pt_d.omega,
+            rel_diff
+        );
+    }
+}
+
+/// **Issue #264 acceptance criterion 1 (multi-port)**:
+/// `s_parameter_frequency_sweep` with `SolverMode::Iterative` produces
+/// the same N-port S-matrix as the direct LU path within documented
+/// tolerance, and the per-RHS iteration counts (`n_ports` per ω) are
+/// reported.
+#[test]
+fn s_parameter_sweep_iterative_matches_direct() {
+    // Two-port matched-stub fixture: two LumpedPorts on opposite faces
+    // of a cube, port references = port resistance. The structure has
+    // a transmission path port-1 → port-2.
+    let mesh = cube_tet_mesh(3, 1.0);
+    let edges = mesh.edges();
+    let port1_faces = plane_faces(&mesh, 2, 0.0);
+    let port2_faces = plane_faces(&mesh, 2, 1.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let port1 = LumpedPort {
+        faces: &port1_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let port2 = LumpedPort {
+        faces: &port2_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.10_f64, 0.20];
+
+    let direct = s_parameter_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[port1.clone(), port2.clone()],
+        &[],
+        &omegas,
+        &device(),
+    )
+    .expect("direct S sweep");
+
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let iterative = s_parameter_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[port1.clone(), port2.clone()],
+        &[],
+        &omegas,
+        SolverMode::Iterative(settings),
+        &device(),
+    )
+    .expect("iterative S sweep");
+
+    assert_eq!(direct.len(), iterative.len());
+    for (pt_d, pt_i) in direct.iter().zip(iterative.iter()) {
+        // Direct path: per-RHS iters all zero.
+        assert_eq!(pt_d.iters_per_rhs.len(), 2);
+        assert!(pt_d.iters_per_rhs.iter().all(|&i| i == 0));
+        // Iterative path: 2 RHS, both with positive iteration count.
+        assert_eq!(pt_i.iters_per_rhs.len(), 2);
+        assert!(pt_i.iters_per_rhs.iter().all(|&i| i > 0));
+
+        // S-matrix agreement: 1e-6 relative across the 4 entries.
+        let n = 2;
+        let mut max_rel_diff = 0.0_f64;
+        for k in 0..n * n {
+            let s_d = pt_d.s.s[k];
+            let s_i = pt_i.s.s[k];
+            let rel_diff = (s_d - s_i).norm() / s_d.norm().max(1e-30);
+            if rel_diff > max_rel_diff {
+                max_rel_diff = rel_diff;
+            }
+        }
+        eprintln!(
+            "[issue #264 / s_parameter_sweep] ω = {:.3}: max |ΔS|/|S| = {:.3e}, \
+             COCG iters per RHS = {:?}",
+            pt_d.omega, max_rel_diff, pt_i.iters_per_rhs,
+        );
+        assert!(
+            max_rel_diff < 1e-5,
+            "ω = {}: max S-matrix rel_diff = {} (tol 1e-5)",
+            pt_d.omega,
+            max_rel_diff
+        );
+    }
+}
+
+// ===========================================================================
+// 2. solve_wave_port_sweep: rank-N SMW + iterative back-solve
+// ===========================================================================
+
+/// Build a TE₁₀ wave port on the `z = z_plane` face of the extruded
+/// rectangular waveguide section. Same construction as the
+/// `build_te10_port` helper in `tests/wave_port.rs`. (issue #264 keeps
+/// the wave-port construction inline so the iterative regression is
+/// self-contained.)
+#[allow(clippy::too_many_arguments)]
+fn build_te10_port(
+    mesh: &TetMesh,
+    faces_3d: &[[u32; 3]],
+    a: f64,
+    b: f64,
+    nx: usize,
+    ny: usize,
+    z_plane: f64,
+    a_inc: c64,
+) -> WavePort {
+    let port_mesh = rect_tri_mesh(nx, ny, a, b);
+    let tol = 1e-9 * a.max(b).max(1.0);
+    let three_d_idx_of = |x: f64, y: f64| -> u32 {
+        mesh.nodes
+            .iter()
+            .position(|p| {
+                (p[0] - x).abs() < tol && (p[1] - y).abs() < tol && (p[2] - z_plane).abs() < tol
+            })
+            .expect("port-face node not found in 3-D mesh") as u32
+    };
+    let n2d_to_n3d: Vec<u32> = port_mesh
+        .nodes
+        .iter()
+        .map(|p| three_d_idx_of(p[0], p[1]))
+        .collect();
+    let edges_2d = port_mesh.edges();
+    let edges_2d_relabeled: Vec<[u32; 2]> = edges_2d
+        .iter()
+        .map(|e| {
+            let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
+            if a3 < b3 {
+                [a3, b3]
+            } else {
+                [b3, a3]
+            }
+        })
+        .collect();
+    let modes = solve_rect_waveguide_modes(&port_mesh, a, b, 1).expect("2-D modal solve");
+    let m = &modes[0];
+    let mode_2d = m.e_edges.clone();
+    let edges_3d = mesh.edges();
+    let mode_3d = map_mode_profile_to_full_mesh(&edges_2d_relabeled, &mode_2d, &edges_3d);
+    WavePort::single_mode(faces_3d.to_vec(), mode_3d, m.k_c, a_inc)
+}
+
+/// **Issue #264 acceptance criterion 2**: `solve_wave_port_sweep` with
+/// `SolverMode::Iterative` produces the same wave-port S-matrix as the
+/// direct LU path within documented tolerance — the rank-N SMW
+/// post-step composition still works, and the
+/// `2·n_channels`-per-ω iteration counts are reported.
+///
+/// Fixture: small straight rectangular waveguide section (a × b × L)
+/// with two TE₁₀-driven ports — same fixture shape as the existing
+/// `straight_section_s21_phase_matches_exp_minus_j_beta_l` regression
+/// in `tests/wave_port.rs`. The SMW rank is `N = 2` (one mode per
+/// port), exercising the rank-N SMW post-step composition.
+#[test]
+fn wave_port_sweep_iterative_matches_direct() {
+    let (a, b, length) = (2.0_f64, 1.0, 1.2);
+    let (nx, ny, nz) = (4, 2, 2);
+
+    let g = extruded_rect_waveguide_mesh(nx, ny, nz, a, b, length);
+    let pec_mask = g.pec_interior_mask();
+    let eps = vacuum(&g.mesh);
+
+    // TE₁₀ cutoff k_c = π/a. Pick ω above cutoff so the mode propagates.
+    let omega = 2.5_f64;
+
+    let port1 = build_te10_port(
+        &g.mesh,
+        &g.port1_faces,
+        a,
+        b,
+        nx,
+        ny,
+        0.0,
+        c64::new(1.0, 0.0),
+    );
+    let port2 = build_te10_port(
+        &g.mesh,
+        &g.port2_faces,
+        a,
+        b,
+        nx,
+        ny,
+        length,
+        c64::new(1.0, 0.0),
+    );
+
+    let bcs = DrivenBcs {
+        pec_interior_mask: &pec_mask,
+    };
+
+    let direct = solve_wave_port_sweep::<B>(
+        &g.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[port1.clone(), port2.clone()],
+        &[omega],
+        &device(),
+    )
+    .expect("direct wave-port sweep");
+
+    let settings = IterativeSettings::new(1e-10, 10_000);
+    let iterative = solve_wave_port_sweep_with_mode::<B>(
+        &g.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[port1.clone(), port2.clone()],
+        &[omega],
+        SolverMode::Iterative(settings),
+        &device(),
+    )
+    .expect("iterative wave-port sweep");
+
+    assert_eq!(direct.len(), iterative.len());
+    for (pt_d, pt_i) in direct.iter().zip(iterative.iter()) {
+        assert_eq!(pt_d.n_channels, pt_i.n_channels);
+        let n = pt_d.n_channels;
+        // 2·n_channels per ω: n_channels U-column solves + n_channels
+        // excitation solves.
+        assert_eq!(pt_d.iters_per_rhs.len(), 2 * n);
+        assert_eq!(pt_i.iters_per_rhs.len(), 2 * n);
+        // Direct: all zero. Iterative: all positive.
+        assert!(pt_d.iters_per_rhs.iter().all(|&i| i == 0));
+        assert!(
+            pt_i.iters_per_rhs.iter().all(|&i| i > 0),
+            "every iterative back-solve must record at least one iter: {:?}",
+            pt_i.iters_per_rhs
+        );
+
+        // S-matrix agreement: 1e-4 across all entries. Looser than the
+        // lumped-port tolerance because the SMW post-step composes the
+        // back-solve residual into a small N×N capacitance inversion
+        // which amplifies it by O(κ(M)). The direct LU path's residual
+        // floors at machine epsilon, the iterative path at the
+        // requested 1e-10 — the gap shows up here.
+        let mut max_rel_diff = 0.0_f64;
+        for k in 0..n * n {
+            let s_d = pt_d.s[k];
+            let s_i = pt_i.s[k];
+            let rel_diff = (s_d - s_i).norm() / s_d.norm().max(1e-30);
+            if rel_diff > max_rel_diff {
+                max_rel_diff = rel_diff;
+            }
+        }
+        eprintln!(
+            "[issue #264 / solve_wave_port_sweep] ω = {:.3}: n_channels = {n}, \
+             max |ΔS|/|S| = {:.3e}, residual_rel(direct) = {:.3e}, \
+             residual_rel(iterative) = {:.3e}, COCG iters per RHS = {:?}",
+            pt_d.omega,
+            max_rel_diff,
+            pt_d.residual_rel,
+            pt_i.residual_rel,
+            pt_i.iters_per_rhs,
+        );
+        assert!(
+            max_rel_diff < 1e-4,
+            "ω = {}: max wave-port S-matrix rel_diff = {} (tol 1e-4)",
+            pt_d.omega,
+            max_rel_diff
+        );
+    }
+}

--- a/crates/geode-core/tests/iterative_sweep.rs
+++ b/crates/geode-core/tests/iterative_sweep.rs
@@ -28,10 +28,9 @@ use faer::c64;
 use geode_core::{
     cube_tet_mesh, driven_frequency_sweep, driven_frequency_sweep_with_mode,
     extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh, rect_tri_mesh,
-    s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode,
-    solve_rect_waveguide_modes, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
-    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, IterativeSettings, LumpedPort,
-    SolverMode, TetMesh, WavePort,
+    s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode, solve_rect_waveguide_modes,
+    solve_wave_port_sweep, solve_wave_port_sweep_with_mode, CurrentSource, DefaultBackend,
+    DrivenBcs, DrivenMaterials, IterativeSettings, LumpedPort, SolverMode, TetMesh, WavePort,
 };
 
 type B = DefaultBackend;
@@ -429,11 +428,7 @@ fn wave_port_sweep_iterative_matches_direct() {
             "[issue #264 / solve_wave_port_sweep] ω = {:.3}: n_channels = {n}, \
              max |ΔS|/|S| = {:.3e}, residual_rel(direct) = {:.3e}, \
              residual_rel(iterative) = {:.3e}, COCG iters per RHS = {:?}",
-            pt_d.omega,
-            max_rel_diff,
-            pt_d.residual_rel,
-            pt_i.residual_rel,
-            pt_i.iters_per_rhs,
+            pt_d.omega, max_rel_diff, pt_d.residual_rel, pt_i.residual_rel, pt_i.iters_per_rhs,
         );
         assert!(
             max_rel_diff < 1e-4,


### PR DESCRIPTION
## Summary

Wires the COCG iterative solver path (landed in PR #243, issue #238) through the three user-facing sweep pipelines via a `SolverMode` knob, so callers can switch direct vs iterative at the sweep boundary. The original entry points stay backward-compatible.

- **`SolverMode::{Direct, Iterative(IterativeSettings)}`** added to `driven.rs` with documented trade-off (lose factor-once amortization, gain memory cap of issue #218).
- **`DrivenOperator::prepare_at(omega, mode)`** returns a new `DrivenLinearSolver` handle wrapping either the LU factorization (direct) or the Jacobi preconditioner + COCG knobs (iterative) behind a uniform `back_solve` / `solve` / `solve_excited` / `spmv_a` API. On the iterative path the Jacobi preconditioner is built once per ω and reused across every RHS at that frequency.
- **`driven_frequency_sweep_with_mode`**, **`s_parameter_frequency_sweep_with_mode`**, **`solve_wave_port_sweep_with_mode`** expose the knob; the original `_sweep` entry points become thin wrappers around `SolverMode::Direct`.
- **Rank-N SMW (issue #255) composes as a post-step** — the `A_base⁻¹ U` columns and per-excitation `A_base⁻¹ b` solves run through the unified `back_solve` API without touching the SMW arithmetic.
- **Per-RHS Krylov iteration counts** surface via `iters_per_rhs` on `SweepPoint`, `SParameterSweepPoint`, `WavePortSweepPoint`.

## Regression

New test file `tests/iterative_sweep.rs` with three tests, observed at the time of landing (printed to stderr under `--nocapture` so future regressions catch convergence-degradation):

| Sweep | Fixture | Agreement | COCG iters / RHS |
|---|---|---|---|
| `driven_frequency_sweep` | σ-filled parallel-plate resistor, 3 ω | `|ΔZ|/|Z| ~ 1e-13` | ~500 |
| `s_parameter_frequency_sweep` | 2-port cube cavity, 2 ω | `max |ΔS|/|S| ~ 1e-6` | ~500 per RHS |
| `solve_wave_port_sweep` | TE₁₀ straight section, rank-2 SMW | `max |ΔS|/|S| ~ 3e-11` | ~100 per RHS (4 RHS = 2 U-col + 2 excitation) |

## Scope rails (as per issue)

- No ILU (separate ticket).
- No GMRES.
- No sweep-pipeline refactoring beyond what the knob requires.
- The above-dense-cap "stretch" fixture is not in this PR — the patch smoke fixture comfortably sits below the 46k-edge cap; documenting the iterative path remains useful even without a >cap fixture currently demonstrated at scale.

## Test plan

- [x] `cargo build -p geode-core` clean
- [x] `cargo build --tests --workspace` clean
- [x] `cargo clippy -p geode-core --tests` clean (large_enum_variant + needless impl_default fixed)
- [x] `cargo test -p geode-core --lib` — 169 passed, 1 ignored
- [x] `cargo test -p geode-core --test iterative_sweep` — 3 passed (the new regressions)
- [x] `cargo test -p geode-core --test extraction --test wave_port` — 11 + 1 passed (heavy tests ignored as usual)
- [x] `cargo test -p geode-core --test patch_antenna_benchmark` — 1 passed

Closes #264