### PR TITLE
feat(viz): Phase 3A 3D radiation-pattern lobe export to surface .vtu (#289)

### DIFF
--- a/crates/geode-core/examples/patch_antenna.rs
+++ b/crates/geode-core/examples/patch_antenna.rs
@@ -63,9 +63,19 @@
 //! reported gain is the physically meaningful number for the tuned
 //! antenna.
 //!
+//! `pattern-3d` (issue #289, Epic #276 Phase 3A) runs the same driven
+//! solve + NTFF as `pattern` on the benchmark fixture, samples the
+//! directivity `D(θ, φ)` on a 37×72 sphere, and writes a triangulated
+//! 3D radiation-*lobe* surface `.vtu` (`geode_core::viz_vtu::write_vtu_surface`,
+//! `VTK_TRIANGLE` cells) whose vertex radius is the dB-floored normalised
+//! directivity (floor −20 dB) and which carries `D` / `D_dB` as `PointData`
+//! for ParaView colouring. Output path defaults to `artifacts/viz/patch_lobe.vtu`
+//! (gitignored) or is set with `--out <path>`.
+//!
 //! ```sh
 //! cargo run -p geode-core --release --example patch_antenna -- pattern
 //! cargo run -p geode-core --release --example patch_antenna -- pattern-matched
+//! cargo run -p geode-core --release --example patch_antenna -- pattern-3d --out /tmp/lobe.vtu
 //! ```
 
 use std::fs;
@@ -75,6 +85,7 @@ use std::process::Command;
 use faer::c64;
 
 use geode_core::mesh::patch::FR4_MATERIALS;
+use geode_core::viz_vtu::write_vtu_surface;
 use geode_core::{
     broadside_directivity, directivity, driven_solve_with_ports, flux_power_box, gain,
     im_z_zero_crossings, ntff_far_field, pec_interior_mask_from_triangles, port_current,
@@ -683,6 +694,220 @@ fn extract_pattern(fixture: &PatchFixture, f_res_ghz: f64, pml_thick: f64, choic
     );
 }
 
+/// 3D radiation-lobe `(θ, φ)` sampling resolution (issue #289).
+///
+/// `LOBE_N_THETA = 37` polar samples over `[0, π]` (5° steps, inclusive of
+/// both poles) and `LOBE_N_PHI = 72` azimuth samples over `[0, 2π)` (5°
+/// steps). This is the spec's suggested 37×72 grid: dense enough that the
+/// triangulated lobe reads smoothly in ParaView (5° facets) while keeping
+/// the driven NTFF cost modest (2664 observation directions). The 2D-cut
+/// `pattern` path uses a finer 91×72 grid because it only reports 1D cuts;
+/// the 3D surface trades a little polar resolution for a balanced sphere.
+const LOBE_N_THETA: usize = 37;
+const LOBE_N_PHI: usize = 72;
+
+/// dB floor (dBi-below-peak) for the radiation-lobe vertex radius (#289).
+///
+/// The lobe vertex radius encodes *normalised* directivity. We use a
+/// dB-floored normalisation: `r = clamp((D_dB - D_dB_max - FLOOR) / -FLOOR,
+/// 0, 1)` so the peak sits at radius 1 and everything `FLOOR` dB or more
+/// below the peak collapses to the origin. A dB floor (vs raw linear)
+/// reads better for antenna lobes — it opens up the sidelobe/null structure
+/// that a linear radius would crush against zero. −20 dB is the textbook
+/// default (Balanis): it shows the first sidelobes without drowning the
+/// plot in noise-floor fuzz.
+const LOBE_DB_FLOOR: f64 = -20.0;
+
+/// Parse an `--out <path>` flag from the CLI args (after the directive).
+/// Returns `None` if absent, so the caller can fall back to a default.
+fn parse_out_flag() -> Option<PathBuf> {
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == "--out" {
+            return args.next().map(PathBuf::from);
+        }
+        if let Some(rest) = a.strip_prefix("--out=") {
+            return Some(PathBuf::from(rest));
+        }
+    }
+    None
+}
+
+/// Re-solve the patch at resonance, run the NTFF (reusing the exact same
+/// `ntff_far_field` / `directivity` machinery as [`extract_pattern`]),
+/// sample `D(θ, φ)` on the `LOBE_N_THETA × LOBE_N_PHI` sphere, build a
+/// triangulated lobe whose vertex radius is the dB-floored normalised
+/// directivity, and write it to `out` as a surface `.vtu` via
+/// [`write_vtu_surface`], carrying `D` and `D_dB` as `PointData` for
+/// ParaView colouring (issue #289, Epic #276 Phase 3A).
+fn extract_pattern_3d(
+    fixture: &PatchFixture,
+    f_res_ghz: f64,
+    pml_thick: f64,
+    out: &std::path::Path,
+) {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+    let device = <B as BackendTypes>::Device::default();
+
+    let edges = fixture.mesh.edges();
+    let patch = fixture.patch_triangles();
+    let ground = fixture.ground_triangles();
+    let outer = fixture.outer_boundary_triangles();
+    let mask = pec_interior_mask_from_triangles(
+        &edges,
+        &[patch.as_slice(), ground.as_slice(), outer.as_slice()],
+    );
+
+    let port = fixture.port();
+    let r_nat = R_PORT_OHM / ETA_0;
+    let lp = port.lumped_port(r_nat, c64::new(1.0, 0.0));
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; fixture.mesh.n_tets()],
+    };
+
+    let (air_lo, air_hi) = fixture.air_box(pml_thick);
+    let center: [f64; 3] = std::array::from_fn(|k| 0.5 * (air_lo[k] + air_hi[k]));
+    let half: [f64; 3] = std::array::from_fn(|k| 0.5 * (air_hi[k] - air_lo[k]));
+    let flux_lo: [f64; 3] = std::array::from_fn(|k| center[k] - (1.0 - FLUX_SHRINK) * half[k]);
+    let flux_hi: [f64; 3] = std::array::from_fn(|k| center[k] + (1.0 - FLUX_SHRINK) * half[k]);
+
+    let omega = ghz_to_omega(f_res_ghz);
+    let (eps_t, nu_t) =
+        fixture.matched_upml_materials(&FR4_MATERIALS, air_lo, air_hi, pml_thick, SIGMA_0, omega);
+    eprintln!("3D-lobe NTFF at f_res = {f_res_ghz:.4} GHz (omega = {omega:.5e} rad/mm)");
+    let sol = driven_solve_with_ports::<B>(
+        &fixture.mesh,
+        DrivenMaterials::MatchedUpml {
+            epsilon_tensor: &eps_t,
+            nu_tensor: &nu_t,
+        },
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&lp),
+        omega,
+        &source,
+        &device,
+    )
+    .expect("patch driven solve for 3D lobe NTFF");
+
+    // Reuse the NTFF transform + directivity exactly (do not reimplement).
+    let ff = ntff_far_field(
+        &fixture.mesh,
+        omega,
+        &sol.e_edges,
+        flux_lo,
+        flux_hi,
+        LOBE_N_THETA,
+        LOBE_N_PHI,
+    );
+    let (d_max, d_grid) = directivity(&ff);
+    eprintln!(
+        "  D_max = {d_max:.3} ({:.2} dBi) on the {LOBE_N_THETA}x{LOBE_N_PHI} sphere",
+        to_db(d_max)
+    );
+
+    let lobe = build_lobe_surface(&ff, &d_grid, d_max);
+
+    fs::create_dir_all(out.parent().expect("out path parent")).expect("mkdir artifacts/viz");
+    write_vtu_surface(
+        out,
+        &lobe.points,
+        &lobe.tris,
+        &[("D", &lobe.d), ("D_dB", &lobe.d_db)],
+    )
+    .expect("write 3D radiation-lobe surface .vtu");
+    eprintln!(
+        "  wrote {} ({} verts, {} tris)",
+        out.display(),
+        lobe.points.len(),
+        lobe.tris.len()
+    );
+}
+
+/// Triangulated 3D radiation-lobe surface produced by [`build_lobe_surface`].
+struct LobeSurface {
+    /// Vertex coordinates (radius = dB-floored normalised directivity).
+    points: Vec<[f64; 3]>,
+    /// Triangle connectivity (0-based indices into `points`).
+    tris: Vec<[usize; 3]>,
+    /// Per-vertex un-scaled linear directivity `D` (colour scalar).
+    d: Vec<f64>,
+    /// Per-vertex directivity in dBi (`D_dB`) (colour scalar).
+    d_db: Vec<f64>,
+}
+
+/// Turn a [`geode_core::FarField`] directivity grid into a triangulated
+/// radiation-lobe surface mesh.
+///
+/// * vertex `(θ_i, φ_j)` sits at radius `r = dB-floored normalised D` along
+///   the observation direction `r̂(θ, φ)` (same convention as the NTFF
+///   `sph_basis`: `x = sinθ cosφ`, `y = sinθ sinφ`, `z = cosθ`),
+/// * triangles wrap the `LOBE_N_THETA × (LOBE_N_PHI + 1)` lat/long grid
+///   (azimuth seam closed by reusing column 0 at φ = 2π), with degenerate
+///   pole triangles dropped,
+/// * `d` carries the *un-scaled* linear `D` and `d_db` the `D_dB` (dBi) at
+///   each vertex for ParaView colouring.
+fn build_lobe_surface(ff: &geode_core::FarField, d_grid: &[f64], d_max: f64) -> LobeSurface {
+    let n_theta = ff.n_theta();
+    let n_phi = ff.n_phi();
+    // Close the azimuth seam: append a duplicate column at φ = 2π so the
+    // surface wraps. Grid width is n_phi + 1.
+    let w = n_phi + 1;
+    let d_db_max = to_db(d_max);
+
+    let mut points = Vec::with_capacity(n_theta * w);
+    let mut d_pd = Vec::with_capacity(n_theta * w);
+    let mut d_db_pd = Vec::with_capacity(n_theta * w);
+
+    for it in 0..n_theta {
+        let th = ff.theta[it];
+        let (st, ct) = th.sin_cos();
+        for jp in 0..w {
+            let ip = jp % n_phi; // seam column reuses ip = 0
+            let phi = 2.0 * std::f64::consts::PI * jp as f64 / n_phi as f64;
+            let (sp, cp) = phi.sin_cos();
+            let d = d_grid[it * n_phi + ip];
+            let d_db = to_db(d);
+            // dB-floored normalised radius in [0, 1].
+            let r = ((d_db - d_db_max - LOBE_DB_FLOOR) / -LOBE_DB_FLOOR).clamp(0.0, 1.0);
+            let r_hat = [st * cp, st * sp, ct];
+            points.push([r * r_hat[0], r * r_hat[1], r * r_hat[2]]);
+            d_pd.push(d);
+            d_db_pd.push(d_db);
+        }
+    }
+
+    let mut tris = Vec::with_capacity(2 * (n_theta - 1) * n_phi);
+    let vid = |it: usize, jp: usize| it * w + jp;
+    for it in 0..n_theta - 1 {
+        for jp in 0..n_phi {
+            // Quad (it,jp)-(it,jp+1)-(it+1,jp+1)-(it+1,jp) → two triangles.
+            let a = vid(it, jp);
+            let b = vid(it, jp + 1);
+            let c = vid(it + 1, jp + 1);
+            let d = vid(it + 1, jp);
+            // Drop degenerate triangles at the poles (θ = 0 or θ = π rows
+            // collapse to a single point, so one tri of each quad is null).
+            if it != 0 {
+                tris.push([a, b, d]);
+            }
+            if it != n_theta - 2 {
+                tris.push([b, c, d]);
+            }
+        }
+    }
+
+    LobeSurface {
+        points,
+        tris,
+        d: d_pd,
+        d_db: d_db_pd,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_pattern_toml(
     choice: FixtureChoice,
@@ -854,6 +1079,28 @@ fn main() {
             );
             return;
         }
+        Some("pattern-3d") => {
+            // 3D radiation-lobe surface `.vtu` export (issue #289, Epic #276
+            // Phase 3A). Same driven solve + NTFF as the `pattern` path on the
+            // benchmark fixture at the Phase-2 committed FEM resonance.
+            let out = parse_out_flag().unwrap_or_else(|| {
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("..")
+                    .join("..")
+                    .join("artifacts")
+                    .join("viz")
+                    .join("patch_lobe.vtu")
+            });
+            let fixture = read_patch_fixture().expect("bundled benchmark patch fixture");
+            let f_res_ghz = 2.274530;
+            extract_pattern_3d(
+                &fixture,
+                f_res_ghz,
+                pml_thick_for(FixtureChoice::Benchmark),
+                &out,
+            );
+            return;
+        }
         _ => {}
     }
 
@@ -863,7 +1110,7 @@ fn main() {
         Some("matched") => FixtureChoice::Matched,
         Some(other) => {
             eprintln!(
-                "unknown argument {other:?} — expected `smoke`, `matched`, `pattern`, `pattern-smoke`, `pattern-matched`, or no argument"
+                "unknown argument {other:?} — expected `smoke`, `matched`, `pattern`, `pattern-smoke`, `pattern-matched`, `pattern-3d`, or no argument"
             );
             std::process::exit(2);
         }

--- a/crates/geode-core/src/viz_vtu.rs
+++ b/crates/geode-core/src/viz_vtu.rs
@@ -233,6 +233,130 @@ pub fn write_vtu(
     std::fs::write(path, s)
 }
 
+/// Serialise a triangulated surface (points + `VTK_TRIANGLE` cells) plus
+/// one or more named scalar `PointData` arrays to an ASCII XML
+/// `UnstructuredGrid` (`.vtu`) file at `path`.
+///
+/// This is the sibling of [`write_vtu`] for *surface* geometry: instead of
+/// `VTK_TETRA` (type 10) volume cells it emits `VTK_TRIANGLE` (type 5)
+/// cells, each contributing three 0-based connectivity entries and a
+/// contiguous `offsets` entry equal to `3 * (cell_index + 1)`. The XML
+/// scaffolding (header, `Points`, `Cells`, `PointData`, `{:?}` f64
+/// formatting for bit-exact round-tripping) is identical to [`write_vtu`]
+/// so all `.vtu` writing stays in this one module — no `vtkio`, no new
+/// dependency.
+///
+/// It is the Phase 3A foundation of Epic #276: the patch-antenna
+/// `pattern-3d` directive uses it to write a 3D radiation-lobe surface
+/// whose vertex radius encodes normalised directivity, with `D` / `D_dB`
+/// carried as `PointData` so ParaView can colour the lobe.
+///
+/// * `points` — surface vertex coordinates, one `[x, y, z]` per point.
+/// * `tris` — triangle connectivity as 0-based indices into `points`.
+/// * `named_scalar_data` — `(name, values)` scalar `PointData` arrays; each
+///   `values` slice must have length `points.len()`. Written in order.
+///
+/// # Panics
+///
+/// Panics if any triangle index is out of range for `points`, or if any
+/// scalar array length does not equal `points.len()`. These are programmer
+/// errors (malformed surface / mismatched scalar), not I/O failures.
+pub fn write_vtu_surface(
+    path: &Path,
+    points: &[[f64; 3]],
+    tris: &[[usize; 3]],
+    named_scalar_data: &[(&str, &[f64])],
+) -> std::io::Result<()> {
+    let n_points = points.len();
+    let n_tris = tris.len();
+
+    for (ti, t) in tris.iter().enumerate() {
+        for &idx in t {
+            assert!(
+                idx < n_points,
+                "triangle {ti} references point {idx} but only {n_points} points exist"
+            );
+        }
+    }
+    for (name, values) in named_scalar_data {
+        assert_eq!(
+            values.len(),
+            n_points,
+            "scalar array {name:?} length ({}) must equal points.len() ({})",
+            values.len(),
+            n_points
+        );
+    }
+
+    let mut s = String::with_capacity(512 + n_points * 96 + n_tris * 24);
+
+    s.push_str("<?xml version=\"1.0\"?>\n");
+    s.push_str("<VTKFile type=\"UnstructuredGrid\" version=\"1.0\" byte_order=\"LittleEndian\">\n");
+    s.push_str("  <UnstructuredGrid>\n");
+    let _ = writeln!(
+        s,
+        "    <Piece NumberOfPoints=\"{n_points}\" NumberOfCells=\"{n_tris}\">"
+    );
+
+    // --- Points -----------------------------------------------------------
+    s.push_str("      <Points>\n");
+    s.push_str("        <DataArray type=\"Float64\" NumberOfComponents=\"3\" format=\"ascii\">\n");
+    for [x, y, z] in points {
+        let _ = writeln!(
+            s,
+            "          {} {} {}",
+            fmt_f64(*x),
+            fmt_f64(*y),
+            fmt_f64(*z)
+        );
+    }
+    s.push_str("        </DataArray>\n");
+    s.push_str("      </Points>\n");
+
+    // --- Cells ------------------------------------------------------------
+    s.push_str("      <Cells>\n");
+    s.push_str("        <DataArray type=\"Int64\" Name=\"connectivity\" format=\"ascii\">\n");
+    for [a, b, c] in tris {
+        let _ = writeln!(s, "          {a} {b} {c}");
+    }
+    s.push_str("        </DataArray>\n");
+
+    s.push_str("        <DataArray type=\"Int64\" Name=\"offsets\" format=\"ascii\">\n");
+    for cell in 0..n_tris {
+        let _ = writeln!(s, "          {}", 3 * (cell + 1));
+    }
+    s.push_str("        </DataArray>\n");
+
+    s.push_str("        <DataArray type=\"UInt8\" Name=\"types\" format=\"ascii\">\n");
+    for _ in 0..n_tris {
+        // 5 == VTK_TRIANGLE
+        s.push_str("          5\n");
+    }
+    s.push_str("        </DataArray>\n");
+    s.push_str("      </Cells>\n");
+
+    // --- PointData --------------------------------------------------------
+    s.push_str("      <PointData>\n");
+    for (name, values) in named_scalar_data {
+        let _ = writeln!(
+            s,
+            "        <DataArray type=\"Float64\" Name=\"{name}\" NumberOfComponents=\"1\" format=\"ascii\">"
+        );
+        for v in *values {
+            let _ = writeln!(s, "          {}", fmt_f64(*v));
+        }
+        s.push_str("        </DataArray>\n");
+    }
+    s.push_str("      </PointData>\n");
+
+    // --- Close ------------------------------------------------------------
+    s.push_str("    </Piece>\n");
+    s.push_str("  </UnstructuredGrid>\n");
+    s.push_str("</VTKFile>\n");
+
+    std::fs::write(path, s)
+}
+
 /// Format an `f64` for the ASCII data arrays with enough precision to
 /// round-trip the IEEE-754 value bit-for-bit (`{:?}` on `f64` emits the
 /// shortest decimal that parses back to the exact same bits).

--- a/crates/geode-core/tests/vtu_roundtrip.rs
+++ b/crates/geode-core/tests/vtu_roundtrip.rs
@@ -17,7 +17,7 @@
 
 use std::path::PathBuf;
 
-use geode_core::{cube_tet_mesh, viz_vtu::write_vtu};
+use geode_core::{cube_tet_mesh, viz_vtu::write_vtu, viz_vtu::write_vtu_surface};
 
 /// Unique tempfile path under the OS temp dir (no `tempfile` dev-dep).
 fn temp_vtu(tag: &str) -> PathBuf {
@@ -215,5 +215,117 @@ fn with_eps_r_overlay() {
     for (i, want) in eps_r.iter().enumerate() {
         let got: f64 = eps[i].parse().unwrap();
         assert_eq!(got.to_bits(), want.to_bits(), "eps_r node {i}");
+    }
+}
+
+/// Build a small known UV-sphere (lat/long grid) surface: `n_theta` polar
+/// rings × `n_phi` azimuth columns, unit radius. Returns
+/// `(points, tris, theta_scalar)` where `theta_scalar` is the polar angle
+/// at each vertex (a deterministic per-vertex scalar to round-trip).
+fn unit_sphere(n_theta: usize, n_phi: usize) -> (Vec<[f64; 3]>, Vec<[usize; 3]>, Vec<f64>) {
+    use std::f64::consts::PI;
+    let mut points = Vec::new();
+    let mut theta_scalar = Vec::new();
+    for it in 0..n_theta {
+        let th = PI * it as f64 / (n_theta - 1) as f64;
+        let (st, ct) = th.sin_cos();
+        for jp in 0..n_phi {
+            let ph = 2.0 * PI * jp as f64 / n_phi as f64;
+            let (sp, cp) = ph.sin_cos();
+            points.push([st * cp, st * sp, ct]);
+            theta_scalar.push(th);
+        }
+    }
+    let mut tris = Vec::new();
+    let vid = |it: usize, jp: usize| it * n_phi + (jp % n_phi);
+    for it in 0..n_theta - 1 {
+        for jp in 0..n_phi {
+            let a = vid(it, jp);
+            let b = vid(it, jp + 1);
+            let c = vid(it + 1, jp + 1);
+            let d = vid(it + 1, jp);
+            tris.push([a, b, d]);
+            tris.push([b, c, d]);
+        }
+    }
+    (points, tris, theta_scalar)
+}
+
+#[test]
+fn surface_writer_roundtrip() {
+    let (points, tris, theta_scalar) = unit_sphere(7, 8);
+    // A second scalar to confirm multiple PointData arrays round-trip.
+    let radius_scalar: Vec<f64> = points
+        .iter()
+        .map(|[x, y, z]| (x * x + y * y + z * z).sqrt())
+        .collect();
+
+    let path = temp_vtu("surface");
+    write_vtu_surface(
+        &path,
+        &points,
+        &tris,
+        &[("theta", &theta_scalar), ("radius", &radius_scalar)],
+    )
+    .expect("write_vtu_surface");
+    let xml = std::fs::read_to_string(&path).expect("read back");
+    let _ = std::fs::remove_file(&path);
+
+    // Header counts.
+    assert!(xml.contains(&format!("NumberOfPoints=\"{}\"", points.len())));
+    assert!(xml.contains(&format!("NumberOfCells=\"{}\"", tris.len())));
+
+    // Structural arrays present; named scalars present.
+    assert!(xml.contains("<Points>"));
+    assert!(xml.contains("Name=\"connectivity\""));
+    assert!(xml.contains("Name=\"offsets\""));
+    assert!(xml.contains("Name=\"types\""));
+    assert!(xml.contains("Name=\"theta\""));
+    assert!(xml.contains("Name=\"radius\""));
+
+    // Points round-trip bit-for-bit, 3 components per vertex.
+    let pts = extract_points(&xml);
+    assert_eq!(pts.len(), points.len() * 3);
+    for (i, node) in points.iter().enumerate() {
+        for c in 0..3 {
+            let got: f64 = pts[i * 3 + c].parse().unwrap();
+            assert_eq!(got.to_bits(), node[c].to_bits(), "point {i} comp {c}");
+        }
+    }
+
+    // Connectivity: 3 indices per triangle, all in range.
+    let conn = extract_array(&xml, "connectivity");
+    assert_eq!(conn.len(), tris.len() * 3);
+    for (i, t) in tris.iter().enumerate() {
+        for c in 0..3 {
+            let got: usize = conn[i * 3 + c].parse().unwrap();
+            assert_eq!(got, t[c], "tri {i} vertex {c}");
+            assert!(got < points.len());
+        }
+    }
+
+    // Offsets contiguous (3 per cell); all cell types == 5 (VTK_TRIANGLE).
+    let offsets = extract_array(&xml, "offsets");
+    assert_eq!(offsets.len(), tris.len());
+    for (i, off) in offsets.iter().enumerate() {
+        let got: usize = off.parse().unwrap();
+        assert_eq!(got, 3 * (i + 1), "offset {i}");
+    }
+    let types = extract_array(&xml, "types");
+    assert_eq!(types.len(), tris.len());
+    assert!(types.iter().all(|t| t == "5"), "all cells VTK_TRIANGLE");
+
+    // Scalars round-trip bit-for-bit.
+    let theta = extract_array(&xml, "theta");
+    assert_eq!(theta.len(), points.len());
+    for (i, want) in theta_scalar.iter().enumerate() {
+        let got: f64 = theta[i].parse().unwrap();
+        assert_eq!(got.to_bits(), want.to_bits(), "theta vertex {i}");
+    }
+    let radius = extract_array(&xml, "radius");
+    assert_eq!(radius.len(), points.len());
+    for (i, want) in radius_scalar.iter().enumerate() {
+        let got: f64 = radius[i].parse().unwrap();
+        assert_eq!(got.to_bits(), want.to_bits(), "radius vertex {i}");
     }
 }


### PR DESCRIPTION
Closes #289

## Summary

Phase 3A of Epic #276: export the patch antenna's full 3D directivity pattern as a radiation-*lobe* surface `.vtu` so a developer can see the lobe in 3D in ParaView, complementing the 2D principal-plane cuts from Phase 1D (#280).

## Writer option chosen: (1) `write_vtu_surface` in `geode_core::viz_vtu`

I took the **preferred** option — a sibling `write_vtu_surface(path, points, tris, named_scalar_data)` helper in `crates/geode-core/src/viz_vtu.rs` — rather than a new `.vtp` PolyData writer.

Why: it keeps **all** `.vtu` writing in one module and reuses the Phase 2A XML scaffolding verbatim (header, `Points`, `Cells`, `PointData`, `{:?}` f64 formatting for bit-exact round-tripping). The only structural difference from `write_vtu` is `VTK_TRIANGLE` (cell type 5, 3 connectivity entries, `offsets = 3*(cell+1)`) instead of `VTK_TETRA` (type 10). A `.vtp` writer would have been a wholly new code path for no rendering benefit — ParaView reads both identically, and an UnstructuredGrid of triangles is a perfectly natural surface representation.

## `pattern-3d` directive

`crates/geode-core/examples/patch_antenna.rs` gains a `pattern-3d` positional directive that:
- runs the **same** driven solve + NTFF as the `pattern` path on the benchmark fixture at the Phase-2 committed FEM resonance (2.274530 GHz),
- **reuses** `geode_core::ntff` exactly (`ntff_far_field`, `FarField`, `directivity`, `to_db`) — the far-field transform is not reimplemented,
- samples `D(theta, phi)` on a **37x72** sphere (`theta in [0, pi]` inclusive, 5 deg steps; `phi in [0, 2pi)`, 5 deg steps),
- builds a triangulated lobe whose vertex radius encodes normalised directivity, with `D` / `D_dB` as `PointData` for colouring,
- writes via `write_vtu_surface` to a user path (`--out <path>`), defaulting to the gitignored `artifacts/viz/patch_lobe.vtu`.

### Grid choice (37x72)
The spec's suggested grid: dense enough that the triangulated lobe reads smoothly (5 deg facets) while keeping the driven NTFF cost modest (2664 directions). The 2D-cut `pattern` path uses a finer 91x72 grid because it only reports 1D cuts; the 3D surface trades a little polar resolution for a balanced sphere.

### Normalisation / dB floor
Vertex radius uses a **dB-floored** normalisation (not raw linear):
`r = clamp((D_dB - D_dB_max - FLOOR) / -FLOOR, 0, 1)`, with **FLOOR = -20 dB**.
The peak sits at radius 1; everything 20 dB or more below peak collapses to the origin. A dB floor reads better for antenna lobes than a linear radius — it opens up the sidelobe/null structure that linear scaling crushes against zero. -20 dB is the textbook default (Balanis): shows the first sidelobes without drowning the plot in noise-floor fuzz. The un-scaled linear `D` and `D_dB` are both carried as `PointData` so ParaView can colour by either.

The azimuth seam is closed (column reused at `phi = 2pi`) and degenerate pole triangles are dropped, giving a watertight lobe.

## Tests
`crates/geode-core/tests/vtu_roundtrip.rs` gains `surface_writer_roundtrip`, mirroring the Phase 2A style: builds a known 7x8 UV sphere, writes it, re-parses the XML, and asserts node/tri counts, `NumberOfPoints`/`NumberOfCells`, all-`VTK_TRIANGLE` (type 5) cells, contiguous offsets, and bit-exact round-trip of both points and the two named scalar arrays.

## Verification (local)
- `cargo build -p geode-core` — clean
- `cargo build -p geode-core --no-default-features --features ndarray` (CI's headless path) — clean
- `cargo test -p geode-core --test vtu_roundtrip` — 4 passed (incl. new `surface_writer_roundtrip`)
- `cargo clippy -p geode-core -- -D warnings` and `--example patch_antenna -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean (no pre-commit fmt hook in this repo)
- `cargo run -p geode-core --release --example patch_antenna -- pattern-3d --out /tmp/lobe.vtu` →
  `D_max = 3.631 (5.60 dBi)` on the 37x72 sphere, wrote a surface `.vtu` with 2701 verts / 5040 VTK_TRIANGLE cells and `D` / `D_dB` PointData.

No new Cargo deps.

## ParaView screenshot
The rendered-lobe screenshot is a **manual local check** — there is no ParaView in CI. The round-trip test is the CI-enforced correctness contract; the `pattern-3d` run above confirms a valid surface `.vtu` is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)