### PR TITLE
feat(viz): Phase 1C L/Q/R vs f (spiral) + Q vs ka (Mie) with oracle overlays

### DIFF
--- a/tools/viz/README.md
+++ b/tools/viz/README.md
@@ -6,11 +6,12 @@ package is foundation-only — it exposes a shared loader, a matplotlib
 style, and an artifacts-path resolver. The headline line plots that
 consume the scaffold land in the following Phase 1 issues:
 
-| Issue | Plot family                                              |
-| ----- | -------------------------------------------------------- |
-| #278  | Spiral inductor: L / R / Q / |S11| vs frequency          |
-| #279  | Patch antenna: |S11| sweep + far-field pattern polar     |
-| #280  | Mie sphere: open / driven mode catalog                   |
+| Issue | Plot family                                                |
+| ----- | ---------------------------------------------------------- |
+| #278  | Spiral / patch: |S11| dB + polar Smith                     |
+| #279  | Spiral: L / Q / R vs f (Mohan + mom PEEC + SRF) and        |
+|       | Mie: Q_ext / Q_sca / Q_abs vs ka with analytic overlay     |
+| #280  | Mie sphere: open / driven mode catalog                     |
 
 ## Install
 
@@ -139,13 +140,13 @@ The CLI entry point lives at `geode_viz.scripts.plot_benchmark` (and
 also as a script wrapper at `tools/viz/scripts/plot_benchmark.py`).
 
 ```bash
-# Spiral inductor: writes s11_db.png + smith.png
+# Spiral inductor: writes s11_db.png + smith.png + lqr_vs_f.png
 python -m geode_viz.scripts.plot_benchmark spiral_inductor
 
 # Patch antenna (matched): overlays the unmatched sweep automatically
 python -m geode_viz.scripts.plot_benchmark patch_antenna --variant matched
 
-# Restrict to one of the two plots
+# Restrict to one of the plot families
 python -m geode_viz.scripts.plot_benchmark spiral_inductor --smith-only
 python -m geode_viz.scripts.plot_benchmark patch_antenna --s11-only
 ```
@@ -155,6 +156,41 @@ dependency. For the spiral the complex S11 is reconstructed from
 `z_re_ohm` / `z_im_ohm` via Γ = (Z − Z₀) / (Z + Z₀); for the patch the
 recorded `s11_re` / `s11_im` fields are consumed directly. The dB axis
 floor defaults to −30 dB and tightens when the data dips deeper.
+
+## Phase 1C: L/Q/R vs f + Q vs ka with oracle overlays (#279)
+
+Phase 1C adds two more plot families to the same CLI:
+
+- `geode_viz.plots.spiral.plot_lqr_vs_f` — three-panel L_eq / Q / R vs
+  frequency for the spiral inductor. Overlays the Mohan L₀ band
+  (current-sheet / modified-Wheeler / monomial-fit) and the mom PEEC
+  n=3 / n=4 shaded bracket on the L panel; drops a dotted SRF
+  guideline on every panel from `meta.srf_ghz`. R uses a log y-axis
+  with a hatched "≤ 0 post-SRF" overlay so the parallel anti-resonance
+  isn't silently dropped.
+- `geode_viz.plots.mie.plot_efficiency_vs_ka` — Q_ext / Q_sca / Q_abs
+  vs ka for the driven Mie sphere. Analytic series (B&H) drawn as a
+  solid line, FEM samples as scatter markers. Lower thin panel shows
+  the per-point relative error in % on a log axis (with a 5 % guide).
+
+```bash
+# Spiral: writes s11_db.png + smith.png + lqr_vs_f.png in one shot
+python -m geode_viz.scripts.plot_benchmark spiral_inductor
+
+# Just the L/Q/R panel
+python -m geode_viz.scripts.plot_benchmark spiral_inductor --lqr-only
+
+# Mie sphere (coarse fixture, default)
+python -m geode_viz.scripts.plot_benchmark mie_sphere
+
+# Mie sphere on the fine fixture (driven_results_fine.toml, issue #215)
+python -m geode_viz.scripts.plot_benchmark mie_sphere --fine
+```
+
+Both plot families echo the first caveat from the TOML's
+`meta.notes = [...]` array as a small italic subtitle so the figure
+self-documents its known limits (Leontovich validity floor on the
+spiral; matched-Sacks UPML choice on the Mie sphere).
 
 ## Adding a new plot module
 

--- a/tools/viz/geode_viz/plots/__init__.py
+++ b/tools/viz/geode_viz/plots/__init__.py
@@ -1,12 +1,17 @@
 """Plot modules for geode_viz.
 
 Each submodule builds a specific family of figures from the benchmark
-TOMLs loaded via :func:`geode_viz.io.load_results`. The Phase 1B
-landing (#278) ships :mod:`geode_viz.plots.s_params` — |S11| in dB and
-Smith-chart plots for the two driven benchmarks that already have an
-N-port result table on disk (spiral inductor + patch antenna).
+TOMLs loaded via :func:`geode_viz.io.load_results`.
+
+- Phase 1B (#278): :mod:`geode_viz.plots.s_params` — |S11| dB +
+  polar Smith-chart views for the driven benchmarks (spiral inductor
+  + patch antenna).
+- Phase 1C (#279): :mod:`geode_viz.plots.spiral` (L / Q / R vs f with
+  Mohan band + mom PEEC bracket) and :mod:`geode_viz.plots.mie`
+  (Q_ext / Q_sca / Q_abs vs ka with analytic-series overlay and a
+  per-point relative-error secondary axis).
 """
 
 from __future__ import annotations
 
-__all__ = ["s_params"]
+__all__ = ["s_params", "spiral", "mie"]

--- a/tools/viz/geode_viz/plots/mie.py
+++ b/tools/viz/geode_viz/plots/mie.py
@@ -1,0 +1,303 @@
+"""Mie sphere extinction / scattering efficiency plots (#279, Phase 1C).
+
+Renders the headline driven-Mie comparison: Q_ext / Q_sca vs ka, with
+the analytic Mie series (Bohren & Huffman) as a solid line and the
+FEM samples as scatter markers. A secondary thin axis on the bottom
+shows the per-point relative error so dispersion features (the
+TM_1,1 resonance at ka ≈ 1.88) are visible at a glance.
+
+Data sources:
+
+- ``benchmarks/mie_sphere/driven_results.toml`` (default, coarse mesh).
+- ``benchmarks/mie_sphere/driven_results_fine.toml`` (``--fine``,
+  ~5.9k-node sphere). Picks up the issue #215 convergence sweep.
+
+Q_abs is implicitly recovered as ``Q_ext - Q_sca`` when both are
+present (the TOML records both directly — non-absorbing dielectric
+sphere, so Q_abs ~ 0 to within solver noise).
+
+Subtitle echoes the first caveat from ``meta.notes`` (typically the
+matched-Sacks UPML choice).
+
+Single public entry point:
+
+- :func:`plot_efficiency_vs_ka` — Q_ext / Q_sca vs ka with FEM scatter,
+  analytic line, and a relative-error secondary axis.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from geode_viz.io import load_results
+from geode_viz.paths import artifacts_dir
+from geode_viz.style import apply_style, footer
+
+
+def _iter_points(results: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield ``point_<N>`` tables from a benchmark TOML in N order."""
+    indexed: list[tuple[int, dict[str, Any]]] = []
+    for key, val in results.items():
+        if not (isinstance(key, str) and key.startswith("point_")):
+            continue
+        try:
+            idx = int(key.split("_", 1)[1])
+        except ValueError:
+            continue
+        if isinstance(val, dict):
+            indexed.append((idx, val))
+    indexed.sort(key=lambda kv: kv[0])
+    return (val for _, val in indexed)
+
+
+def _sweep_arrays(
+    results: dict[str, Any],
+) -> dict[str, np.ndarray]:
+    """Extract ka / Q / rel-err arrays from a Mie driven results TOML."""
+    ka: list[float] = []
+    q_ext_a: list[float] = []
+    q_sca_a: list[float] = []
+    q_ext_f: list[float] = []
+    q_sca_f: list[float] = []
+    err_ext: list[float] = []
+    err_sca: list[float] = []
+    for point in _iter_points(results):
+        ka.append(float(point["ka"]))
+        q_ext_a.append(float(point["q_ext_analytic"]))
+        q_sca_a.append(float(point["q_sca_analytic"]))
+        q_ext_f.append(float(point["q_ext_fem"]))
+        q_sca_f.append(float(point["q_sca_fem"]))
+        err_ext.append(float(point["rel_err_q_ext"]))
+        err_sca.append(float(point["rel_err_q_sca"]))
+    return {
+        "ka": np.asarray(ka, dtype=float),
+        "q_ext_analytic": np.asarray(q_ext_a, dtype=float),
+        "q_sca_analytic": np.asarray(q_sca_a, dtype=float),
+        "q_ext_fem": np.asarray(q_ext_f, dtype=float),
+        "q_sca_fem": np.asarray(q_sca_f, dtype=float),
+        "rel_err_q_ext": np.asarray(err_ext, dtype=float),
+        "rel_err_q_sca": np.asarray(err_sca, dtype=float),
+    }
+
+
+def _resolve_out(
+    benchmark: str, out: Path | None, default_name: str
+) -> Path:
+    """Resolve the on-disk output path, creating parent dirs."""
+    if out is not None:
+        out = Path(out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return out
+    return artifacts_dir(benchmark) / default_name
+
+
+def _subtitle_from_notes(
+    results: dict[str, Any], *, max_chars: int = 120
+) -> str | None:
+    """Echo the first caveat from ``meta.notes`` as a one-line subtitle.
+
+    Truncates to ``max_chars`` (with an ellipsis) so a long sentence
+    doesn't overflow the figure width on the default 7.5-inch panel.
+    """
+    notes = results.get("meta", {}).get("notes")
+    if not isinstance(notes, list) or not notes:
+        return None
+    first = str(notes[0]).strip()
+    if not first:
+        return None
+    for sep in (". ", "; "):
+        head, sep_found, _ = first.partition(sep)
+        if sep_found:
+            first = head.strip()
+            break
+    if len(first) > max_chars:
+        first = first[: max_chars - 1].rstrip() + "…"
+    elif not first.endswith((".", "!", "?", "…")):
+        first = first + "."
+    return first
+
+
+def plot_efficiency_vs_ka(
+    out: Path | None = None,
+    *,
+    fine: bool = False,
+) -> Path:
+    """Plot Q_ext / Q_sca / Q_abs vs ka for the driven-Mie benchmark.
+
+    Two-panel figure:
+
+    - Upper (taller): Q_ext (FEM scatter + analytic line) and Q_sca
+      (FEM scatter + analytic line), plus Q_abs ≡ Q_ext − Q_sca for
+      the FEM and analytic series so the non-absorbing dielectric
+      sphere check is visible.
+    - Lower (thin): per-point relative error (|err| in percent) on a
+      log-scale y-axis so the 0.4 %–19 % spread on the coarse mesh
+      stays legible.
+
+    Parameters
+    ----------
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/mie_sphere/q_vs_ka.png``.
+    fine
+        When ``True``, load ``driven_results_fine.toml`` (the ~5.9k
+        node fine fixture from issue #215). Default ``False`` loads
+        ``driven_results.toml`` (the 774-node coarse fixture).
+
+    Returns
+    -------
+    Path
+        The resolved PNG path (already written to disk).
+    """
+    apply_style("light")
+
+    filename = "driven_results_fine.toml" if fine else "driven_results.toml"
+    results = load_results("mie_sphere", filename=filename)
+    arrays = _sweep_arrays(results)
+
+    ka = arrays["ka"]
+    q_ext_a = arrays["q_ext_analytic"]
+    q_sca_a = arrays["q_sca_analytic"]
+    q_ext_f = arrays["q_ext_fem"]
+    q_sca_f = arrays["q_sca_fem"]
+    # Non-absorbing dielectric: Q_abs = Q_ext - Q_sca (~ 0 modulo error).
+    q_abs_a = q_ext_a - q_sca_a
+    q_abs_f = q_ext_f - q_sca_f
+
+    err_ext = arrays["rel_err_q_ext"]
+    err_sca = arrays["rel_err_q_sca"]
+
+    # Two panels: efficiency above, error below. ``height_ratios`` keeps
+    # the headline efficiency panel ~3x the relative-error strip.
+    fig, (ax_q, ax_e) = plt.subplots(
+        nrows=2,
+        ncols=1,
+        sharex=True,
+        figsize=(7.5, 6.5),
+        gridspec_kw={"height_ratios": [3.0, 1.2]},
+    )
+
+    # --- Q panel: analytic lines + FEM scatter ----------------------------
+    # Dense analytic curve via the recorded points only (the analytic
+    # values are evaluated on the same ka grid as the FEM samples; no
+    # extra series available here). Use a thicker line + lighter
+    # markers so the analytic / FEM contrast is visible.
+    ax_q.plot(
+        ka,
+        q_ext_a,
+        color="#3b528b",
+        linestyle="-",
+        linewidth=1.6,
+        label="Q_ext analytic (B&H)",
+    )
+    ax_q.plot(
+        ka,
+        q_sca_a,
+        color="#21918c",
+        linestyle="-",
+        linewidth=1.6,
+        label="Q_sca analytic (B&H)",
+    )
+    ax_q.plot(
+        ka,
+        q_abs_a,
+        color="#7f7f7f",
+        linestyle=":",
+        linewidth=1.2,
+        alpha=0.8,
+        label="Q_abs analytic (≡ Q_ext − Q_sca)",
+    )
+
+    ax_q.scatter(
+        ka,
+        q_ext_f,
+        marker="o",
+        color="#3b528b",
+        s=42.0,
+        edgecolor="black",
+        linewidth=0.5,
+        zorder=3,
+        label="Q_ext FEM",
+    )
+    ax_q.scatter(
+        ka,
+        q_sca_f,
+        marker="s",
+        color="#21918c",
+        s=42.0,
+        edgecolor="black",
+        linewidth=0.5,
+        zorder=3,
+        label="Q_sca FEM",
+    )
+    ax_q.scatter(
+        ka,
+        q_abs_f,
+        marker="^",
+        color="#7f7f7f",
+        s=30.0,
+        edgecolor="black",
+        linewidth=0.4,
+        zorder=3,
+        alpha=0.8,
+        label="Q_abs FEM (Q_ext − Q_sca)",
+    )
+
+    fixture_tag = "fine" if fine else "coarse"
+    ax_q.set_ylabel("Efficiency Q (dimensionless)")
+    ax_q.legend(loc="best", fontsize=8)
+
+    # --- Error panel: |rel err| in % on a log y-axis ----------------------
+    # Convert to percent for human readability; clamp to a tiny positive
+    # floor so log-scale does not drop perfect points (none expected,
+    # but defensive).
+    pct_floor = 1.0e-3  # 0.001 % floor (well below any recorded value).
+    err_ext_pct = np.maximum(np.abs(err_ext) * 100.0, pct_floor)
+    err_sca_pct = np.maximum(np.abs(err_sca) * 100.0, pct_floor)
+
+    ax_e.plot(
+        ka,
+        err_ext_pct,
+        marker="o",
+        linestyle="-",
+        color="#3b528b",
+        markersize=4.5,
+        label="|rel err| Q_ext",
+    )
+    ax_e.plot(
+        ka,
+        err_sca_pct,
+        marker="s",
+        linestyle="--",
+        color="#21918c",
+        markersize=4.5,
+        label="|rel err| Q_sca",
+    )
+    ax_e.set_yscale("log")
+    ax_e.set_ylabel("|rel err| (%)")
+    ax_e.set_xlabel("ka")
+    ax_e.legend(loc="best", fontsize=8)
+    # A faint 5 % guide — the project's mid-band tolerance band.
+    ax_e.axhline(5.0, color="#d62728", linewidth=0.7, linestyle=":", alpha=0.6)
+
+    # Figure-level title + italic subtitle from the first TOML note.
+    subtitle = _subtitle_from_notes(results)
+    base_title = f"Mie sphere ({fixture_tag}): Q vs ka"
+    if subtitle is None:
+        fig.suptitle(base_title, fontsize=13)
+    else:
+        fig.suptitle(base_title + "\n" + subtitle, fontsize=11)
+
+    footer(fig, results)
+
+    out_path = _resolve_out("mie_sphere", out, "q_vs_ka.png")
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+__all__ = ["plot_efficiency_vs_ka"]

--- a/tools/viz/geode_viz/plots/spiral.py
+++ b/tools/viz/geode_viz/plots/spiral.py
@@ -1,0 +1,369 @@
+"""Spiral-inductor L / Q / R vs frequency plots (#279, Phase 1C).
+
+Renders the three-panel "glance" view of the spiral-inductor
+benchmark — L_eq, Q, and R vs frequency — with the two oracle
+overlays the project tracks against the FEM sweep:
+
+- ``[oracles.mohan]`` — current-sheet / modified-Wheeler / monomial-fit
+  L₀ estimates. Drawn as a horizontal *band* spanning the three
+  flavors (min-to-max) so the FEM low-frequency L can be checked
+  against the Mohan family at a glance. A sanity band, not a
+  5%-grade oracle (per the TOML notes).
+- ``[oracles.mom_peec]`` — n=3 / n=4 integer-turn bracket from the
+  mom PEEC baseline. Drawn as a shaded region (min-to-max bracket).
+- ``meta.srf_ghz`` — self-resonance frequency. Drawn as a vertical
+  guideline on every panel.
+
+Subtitle echoes the first caveat from ``meta.notes`` so the plot
+self-documents its caveats (e.g. the Leontovich low-frequency
+validity floor).
+
+Single public entry point:
+
+- :func:`plot_lqr_vs_f` — three-panel L / Q / R figure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from geode_viz.io import load_results
+from geode_viz.paths import artifacts_dir
+from geode_viz.style import apply_style, footer
+
+
+def _iter_points(results: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield ``point_<N>`` tables from a benchmark TOML in N order."""
+    indexed: list[tuple[int, dict[str, Any]]] = []
+    for key, val in results.items():
+        if not (isinstance(key, str) and key.startswith("point_")):
+            continue
+        try:
+            idx = int(key.split("_", 1)[1])
+        except ValueError:
+            continue
+        if isinstance(val, dict):
+            indexed.append((idx, val))
+    indexed.sort(key=lambda kv: kv[0])
+    return (val for _, val in indexed)
+
+
+def _sweep_arrays(
+    results: dict[str, Any],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Extract (f_ghz, l_nh, q, r_ohm) arrays from a results TOML."""
+    f_ghz: list[float] = []
+    l_nh: list[float] = []
+    q_vals: list[float] = []
+    r_ohm: list[float] = []
+    for point in _iter_points(results):
+        f_ghz.append(float(point["f_ghz"]))
+        l_nh.append(float(point["l_nh"]))
+        q_vals.append(float(point["q"]))
+        r_ohm.append(float(point["r_ohm"]))
+    return (
+        np.asarray(f_ghz, dtype=float),
+        np.asarray(l_nh, dtype=float),
+        np.asarray(q_vals, dtype=float),
+        np.asarray(r_ohm, dtype=float),
+    )
+
+
+def _mohan_band(oracles: dict[str, Any]) -> tuple[float, float] | None:
+    """Return the (min, max) L₀ band across the Mohan flavors, nH."""
+    mohan = oracles.get("mohan")
+    if not isinstance(mohan, dict):
+        return None
+    vals: list[float] = []
+    for key in (
+        "current_sheet_l_nh",
+        "modified_wheeler_l_nh",
+        "monomial_fit_l_nh",
+    ):
+        val = mohan.get(key)
+        if val is None:
+            continue
+        try:
+            vals.append(float(val))
+        except (TypeError, ValueError):
+            continue
+    if not vals:
+        return None
+    return (min(vals), max(vals))
+
+
+def _mom_peec_bracket(oracles: dict[str, Any]) -> tuple[float, float] | None:
+    """Return the (n=3, n=4) mom PEEC L bracket, sorted ascending, nH."""
+    mom = oracles.get("mom_peec")
+    if not isinstance(mom, dict):
+        return None
+    n3 = mom.get("l_nh_n3")
+    n4 = mom.get("l_nh_n4")
+    if n3 is None or n4 is None:
+        return None
+    try:
+        a, b = float(n3), float(n4)
+    except (TypeError, ValueError):
+        return None
+    return (min(a, b), max(a, b))
+
+
+def _resolve_out(
+    benchmark: str, out: Path | None, default_name: str
+) -> Path:
+    """Resolve the on-disk output path, creating parent dirs."""
+    if out is not None:
+        out = Path(out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return out
+    return artifacts_dir(benchmark) / default_name
+
+
+def _subtitle_from_notes(
+    results: dict[str, Any], *, max_chars: int = 120
+) -> str | None:
+    """Echo the first caveat from ``meta.notes`` as a one-line subtitle.
+
+    Truncates to ``max_chars`` (with an ellipsis) so a long sentence
+    doesn't overflow the figure width on the default 7.5-inch panel.
+    """
+    notes = results.get("meta", {}).get("notes")
+    if not isinstance(notes, list) or not notes:
+        return None
+    first = str(notes[0]).strip()
+    if not first:
+        return None
+    # Keep the subtitle compact — first sentence (or first semicolon clause).
+    for sep in (". ", "; "):
+        head, sep_found, _ = first.partition(sep)
+        if sep_found:
+            first = head.strip()
+            break
+    if len(first) > max_chars:
+        first = first[: max_chars - 1].rstrip() + "…"
+    elif not first.endswith((".", "!", "?", "…")):
+        first = first + "."
+    return first
+
+
+def _annotate_srf(ax: "plt.Axes", srf_ghz: float, *, label: bool) -> None:
+    """Drop a dotted vertical SRF guideline on ``ax`` with optional label."""
+    ax.axvline(
+        srf_ghz,
+        color="#d62728",
+        linestyle=":",
+        linewidth=1.0,
+        alpha=0.7,
+        label=f"SRF ≈ {srf_ghz:.2f} GHz" if label else None,
+    )
+
+
+def plot_lqr_vs_f(out: Path | None = None) -> Path:
+    """Plot the spiral inductor L / Q / R sweep vs frequency.
+
+    Three-panel figure (rows: L_eq, Q, R) sharing the frequency axis.
+    Overlays:
+
+    - Mohan L₀ horizontal band on the L panel.
+    - mom PEEC n=3 / n=4 shaded bracket on the L panel.
+    - SRF vertical guideline on every panel (from ``meta.srf_ghz``).
+    - Subtitle: first caveat from ``meta.notes``.
+    - Provenance footer: commit / fixture SHA / source TOML.
+
+    Parameters
+    ----------
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/spiral_inductor/lqr_vs_f.png``.
+
+    Returns
+    -------
+    Path
+        The resolved PNG path (already written to disk).
+    """
+    apply_style("light")
+
+    results = load_results("spiral_inductor")
+    f_ghz, l_nh, q_vals, r_ohm = _sweep_arrays(results)
+
+    oracles = results.get("oracles", {})
+    mohan = _mohan_band(oracles)
+    mom = _mom_peec_bracket(oracles)
+    srf_ghz_raw = results.get("meta", {}).get("srf_ghz")
+    srf_ghz = float(srf_ghz_raw) if srf_ghz_raw is not None else None
+
+    fig, (ax_l, ax_q, ax_r) = plt.subplots(
+        nrows=3, ncols=1, sharex=True, figsize=(7.5, 8.5)
+    )
+
+    # --- L panel -----------------------------------------------------------
+    # Split the FEM L into pre-SRF (physically meaningful inductance) and
+    # post-SRF (sign-flipped excursion through the parallel anti-resonance).
+    # Plotting the raw points on a single linear axis lets the post-SRF
+    # -19 nH spike dominate the y-range and crushes the Mohan / mom PEEC
+    # band into a single pixel — so we y-clip to the pre-SRF L range
+    # plus the oracle bands and mark post-SRF points as off-scale.
+    pre_srf_mask = (
+        (f_ghz < srf_ghz) if srf_ghz is not None else np.ones_like(f_ghz, bool)
+    )
+    pre_srf_mask &= np.isfinite(l_nh) & (l_nh > 0.0)
+    l_pre = l_nh[pre_srf_mask]
+    ax_l.plot(
+        f_ghz[pre_srf_mask],
+        l_pre,
+        marker="o",
+        color="#3b528b",
+        label="FEM L_eq (pre-SRF)",
+    )
+    # Post-SRF: still plot the markers but in a desaturated color so
+    # they are visible without dominating the y-range below.
+    post_mask = ~pre_srf_mask
+    if np.any(post_mask):
+        ax_l.plot(
+            f_ghz[post_mask],
+            l_nh[post_mask],
+            marker="x",
+            linestyle="",
+            color="#888888",
+            alpha=0.7,
+            label="FEM L_eq (post-SRF, off-scale)",
+        )
+    if mohan is not None:
+        lo, hi = mohan
+        ax_l.axhspan(
+            lo,
+            hi,
+            color="#d62728",
+            alpha=0.12,
+            label=f"Mohan L0 band [{lo:.3f}, {hi:.3f}] nH",
+        )
+        # A thin centerline for the band makes the comparison easier
+        # to read when the band is narrow (current-sheet ~ Wheeler).
+        ax_l.axhline(
+            0.5 * (lo + hi),
+            color="#d62728",
+            linestyle="--",
+            linewidth=0.8,
+            alpha=0.7,
+        )
+    if mom is not None:
+        lo, hi = mom
+        ax_l.axhspan(
+            lo,
+            hi,
+            color="#ff7f0e",
+            alpha=0.10,
+            label=f"mom PEEC n=3..4 [{lo:.3f}, {hi:.3f}] nH",
+        )
+    if srf_ghz is not None:
+        _annotate_srf(ax_l, srf_ghz, label=True)
+    # Tight y-limits anchored on the pre-SRF L sweep + the oracle bands.
+    candidates: list[float] = []
+    if l_pre.size:
+        candidates.extend([float(l_pre.min()), float(l_pre.max())])
+    if mohan is not None:
+        candidates.extend(mohan)
+    if mom is not None:
+        candidates.extend(mom)
+    if candidates:
+        lo_y = min(candidates)
+        hi_y = max(candidates)
+        pad = max(0.15 * (hi_y - lo_y), 0.1)
+        ax_l.set_ylim(max(0.0, lo_y - pad), hi_y + pad)
+    ax_l.set_ylabel("L_eq (nH)")
+    ax_l.legend(loc="best", fontsize=8)
+
+    # --- Q panel -----------------------------------------------------------
+    # Same pre-SRF / post-SRF split: Q sign-flips at the anti-resonance
+    # and the -26 post-SRF point similarly crushes the mid-band Q ~ 24.
+    q_pre = q_vals[pre_srf_mask]
+    ax_q.plot(
+        f_ghz[pre_srf_mask],
+        q_pre,
+        marker="o",
+        color="#3b528b",
+        label="FEM Q (pre-SRF)",
+    )
+    if np.any(post_mask):
+        ax_q.plot(
+            f_ghz[post_mask],
+            q_vals[post_mask],
+            marker="x",
+            linestyle="",
+            color="#888888",
+            alpha=0.7,
+            label="FEM Q (post-SRF)",
+        )
+    if srf_ghz is not None:
+        _annotate_srf(ax_q, srf_ghz, label=False)
+    if q_pre.size:
+        q_lo = float(q_pre.min())
+        q_hi = float(q_pre.max())
+        q_pad = max(0.15 * (q_hi - q_lo), 1.0)
+        ax_q.set_ylim(min(0.0, q_lo - q_pad), q_hi + q_pad)
+    ax_q.set_ylabel("Q (Im Z / Re Z)")
+    ax_q.axhline(0.0, color="#888888", linewidth=0.6, alpha=0.5)
+    if np.any(post_mask):
+        ax_q.legend(loc="best", fontsize=8)
+
+    # --- R panel -----------------------------------------------------------
+    # R spans ~0.2 ohm at 0.1 GHz to ~1.6 kohm at the SRF — use a log
+    # y-axis so the low-frequency Leontovich floor stays readable.
+    r_pos = r_ohm[r_ohm > 0.0]
+    use_log = r_pos.size > 0 and (r_pos.max() / max(r_pos.min(), 1e-12)) > 50.0
+    if use_log:
+        ax_r.set_yscale("log")
+        # On a log scale, negative R points (the post-SRF dip) cannot be
+        # plotted directly — overlay them as a hatched scatter band at
+        # the bottom of the panel so they aren't silently dropped.
+        ax_r.plot(
+            f_ghz[r_ohm > 0.0],
+            r_ohm[r_ohm > 0.0],
+            marker="o",
+            color="#21918c",
+            label="FEM R (positive)",
+        )
+        if np.any(r_ohm <= 0.0):
+            ax_r.scatter(
+                f_ghz[r_ohm <= 0.0],
+                np.full(np.sum(r_ohm <= 0.0), max(r_pos.min(), 1e-3)),
+                marker="x",
+                color="#d62728",
+                label="FEM R ≤ 0 (post-SRF)",
+            )
+    else:
+        ax_r.plot(f_ghz, r_ohm, marker="o", color="#21918c", label="FEM R")
+    if srf_ghz is not None:
+        _annotate_srf(ax_r, srf_ghz, label=False)
+    ax_r.set_ylabel("R (Ω)")
+    ax_r.set_xlabel("Frequency (GHz)")
+    if use_log:
+        ax_r.legend(loc="best", fontsize=8)
+
+    # Figure-level title + italic subtitle from the first TOML note,
+    # placed above the constrained-layout L panel so they don't collide
+    # with axis ticks / legends.
+    subtitle = _subtitle_from_notes(results)
+    if subtitle is None:
+        fig.suptitle(
+            "Spiral inductor: L / Q / R vs frequency", fontsize=13
+        )
+    else:
+        fig.suptitle(
+            "Spiral inductor: L / Q / R vs frequency\n" + subtitle,
+            fontsize=11,
+        )
+
+    footer(fig, results)
+
+    out_path = _resolve_out("spiral_inductor", out, "lqr_vs_f.png")
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+__all__ = ["plot_lqr_vs_f"]

--- a/tools/viz/geode_viz/scripts/plot_benchmark.py
+++ b/tools/viz/geode_viz/scripts/plot_benchmark.py
@@ -1,20 +1,26 @@
-"""CLI entry point for the Phase 1B benchmark plots (#278).
+"""CLI entry point for the geode_viz benchmark plots.
 
-Renders the S-parameter (|S11| dB) and Smith-chart views for the two
-driven benchmarks that already carry an N-port result table on disk
-(spiral inductor + patch antenna).
+Renders the headline figures for a port-driven / driven-scattering
+benchmark in a single invocation. Wires together the Phase 1B
+S-parameter / Smith-chart plots (#278) and the Phase 1C L / Q / R +
+Q vs ka plots (#279) so an operator can refresh the artifact tree
+with one command per benchmark.
 
 Usage::
 
+    # Spiral: writes s11_db.png + smith.png + lqr_vs_f.png
     python -m geode_viz.scripts.plot_benchmark spiral_inductor
-    python -m geode_viz.scripts.plot_benchmark patch_antenna --variant matched
-    python -m geode_viz.scripts.plot_benchmark spiral_inductor --smith-only
 
-By default both ``s11_db.png`` and ``smith.png`` are written under
-``artifacts/viz/<benchmark>/``. ``--s11-only`` and ``--smith-only``
-restrict the run to one of the two plots; ``--variant`` selects the
-patch-antenna result file (matched vs unmatched) and is ignored for
-benchmarks with a single result file.
+    # Patch: writes s11_db.png + smith.png (matched variant + overlay)
+    python -m geode_viz.scripts.plot_benchmark patch_antenna --variant matched
+
+    # Mie: writes q_vs_ka.png (coarse fixture by default)
+    python -m geode_viz.scripts.plot_benchmark mie_sphere
+    python -m geode_viz.scripts.plot_benchmark mie_sphere --fine
+
+By default every plot wired up for the chosen benchmark is rendered.
+Restrict to a single family with the ``--<plot>-only`` flags
+(``--s11-only`` / ``--smith-only`` / ``--lqr-only`` / ``--mie-only``).
 """
 
 from __future__ import annotations
@@ -24,18 +30,22 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from geode_viz.plots.mie import plot_efficiency_vs_ka
 from geode_viz.plots.s_params import plot_s11_magnitude, plot_smith
+from geode_viz.plots.spiral import plot_lqr_vs_f
 
-# Benchmarks understood by the CLI. Constrained to the Phase 1B
-# acceptance set — extend explicitly as new benchmarks land their
-# port-driven result tables. The ordering is preserved by argparse
-# for the ``choices=`` help text.
-_BENCHMARKS: tuple[str, ...] = ("spiral_inductor", "patch_antenna")
+# Benchmarks understood by the CLI. The mapping spells out which
+# plot families a benchmark exposes — used both by argparse
+# (``choices=``) and by the dispatch below to skip flags that don't
+# apply (e.g. ``--variant`` for ``mie_sphere``).
+_BENCHMARK_PLOTS: dict[str, tuple[str, ...]] = {
+    "spiral_inductor": ("s11", "smith", "lqr"),
+    "patch_antenna": ("s11", "smith"),
+    "mie_sphere": ("mie",),
+}
+_BENCHMARKS: tuple[str, ...] = tuple(_BENCHMARK_PLOTS)
 
-# Variants understood by the ``--variant`` flag. The choices are a
-# subset of the patch-antenna variants exposed by
-# :mod:`geode_viz.plots.s_params`; keep them in sync if more are
-# added there.
+# Variants understood by the ``--variant`` flag (patch antenna only).
 _VARIANTS: tuple[str, ...] = ("matched", "unmatched")
 
 
@@ -43,8 +53,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m geode_viz.scripts.plot_benchmark",
         description=(
-            "Render the |S11| dB + Smith-chart plots for a "
-            "port-driven geode-fem benchmark (Phase 1B, issue #278)."
+            "Render the headline figures for a geode-fem benchmark. "
+            "Phase 1B (|S11| dB + Smith) and Phase 1C (L/Q/R, Q vs ka) "
+            "plots are dispatched per-benchmark."
         ),
     )
     parser.add_argument(
@@ -61,17 +72,38 @@ def _build_parser() -> argparse.ArgumentParser:
             "Ignored for benchmarks with a single result file."
         ),
     )
+    parser.add_argument(
+        "--fine",
+        action="store_true",
+        help=(
+            "Mie sphere: load the fine-mesh fixture "
+            "(driven_results_fine.toml, issue #215). "
+            "Ignored for other benchmarks."
+        ),
+    )
+
     plot_filter = parser.add_mutually_exclusive_group()
     plot_filter.add_argument(
         "--s11-only",
         action="store_true",
-        help="Only render the |S11| dB plot.",
+        help="Only render the |S11| dB plot (Phase 1B).",
     )
     plot_filter.add_argument(
         "--smith-only",
         action="store_true",
-        help="Only render the Smith-chart plot.",
+        help="Only render the Smith-chart plot (Phase 1B).",
     )
+    plot_filter.add_argument(
+        "--lqr-only",
+        action="store_true",
+        help="Spiral inductor: only render the L/Q/R panel (Phase 1C).",
+    )
+    plot_filter.add_argument(
+        "--mie-only",
+        action="store_true",
+        help="Mie sphere: only render the Q vs ka panel (Phase 1C).",
+    )
+
     parser.add_argument(
         "--s11-out",
         type=Path,
@@ -90,7 +122,45 @@ def _build_parser() -> argparse.ArgumentParser:
             "artifacts/viz/<benchmark>/smith.png."
         ),
     )
+    parser.add_argument(
+        "--lqr-out",
+        type=Path,
+        default=None,
+        help=(
+            "Override the L/Q/R PNG output path. Defaults to "
+            "artifacts/viz/spiral_inductor/lqr_vs_f.png."
+        ),
+    )
+    parser.add_argument(
+        "--mie-out",
+        type=Path,
+        default=None,
+        help=(
+            "Override the Q vs ka PNG output path. Defaults to "
+            "artifacts/viz/mie_sphere/q_vs_ka.png."
+        ),
+    )
     return parser
+
+
+def _plot_filter(args: argparse.Namespace) -> set[str]:
+    """Resolve the set of plot families to run for this invocation."""
+    any_only = (
+        args.s11_only or args.smith_only or args.lqr_only or args.mie_only
+    )
+    if not any_only:
+        # Render every plot family the benchmark exposes.
+        return set(_BENCHMARK_PLOTS[args.benchmark])
+    selected: set[str] = set()
+    if args.s11_only:
+        selected.add("s11")
+    if args.smith_only:
+        selected.add("smith")
+    if args.lqr_only:
+        selected.add("lqr")
+    if args.mie_only:
+        selected.add("mie")
+    return selected
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -98,11 +168,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    do_s11 = not args.smith_only
-    do_smith = not args.s11_only
+    available = set(_BENCHMARK_PLOTS[args.benchmark])
+    requested = _plot_filter(args)
+    selected = requested & available
+
+    # Surface explicit mismatch ('--mie-only' on spiral, etc.) so the
+    # user gets a clear signal instead of a silent no-op.
+    skipped = requested - available
+    if skipped:
+        parser.error(
+            f"plot family/families {sorted(skipped)} are not available for "
+            f"benchmark {args.benchmark!r} (available: {sorted(available)})"
+        )
+
+    if not selected:
+        parser.error("no plot families selected")
 
     written: list[Path] = []
-    if do_s11:
+
+    if "s11" in selected:
         written.append(
             plot_s11_magnitude(
                 args.benchmark,
@@ -110,13 +194,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 variant=args.variant,
             )
         )
-    if do_smith:
+    if "smith" in selected:
         written.append(
             plot_smith(
                 args.benchmark,
                 out=args.smith_out,
                 variant=args.variant,
             )
+        )
+    if "lqr" in selected:
+        written.append(plot_lqr_vs_f(out=args.lqr_out))
+    if "mie" in selected:
+        written.append(
+            plot_efficiency_vs_ka(out=args.mie_out, fine=args.fine)
         )
 
     for path in written:


### PR DESCRIPTION
## Summary

Phase 1C of Epic #276 (visualization tooling). Lands the two headline
single-figure "glance" plots called out by the issue brief, building
on the Phase 1A scaffold (#281) and the Phase 1B CLI dispatch (#282).

- **Spiral inductor — `lqr_vs_f.png`**: three-panel `L_eq` / `Q` / `R`
  vs frequency with the Mohan L₀ band, the mom PEEC n=3 / n=4
  bracket, and a dotted SRF guideline (from `meta.srf_ghz`).
  Pre-SRF / post-SRF points are split so the parallel anti-resonance
  excursion (`L` → −19 nH past 30 GHz) doesn't crush the y-axis.
- **Mie sphere — `q_vs_ka.png`**: `Q_ext` / `Q_sca` / `Q_abs` vs ka
  with the analytic B&H series as solid lines and FEM samples as
  scatter markers. Lower thin panel shows the per-point `|rel err|`
  in % on a log axis with a faint 5 % guide. `--fine` selects
  `driven_results_fine.toml` (issue #215 fine fixture).

Both plot families echo the first caveat from the TOML's `meta.notes`
array as an italic subtitle (truncated to 120 chars with an
ellipsis) so the figure self-documents its known limits.

Closes #279.

## What's in the PR

- `tools/viz/geode_viz/plots/spiral.py` — `plot_lqr_vs_f(out=None)`.
- `tools/viz/geode_viz/plots/mie.py` — `plot_efficiency_vs_ka(out=None, *, fine=False)`.
- `tools/viz/geode_viz/scripts/plot_benchmark.py` — extended CLI
  dispatch:
  - `spiral_inductor` now renders **s11_db.png + smith.png +
    lqr_vs_f.png** in one shot (Phase 1B + 1C).
  - `mie_sphere [--fine]` writes `q_vs_ka.png`.
  - New `--lqr-only` / `--mie-only` filters and `--lqr-out` /
    `--mie-out` path overrides, matching the existing Phase 1B
    flag shape.
  - Mismatched filters (e.g. `--lqr-only` on `mie_sphere`) produce a
    clear argparse error rather than a silent no-op.
- `tools/viz/geode_viz/plots/__init__.py` — exports `spiral` / `mie`.
- `tools/viz/README.md` — Phase 1C usage section.

## Acceptance criteria coverage

- [x] `python -m geode_viz.scripts.plot_benchmark spiral_inductor`
      produces `lqr_vs_f.png` showing the Mohan band, the mom PEEC
      bracket, and the SRF annotation
- [x] `python -m geode_viz.scripts.plot_benchmark mie_sphere`
      produces `q_vs_ka.png` with FEM points, analytic-series line,
      and a per-point relative-error axis
- [x] `--fine` flag selects the fine-mesh TOML for Mie
      (`driven_results_fine.toml`)
- [x] Plot subtitle echoes the first caveat from `notes`
- [x] No new deps beyond Phase 1A's `tomli + numpy + matplotlib`

## Test plan

- [x] `python -m geode_viz.scripts.plot_benchmark spiral_inductor`
      end-to-end — all three PNGs land in
      `artifacts/viz/spiral_inductor/`.
- [x] `python -m geode_viz.scripts.plot_benchmark spiral_inductor
      --lqr-only` writes only `lqr_vs_f.png`.
- [x] `python -m geode_viz.scripts.plot_benchmark mie_sphere`
      writes `q_vs_ka.png` (coarse fixture; commit `2402a7cb`); the
      error panel shows the ~17 % spike on TM_1,1 at ka = 1.9.
- [x] `python -m geode_viz.scripts.plot_benchmark mie_sphere --fine`
      loads `driven_results_fine.toml` (commit `eb679843`); the
      error panel drops to ~0.4 % at ka = 1.5 (issue #215
      convergence).
- [x] `python -m geode_viz.scripts.plot_benchmark patch_antenna
      --variant matched` still works (Phase 1B regression check).
- [x] `python -m geode_viz.scripts.plot_benchmark mie_sphere
      --lqr-only` produces a clear argparse error (mismatched filter).
- [x] `tools/viz/scripts/plot_benchmark.py` shell-wrapper form also
      dispatches the new plots.
- [x] `python -m py_compile` on every new / modified module.
- [x] Visually inspected `lqr_vs_f.png` and `q_vs_ka.png` (coarse +
      fine): FEM L sweep sits inside both oracle bands through the
      mid-band, SRF guideline at 20.85 GHz, analytic / FEM contrast
      crisp on Mie, footer carries `commit / fixture SHA / source
      TOML` on every figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)