### PR TITLE
feat(#266): Palace 3D oracle parity for spiral inductor benchmark

### DIFF
--- a/benchmarks/spiral_inductor/results.toml
+++ b/benchmarks/spiral_inductor/results.toml
@@ -42,6 +42,10 @@ l_nh_n4 = 2.2055
 status = "deferred"
 note = "FastHenry is not installed on the generation machine (toolchain gap, same convention as the Julia sidecars). Operator-supplied values can be recorded here with their own provenance."
 
+[oracles.palace]
+status = "pending_operator_run"
+note = "Palace is not installed on the generation machine (only a Docker build recipe under ~/GitHub/sphere/eda/mom/docker/palace). The geode-fem-side config generator + result ingester (issue #266, parity with the patch-antenna wiring from issue #239) live in reference/palace/geode_spiral_baseline/ (emits palace_config.json) and crates/geode-core/src/palace.rs (parses Palace's s-parameters.csv into a populated [oracles.palace] block). Operator workflow: (1) emit the config, (2) run Palace, (3) populate this slot via geode_core::palace::PalaceResults with full provenance (palace_version, config_sha256). Same toolchain-gap convention as the FastHenry slot above. Tolerance bands when populated: 5% L at the 1 GHz reference point, 10% Q at mid-band (4 GHz) — see crates/geode-core/tests/spiral_inductor_benchmark.rs::fem_vs_palace_oracle_within_band_or_skip_with_note."
+
 [comparison]
 # Achieved low-frequency L figures at the reference point.
 l_ref_ghz = 1

--- a/crates/geode-core/tests/spiral_inductor_benchmark.rs
+++ b/crates/geode-core/tests/spiral_inductor_benchmark.rs
@@ -440,3 +440,190 @@ fn benchmark_fixture_reference_point_matches_committed_results() {
         "L = {l:.4} nH vs Mohan {l_mohan:.4} nH outside the 10% oracle band"
     );
 }
+
+/// Tier 4: **Palace 3D oracle wiring** (issue #266, parity with the
+/// patch-antenna wiring from issue #239 / PR #242).
+///
+/// Loads the `[oracles.palace]` slot from
+/// `benchmarks/spiral_inductor/results.toml` and, if it is populated
+/// with an operator-run Palace reference, compares the committed FEM
+/// sweep against it within calibrated bands. While the slot is still
+/// `pending_operator_run` (the default state — Palace is not installed
+/// on the geode-fem dev machine), the test **skips with a note** so a
+/// missing Palace oracle never silently passes.
+///
+/// The honest contract — same convention as the FastHenry / mom slots
+/// in the same TOML — is: committed FEM artifacts can be cross-checked
+/// against the in-repo Mohan analytic oracle (10 % band), the mom PEEC
+/// baseline (12 % band on the L bracket mean), plus *whatever
+/// operator-supplied references have been ingested with full
+/// provenance.* No fabricated Palace numbers ever live in the real
+/// `[oracles.palace]` slot.
+///
+/// # Tolerance bands (when populated)
+///
+/// - **L at 1 GHz: 5 % relative**. Palace and FEM solve the same wave
+///   equation on the same fixture mesh (same lumped-port shape,
+///   permittivities, geometry); they should agree closely on the
+///   low-frequency L plateau. The dominant residual is the conductor
+///   model: the FEM benchmark uses Leontovich surface impedance for
+///   skin-depth loss, while the Palace config generator emits PEC on
+///   the conductor walls (the lossless limit). Below ~1 GHz the copper
+///   skin depth exceeds the trace thickness, so Leontovich
+///   underestimates internal inductance — the FEM L sits *above* the
+///   PEC value at low frequency. 5 % absorbs that delta plus mesh
+///   discretization differences.
+/// - **Q at 4 GHz: 10 % relative**. Q is dominated by R = Re Z, where
+///   the conductor loss model matters most. With PEC conductors Palace
+///   sees no skin loss at all, so the Palace Q will be much *higher*
+///   than the FEM Q (which carries the Leontovich loss). The 10 % band
+///   is a tracking band that will fail until the operator either:
+///   (a) configures Palace with a conductor-loss model that matches
+///   Leontovich, or (b) the spiral results.toml notes are updated to
+///   document the wider-band lossless-Palace-vs-Leontovich-FEM
+///   comparison. Either way, the test surfaces the model delta.
+/// - **Sample-point comparison: at least one shared frequency**. The
+///   FEM and Palace sweeps share the same nominal sample grid (0.1 -
+///   40 GHz, irregular log-ish) — see
+///   `reference/palace/geode_spiral_baseline/src/main.rs` `FREQS_GHZ`.
+///   If they fully diverge, the test fails loud rather than vacuously
+///   pass.
+#[test]
+fn fem_vs_palace_oracle_within_band_or_skip_with_note() {
+    use geode_core::palace::PalaceOracleSlot;
+
+    let path = repo_root().join("benchmarks/spiral_inductor/results.toml");
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read committed results {}: {e}", path.display()));
+    let doc: toml::Value = toml::from_str(&raw).expect("results.toml is valid TOML");
+    let palace_block = doc
+        .get("oracles")
+        .and_then(|o| o.get("palace"))
+        .expect("results.toml has [oracles.palace] block");
+
+    let slot = PalaceOracleSlot::from_toml_table(palace_block)
+        .unwrap_or_else(|e| panic!("[oracles.palace] in {} did not parse: {e}", path.display()));
+
+    let Some(palace) = slot.as_results() else {
+        // Honest skip-with-note. Eprintln so the test runner surface
+        // shows it; the test passes (no comparison to do) but never
+        // silently — the operator workflow is documented in
+        // `reference/palace/geode_spiral_baseline/` + `src/palace.rs`.
+        eprintln!(
+            "\nSKIP: [oracles.palace] in {} is `pending_operator_run` — \
+             no Palace reference ingested.\n  \
+             To populate: emit the config via `cd reference/palace/\
+             geode_spiral_baseline && cargo run --release`, run Palace \
+             on it (`palace -np N reference/fixtures/spiral_palace/\
+             palace_config.json`), then ingest the s-parameters.csv via \
+             `geode_core::palace::PalaceResults::from_palace_csv_file` \
+             and write the populated [oracles.palace] block in the \
+             benchmark TOML with full provenance.",
+            path.display()
+        );
+        return;
+    };
+
+    // --- Sanity provenance checks before the numeric comparison ---------
+    assert!(
+        !palace.palace_version.is_empty(),
+        "populated [oracles.palace] must record `palace_version` (provenance)"
+    );
+    assert!(
+        palace.config_sha256.len() == 64,
+        "populated [oracles.palace] must record a hex sha256 of the Palace config \
+         (provenance), got length {}",
+        palace.config_sha256.len()
+    );
+    // Cross-check: the Palace port-impedance should agree with the FEM
+    // benchmark drive (both are 50 ohm by construction).
+    const R_PORT_OHM: f64 = 50.0;
+    assert!(
+        (palace.port_resistance_ohm - R_PORT_OHM).abs() < 0.5,
+        "Palace port R = {} ohm, FEM benchmark drives at {R_PORT_OHM} ohm — \
+         the two oracles must be on the same reference impedance",
+        palace.port_resistance_ohm
+    );
+
+    let (fem_rows, _) = committed_results();
+
+    // --- Numeric band: low-frequency L at the 1 GHz reference point ----
+    let (_, l_fem, _, _) = row_at(&fem_rows, L_REF_GHZ);
+    let palace_l_at_ref = palace
+        .points
+        .iter()
+        .find(|p| (p.f_ghz - L_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - L_REF_GHZ).abs() / L_REF_GHZ) < 1e-4);
+    if let Some(palace_pt) = palace_l_at_ref {
+        let (_, z_im) = palace_pt.z_from_s11(palace.port_resistance_ohm);
+        // L (nH) = Im(Z, Ω) / (2π f_GHz)  (Ω = nH · 2π GHz at GHz freqs).
+        let l_palace = z_im / (2.0 * std::f64::consts::PI * L_REF_GHZ);
+        let rel = (l_palace - l_fem) / l_fem;
+        eprintln!(
+            "L at {L_REF_GHZ} GHz: FEM {l_fem:.4} nH vs Palace {l_palace:.4} nH ({:+.2}%)",
+            100.0 * rel
+        );
+        assert!(
+            rel.abs() < 0.05,
+            "L at {L_REF_GHZ} GHz: FEM {l_fem:.4} nH vs Palace {l_palace:.4} nH ({:+.2}%) \
+             exceeds the 5 % band. Palace solves the same wave equation as the FEM; \
+             if drift > 5 %, suspect the conductor-loss model (FEM Leontovich vs \
+             Palace PEC — see issue #266) or a port-direction sign convention.",
+            100.0 * rel
+        );
+    } else {
+        panic!(
+            "Palace sweep has no sample near {L_REF_GHZ} GHz (the L reference point); \
+             Palace freqs: {:?}",
+            palace.points.iter().map(|p| p.f_ghz).collect::<Vec<_>>()
+        );
+    }
+
+    // --- Numeric band: Q at 4 GHz mid-band tracking band ---------------
+    const Q_REF_GHZ: f64 = 4.0;
+    let (_, _, _, q_fem_4) = row_at(&fem_rows, Q_REF_GHZ);
+    let palace_q_at_ref = palace
+        .points
+        .iter()
+        .find(|p| (p.f_ghz - Q_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - Q_REF_GHZ).abs() / Q_REF_GHZ) < 1e-4);
+    if let Some(palace_pt) = palace_q_at_ref {
+        let (z_re, z_im) = palace_pt.z_from_s11(palace.port_resistance_ohm);
+        let q_palace = if z_re > 0.0 { z_im / z_re } else { f64::NAN };
+        let rel = (q_palace - q_fem_4) / q_fem_4;
+        eprintln!("Q at {Q_REF_GHZ} GHz: FEM {q_fem_4:.2} vs Palace {q_palace:.2} ({:+.2}%)",
+                  100.0 * rel);
+        assert!(
+            rel.abs() < 0.10,
+            "Q at {Q_REF_GHZ} GHz: FEM {q_fem_4:.2} vs Palace {q_palace:.2} ({:+.2}%) \
+             exceeds the 10 % tracking band. NOTE: the spiral Palace config currently \
+             uses PEC on the conductor (lossless limit), while the FEM benchmark uses \
+             Leontovich surface impedance — expect a Q ratio > 1 in the lossless \
+             direction until the operator configures matched conductor loss. Update \
+             the band / TOML notes if the model mismatch widens.",
+            100.0 * rel
+        );
+    } else {
+        panic!(
+            "Palace sweep has no sample near {Q_REF_GHZ} GHz (the Q reference point); \
+             Palace freqs: {:?}",
+            palace.points.iter().map(|p| p.f_ghz).collect::<Vec<_>>()
+        );
+    }
+
+    // --- At least one shared-frequency sample, in case the band asserts
+    //     above run out of samples but the slot was somehow still populated.
+    let mut shared = 0_usize;
+    for fem_row in &fem_rows {
+        if palace.points.iter().any(|p| {
+            (p.f_ghz - fem_row.0).abs() < 1e-6 || ((p.f_ghz - fem_row.0).abs() / fem_row.0) < 1e-4
+        }) {
+            shared += 1;
+        }
+    }
+    assert!(
+        shared >= 1,
+        "Palace sweep shares no frequency points with the FEM benchmark sweep \
+         (Palace freqs: {:?}, FEM freqs: {:?})",
+        palace.points.iter().map(|p| p.f_ghz).collect::<Vec<_>>(),
+        fem_rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+    );
+}

--- a/crates/geode-core/tests/spiral_inductor_benchmark.rs
+++ b/crates/geode-core/tests/spiral_inductor_benchmark.rs
@@ -549,10 +549,9 @@ fn fem_vs_palace_oracle_within_band_or_skip_with_note() {
 
     // --- Numeric band: low-frequency L at the 1 GHz reference point ----
     let (_, l_fem, _, _) = row_at(&fem_rows, L_REF_GHZ);
-    let palace_l_at_ref = palace
-        .points
-        .iter()
-        .find(|p| (p.f_ghz - L_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - L_REF_GHZ).abs() / L_REF_GHZ) < 1e-4);
+    let palace_l_at_ref = palace.points.iter().find(|p| {
+        (p.f_ghz - L_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - L_REF_GHZ).abs() / L_REF_GHZ) < 1e-4
+    });
     if let Some(palace_pt) = palace_l_at_ref {
         let (_, z_im) = palace_pt.z_from_s11(palace.port_resistance_ohm);
         // L (nH) = Im(Z, Ω) / (2π f_GHz)  (Ω = nH · 2π GHz at GHz freqs).
@@ -581,16 +580,17 @@ fn fem_vs_palace_oracle_within_band_or_skip_with_note() {
     // --- Numeric band: Q at 4 GHz mid-band tracking band ---------------
     const Q_REF_GHZ: f64 = 4.0;
     let (_, _, _, q_fem_4) = row_at(&fem_rows, Q_REF_GHZ);
-    let palace_q_at_ref = palace
-        .points
-        .iter()
-        .find(|p| (p.f_ghz - Q_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - Q_REF_GHZ).abs() / Q_REF_GHZ) < 1e-4);
+    let palace_q_at_ref = palace.points.iter().find(|p| {
+        (p.f_ghz - Q_REF_GHZ).abs() < 1e-6 || ((p.f_ghz - Q_REF_GHZ).abs() / Q_REF_GHZ) < 1e-4
+    });
     if let Some(palace_pt) = palace_q_at_ref {
         let (z_re, z_im) = palace_pt.z_from_s11(palace.port_resistance_ohm);
         let q_palace = if z_re > 0.0 { z_im / z_re } else { f64::NAN };
         let rel = (q_palace - q_fem_4) / q_fem_4;
-        eprintln!("Q at {Q_REF_GHZ} GHz: FEM {q_fem_4:.2} vs Palace {q_palace:.2} ({:+.2}%)",
-                  100.0 * rel);
+        eprintln!(
+            "Q at {Q_REF_GHZ} GHz: FEM {q_fem_4:.2} vs Palace {q_palace:.2} ({:+.2}%)",
+            100.0 * rel
+        );
         assert!(
             rel.abs() < 0.10,
             "Q at {Q_REF_GHZ} GHz: FEM {q_fem_4:.2} vs Palace {q_palace:.2} ({:+.2}%) \

--- a/reference/fixtures/spiral_palace/palace_config.json
+++ b/reference/fixtures/spiral_palace/palace_config.json
@@ -1,0 +1,90 @@
+{
+  "Problem": {
+    "Output": "postpro/spiral_palace",
+    "Type": "Driven",
+    "Verbose": 2
+  },
+  "Model": {
+    "L0": 1e-6,
+    "Mesh": "crates/geode-core/tests/fixtures/spiral_3p5.msh",
+    "Refinement": {
+      "UniformLevels": 0
+    }
+  },
+  "Domains": {
+    "Materials": [
+      {
+        "Attributes": [
+          1
+        ],
+        "LossTan": 0.005,
+        "Permittivity": 11.9
+      },
+      {
+        "Attributes": [
+          2
+        ],
+        "LossTan": 0.001,
+        "Permittivity": 4.0
+      },
+      {
+        "Attributes": [
+          3,
+          4
+        ],
+        "LossTan": 0.0,
+        "Permittivity": 1.0
+      }
+    ]
+  },
+  "Boundaries": {
+    "LumpedPort": [
+      {
+        "Attributes": [
+          11
+        ],
+        "Direction": "+Y",
+        "Excitation": true,
+        "Index": 1,
+        "R": 50.0
+      }
+    ],
+    "PEC": {
+      "Attributes": [
+        12,
+        13
+      ]
+    }
+  },
+  "Solver": {
+    "Driven": {
+      "FreqStep": 1.0,
+      "MaxFreq": 40.0,
+      "MinFreq": 0.1,
+      "Restart": 1,
+      "Samples": [
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.0,
+        4.0,
+        6.0,
+        8.0,
+        10.0,
+        15.0,
+        20.0,
+        30.0,
+        40.0
+      ],
+      "SaveStep": 0
+    },
+    "Linear": {
+      "KSPType": "GMRES",
+      "MaxIts": 200,
+      "Tol": 1e-8,
+      "Type": "Default"
+    },
+    "Order": 1
+  }
+}

--- a/reference/fixtures/spiral_palace/palace_config.provenance.txt
+++ b/reference/fixtures/spiral_palace/palace_config.provenance.txt
@@ -1,0 +1,55 @@
+fixture:        spiral_3p5.msh
+mesh_sha256:    c9707fb9bd5f3f484b845e96b90cf53f0b196794c5793f7e4f682bf97e101589
+generator:      reference/palace/geode_spiral_baseline (cargo run --release)
+palace docs:    https://awslabs.github.io/palace/dev/config/
+palace recipe:  ~/GitHub/sphere/eda/mom/docker/palace (sister-repo Docker build)
+
+problem:        Driven (frequency-domain driven solver)
+port:           LumpedPort, R = 50 ohm, +Y direction,
+attribute 11 (matches reference/gmsh/spiral_inductor.geo)
+materials:
+substrate:    silicon, eps_r = 11.9, tan_delta = 0.005
+(attribute 1 — substrate slab)
+dielectric:   SiO2, eps_r = 4, tan_delta = 0.001
+(attribute 2 — oxide slab minus conductor cavity)
+air + buffer: vacuum (attributes 3, 4)
+boundaries:
+PEC:          conductor cavity walls (attribute 12) + outer walls (attribute 13)
+— geode-fem uses Leontovich surface impedance on the
+conductor for skin-depth loss; Palace's PEC is the
+lossless limit (documented oracle delta)
+(no absorber: the spiral fixture is fully PEC-enclosed; the
+geode-fem benchmark also runs without a UPML, so this is the
+apples-to-apples shape)
+sweep:          0.1 GHz to 40 GHz, irregular grid bracketing the
+1 GHz L plateau and the ~21 GHz SRF (matches the
+geode benchmark sweep).
+Recorded both as a Samples array (newer Palace)
+and a MinFreq/MaxFreq/FreqStep linear form
+(older Palace) so the operator can use whichever
+their build supports.
+
+expected run time:
+The spiral mesh is ~54k unique edges (vs the
+patch fixture's ~30k), so the Palace run will
+be ~2-3x longer per frequency. With 13 sweep
+points, plan for ~30-60 minutes on 4 ranks for
+a Palace 0.13 GMRES driven solve at order 1
+(heavily dependent on the local Palace build /
+partitioning — measure on your hardware).
+
+operator workflow:
+1. cd <geode-fem repo root>
+2. palace -np <N> reference/fixtures/spiral_palace/palace_config.json
+(or via the sister-repo Docker image)
+3. The Palace run writes postpro/spiral_palace/{s-parameters.csv,
+port-V.csv, ...}. Ingest these via
+`geode_core::palace::PalaceResults::from_palace_csv_file(...)` and
+fill `benchmarks/spiral_inductor/results.toml`'s [oracles.palace]
+slot with the parsed values + this provenance file's SHA.
+
+status:         pending_operator_run — Palace is NOT installed on the
+generation machine; the [oracles.palace] slot in
+benchmarks/spiral_inductor/results.toml stays
+`pending_operator_run` until an operator-run reference
+is ingested (see crates/geode-core/src/palace.rs).

--- a/reference/palace/README.md
+++ b/reference/palace/README.md
@@ -26,14 +26,18 @@ unit-tested against synthetic fixtures under
 ```
 reference/palace/
 ├── README.md                            — this file
-└── geode_patch_baseline/
+├── geode_patch_baseline/
+│   ├── Cargo.toml                       — offline-driver workspace
+│   └── src/main.rs                      — Palace JSON config emitter for
+│                                          the FR-4 patch fixture (#228)
+└── geode_spiral_baseline/
     ├── Cargo.toml                       — offline-driver workspace
     └── src/main.rs                      — Palace JSON config emitter for
-                                          the FR-4 patch fixture (#228)
+                                          the 3.5-turn spiral inductor
+                                          fixture (#211 / #266)
 ```
 
-The committed config output lives at
-`reference/fixtures/patch_palace/`:
+The committed config outputs live under `reference/fixtures/`:
 
 ```
 reference/fixtures/patch_palace/
@@ -41,19 +45,30 @@ reference/fixtures/patch_palace/
 └── palace_config.provenance.txt         — generator provenance (mesh
                                           sha256, sweep / boundary
                                           mapping, operator workflow)
+
+reference/fixtures/spiral_palace/
+├── palace_config.json                   — Palace 0.13 driven-port config
+└── palace_config.provenance.txt         — generator provenance
 ```
 
 ## Generating the config
 
 ```sh
+# Patch antenna
 cd reference/palace/geode_patch_baseline
 cargo run --release
 # → reference/fixtures/patch_palace/palace_config.json
 #   reference/fixtures/patch_palace/palace_config.provenance.txt
+
+# Spiral inductor (parity, issue #266)
+cd reference/palace/geode_spiral_baseline
+cargo run --release
+# → reference/fixtures/spiral_palace/palace_config.json
+#   reference/fixtures/spiral_palace/palace_config.provenance.txt
 ```
 
-The generator is **offline** — it does *not* link against Palace; it
-only writes JSON. The sister-repo Docker image
+The generators are **offline** — they do *not* link against Palace; they
+only write JSON. The sister-repo Docker image
 (`~/GitHub/sphere/eda/mom/docker/palace`) is the suggested runtime.
 
 ## Running Palace (operator-assisted)
@@ -61,14 +76,21 @@ only writes JSON. The sister-repo Docker image
 From the geode-fem repo root, with a working Palace install:
 
 ```sh
+# Patch antenna
 palace -np 4 reference/fixtures/patch_palace/palace_config.json
 # Or via the sister-repo Docker image (paths mounted at /work):
 #   docker run --rm -v $(pwd):/work palace:latest \
 #     -np 4 /work/reference/fixtures/patch_palace/palace_config.json
+
+# Spiral inductor
+palace -np 4 reference/fixtures/spiral_palace/palace_config.json
 ```
 
 Palace writes the standard driven-solve artifacts (`s-parameters.csv`,
-`port-V.csv`, `port-I.csv`, ...) under `postpro/patch_palace/`.
+`port-V.csv`, `port-I.csv`, ...) under `postpro/patch_palace/` or
+`postpro/spiral_palace/` respectively. The spiral fixture has roughly
+2× the unique edges of the patch (~54k vs ~30k); plan for a
+proportionally longer Palace run per frequency.
 
 ## Ingesting results
 
@@ -89,16 +111,26 @@ let r = PalaceResults::from_palace_csv_file(
 // `PalaceOracleSlot` in `crates/geode-core/src/palace.rs`).
 ```
 
-The benchmark test
+The benchmark tests
 (`crates/geode-core/tests/patch_antenna_extraction.rs::
-fem_vs_palace_oracle_within_band_or_skip_with_note`) then compares the
-committed FEM sweep against the populated Palace block within a 5 %
-S11-dip-frequency band and a 0.10 absolute `|S11|` tracking band.
+fem_vs_palace_oracle_within_band_or_skip_with_note` for the patch and
+`crates/geode-core/tests/spiral_inductor_benchmark.rs::
+fem_vs_palace_oracle_within_band_or_skip_with_note` for the spiral) then
+compare the committed FEM sweep against the populated Palace block:
 
-**Until** an operator populates the slot, that test prints a clear
-"SKIP" note (with the operator workflow inlined) and passes — the slot
-in `benchmarks/patch_antenna/results.toml` stays
-`status = "pending_operator_run"`. The test **never silently passes**
+- **Patch antenna**: 5 % S11-dip-frequency band and a 0.10 absolute
+  `|S11|` tracking band.
+- **Spiral inductor**: 5 % L band at the 1 GHz reference point and a
+  10 % Q tracking band at 4 GHz mid-band. (Note: the spiral Palace
+  config currently emits PEC conductors — the lossless limit — while
+  the FEM benchmark uses Leontovich surface impedance for skin-depth
+  loss; expect a Q ratio > 1 in the lossless direction until matched
+  conductor loss is configured. See the test's calibrated-band docs.)
+
+**Until** an operator populates the slot, those tests print a clear
+"SKIP" note (with the operator workflow inlined) and pass — the slot
+in `benchmarks/{patch_antenna,spiral_inductor}/results.toml` stays
+`status = "pending_operator_run"`. The tests **never silently pass**
 on a missing oracle.
 
 ## Why "offline driver" and not a built-in test?
@@ -119,7 +151,9 @@ Same reason as `reference/mom/geode_*_baseline/`:
 
 - **#226** — patch antenna benchmark (Phase 2 #228, matched feed #237)
 - **#193** — spiral inductor benchmark (Phase 3 #211)
-- **#239** — this scaffolding (config generator + ingester + one
-  wired benchmark test)
+- **#239** — Palace scaffolding (config generator + ingester + patch
+  benchmark test)
+- **#266** — spiral parity (mirrors the patch wiring under the
+  spiral benchmark)
 - **#5** — operator-only tracker (catches the "the operator has to
   run X" steps so they don't get lost)

--- a/reference/palace/geode_spiral_baseline/.gitignore
+++ b/reference/palace/geode_spiral_baseline/.gitignore
@@ -1,0 +1,4 @@
+# Offline sidecar build artifacts (this crate is not part of the
+# geode workspace; see Cargo.toml).
+/target
+/Cargo.lock

--- a/reference/palace/geode_spiral_baseline/Cargo.toml
+++ b/reference/palace/geode_spiral_baseline/Cargo.toml
@@ -1,0 +1,34 @@
+# Offline Palace config generator for the geode-fem spiral-inductor
+# benchmark (issue #266, parity with the patch-antenna driver from
+# issue #239 / PR #242). NOT part of the geode workspace and NOT built
+# in CI — same offline-sidecar convention as `reference/mom/` and
+# `reference/numpy/`.
+#
+# Palace itself is NOT a dependency of this generator: this binary
+# **only emits a Palace JSON configuration file** that an operator
+# (with a working Palace install or a Docker recipe such as the one
+# under `~/GitHub/sphere/eda/mom/docker/palace`) can feed to Palace
+# directly. The run + result-ingestion step lives in
+# `reference/palace/README.md`.
+#
+# Usage:
+#
+#   cd reference/palace/geode_spiral_baseline
+#   cargo run --release
+#
+# Writes:
+#   reference/fixtures/spiral_palace/palace_config.json
+#   reference/fixtures/spiral_palace/palace_config.provenance.txt
+
+[package]
+name = "geode-spiral-palace-baseline"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"

--- a/reference/palace/geode_spiral_baseline/src/main.rs
+++ b/reference/palace/geode_spiral_baseline/src/main.rs
@@ -1,0 +1,334 @@
+//! Palace JSON config generator for the geode-fem spiral-inductor
+//! benchmark (issue #266, parity with the patch-antenna driver from
+//! issue #239 / PR #242).
+//!
+//! Emits a [Palace](https://github.com/awslabs/palace) driven-port
+//! configuration that targets the **same geometry / stack / port /
+//! frequency set** the geode-fem spiral benchmark uses
+//! (`benchmarks/spiral_inductor/results.toml`,
+//! `tests/fixtures/spiral_3p5.msh`).
+//!
+//! # Why "offline"?
+//!
+//! Palace is a heavy MFEM-based 3D full-wave solver and is **not
+//! installed on the geode-fem dev machine** (only a Docker build recipe
+//! exists in the sister monorepo, `~/GitHub/sphere/eda/mom/docker/palace`).
+//! This generator therefore only writes the *configuration file* and a
+//! provenance stub; the actual Palace run and the resulting
+//! `s-parameters.csv` / `port-V.csv` artifacts are operator-assisted
+//! and slotted into `benchmarks/spiral_inductor/results.toml`'s
+//! `[oracles.palace]` table via the ingester in
+//! `crates/geode-core/src/palace.rs`.
+//!
+//! # What Palace solves for this fixture
+//!
+//! The spiral fixture is a 3.5-turn square planar inductor on m2 with a
+//! lower-metal underpass return, embedded in a PDK-style oxide-on-silicon
+//! stack. The driven port spans the gap between the m2 feed stub and the
+//! m2 return stub, polarized along **+y** (the gap direction:
+//! [`crate::mesh::spiral::PORT_E_HAT`] in geode-fem). In Palace terms:
+//!
+//! - **Problem**: `Driven` (frequency-domain driven solver).
+//! - **Boundaries**: PEC on the conductor cavity walls (geode-fem uses a
+//!   Leontovich surface impedance — same field-equation closure, with
+//!   skin-depth loss; Palace's PEC is the lossless limit of that. The
+//!   side-by-side comparison **is** part of the oracle value); PEC on
+//!   the six outer-domain walls (the spiral fixture is fully enclosed,
+//!   not radiating — no UPML/absorbing boundary).
+//! - **Lumped port**: the rectangular port surface at the m2 mid-height
+//!   plane spanning the gap, R = 50 Ω, V_inc = 1 V, polarization +Y.
+//! - **Materials**: silicon substrate (ε_r = 11.9, tan δ = 0.005), SiO₂
+//!   oxide / dielectric (ε_r = 4.0, tan δ = 0.001), air (ε_r = 1) for
+//!   the air core + buffer slab (no UPML in this fixture).
+//! - **Sweep**: 0.1 - 40 GHz, irregular (log-ish), mirroring the
+//!   committed `examples/spiral_inductor.rs` sample grid that brackets
+//!   the SRF ≈ 21 GHz and the 1 GHz low-frequency L plateau.
+//!
+//! # Output
+//!
+//! `reference/fixtures/spiral_palace/palace_config.json` — Palace's
+//! native JSON config, with the fixture-mesh path resolved relative to
+//! the geode-fem repo root.
+//!
+//! Operator workflow (e.g. via the sister-repo Docker recipe):
+//!
+//! ```sh
+//! palace -np 4 reference/fixtures/spiral_palace/palace_config.json
+//! # → palace.s-parameters.csv, palace.port-V.csv, ...
+//! ```
+//!
+//! The ingester (see `crates/geode-core/src/palace.rs`) parses those
+//! outputs into the schema the benchmark's `[oracles.palace]` slot
+//! expects.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Spiral-fixture frequency sweep (GHz). Mirrors the committed sweep in
+/// `examples/spiral_inductor.rs` / `benchmarks/spiral_inductor/results.toml`,
+/// which is an irregular log-ish grid bracketing both the 1 GHz L
+/// plateau and the ~21 GHz SRF.
+const FREQS_GHZ: &[f64] = &[
+    0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 15.0, 20.0, 30.0, 40.0,
+];
+
+/// Silicon substrate relative permittivity (matches
+/// `mesh::spiral::EPS_R_SUBSTRATE`).
+const SUBSTRATE_EPS_R: f64 = 11.9;
+/// Silicon substrate loss tangent (matches
+/// `mesh::spiral::TAN_DELTA_SUBSTRATE`).
+const SUBSTRATE_TAN_DELTA: f64 = 0.005;
+/// SiO₂ "dielectric" slab relative permittivity (matches
+/// `mesh::spiral::EPS_R_DIELECTRIC`).
+const DIELECTRIC_EPS_R: f64 = 4.0;
+/// SiO₂ dielectric loss tangent (matches
+/// `mesh::spiral::TAN_DELTA_DIELECTRIC`).
+const DIELECTRIC_TAN_DELTA: f64 = 0.001;
+
+/// Port reference impedance (Ω). Matches the geode-fem benchmark drive.
+const PORT_RESISTANCE_OHM: f64 = 50.0;
+
+/// Spiral-fixture gmsh physical-group tags (must match
+/// `reference/gmsh/spiral_inductor.geo` and `mesh::spiral::PHYS_*`).
+mod phys {
+    pub const SUBSTRATE_VOL: u32 = 1;
+    pub const DIELECTRIC_VOL: u32 = 2;
+    pub const AIR_VOL: u32 = 3;
+    pub const AIR_BUFFER_VOL: u32 = 4;
+    pub const PORT_SURF: u32 = 11;
+    pub const CONDUCTOR_SURF: u32 = 12;
+    pub const OUTER_SURF: u32 = 13;
+}
+
+/// Repo root, two levels up from this offline driver
+/// (`reference/palace/geode_spiral_baseline/`).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+}
+
+/// Sha256 of the mesh file (recorded in the provenance stub so the
+/// operator can confirm they ran Palace on the committed mesh).
+fn mesh_sha256(path: &Path) -> String {
+    let bytes = fs::read(path).expect("read fixture mesh");
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Build the Palace JSON config tree for the spiral-inductor fixture.
+///
+/// Field names follow Palace 0.13's `config` schema (see
+/// <https://awslabs.github.io/palace/dev/config/>). The structure here
+/// is a **canonical driven-port config**; a real operator may need to
+/// adjust solver tolerances / partitioning to the local Palace build.
+#[derive(Serialize)]
+struct PalaceConfig {
+    #[serde(rename = "Problem")]
+    problem: Value,
+    #[serde(rename = "Model")]
+    model: Value,
+    #[serde(rename = "Domains")]
+    domains: Value,
+    #[serde(rename = "Boundaries")]
+    boundaries: Value,
+    #[serde(rename = "Solver")]
+    solver: Value,
+}
+
+fn build_config(mesh_path_str: &str) -> PalaceConfig {
+    // The spiral sweep is irregular (log-ish, brackets the L plateau and
+    // the SRF). Palace's `Driven` solver supports a `Samples` array of
+    // explicit sample points in addition to the linear `MinFreq` /
+    // `MaxFreq` / `FreqStep` form used by the patch generator. For
+    // older Palace builds without the samples API, an operator can fall
+    // back to the linear form with a fine step (e.g.
+    // `MinFreq: 0.1, MaxFreq: 40, FreqStep: 0.5`) and the ingester will
+    // pick out the points that coincide with the FEM sweep grid.
+    let samples: Vec<Value> = FREQS_GHZ.iter().map(|&f| json!(f)).collect();
+    let min_freq = FREQS_GHZ.first().copied().unwrap_or(0.1);
+    let max_freq = FREQS_GHZ.last().copied().unwrap_or(40.0);
+
+    PalaceConfig {
+        problem: json!({
+            "Type": "Driven",
+            "Verbose": 2,
+            "Output": "postpro/spiral_palace"
+        }),
+        model: json!({
+            "Mesh": mesh_path_str,
+            // Convert µm (the gmsh fixture's authoring units — see
+            // `reference/gmsh/spiral_inductor.geo`: "Units: microns") to
+            // meters for Palace, which works internally in SI.
+            "L0": 1.0e-6,
+            "Refinement": { "UniformLevels": 0 }
+        }),
+        domains: json!({
+            "Materials": [
+                {
+                    "Attributes": [phys::SUBSTRATE_VOL],
+                    "Permittivity": SUBSTRATE_EPS_R,
+                    "LossTan": SUBSTRATE_TAN_DELTA
+                },
+                {
+                    "Attributes": [phys::DIELECTRIC_VOL],
+                    "Permittivity": DIELECTRIC_EPS_R,
+                    "LossTan": DIELECTRIC_TAN_DELTA
+                },
+                {
+                    "Attributes": [phys::AIR_VOL, phys::AIR_BUFFER_VOL],
+                    "Permittivity": 1.0,
+                    "LossTan": 0.0
+                }
+            ]
+        }),
+        boundaries: json!({
+            // Conductor cavity walls + outer enclosure walls are both
+            // PEC for Palace. The geode-fem benchmark uses Leontovich
+            // surface impedance on the conductor walls for skin-depth
+            // loss; Palace's PEC is the lossless limit. Differences in
+            // mid-band R / Q come straight out of this side-by-side.
+            "PEC": {
+                "Attributes": [phys::CONDUCTOR_SURF, phys::OUTER_SURF]
+            },
+            "LumpedPort": [
+                {
+                    "Index": 1,
+                    "R": PORT_RESISTANCE_OHM,
+                    "Excitation": true,
+                    "Attributes": [phys::PORT_SURF],
+                    // The spiral port rectangle lies in the m2 mid-height
+                    // plane with the gap spanning **y** (the feed-stub /
+                    // return-stub end faces face each other along ±y).
+                    // `mesh::spiral::PORT_E_HAT = [0, 1, 0]`. The
+                    // observables (Z, Q, S11) are invariant under
+                    // ê → −ê since V and I flip together.
+                    "Direction": "+Y"
+                }
+            ]
+        }),
+        solver: json!({
+            "Order": 1,
+            "Driven": {
+                // Both forms recorded so the operator can pick whichever
+                // their Palace build supports. Newer Palace builds (0.13+)
+                // honor `Samples`; older builds use MinFreq/MaxFreq/FreqStep.
+                "MinFreq": min_freq,
+                "MaxFreq": max_freq,
+                "FreqStep": 1.0,
+                "Samples": samples,
+                "SaveStep": 0,
+                "Restart": 1
+            },
+            "Linear": {
+                "Type": "Default",
+                "KSPType": "GMRES",
+                "Tol": 1e-8,
+                "MaxIts": 200
+            }
+        }),
+    }
+}
+
+fn main() {
+    let root = repo_root();
+    let mesh_path = root.join("crates/geode-core/tests/fixtures/spiral_3p5.msh");
+    assert!(
+        mesh_path.exists(),
+        "spiral fixture mesh not found at {}",
+        mesh_path.display()
+    );
+    let mesh_sha = mesh_sha256(&mesh_path);
+    // The Palace mesh path is recorded **relative to the repo root** in
+    // the JSON so the same config works whether the operator runs Palace
+    // from the repo root or from a Docker mount at `/work`.
+    let mesh_path_str = "crates/geode-core/tests/fixtures/spiral_3p5.msh";
+
+    let cfg = build_config(mesh_path_str);
+
+    let out_dir = root.join("reference/fixtures/spiral_palace");
+    fs::create_dir_all(&out_dir).expect("create spiral_palace fixture dir");
+    let cfg_path = out_dir.join("palace_config.json");
+    let cfg_json = serde_json::to_string_pretty(&cfg).expect("serialize palace config");
+    fs::write(&cfg_path, &cfg_json).expect("write palace_config.json");
+    eprintln!("wrote {}", cfg_path.display());
+
+    // Provenance stub: records the exact mesh + parameter values so an
+    // operator-ingested Palace result can be cross-checked against the
+    // committed geode-fem fixture state.
+    let prov_path = out_dir.join("palace_config.provenance.txt");
+    let prov = format!(
+        "fixture:        spiral_3p5.msh\n\
+         mesh_sha256:    {mesh_sha}\n\
+         generator:      reference/palace/geode_spiral_baseline (cargo run --release)\n\
+         palace docs:    https://awslabs.github.io/palace/dev/config/\n\
+         palace recipe:  ~/GitHub/sphere/eda/mom/docker/palace (sister-repo Docker build)\n\
+         \n\
+         problem:        Driven (frequency-domain driven solver)\n\
+         port:           LumpedPort, R = {PORT_RESISTANCE_OHM} ohm, +Y direction,\n\
+                         attribute {} (matches reference/gmsh/spiral_inductor.geo)\n\
+         materials:\n\
+           substrate:    silicon, eps_r = {SUBSTRATE_EPS_R}, tan_delta = {SUBSTRATE_TAN_DELTA}\n\
+                         (attribute {} — substrate slab)\n\
+           dielectric:   SiO2, eps_r = {DIELECTRIC_EPS_R}, tan_delta = {DIELECTRIC_TAN_DELTA}\n\
+                         (attribute {} — oxide slab minus conductor cavity)\n\
+           air + buffer: vacuum (attributes {}, {})\n\
+         boundaries:\n\
+           PEC:          conductor cavity walls (attribute {}) + outer walls (attribute {})\n\
+                         — geode-fem uses Leontovich surface impedance on the\n\
+                         conductor for skin-depth loss; Palace's PEC is the\n\
+                         lossless limit (documented oracle delta)\n\
+           (no absorber: the spiral fixture is fully PEC-enclosed; the\n\
+            geode-fem benchmark also runs without a UPML, so this is the\n\
+            apples-to-apples shape)\n\
+         sweep:          {} GHz to {} GHz, irregular grid bracketing the\n\
+                         1 GHz L plateau and the ~21 GHz SRF (matches the\n\
+                         geode benchmark sweep).\n\
+                         Recorded both as a Samples array (newer Palace)\n\
+                         and a MinFreq/MaxFreq/FreqStep linear form\n\
+                         (older Palace) so the operator can use whichever\n\
+                         their build supports.\n\
+         \n\
+         expected run time:\n\
+                         The spiral mesh is ~54k unique edges (vs the\n\
+                         patch fixture's ~30k), so the Palace run will\n\
+                         be ~2-3x longer per frequency. With 13 sweep\n\
+                         points, plan for ~30-60 minutes on 4 ranks for\n\
+                         a Palace 0.13 GMRES driven solve at order 1\n\
+                         (heavily dependent on the local Palace build /\n\
+                         partitioning — measure on your hardware).\n\
+         \n\
+         operator workflow:\n\
+           1. cd <geode-fem repo root>\n\
+           2. palace -np <N> reference/fixtures/spiral_palace/palace_config.json\n\
+              (or via the sister-repo Docker image)\n\
+           3. The Palace run writes postpro/spiral_palace/{{s-parameters.csv,\n\
+              port-V.csv, ...}}. Ingest these via\n\
+              `geode_core::palace::PalaceResults::from_palace_csv_file(...)` and\n\
+              fill `benchmarks/spiral_inductor/results.toml`'s [oracles.palace]\n\
+              slot with the parsed values + this provenance file's SHA.\n\
+         \n\
+         status:         pending_operator_run — Palace is NOT installed on the\n\
+                         generation machine; the [oracles.palace] slot in\n\
+                         benchmarks/spiral_inductor/results.toml stays\n\
+                         `pending_operator_run` until an operator-run reference\n\
+                         is ingested (see crates/geode-core/src/palace.rs).\n\
+        ",
+        phys::PORT_SURF,
+        phys::SUBSTRATE_VOL,
+        phys::DIELECTRIC_VOL,
+        phys::AIR_VOL,
+        phys::AIR_BUFFER_VOL,
+        phys::CONDUCTOR_SURF,
+        phys::OUTER_SURF,
+        FREQS_GHZ.first().copied().unwrap_or(0.1),
+        FREQS_GHZ.last().copied().unwrap_or(40.0),
+    );
+    fs::write(&prov_path, prov).expect("write palace_config.provenance.txt");
+    eprintln!("wrote {}", prov_path.display());
+}


### PR DESCRIPTION
## Summary

Mirror the patch-antenna Palace wiring (PR #242 / issue #239) under the spiral inductor benchmark — parity work, scope rails: spiral only, no third benchmark, no attempt to run Palace.

- New offline driver `reference/palace/geode_spiral_baseline/` (Rust subcrate with its own `[workspace]`, same pattern as `geode_patch_baseline/`). Reads the committed `spiral_3p5.msh` and emits a Palace 0.13 driven-port JSON config + provenance stub.
- Emitted artifacts committed at `reference/fixtures/spiral_palace/`: silicon + SiO2 + air materials, PEC on conductor walls (attribute 12) + outer enclosure (attribute 13), LumpedPort along +Y at attribute 11. Irregular log-ish sweep matching the FEM benchmark; recorded both as a `Samples` array (newer Palace) and a linear `MinFreq/MaxFreq/FreqStep` form (older Palace).
- `benchmarks/spiral_inductor/results.toml` gains an `[oracles.palace]` block in the `pending_operator_run` shape — no fabricated numbers, documents the 5 % L / 10 % Q tolerance bands the test asserts when populated.
- New test `tests/spiral_inductor_benchmark.rs::fem_vs_palace_oracle_within_band_or_skip_with_note`: parses via `PalaceOracleSlot::from_toml_table`, skips-with-note while pending, compares L at 1 GHz (5 % band) and Q at 4 GHz (10 % tracking band) when populated. Documents the PEC-vs-Leontovich conductor-model delta.
- `reference/palace/README.md` and the parent-epics block updated to mention the new spiral baseline.

### Design notes

- **Lumped port, not wave port** — the spiral has lumped ports (#202 / PR #206), so the Palace config uses Palace's `LumpedPort` JSON block (different shape than the patch's, but on the same code path).
- **No absorber** — the spiral fixture is fully PEC-enclosed (no UPML); the FEM benchmark also runs without a UPML, so the Palace config matches.
- **Conductor model delta** — the FEM uses Leontovich surface impedance for skin-depth loss, the Palace config emits PEC (lossless limit). The test's calibrated-bands rustdoc documents the expected Q delta until matched conductor loss is configured.
- **Existing patch antenna Palace wiring unchanged** — verified by re-running `cargo test -p geode-core --test patch_antenna_extraction --test palace_ingestion` (all 8 tests pass).
- **Synthetic Palace fixtures reused** — `crates/geode-core/tests/fixtures/palace/` is untouched; the spiral output uses the same Palace CSV schema as the patch.

## Test plan

- [x] `cargo build --release` in `reference/palace/geode_spiral_baseline/` succeeds, `cargo run --release` emits the JSON config + provenance stub against the committed `spiral_3p5.msh`.
- [x] `cargo test -p geode-core --test spiral_inductor_benchmark fem_vs_palace_oracle_within_band_or_skip_with_note` passes (skip-with-note path, including the operator-workflow message).
- [x] `cargo test -p geode-core --test spiral_inductor_benchmark` — all 3 default tests pass (committed-results, smoke, palace skip-with-note); heavy benchmark-fixture test ignored as before.
- [x] `cargo test -p geode-core --test patch_antenna_extraction --test palace_ingestion` — all 8 tests pass (patch Palace wiring unchanged, palace ingestion unchanged).
- [x] `cargo check -p geode-core --tests` clean.

Closes #266

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>