### PR TITLE
feat(viz): Phase 2A geode-core VTK .vtu writer (#285)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 285
+# Branch: feature/issue-285
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,0 @@
-# Loom-managed worktree marker
-# Created by .loom/scripts/worktree.sh
-# Issue: 285
-# Branch: feature/issue-285
-# Removing this file makes Loom treat the worktree as user-owned and refuse
-# to clean it up automatically.

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod scattering;
 pub mod silvermuller;
 pub mod silvermuller_self_consistent;
 pub mod sparse;
+pub mod viz_vtu;
 pub mod wave_port;
 pub mod waveguide_modes;
 pub(crate) mod whitney_face;

--- a/crates/geode-core/src/viz_vtu.rs
+++ b/crates/geode-core/src/viz_vtu.rs
@@ -1,0 +1,241 @@
+//! VTK `UnstructuredGrid` (`.vtu`) writer for tetrahedral meshes plus
+//! per-node electromagnetic field data.
+//!
+//! This module serialises a [`TetMesh`] together with a complex `E`-field
+//! sampled at the mesh nodes into the ASCII XML `UnstructuredGrid` (`.vtu`)
+//! format understood by ParaView 5.x and the wider EM/VTK community. It is
+//! the Phase 2A foundation of Epic #276: Phase 2B wires an `--export-field`
+//! flag onto the benchmark examples and Phase 2C renders the result
+//! headlessly with `pvbatch`.
+//!
+//! # Chosen XML schema
+//!
+//! We emit the "inline ASCII" flavour of the VTK XML format (no
+//! appended/base64 binary blob). The document layout is:
+//!
+//! ```xml
+//! <?xml version="1.0"?>
+//! <VTKFile type="UnstructuredGrid" version="1.0" byte_order="LittleEndian">
+//!   <UnstructuredGrid>
+//!     <Piece NumberOfPoints="N" NumberOfCells="M">
+//!       <Points>
+//!         <DataArray type="Float64" NumberOfComponents="3" format="ascii"> ... </DataArray>
+//!       </Points>
+//!       <Cells>
+//!         <DataArray type="Int64" Name="connectivity" format="ascii"> ... </DataArray>
+//!         <DataArray type="Int64" Name="offsets"      format="ascii"> ... </DataArray>
+//!         <DataArray type="UInt8" Name="types"        format="ascii"> ... </DataArray>
+//!       </Cells>
+//!       <PointData>
+//!         <DataArray type="Float64" Name="E_real" NumberOfComponents="3" format="ascii"> ... </DataArray>
+//!         <DataArray type="Float64" Name="|E|"    NumberOfComponents="1" format="ascii"> ... </DataArray>
+//!         <!-- optional --> <DataArray Name="E_imag" .../>
+//!         <!-- optional --> <DataArray Name="eps_r" .../>
+//!       </PointData>
+//!     </Piece>
+//!   </UnstructuredGrid>
+//! </VTKFile>
+//! ```
+//!
+//! Cells use VTK cell type `10` (`VTK_TETRA`): each tet contributes four
+//! connectivity entries (0-based node indices, matching `mesh.tets`
+//! directly — VTK is 0-based) and a contiguous `offsets` entry equal to
+//! `4 * (cell_index + 1)`.
+//!
+//! Point coordinates are written in `mesh.nodes` order so that point id `i`
+//! is `mesh.nodes[i]`; the field arrays are indexed identically.
+//!
+//! The string is hand-rolled with [`std::fmt::Write`] and flushed in one
+//! [`std::fs::write`] — no `vtkio` / serialisation dependency is pulled in,
+//! matching the other text-format writers in this crate.
+//!
+//! # Reference
+//!
+//! Kitware VTK XML file format specification:
+//! <https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html#xml-file-formats>
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::TetMesh;
+
+/// Serialise `mesh` plus the node-sampled field data to an ASCII XML
+/// `UnstructuredGrid` (`.vtu`) file at `path`.
+///
+/// * `e_field` — real part of the per-node `E` field, length
+///   `mesh.n_nodes()`. Written as the `E_real` Vec3 `PointData` array.
+/// * `e_imag` — optional imaginary part (same length); when present it is
+///   written as the `E_imag` Vec3 array and folded into the `|E|` magnitude
+///   (`sqrt(re² + im²)` per component, summed). When absent, `|E|` is just
+///   the magnitude of `e_field`.
+/// * `eps_r` — optional per-node relative permittivity (length
+///   `mesh.n_nodes()`); written as the scalar `eps_r` array when present.
+///
+/// The writer does not decide where `e_field` comes from — evaluating the
+/// Nédélec edge DOFs at nodes is the caller's responsibility (Phase 2B).
+///
+/// # Panics
+///
+/// Panics if any provided slice length does not equal `mesh.n_nodes()`.
+/// This is a programmer error (mismatched field/mesh), not an I/O failure.
+pub fn write_vtu(
+    path: &Path,
+    mesh: &TetMesh,
+    e_field: &[[f64; 3]],
+    e_imag: Option<&[[f64; 3]]>,
+    eps_r: Option<&[f64]>,
+) -> std::io::Result<()> {
+    let n_nodes = mesh.n_nodes();
+    let n_tets = mesh.n_tets();
+
+    assert_eq!(
+        e_field.len(),
+        n_nodes,
+        "e_field length ({}) must equal mesh.n_nodes() ({})",
+        e_field.len(),
+        n_nodes
+    );
+    if let Some(im) = e_imag {
+        assert_eq!(
+            im.len(),
+            n_nodes,
+            "e_imag length ({}) must equal mesh.n_nodes() ({})",
+            im.len(),
+            n_nodes
+        );
+    }
+    if let Some(eps) = eps_r {
+        assert_eq!(
+            eps.len(),
+            n_nodes,
+            "eps_r length ({}) must equal mesh.n_nodes() ({})",
+            eps.len(),
+            n_nodes
+        );
+    }
+
+    // Pre-size generously: header + per-node and per-tet lines. Growth is
+    // cheap; this just avoids a handful of early reallocations.
+    let mut s = String::with_capacity(512 + n_nodes * 96 + n_tets * 32);
+
+    s.push_str("<?xml version=\"1.0\"?>\n");
+    s.push_str("<VTKFile type=\"UnstructuredGrid\" version=\"1.0\" byte_order=\"LittleEndian\">\n");
+    s.push_str("  <UnstructuredGrid>\n");
+    let _ = writeln!(
+        s,
+        "    <Piece NumberOfPoints=\"{n_nodes}\" NumberOfCells=\"{n_tets}\">"
+    );
+
+    // --- Points -----------------------------------------------------------
+    s.push_str("      <Points>\n");
+    s.push_str("        <DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">\n");
+    for [x, y, z] in &mesh.nodes {
+        let _ = writeln!(
+            s,
+            "          {} {} {}",
+            fmt_f64(*x),
+            fmt_f64(*y),
+            fmt_f64(*z)
+        );
+    }
+    s.push_str("        </DataArray>\n");
+    s.push_str("      </Points>\n");
+
+    // --- Cells ------------------------------------------------------------
+    s.push_str("      <Cells>\n");
+    s.push_str("        <DataArray type=\"Int64\" Name=\"connectivity\" format=\"ascii\">\n");
+    for [a, b, c, d] in &mesh.tets {
+        let _ = writeln!(s, "          {a} {b} {c} {d}");
+    }
+    s.push_str("        </DataArray>\n");
+
+    s.push_str("        <DataArray type=\"Int64\" Name=\"offsets\" format=\"ascii\">\n");
+    for cell in 0..n_tets {
+        let _ = writeln!(s, "          {}", 4 * (cell + 1));
+    }
+    s.push_str("        </DataArray>\n");
+
+    s.push_str("        <DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">\n");
+    for _ in 0..n_tets {
+        // 10 == VTK_TETRA
+        s.push_str("          10\n");
+    }
+    s.push_str("        </DataArray>\n");
+    s.push_str("      </Cells>\n");
+
+    // --- PointData --------------------------------------------------------
+    s.push_str("      <PointData>\n");
+
+    // E_real (Vec3)
+    s.push_str(
+        "        <DataArray type=\"Float64\" Name=\"E_real\" NumberOfComponents=\"3\" format=\"ascii\">\n",
+    );
+    for [x, y, z] in e_field {
+        let _ = writeln!(
+            s,
+            "          {} {} {}",
+            fmt_f64(*x),
+            fmt_f64(*y),
+            fmt_f64(*z)
+        );
+    }
+    s.push_str("        </DataArray>\n");
+
+    // |E| (scalar): sqrt(re² + im²) folded over components when imag present.
+    s.push_str(
+        "        <DataArray type=\"Float64\" Name=\"|E|\" NumberOfComponents=\"1\" format=\"ascii\">\n",
+    );
+    for (node, re) in e_field.iter().enumerate() {
+        let mut sumsq = re[0] * re[0] + re[1] * re[1] + re[2] * re[2];
+        if let Some(im) = e_imag {
+            let imv = im[node];
+            sumsq += imv[0] * imv[0] + imv[1] * imv[1] + imv[2] * imv[2];
+        }
+        let _ = writeln!(s, "          {}", fmt_f64(sumsq.sqrt()));
+    }
+    s.push_str("        </DataArray>\n");
+
+    // E_imag (Vec3) — optional.
+    if let Some(im) = e_imag {
+        s.push_str(
+            "        <DataArray type=\"Float64\" Name=\"E_imag\" NumberOfComponents=\"3\" format=\"ascii\">\n",
+        );
+        for [x, y, z] in im {
+            let _ = writeln!(
+                s,
+                "          {} {} {}",
+                fmt_f64(*x),
+                fmt_f64(*y),
+                fmt_f64(*z)
+            );
+        }
+        s.push_str("        </DataArray>\n");
+    }
+
+    // eps_r (scalar) — optional.
+    if let Some(eps) = eps_r {
+        s.push_str(
+            "        <DataArray type=\"Float64\" Name=\"eps_r\" NumberOfComponents=\"1\" format=\"ascii\">\n",
+        );
+        for v in eps {
+            let _ = writeln!(s, "          {}", fmt_f64(*v));
+        }
+        s.push_str("        </DataArray>\n");
+    }
+
+    s.push_str("      </PointData>\n");
+
+    // --- Close ------------------------------------------------------------
+    s.push_str("    </Piece>\n");
+    s.push_str("  </UnstructuredGrid>\n");
+    s.push_str("</VTKFile>\n");
+
+    std::fs::write(path, s)
+}
+
+/// Format an `f64` for the ASCII data arrays with enough precision to
+/// round-trip the IEEE-754 value bit-for-bit (`{:?}` on `f64` emits the
+/// shortest decimal that parses back to the exact same bits).
+fn fmt_f64(v: f64) -> String {
+    format!("{v:?}")
+}

--- a/crates/geode-core/tests/vtu_roundtrip.rs
+++ b/crates/geode-core/tests/vtu_roundtrip.rs
@@ -1,0 +1,219 @@
+//! Round-trip integration test for the VTK `.vtu` writer
+//! ([`geode_core::viz_vtu::write_vtu`]).
+//!
+//! Builds a `cube_tet_mesh(2, 1.0)`, assigns a synthetic linear field
+//! `E(r) = [x, y, z]` at each node, writes it to a tempfile, then re-parses
+//! the ASCII XML with a tiny in-test reader and asserts the structural and
+//! numerical contract:
+//!
+//! * node count and tet count match the mesh,
+//! * `Points`, `connectivity`, `offsets`, `types` arrays are present,
+//! * `E_real` round-trips bit-for-bit,
+//! * `|E|` matches `sqrt(x² + y² + z²)` within `1e-12`,
+//! * optional `E_imag` and `eps_r` arrays appear only when supplied.
+//!
+//! This test is the de-facto correctness contract for Phase 2A and runs in
+//! CI (no ParaView dependency).
+
+use std::path::PathBuf;
+
+use geode_core::{cube_tet_mesh, viz_vtu::write_vtu};
+
+/// Unique tempfile path under the OS temp dir (no `tempfile` dev-dep).
+fn temp_vtu(tag: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!(
+        "geode_vtu_roundtrip_{tag}_{}_{nanos}.vtu",
+        std::process::id()
+    ));
+    p
+}
+
+/// Extract the whitespace-separated tokens between the opening and closing
+/// tags of the `DataArray` whose `Name="{name}"`. For the unnamed `Points`
+/// array pass `name = ""` and we key off the `<Points>` block instead.
+fn extract_array(xml: &str, name: &str) -> Vec<String> {
+    // Find the DataArray open tag containing `Name="{name}"`.
+    let needle = format!("Name=\"{name}\"");
+    let tag_start = xml
+        .find(&needle)
+        .unwrap_or_else(|| panic!("array Name=\"{name}\" not found"));
+    // From there, the array body starts after the next '>'.
+    let body_start = tag_start + xml[tag_start..].find('>').unwrap() + 1;
+    let body_end = body_start + xml[body_start..].find("</DataArray>").unwrap();
+    xml[body_start..body_end]
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The Points block has no `Name`; pull its single DataArray body directly.
+fn extract_points(xml: &str) -> Vec<String> {
+    let p_start = xml.find("<Points>").expect("<Points> not found");
+    let da = p_start + xml[p_start..].find("<DataArray").unwrap();
+    let body_start = da + xml[da..].find('>').unwrap() + 1;
+    let body_end = body_start + xml[body_start..].find("</DataArray>").unwrap();
+    xml[body_start..body_end]
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect()
+}
+
+fn linear_field(mesh: &geode_core::TetMesh) -> Vec<[f64; 3]> {
+    mesh.nodes.iter().map(|&[x, y, z]| [x, y, z]).collect()
+}
+
+#[test]
+fn real_only_roundtrip() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let e = linear_field(&mesh);
+
+    let path = temp_vtu("real");
+    write_vtu(&path, &mesh, &e, None, None).expect("write_vtu");
+    let xml = std::fs::read_to_string(&path).expect("read back");
+    let _ = std::fs::remove_file(&path);
+
+    // Header counts.
+    assert!(xml.contains(&format!("NumberOfPoints=\"{}\"", mesh.n_nodes())));
+    assert!(xml.contains(&format!("NumberOfCells=\"{}\"", mesh.n_tets())));
+
+    // Required structural arrays present.
+    assert!(xml.contains("<Points>"));
+    assert!(xml.contains("Name=\"connectivity\""));
+    assert!(xml.contains("Name=\"offsets\""));
+    assert!(xml.contains("Name=\"types\""));
+    assert!(xml.contains("Name=\"E_real\""));
+    assert!(xml.contains("Name=\"|E|\""));
+    // Optional arrays must be absent.
+    assert!(!xml.contains("Name=\"E_imag\""));
+    assert!(!xml.contains("Name=\"eps_r\""));
+
+    // Points round-trip: 3 components per node.
+    let pts = extract_points(&xml);
+    assert_eq!(pts.len(), mesh.n_nodes() * 3);
+    for (i, node) in mesh.nodes.iter().enumerate() {
+        for c in 0..3 {
+            let got: f64 = pts[i * 3 + c].parse().unwrap();
+            assert_eq!(got, node[c], "point {i} comp {c}");
+        }
+    }
+
+    // Cells: connectivity (4/tet), offsets contiguous, all types == 10.
+    let conn = extract_array(&xml, "connectivity");
+    assert_eq!(conn.len(), mesh.n_tets() * 4);
+    for (i, tet) in mesh.tets.iter().enumerate() {
+        for c in 0..4 {
+            let got: u32 = conn[i * 4 + c].parse().unwrap();
+            assert_eq!(got, tet[c], "tet {i} vertex {c}");
+        }
+    }
+    let offsets = extract_array(&xml, "offsets");
+    assert_eq!(offsets.len(), mesh.n_tets());
+    for (i, off) in offsets.iter().enumerate() {
+        let got: usize = off.parse().unwrap();
+        assert_eq!(got, 4 * (i + 1), "offset {i}");
+    }
+    let types = extract_array(&xml, "types");
+    assert_eq!(types.len(), mesh.n_tets());
+    assert!(types.iter().all(|t| t == "10"), "all cells VTK_TETRA");
+
+    // E_real round-trips bit-for-bit.
+    let ereal = extract_array(&xml, "E_real");
+    assert_eq!(ereal.len(), mesh.n_nodes() * 3);
+    for (i, v) in e.iter().enumerate() {
+        for c in 0..3 {
+            let got: f64 = ereal[i * 3 + c].parse().unwrap();
+            assert_eq!(got.to_bits(), v[c].to_bits(), "E_real {i} comp {c}");
+        }
+    }
+
+    // |E| == sqrt(x² + y² + z²) within 1e-12.
+    let mag = extract_array(&xml, "|E|");
+    assert_eq!(mag.len(), mesh.n_nodes());
+    for (i, v) in e.iter().enumerate() {
+        let got: f64 = mag[i].parse().unwrap();
+        let want = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+        assert!((got - want).abs() < 1e-12, "|E| node {i}: {got} vs {want}");
+    }
+}
+
+#[test]
+fn real_plus_imag_roundtrip() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let e = linear_field(&mesh);
+    // Imag part: a distinct linear field so magnitude folds both in.
+    let e_imag: Vec<[f64; 3]> = mesh
+        .nodes
+        .iter()
+        .map(|&[x, y, z]| [0.5 * x, -y, 2.0 * z])
+        .collect();
+
+    let path = temp_vtu("imag");
+    write_vtu(&path, &mesh, &e, Some(&e_imag), None).expect("write_vtu");
+    let xml = std::fs::read_to_string(&path).expect("read back");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(xml.contains("Name=\"E_real\""));
+    assert!(xml.contains("Name=\"E_imag\""));
+    assert!(xml.contains("Name=\"|E|\""));
+    assert!(!xml.contains("Name=\"eps_r\""));
+
+    // E_imag round-trips bit-for-bit.
+    let eimag = extract_array(&xml, "E_imag");
+    assert_eq!(eimag.len(), mesh.n_nodes() * 3);
+    for (i, v) in e_imag.iter().enumerate() {
+        for c in 0..3 {
+            let got: f64 = eimag[i * 3 + c].parse().unwrap();
+            assert_eq!(got.to_bits(), v[c].to_bits(), "E_imag {i} comp {c}");
+        }
+    }
+
+    // |E| folds in the imaginary part: sqrt(|re|² + |im|²).
+    let mag = extract_array(&xml, "|E|");
+    assert_eq!(mag.len(), mesh.n_nodes());
+    for i in 0..mesh.n_nodes() {
+        let re = e[i];
+        let im = e_imag[i];
+        let want = (re[0] * re[0]
+            + re[1] * re[1]
+            + re[2] * re[2]
+            + im[0] * im[0]
+            + im[1] * im[1]
+            + im[2] * im[2])
+            .sqrt();
+        let got: f64 = mag[i].parse().unwrap();
+        assert!((got - want).abs() < 1e-12, "|E| node {i}: {got} vs {want}");
+    }
+}
+
+#[test]
+fn with_eps_r_overlay() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let e = linear_field(&mesh);
+    // eps_r: 1.0 in lower half-space, 4.0 in upper (z >= 0.5).
+    let eps_r: Vec<f64> = mesh
+        .nodes
+        .iter()
+        .map(|&[_, _, z]| if z >= 0.5 { 4.0 } else { 1.0 })
+        .collect();
+
+    let path = temp_vtu("eps");
+    write_vtu(&path, &mesh, &e, None, Some(&eps_r)).expect("write_vtu");
+    let xml = std::fs::read_to_string(&path).expect("read back");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(xml.contains("Name=\"E_real\""));
+    assert!(xml.contains("Name=\"eps_r\""));
+    assert!(!xml.contains("Name=\"E_imag\""));
+
+    let eps = extract_array(&xml, "eps_r");
+    assert_eq!(eps.len(), mesh.n_nodes());
+    for (i, want) in eps_r.iter().enumerate() {
+        let got: f64 = eps[i].parse().unwrap();
+        assert_eq!(got.to_bits(), want.to_bits(), "eps_r node {i}");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2A of Epic #276 (visualization tooling). Adds a VTK `UnstructuredGrid` (`.vtu`) writer to `geode-core` that serialises a `TetMesh` plus per-node complex `E`-field data, so a developer can open volumetric field results in ParaView 5.x. This is the foundation for Phase 2B (`--export-field` flag on the benchmark examples) and Phase 2C (the `pvbatch` render script). Phase 2A produces no benchmark integration — only the writer and its round-trip correctness test.

## What changed

- **New module** `crates/geode-core/src/viz_vtu.rs` with one public entry point:
  ```rust
  pub fn write_vtu(
      path: &std::path::Path,
      mesh: &TetMesh,
      e_field: &[[f64; 3]],
      e_imag: Option<&[[f64; 3]]>,
      eps_r: Option<&[f64]>,
  ) -> std::io::Result<()>
  ```
  - Writes the inline-ASCII flavour of the XML `UnstructuredGrid` format (binary/base64 is a future optimisation, out of scope here).
  - `PointData` arrays: `E_real` (Vec3), `|E|` (scalar — `sqrt(re² + im²)` when `e_imag` is supplied, else `|E_real|`), `E_imag` (Vec3, only when provided), `eps_r` (scalar, only when provided).
  - `Cells` use VTK cell type `10` (`VTK_TETRA`): 4 connectivity entries per tet (0-based, matches `mesh.tets` directly), contiguous `offsets = 4*(cell+1)`.
  - Hand-rolled XML via `std::fmt::Write` into a `String`, flushed in one `std::fs::write` — **no new crate deps** (no `vtkio`). `f64` is formatted with `{:?}` for shortest round-tripping decimals.
  - Module-level doc comment documents the chosen XML schema with a link to the Kitware VTK XML format spec.
- Registered `pub mod viz_vtu;` in `crates/geode-core/src/lib.rs`.
- **New integration test** `crates/geode-core/tests/vtu_roundtrip.rs`: builds `cube_tet_mesh(2, 1.0)`, assigns a synthetic linear `E(r) = [x, y, z]` per node, writes to a tempfile (no `tempfile` dev-dep — uses `std::env::temp_dir()` + a unique name), re-parses with a tiny in-test XML token reader, and asserts node count, tet count, all `Points`/`Cells` arrays present, `E_real` bit-for-bit round-trip, and `|E|` within `1e-12`. Three cases: real-only, real+imag, with-`eps_r`.

## Verification

All run in the worktree:

- `cargo build -p geode-core` — **OK** (Finished in 1m 11s; no new `Cargo.toml` deps)
- `cargo test -p geode-core --test vtu_roundtrip --no-default-features --features ndarray` — **OK** (3 passed: `real_only_roundtrip`, `real_plus_imag_roundtrip`, `with_eps_r_overlay`)
- `cargo fmt --all` then `cargo fmt --all -- --check` — **clean**
- `cargo clippy -p geode-core -- -D warnings` (default wgpu) — **clean**
- `cargo clippy -p geode-core --no-default-features --features ndarray --tests -- -D warnings` — **clean**

## Manual follow-up (human, not CI)

The ParaView 5.x eyeball/screenshot acceptance criterion cannot be generated in CI (no ParaView dependency on the runner). To produce the smoke fixture for the manual check:

```rust
use geode_core::{cube_tet_mesh, viz_vtu::write_vtu};
let mesh = cube_tet_mesh(8, 1.0);
let e: Vec<[f64;3]> = mesh.nodes.iter().map(|&[x,y,z]| [x, y, z]).collect();
write_vtu(std::path::Path::new("target/vtu_smoke.vtu"), &mesh, &e, None, None).unwrap();
```

Then open `target/vtu_smoke.vtu` in ParaView 5.x and color by `|E|` / `E_real`; the mesh and colormap should render cleanly. A reviewer should attach that screenshot here to satisfy the manual AC. (Phase 2B/2C will wire this into the benchmark examples and a headless `pvbatch` render.)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)