### PR TITLE
feat(viz): Phase 1D patch-antenna radiation-pattern polar cuts (#280)

### DIFF
--- a/tools/viz/geode_viz/plots/__init__.py
+++ b/tools/viz/geode_viz/plots/__init__.py
@@ -10,8 +10,15 @@ TOMLs loaded via :func:`geode_viz.io.load_results`.
   Mohan band + mom PEEC bracket) and :mod:`geode_viz.plots.mie`
   (Q_ext / Q_sca / Q_abs vs ka with analytic-series overlay and a
   per-point relative-error secondary axis).
+- Phase 1D (#280): :mod:`geode_viz.plots.pattern` — patch-antenna
+  E-plane / H-plane radiation pattern polar cuts with the Balanis
+  cavity-model oracle overlaid as a reference ring.
+
+Shared helpers (``iter_points`` / ``subtitle_from_notes`` /
+``resolve_out``) live in :mod:`geode_viz.plots._common` so all
+per-benchmark modules import them from one source of truth.
 """
 
 from __future__ import annotations
 
-__all__ = ["s_params", "spiral", "mie"]
+__all__ = ["s_params", "spiral", "mie", "pattern"]

--- a/tools/viz/geode_viz/plots/_common.py
+++ b/tools/viz/geode_viz/plots/_common.py
@@ -1,0 +1,142 @@
+"""Shared helpers reused by per-benchmark plot modules.
+
+Phase 1C judge feedback (#283) called out that ``_iter_points``,
+``_subtitle_from_notes``, and ``_resolve_out`` were duplicated across
+:mod:`geode_viz.plots.spiral` and :mod:`geode_viz.plots.mie`. Phase 1D
+(#280) introduces a third module (:mod:`geode_viz.plots.pattern`) that
+would carry the same trio, so the helpers are lifted here and the
+three call sites import from a single source of truth.
+
+The helpers are intentionally narrow:
+
+- :func:`iter_points` — yield ``point_<N>`` tables from a benchmark
+  TOML in N order. Used by sweep-style benchmarks
+  (spiral_inductor / mie_sphere).
+- :func:`subtitle_from_notes` — compact one-line subtitle pulled from
+  ``meta.notes[0]`` (truncated, sentence-tidy) so the figure
+  self-documents its caveats.
+- :func:`resolve_out` — resolve the on-disk output path, defaulting
+  to ``artifacts/viz/<benchmark>/<default_name>`` and creating parent
+  directories on demand.
+
+Keep this module dependency-free beyond ``geode_viz.paths`` so plot
+modules importing it pick up only what they need.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from geode_viz.paths import artifacts_dir
+
+
+def iter_points(results: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield ``point_<N>`` tables from a benchmark TOML in N order.
+
+    The Phase-1 sweep TOMLs (``spiral_inductor`` /
+    ``mie_sphere``) record sweep points as ``[point_0]`` /
+    ``[point_1]`` / ... tables. Iterate them in numeric order so
+    downstream code can build per-axis arrays without re-sorting.
+
+    Parameters
+    ----------
+    results
+        Parsed TOML dict from :func:`geode_viz.io.load_results`.
+
+    Yields
+    ------
+    dict
+        Each ``point_<N>`` table in ascending ``N`` order. Tables
+        whose suffix is non-integer are silently skipped.
+    """
+    indexed: list[tuple[int, dict[str, Any]]] = []
+    for key, val in results.items():
+        if not (isinstance(key, str) and key.startswith("point_")):
+            continue
+        try:
+            idx = int(key.split("_", 1)[1])
+        except ValueError:
+            continue
+        if isinstance(val, dict):
+            indexed.append((idx, val))
+    indexed.sort(key=lambda kv: kv[0])
+    return (val for _, val in indexed)
+
+
+def subtitle_from_notes(
+    results: dict[str, Any], *, max_chars: int = 120
+) -> str | None:
+    """Echo the first caveat from ``meta.notes`` as a one-line subtitle.
+
+    The benchmark TOMLs carry a ``meta.notes`` list of free-form
+    caveats; the first entry is typically the headline caveat (e.g.
+    "matched-Sacks UPML choice", "Leontovich low-frequency validity
+    floor"). Truncates to ``max_chars`` (with an ellipsis) so a long
+    sentence doesn't overflow the figure width on the default 7.5-inch
+    panel, and stops at the first sentence / semicolon clause so the
+    subtitle stays compact.
+
+    Parameters
+    ----------
+    results
+        Parsed TOML dict from :func:`geode_viz.io.load_results`.
+    max_chars
+        Soft upper bound on the rendered subtitle length.
+
+    Returns
+    -------
+    str or None
+        The cleaned subtitle, or ``None`` if no notes are present.
+    """
+    notes = results.get("meta", {}).get("notes")
+    if not isinstance(notes, list) or not notes:
+        return None
+    first = str(notes[0]).strip()
+    if not first:
+        return None
+    # Keep the subtitle compact — first sentence (or first
+    # semicolon clause).
+    for sep in (". ", "; "):
+        head, sep_found, _ = first.partition(sep)
+        if sep_found:
+            first = head.strip()
+            break
+    if len(first) > max_chars:
+        first = first[: max_chars - 1].rstrip() + "…"
+    elif not first.endswith((".", "!", "?", "…")):
+        first = first + "."
+    return first
+
+
+def resolve_out(
+    benchmark: str, out: Path | None, default_name: str
+) -> Path:
+    """Resolve the on-disk output path, creating parent directories.
+
+    Parameters
+    ----------
+    benchmark
+        Benchmark name — the subdirectory under
+        ``artifacts/viz/`` used when ``out`` is ``None``.
+    out
+        Optional explicit output path; when provided, parent
+        directories are created and the path is returned as-is.
+    default_name
+        Filename used under ``artifacts/viz/<benchmark>/`` when
+        ``out`` is ``None``.
+
+    Returns
+    -------
+    Path
+        The resolved output path. Parent directories are guaranteed
+        to exist on return.
+    """
+    if out is not None:
+        out = Path(out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return out
+    return artifacts_dir(benchmark) / default_name
+
+
+__all__ = ["iter_points", "subtitle_from_notes", "resolve_out"]

--- a/tools/viz/geode_viz/plots/mie.py
+++ b/tools/viz/geode_viz/plots/mie.py
@@ -28,30 +28,18 @@ Single public entry point:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from geode_viz.io import load_results
-from geode_viz.paths import artifacts_dir
+from geode_viz.plots._common import (
+    iter_points as _iter_points,
+    resolve_out as _resolve_out,
+    subtitle_from_notes as _subtitle_from_notes,
+)
 from geode_viz.style import apply_style, footer
-
-
-def _iter_points(results: dict[str, Any]) -> Iterable[dict[str, Any]]:
-    """Yield ``point_<N>`` tables from a benchmark TOML in N order."""
-    indexed: list[tuple[int, dict[str, Any]]] = []
-    for key, val in results.items():
-        if not (isinstance(key, str) and key.startswith("point_")):
-            continue
-        try:
-            idx = int(key.split("_", 1)[1])
-        except ValueError:
-            continue
-        if isinstance(val, dict):
-            indexed.append((idx, val))
-    indexed.sort(key=lambda kv: kv[0])
-    return (val for _, val in indexed)
 
 
 def _sweep_arrays(
@@ -82,43 +70,6 @@ def _sweep_arrays(
         "rel_err_q_ext": np.asarray(err_ext, dtype=float),
         "rel_err_q_sca": np.asarray(err_sca, dtype=float),
     }
-
-
-def _resolve_out(
-    benchmark: str, out: Path | None, default_name: str
-) -> Path:
-    """Resolve the on-disk output path, creating parent dirs."""
-    if out is not None:
-        out = Path(out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        return out
-    return artifacts_dir(benchmark) / default_name
-
-
-def _subtitle_from_notes(
-    results: dict[str, Any], *, max_chars: int = 120
-) -> str | None:
-    """Echo the first caveat from ``meta.notes`` as a one-line subtitle.
-
-    Truncates to ``max_chars`` (with an ellipsis) so a long sentence
-    doesn't overflow the figure width on the default 7.5-inch panel.
-    """
-    notes = results.get("meta", {}).get("notes")
-    if not isinstance(notes, list) or not notes:
-        return None
-    first = str(notes[0]).strip()
-    if not first:
-        return None
-    for sep in (". ", "; "):
-        head, sep_found, _ = first.partition(sep)
-        if sep_found:
-            first = head.strip()
-            break
-    if len(first) > max_chars:
-        first = first[: max_chars - 1].rstrip() + "…"
-    elif not first.endswith((".", "!", "?", "…")):
-        first = first + "."
-    return first
 
 
 def plot_efficiency_vs_ka(

--- a/tools/viz/geode_viz/plots/pattern.py
+++ b/tools/viz/geode_viz/plots/pattern.py
@@ -1,0 +1,420 @@
+"""Patch-antenna radiation-pattern polar cuts (#280, Phase 1D).
+
+Renders the headline NTFF radiation-pattern view from
+``benchmarks/patch_antenna/pattern.toml`` (untuned) or
+``pattern_matched.toml`` (matched feed, default): the E-plane and
+H-plane principal cuts on a single polar axes, plus the Balanis
+cavity-model oracle overlaid as a thin reference line. A corner
+annotation surfaces the broadside directivity and gain scalars
+(``D_broadside_dBi`` / ``G_broadside_dBi``) alongside the cavity-model
+``directivity_broadside_dbi`` so the FEM-vs-oracle delta is visible at
+a glance.
+
+Antenna-engineering convention (per the issue brief):
+
+- ``projection="polar"`` with ``set_theta_zero_location("N")`` so
+  broadside (θ = 0, +z) is up.
+- ``set_theta_direction(-1)`` so θ increases clockwise — the
+  convention every patch-antenna textbook uses for the principal
+  cuts.
+
+Magnitude axis is in dB (``20·log10|E|``) with a fixed −30 dB floor,
+matching the |S11| dB axis convention in :mod:`geode_viz.plots.s_params`.
+Side-lobe / back-lobe behaviour matters as much as the main beam for
+debugging the NTFF, so the floor is fixed rather than data-driven.
+
+Single public entry point:
+
+- :func:`plot_pattern_cut` — polar plot of the E-plane + H-plane
+  principal cuts (solid + dashed) with the cavity-model oracle
+  overlaid as a thin line.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from geode_viz.io import load_results
+from geode_viz.plots._common import (
+    resolve_out as _resolve_out,
+    subtitle_from_notes as _subtitle_from_notes,
+)
+from geode_viz.style import apply_style, footer
+
+# Default dB floor for the radial axis. Matches the |S11| dB floor
+# in :mod:`geode_viz.plots.s_params`; tuned so the −10 dB / −20 dB
+# side-lobe band stays legible without the back-lobe noise dominating
+# the panel.
+_PATTERN_DB_FLOOR: float = -30.0
+
+# Patch-antenna pattern variants. Keyed on the ``--variant`` flag
+# value and resolved to the on-disk TOML filename + human label used
+# in legends + titles. ``matched`` is the default (the tuned feed
+# inset that lands the S11 dip at the design frequency).
+_PATCH_PATTERN_VARIANTS: dict[str, tuple[str, str]] = {
+    "matched": ("pattern_matched.toml", "matched"),
+    "unmatched": ("pattern.toml", "unmatched"),
+}
+
+
+def _cut_arrays(cut: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+    """Extract (theta_deg, e_norm) arrays from a ``[cut.<plane>]`` table.
+
+    The TOML records both fields as homogeneous float arrays; we
+    coerce to ``np.float64`` so downstream arithmetic (``log10``,
+    polar deg-to-rad conversion) is well-behaved.
+    """
+    theta_deg = np.asarray(cut["theta_deg"], dtype=float)
+    e_norm = np.asarray(cut["e_norm"], dtype=float)
+    if theta_deg.shape != e_norm.shape:
+        raise ValueError(
+            "theta_deg and e_norm must have the same shape; "
+            f"got {theta_deg.shape} vs {e_norm.shape}"
+        )
+    return theta_deg, e_norm
+
+
+def _to_db(e_norm: np.ndarray, *, floor_db: float) -> np.ndarray:
+    """Convert ``|E|`` to dB (``20·log10|E|``) with a hard floor.
+
+    The recorded ``e_norm`` is normalized so the lobe peak hits 1.0
+    (0 dB); the floor protects against null directions where
+    ``e_norm`` rounds to zero on the recorded precision.
+    """
+    # Floor the linear magnitude so ``log10`` is finite even at deep nulls.
+    floor_lin = 10.0 ** (floor_db / 20.0)
+    e_safe = np.maximum(np.abs(e_norm), floor_lin)
+    return 20.0 * np.log10(e_safe)
+
+
+def _polar_radius(
+    e_db: np.ndarray, *, floor_db: float
+) -> np.ndarray:
+    """Convert a dB array to a non-negative polar radius.
+
+    The polar axes wants ``r >= 0``; the data range is ``[floor_db, 0]``
+    so we shift by ``-floor_db`` to land in ``[0, -floor_db]``.
+    Tick labels on the radial axis are restored to the dB convention
+    in :func:`_format_radial_ticks`.
+    """
+    return e_db - floor_db
+
+
+def _format_radial_ticks(
+    ax: "plt.Axes", *, floor_db: float, step_db: float = 10.0
+) -> None:
+    """Label the polar radial axis in dB (``0 dB`` at the rim)."""
+    # Walk from 0 dB inward by ``step_db``; skip the dead-center label
+    # to keep the chart from overplotting at the origin.
+    db_levels = np.arange(0.0, floor_db - 0.1, -step_db)
+    r_levels = db_levels - floor_db
+    ax.set_rticks(r_levels)
+    ax.set_yticklabels([f"{int(db)} dB" for db in db_levels])
+    ax.set_rlabel_position(135.0)
+    ax.set_rlim(0.0, -floor_db)
+
+
+def _load_pattern_variant(
+    variant: str,
+) -> tuple[dict[str, Any], str]:
+    """Load the patch-antenna pattern TOML for the requested variant.
+
+    Parameters
+    ----------
+    variant
+        ``"matched"`` (default — ``pattern_matched.toml``) or
+        ``"unmatched"`` (``pattern.toml``).
+
+    Returns
+    -------
+    tuple
+        ``(results, label)``. ``results`` is the parsed TOML dict;
+        ``label`` is the human-readable variant tag used in titles
+        and legends.
+    """
+    if variant not in _PATCH_PATTERN_VARIANTS:
+        raise ValueError(
+            f"unknown patch pattern variant {variant!r}; "
+            f"expected one of {sorted(_PATCH_PATTERN_VARIANTS)}"
+        )
+    filename, label = _PATCH_PATTERN_VARIANTS[variant]
+    results = load_results("patch_antenna", filename=filename)
+    return results, label
+
+
+def _annotation_text(
+    results: dict[str, Any],
+    *,
+    label: str,
+) -> str:
+    """Build the corner annotation summarizing FEM + cavity-model scalars.
+
+    Surfaces (in order) the FEM broadside directivity, FEM broadside
+    gain, and the Balanis cavity-model oracle's broadside directivity
+    so the FEM-vs-oracle delta is visible without cross-referencing
+    the TOML.
+    """
+    fem_results = results.get("results", {})
+    oracle = results.get("oracles", {}).get("cavity_model", {})
+
+    lines: list[str] = [f"variant: {label}"]
+    f_res = results.get("meta", {}).get("f_res_ghz")
+    if f_res is not None:
+        try:
+            lines.append(f"f_res = {float(f_res):.3f} GHz")
+        except (TypeError, ValueError):
+            pass
+
+    d_b = fem_results.get("directivity_broadside_dbi")
+    if d_b is not None:
+        try:
+            lines.append(f"D_broadside = {float(d_b):.2f} dBi")
+        except (TypeError, ValueError):
+            pass
+
+    g_b = fem_results.get("gain_broadside_dbi")
+    if g_b is not None:
+        try:
+            lines.append(f"G_broadside = {float(g_b):.2f} dBi")
+        except (TypeError, ValueError):
+            pass
+
+    d_b_cavity = oracle.get("directivity_broadside_dbi")
+    if d_b_cavity is not None:
+        try:
+            lines.append(
+                f"D_broadside (cavity) = {float(d_b_cavity):.2f} dBi"
+            )
+        except (TypeError, ValueError):
+            pass
+
+    delta = oracle.get("directivity_delta_db")
+    if delta is not None:
+        try:
+            lines.append(f"Δ vs cavity = {float(delta):+.2f} dB")
+        except (TypeError, ValueError):
+            pass
+
+    return "\n".join(lines)
+
+
+def _plot_cut(
+    ax: "plt.Axes",
+    theta_deg: np.ndarray,
+    e_db: np.ndarray,
+    *,
+    label: str,
+    linestyle: str,
+    color: str,
+    linewidth: float = 1.6,
+    floor_db: float,
+) -> None:
+    """Plot a single E-plane / H-plane cut on the polar axes.
+
+    The cut is recorded over ``theta_deg ∈ [0, 180]`` (the upper
+    hemisphere principal cut). Mirror it to ``[-180, 180]`` so the
+    polar trace closes back at broadside, matching the convention
+    used in Balanis Figs. 14.40-14.44.
+    """
+    # Mirror the upper-hemisphere cut into the lower hemisphere so
+    # the polar trace runs through θ = -180 ... 180 (closed loop).
+    # The mirrored half uses the same |E| values; the principal cuts
+    # for a broadside patch have phi-symmetry across the relevant
+    # plane.
+    theta_full_deg = np.concatenate([-theta_deg[::-1], theta_deg])
+    e_db_full = np.concatenate([e_db[::-1], e_db])
+    # Drop the duplicate θ = 0 sample introduced by the mirror.
+    theta_full_deg = np.concatenate([theta_full_deg[:-1], theta_full_deg[-1:]])
+    # Convert dB to polar radius (radius >= 0, 0 dB at rim).
+    r_full = _polar_radius(e_db_full, floor_db=floor_db)
+    theta_rad = np.deg2rad(theta_full_deg)
+    ax.plot(
+        theta_rad,
+        r_full,
+        linestyle=linestyle,
+        color=color,
+        linewidth=linewidth,
+        label=label,
+    )
+
+
+def plot_pattern_cut(
+    benchmark: str = "patch_antenna",
+    *,
+    variant: str = "matched",
+    out: Path | None = None,
+) -> Path:
+    """Plot the E-plane + H-plane radiation pattern on a polar axes.
+
+    Loads ``pattern_matched.toml`` (default) or ``pattern.toml`` and
+    renders the two principal cuts on a single polar axes:
+
+    - E-plane (solid).
+    - H-plane (dashed).
+    - Balanis cavity-model oracle as a thin reference circle at
+      ``directivity_broadside_dbi`` relative to the FEM lobe peak (the
+      cavity model is a scalar oracle; the trace is a constant-D ring
+      annotated with the cavity D value).
+
+    The radial axis is dB (``20·log10|E|``) with a fixed −30 dB floor.
+    A corner annotation surfaces the FEM ``D_broadside`` /
+    ``G_broadside`` and the cavity-model ``D_broadside`` scalars.
+
+    Parameters
+    ----------
+    benchmark
+        Benchmark name (currently only ``"patch_antenna"`` is wired).
+        Kept as a parameter for symmetry with the other plot helpers.
+    variant
+        ``"matched"`` (default — the tuned-feed pattern) or
+        ``"unmatched"`` (the untuned ``pattern.toml``).
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/<benchmark>/pattern_cuts.png``.
+
+    Returns
+    -------
+    Path
+        The resolved PNG path (already written to disk).
+    """
+    if benchmark != "patch_antenna":
+        raise ValueError(
+            f"plot_pattern_cut is only wired for patch_antenna; "
+            f"got benchmark {benchmark!r}"
+        )
+
+    apply_style("light")
+
+    results, label = _load_pattern_variant(variant)
+
+    cuts = results.get("cut", {})
+    if "e_plane" not in cuts or "h_plane" not in cuts:
+        raise KeyError(
+            "pattern TOML is missing [cut.e_plane] or [cut.h_plane]"
+        )
+    theta_e_deg, e_norm_e = _cut_arrays(cuts["e_plane"])
+    theta_h_deg, e_norm_h = _cut_arrays(cuts["h_plane"])
+
+    floor_db = _PATTERN_DB_FLOOR
+    e_db_e = _to_db(e_norm_e, floor_db=floor_db)
+    e_db_h = _to_db(e_norm_h, floor_db=floor_db)
+
+    # Constrained-layout (enabled by ``apply_style``) does not always
+    # interact well with polar subplots; turn it off here so we can
+    # hand-tune the suptitle / annotation positions without the
+    # legend bouncing around.
+    fig = plt.figure(figsize=(8.0, 7.5))
+    fig.set_constrained_layout(False)
+    ax = fig.add_subplot(111, projection="polar")
+    # Antenna-engineering convention: broadside (θ = 0) up, θ
+    # increases clockwise.
+    ax.set_theta_zero_location("N")
+    ax.set_theta_direction(-1)
+
+    _plot_cut(
+        ax,
+        theta_e_deg,
+        e_db_e,
+        label="E-plane (FEM)",
+        linestyle="-",
+        color="#3b528b",
+        floor_db=floor_db,
+    )
+    _plot_cut(
+        ax,
+        theta_h_deg,
+        e_db_h,
+        label="H-plane (FEM)",
+        linestyle="--",
+        color="#21918c",
+        floor_db=floor_db,
+    )
+
+    # --- Cavity-model oracle overlay --------------------------------------
+    # The Balanis cavity-model oracle records only the broadside
+    # directivity scalar, not a full angular pattern. Surface it as a
+    # thin reference ring at the dB delta between FEM and cavity-model
+    # broadside D so the FEM-vs-cavity gap is visible on the polar
+    # axes itself, not only in the annotation block.
+    oracle = results.get("oracles", {}).get("cavity_model", {})
+    d_fem_dbi = results.get("results", {}).get("directivity_broadside_dbi")
+    d_cavity_dbi = oracle.get("directivity_broadside_dbi")
+    if d_fem_dbi is not None and d_cavity_dbi is not None:
+        try:
+            delta = float(d_cavity_dbi) - float(d_fem_dbi)
+        except (TypeError, ValueError):
+            delta = None
+        if delta is not None and floor_db < delta < 0.0:
+            # The cavity D is below the FEM D (the recorded pattern is
+            # normalized so the FEM lobe peak sits at 0 dB); draw the
+            # cavity reference as a thin ring at ``delta`` dB.
+            theta_ring = np.linspace(-np.pi, np.pi, 361)
+            r_ring = np.full_like(
+                theta_ring, _polar_radius(delta, floor_db=floor_db)
+            )
+            ax.plot(
+                theta_ring,
+                r_ring,
+                color="#d62728",
+                linestyle=":",
+                linewidth=1.0,
+                alpha=0.7,
+                label=(
+                    f"cavity-model D_broadside "
+                    f"({delta:+.2f} dB vs FEM peak)"
+                ),
+            )
+
+    _format_radial_ticks(ax, floor_db=floor_db)
+    # Constrain the angular grid to the standard antenna-convention
+    # ticks (every 30°) so the polar backdrop matches Balanis Figs.
+    ax.set_thetagrids(np.arange(0, 360, 30))
+
+    # --- Annotation block --------------------------------------------------
+    # Anchored to the lower-left so the suptitle has the whole top
+    # band to itself and the long ``meta.notes`` subtitle has room
+    # to wrap.
+    annotation = _annotation_text(results, label=label)
+    fig.text(
+        0.015,
+        0.18,
+        annotation,
+        fontsize=8,
+        family="monospace",
+        ha="left",
+        va="bottom",
+        bbox=dict(
+            boxstyle="round,pad=0.4",
+            facecolor="white",
+            edgecolor="#888888",
+            alpha=0.85,
+        ),
+    )
+
+    # Figure-level title + optional subtitle from the first TOML note.
+    subtitle = _subtitle_from_notes(results)
+    base_title = f"Patch antenna ({label}): radiation pattern cuts"
+    if subtitle is None:
+        fig.suptitle(base_title, fontsize=13, y=0.97)
+    else:
+        fig.suptitle(base_title + "\n" + subtitle, fontsize=11, y=0.97)
+
+    # Tighten the polar axes inside the figure so the suptitle and
+    # the bottom legend / footer don't overlap the axes labels.
+    ax.set_position([0.13, 0.13, 0.74, 0.74])
+    ax.legend(
+        loc="lower center", bbox_to_anchor=(0.5, -0.18), fontsize=8
+    )
+    footer(fig, results)
+
+    out_path = _resolve_out(benchmark, out, "pattern_cuts.png")
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+__all__ = ["plot_pattern_cut"]

--- a/tools/viz/geode_viz/plots/spiral.py
+++ b/tools/viz/geode_viz/plots/spiral.py
@@ -26,30 +26,18 @@ Single public entry point:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from geode_viz.io import load_results
-from geode_viz.paths import artifacts_dir
+from geode_viz.plots._common import (
+    iter_points as _iter_points,
+    resolve_out as _resolve_out,
+    subtitle_from_notes as _subtitle_from_notes,
+)
 from geode_viz.style import apply_style, footer
-
-
-def _iter_points(results: dict[str, Any]) -> Iterable[dict[str, Any]]:
-    """Yield ``point_<N>`` tables from a benchmark TOML in N order."""
-    indexed: list[tuple[int, dict[str, Any]]] = []
-    for key, val in results.items():
-        if not (isinstance(key, str) and key.startswith("point_")):
-            continue
-        try:
-            idx = int(key.split("_", 1)[1])
-        except ValueError:
-            continue
-        if isinstance(val, dict):
-            indexed.append((idx, val))
-    indexed.sort(key=lambda kv: kv[0])
-    return (val for _, val in indexed)
 
 
 def _sweep_arrays(
@@ -110,44 +98,6 @@ def _mom_peec_bracket(oracles: dict[str, Any]) -> tuple[float, float] | None:
     except (TypeError, ValueError):
         return None
     return (min(a, b), max(a, b))
-
-
-def _resolve_out(
-    benchmark: str, out: Path | None, default_name: str
-) -> Path:
-    """Resolve the on-disk output path, creating parent dirs."""
-    if out is not None:
-        out = Path(out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        return out
-    return artifacts_dir(benchmark) / default_name
-
-
-def _subtitle_from_notes(
-    results: dict[str, Any], *, max_chars: int = 120
-) -> str | None:
-    """Echo the first caveat from ``meta.notes`` as a one-line subtitle.
-
-    Truncates to ``max_chars`` (with an ellipsis) so a long sentence
-    doesn't overflow the figure width on the default 7.5-inch panel.
-    """
-    notes = results.get("meta", {}).get("notes")
-    if not isinstance(notes, list) or not notes:
-        return None
-    first = str(notes[0]).strip()
-    if not first:
-        return None
-    # Keep the subtitle compact — first sentence (or first semicolon clause).
-    for sep in (". ", "; "):
-        head, sep_found, _ = first.partition(sep)
-        if sep_found:
-            first = head.strip()
-            break
-    if len(first) > max_chars:
-        first = first[: max_chars - 1].rstrip() + "…"
-    elif not first.endswith((".", "!", "?", "…")):
-        first = first + "."
-    return first
 
 
 def _annotate_srf(ax: "plt.Axes", srf_ghz: float, *, label: bool) -> None:

--- a/tools/viz/geode_viz/scripts/plot_benchmark.py
+++ b/tools/viz/geode_viz/scripts/plot_benchmark.py
@@ -2,16 +2,17 @@
 
 Renders the headline figures for a port-driven / driven-scattering
 benchmark in a single invocation. Wires together the Phase 1B
-S-parameter / Smith-chart plots (#278) and the Phase 1C L / Q / R +
-Q vs ka plots (#279) so an operator can refresh the artifact tree
-with one command per benchmark.
+S-parameter / Smith-chart plots (#278), the Phase 1C L / Q / R +
+Q vs ka plots (#279), and the Phase 1D radiation-pattern polar
+cuts (#280) so an operator can refresh the artifact tree with one
+command per benchmark.
 
 Usage::
 
     # Spiral: writes s11_db.png + smith.png + lqr_vs_f.png
     python -m geode_viz.scripts.plot_benchmark spiral_inductor
 
-    # Patch: writes s11_db.png + smith.png (matched variant + overlay)
+    # Patch: writes s11_db.png + smith.png + pattern_cuts.png
     python -m geode_viz.scripts.plot_benchmark patch_antenna --variant matched
 
     # Mie: writes q_vs_ka.png (coarse fixture by default)
@@ -20,7 +21,8 @@ Usage::
 
 By default every plot wired up for the chosen benchmark is rendered.
 Restrict to a single family with the ``--<plot>-only`` flags
-(``--s11-only`` / ``--smith-only`` / ``--lqr-only`` / ``--mie-only``).
+(``--s11-only`` / ``--smith-only`` / ``--lqr-only`` / ``--mie-only`` /
+``--pattern-only``).
 """
 
 from __future__ import annotations
@@ -31,6 +33,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from geode_viz.plots.mie import plot_efficiency_vs_ka
+from geode_viz.plots.pattern import plot_pattern_cut
 from geode_viz.plots.s_params import plot_s11_magnitude, plot_smith
 from geode_viz.plots.spiral import plot_lqr_vs_f
 
@@ -40,7 +43,7 @@ from geode_viz.plots.spiral import plot_lqr_vs_f
 # apply (e.g. ``--variant`` for ``mie_sphere``).
 _BENCHMARK_PLOTS: dict[str, tuple[str, ...]] = {
     "spiral_inductor": ("s11", "smith", "lqr"),
-    "patch_antenna": ("s11", "smith"),
+    "patch_antenna": ("s11", "smith", "pattern"),
     "mie_sphere": ("mie",),
 }
 _BENCHMARKS: tuple[str, ...] = tuple(_BENCHMARK_PLOTS)
@@ -54,8 +57,9 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="python -m geode_viz.scripts.plot_benchmark",
         description=(
             "Render the headline figures for a geode-fem benchmark. "
-            "Phase 1B (|S11| dB + Smith) and Phase 1C (L/Q/R, Q vs ka) "
-            "plots are dispatched per-benchmark."
+            "Phase 1B (|S11| dB + Smith), Phase 1C (L/Q/R, Q vs ka), "
+            "and Phase 1D (radiation-pattern polar cuts) plots are "
+            "dispatched per-benchmark."
         ),
     )
     parser.add_argument(
@@ -103,6 +107,14 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Mie sphere: only render the Q vs ka panel (Phase 1C).",
     )
+    plot_filter.add_argument(
+        "--pattern-only",
+        action="store_true",
+        help=(
+            "Patch antenna: only render the radiation-pattern polar "
+            "cuts (Phase 1D)."
+        ),
+    )
 
     parser.add_argument(
         "--s11-out",
@@ -140,13 +152,26 @@ def _build_parser() -> argparse.ArgumentParser:
             "artifacts/viz/mie_sphere/q_vs_ka.png."
         ),
     )
+    parser.add_argument(
+        "--pattern-out",
+        type=Path,
+        default=None,
+        help=(
+            "Override the radiation-pattern PNG output path. "
+            "Defaults to artifacts/viz/patch_antenna/pattern_cuts.png."
+        ),
+    )
     return parser
 
 
 def _plot_filter(args: argparse.Namespace) -> set[str]:
     """Resolve the set of plot families to run for this invocation."""
     any_only = (
-        args.s11_only or args.smith_only or args.lqr_only or args.mie_only
+        args.s11_only
+        or args.smith_only
+        or args.lqr_only
+        or args.mie_only
+        or args.pattern_only
     )
     if not any_only:
         # Render every plot family the benchmark exposes.
@@ -160,6 +185,8 @@ def _plot_filter(args: argparse.Namespace) -> set[str]:
         selected.add("lqr")
     if args.mie_only:
         selected.add("mie")
+    if args.pattern_only:
+        selected.add("pattern")
     return selected
 
 
@@ -207,6 +234,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if "mie" in selected:
         written.append(
             plot_efficiency_vs_ka(out=args.mie_out, fine=args.fine)
+        )
+    if "pattern" in selected:
+        written.append(
+            plot_pattern_cut(
+                args.benchmark,
+                variant=args.variant,
+                out=args.pattern_out,
+            )
         )
 
     for path in written:


### PR DESCRIPTION
## Summary

Closes #280 — Phase 1D of Epic #276 (visualization tooling).

- Adds `geode_viz.plots.pattern.plot_pattern_cut(benchmark, *, variant, out)` — polar plot of the E-plane (solid) and H-plane (dashed) principal radiation-pattern cuts from `benchmarks/patch_antenna/pattern.toml` (unmatched) or `pattern_matched.toml` (matched, default), with the Balanis cavity-model oracle overlaid as a thin reference ring at the FEM-vs-cavity broadside-D delta. Radial axis in dB (20·log10|E|), fixed −30 dB floor, antenna-engineering convention (`set_theta_zero_location("N")` / `set_theta_direction(-1)` → broadside up, θ increases clockwise). Corner annotation surfaces `D_broadside_dBi`, `G_broadside_dBi`, and the cavity-model `directivity_broadside_dbi`.
- Extends the `plot_benchmark` CLI: `_BENCHMARK_PLOTS["patch_antenna"]` now includes `"pattern"`, so `python -m geode_viz.scripts.plot_benchmark patch_antenna --pattern-only` writes `artifacts/viz/patch_antenna/pattern_cuts.png`. New `--pattern-out` flag mirrors `--s11-out` / `--smith-out`. `--variant matched|unmatched` selects the on-disk TOML.
- Small refactor (per Phase 1C judge note on PR #283): lift the duplicated `_iter_points` / `_subtitle_from_notes` / `_resolve_out` helpers from `spiral.py` + `mie.py` into a new `geode_viz.plots._common` module so the three per-benchmark plot modules import them from one source of truth.
- No new deps (matplotlib + numpy + tomllib only; no `scikit-rf`, no `scipy`).

## Test plan

- [x] `python -m geode_viz.scripts.plot_benchmark patch_antenna --pattern-only` writes `artifacts/viz/patch_antenna/pattern_cuts.png` for the matched variant
- [x] E-plane (solid blue) and H-plane (dashed teal) are both visible and distinguishable
- [x] Cavity-model `directivity_broadside_dbi` (4.34 dBi) is shown in the annotation block alongside FEM `D_broadside` (5.21 dBi matched, 5.52 dBi unmatched) and `G_broadside` (−0.21 dBi matched, 0.38 dBi unmatched)
- [x] Cavity-model reference ring appears at the FEM-vs-cavity dB delta (−0.86 dB matched, −1.17 dB unmatched)
- [x] `--variant unmatched` correctly selects `pattern.toml`
- [x] Full `python -m geode_viz.scripts.plot_benchmark patch_antenna` (no `--*-only` flag) renders all three: `s11_db.png`, `smith.png`, `pattern_cuts.png`
- [x] Refactor is transparent — `spiral_inductor --lqr-only` and `mie_sphere` still render after the `_common` lift

🤖 Generated with [Claude Code](https://claude.com/claude-code)