### PR TITLE
feat(viz): --export-field flag dumps driven E to .vtu (mie/spiral/patch) (#287)

### DIFF
--- a/crates/geode-core/examples/common/viz_export_helper.rs
+++ b/crates/geode-core/examples/common/viz_export_helper.rs
@@ -1,0 +1,181 @@
+//! Shared `--export-field` helper for the driven/scattering benchmark
+//! examples (Epic #276 Phase 2B, issue #287).
+//!
+//! This module is `#[path]`-included by `mie_sphere.rs`,
+//! `spiral_inductor.rs`, and `patch_antenna.rs`. It owns two pieces of
+//! example-local logic so the three examples do not each hand-roll
+//! them:
+//!
+//! 1. [`parse_export_field`] — recognise the opt-in
+//!    `--export-field <path.vtu>` directive in the example's argv,
+//!    matching the by-hand positional-arg style the examples already
+//!    use (no new arg-parsing crate).
+//! 2. [`edge_field_to_nodes`] — collapse a lowest-order Nédélec
+//!    edge-DOF solution (`e_edges`, one complex DOF per global edge in
+//!    `mesh.edges()` order) into the per-node `E` vectors
+//!    (`[[f64; 3]]`, length `mesh.n_nodes()`) that
+//!    [`geode_core::viz_vtu::write_vtu`] consumes.
+//!
+//! # Sampling choice (v1, intentionally crude)
+//!
+//! `write_vtu` wants `E` sampled at the mesh *nodes*, but the Whitney
+//! 1-form interpolant `E(x) = Σ_e d_e (λ_a ∇λ_b − λ_b ∇λ_a)` is only
+//! tangentially continuous across faces — it is multi-valued at a
+//! shared node. We evaluate the interpolant at each vertex of every
+//! incident tet (barycentric coordinate = the unit vector at that
+//! local vertex) and **average** the contributions over the tets that
+//! touch the node. This is a debugging visual for ParaView, not a
+//! quadrature-accurate reconstruction; the averaging smooths the
+//! per-tet discontinuity into a single nodal value.
+//!
+//! The geometry / DOF-folding / Whitney evaluation mirror the verified
+//! `pub(crate)` evaluators in `geode_core::scattering`
+//! (`tet_geometry`, `local_dofs`, `eval_field_at_bary`), re-implemented
+//! here against the public mesh API because those crate-internal
+//! helpers are not visible from an example (a separate crate). Keeping
+//! them example-local avoids widening `geode-core`'s public surface for
+//! a viz-only need.
+//!
+//! TODO(viz): higher-order sampling (e.g. quadrature-projected nodal
+//! averaging) if the crude per-tet-vertex average proves too noisy for
+//! the intended ParaView inspection.
+
+use faer::c64;
+
+use geode_core::TetMesh;
+
+/// Local edge → (local vertex a, local vertex b), the canonical
+/// lowest-order Nédélec edge ordering (`geode_core::mesh::TET_LOCAL_EDGES`).
+const LOCAL_EDGES: [(usize, usize); 6] = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)];
+
+/// Scan `args` (the full process argv) for the opt-in
+/// `--export-field <path>` directive and return the requested output
+/// path when present.
+///
+/// The directive is recognised in two equivalent spellings so it slots
+/// next to the examples' existing by-hand positional dispatch:
+///
+/// * `--export-field <path>` (flag + following token), or
+/// * the positional pair `export-field <path>`.
+///
+/// Returns `None` when neither spelling is present, leaving the
+/// example's default benchmark behaviour byte-for-byte unchanged.
+pub fn parse_export_field(args: &[String]) -> Option<String> {
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--export-field" || a == "export-field" {
+            return it.next().cloned();
+        }
+        if let Some(rest) = a.strip_prefix("--export-field=") {
+            return Some(rest.to_string());
+        }
+    }
+    None
+}
+
+/// Cross product of two 3-vectors.
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+/// Dot product of two 3-vectors.
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// `a - b` for 3-vectors.
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+/// Barycentric gradients `∇λ_i` (constant over the tet) for the tet
+/// with the given 0-based vertex indices.
+///
+/// Mirrors `geode_core::scattering::tet_geometry`.
+fn tet_grads(mesh: &TetMesh, tet: &[u32; 4]) -> [[f64; 3]; 4] {
+    let v = [
+        mesh.nodes[tet[0] as usize],
+        mesh.nodes[tet[1] as usize],
+        mesh.nodes[tet[2] as usize],
+        mesh.nodes[tet[3] as usize],
+    ];
+    let e1 = sub(v[1], v[0]);
+    let e2 = sub(v[2], v[0]);
+    let e3 = sub(v[3], v[0]);
+    let det = dot(e1, cross(e2, e3));
+    let inv = if det != 0.0 { 1.0 / det } else { 0.0 };
+    let grad1 = cross(e2, e3).map(|x| x * inv);
+    let grad2 = cross(e3, e1).map(|x| x * inv);
+    let grad3 = cross(e1, e2).map(|x| x * inv);
+    let grad0 = [
+        -(grad1[0] + grad2[0] + grad3[0]),
+        -(grad1[1] + grad2[1] + grad3[1]),
+        -(grad1[2] + grad2[2] + grad3[2]),
+    ];
+    [grad0, grad1, grad2, grad3]
+}
+
+/// Average the Whitney edge-DOF field at the mesh nodes.
+///
+/// `e_edges` is the full-length complex edge-DOF vector (one entry per
+/// global edge in `mesh.edges()` order, e.g.
+/// `geode_core::driven::DrivenSolution::e_edges`). Returns the per-node
+/// real and imaginary `E` vectors, each of length `mesh.n_nodes()`,
+/// ready to hand to `geode_core::viz_vtu::write_vtu`.
+///
+/// See the module docs for the (crude, averaging) sampling choice.
+pub fn edge_field_to_nodes(mesh: &TetMesh, e_edges: &[c64]) -> (Vec<[f64; 3]>, Vec<[f64; 3]>) {
+    let n_nodes = mesh.n_nodes();
+    let tet_edges = mesh.tet_edges();
+
+    let mut e_re = vec![[0.0_f64; 3]; n_nodes];
+    let mut e_im = vec![[0.0_f64; 3]; n_nodes];
+    let mut counts = vec![0_u32; n_nodes];
+
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let grad = tet_grads(mesh, tet);
+        // Sign-folded local edge DOFs, in LOCAL_EDGES order.
+        let dofs: [c64; 6] = std::array::from_fn(|e| {
+            let (idx, sign) = tet_edges[t][e];
+            e_edges[idx as usize] * c64::new(sign as f64, 0.0)
+        });
+
+        // Evaluate the Whitney interpolant at each of the 4 vertices
+        // (barycentric coord = unit vector at that local vertex) and
+        // accumulate onto the corresponding global node.
+        for local_v in 0..4 {
+            let mut lambda = [0.0_f64; 4];
+            lambda[local_v] = 1.0;
+            let mut e = [c64::new(0.0, 0.0); 3];
+            for (slot, &(a, b)) in LOCAL_EDGES.iter().enumerate() {
+                let d = dofs[slot];
+                for (k, e_k) in e.iter_mut().enumerate() {
+                    let w = lambda[a] * grad[b][k] - lambda[b] * grad[a][k];
+                    *e_k += d * c64::new(w, 0.0);
+                }
+            }
+            let node = tet[local_v] as usize;
+            for k in 0..3 {
+                e_re[node][k] += e[k].re;
+                e_im[node][k] += e[k].im;
+            }
+            counts[node] += 1;
+        }
+    }
+
+    for node in 0..n_nodes {
+        if counts[node] > 0 {
+            let inv = 1.0 / counts[node] as f64;
+            for k in 0..3 {
+                e_re[node][k] *= inv;
+                e_im[node][k] *= inv;
+            }
+        }
+    }
+
+    (e_re, e_im)
+}

--- a/crates/geode-core/examples/mie_sphere.rs
+++ b/crates/geode-core/examples/mie_sphere.rs
@@ -66,6 +66,29 @@
 //!
 //! Writes `benchmarks/mie_sphere/results.toml` relative to the
 //! workspace root (located via `CARGO_MANIFEST_DIR`).
+//!
+//! # Field export (Epic #276 Phase 2B, issue #287)
+//!
+//! Passing `--export-field <path.vtu>` is an opt-in side channel that
+//! does **not** touch the eigenmode benchmark above (the `results.toml`
+//! is byte-identical with or without it). When present, the bundled
+//! sphere is solved once as a *driven scattering* problem — a plane
+//! wave `E_inc = x̂·exp(−iωz)` illuminating the `n = 1.5` dielectric
+//! sphere via the matched (full Sacks) UPML scattered-field solve
+//! (`geode_core::solve_scattered_field_matched_upml`, the same machinery
+//! as the `mie_driven_scattering` example) — and the scattered near
+//! field `E_sca(r)` is dumped to `<path.vtu>` for ParaView inspection:
+//!
+//! ```sh
+//! cargo run -p geode-core --release --example mie_sphere -- --export-field artifacts/viz/E_mie.vtu
+//! ```
+//!
+//! The default frequency is the **mid-`ka` point** of the driven
+//! benchmark sweep (`ka = 1.9`, between the TE_1,1 and TM_1,1 Mie
+//! resonances; `ω = ka / R_SPHERE`). The exported per-node `E` is the
+//! crude per-tet-vertex average of the Whitney interpolant (see
+//! `examples/viz_export_helper.rs`); a per-node `eps_r` map (n² inside
+//! the sphere, 1 outside) accompanies it.
 
 use std::fs;
 use std::path::PathBuf;
@@ -78,11 +101,15 @@ use geode_core::{
     apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_complex_epsilon, build_anisotropic_pml_tensor_diag,
     build_complex_epsilon_r_pml, burn_complex_mass_to_faer, burn_matrix_to_faer, mie_roots_catalog,
-    open_space_wgm_roots_n15, read_sphere_fixture, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroid_radii, tet_centroids, upload_mesh, ComplexEigenSolver,
-    DefaultBackend, FaerComplexEigensolver, MiePolarisation, MieRoot, SparseComplexEigenSolver,
-    SparseComplexShiftInvertLanczos, R_BUFFER, R_SPHERE,
+    open_space_wgm_roots_n15, plane_wave_polarization_current, read_sphere_fixture,
+    solve_scattered_field_matched_upml, sphere_n_interior_nodes, sphere_pec_interior_edges,
+    tet_centroid_radii, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
+    FaerComplexEigensolver, MiePolarisation, MieRoot, SparseComplexEigenSolver,
+    SparseComplexShiftInvertLanczos, PHYS_SPHERE_INTERIOR, R_BUFFER, R_SPHERE,
 };
+
+#[path = "common/viz_export_helper.rs"]
+mod viz_export_helper;
 
 type B = DefaultBackend;
 
@@ -635,8 +662,106 @@ fn write_toml(rows: &[Row], path: &PathBuf, scalar_pml: bool, n_modes: usize) {
     eprintln!("wrote {}", path.display());
 }
 
+/// Mid-`ka` operating point of the driven benchmark sweep
+/// (`mie_driven_scattering`'s `KA_VALUES = [1.0, 1.5, 1.9, 2.4, 3.0]`),
+/// used as the default frequency for `--export-field`. `ω = ka / R_SPHERE`.
+const EXPORT_KA: f64 = 1.9;
+
+/// Matched-UPML strength for the `--export-field` driven solve — same
+/// value as `mie_driven_scattering` (continuum round-trip attenuation
+/// `exp(−2σ₀d/3) ≈ 2e-4`).
+const EXPORT_SIGMA_0: f64 = 25.0;
+
+/// Opt-in `--export-field` path (Epic #276 Phase 2B, issue #287):
+/// solve the bundled sphere once as a driven scattering problem at the
+/// mid-`ka` point and dump the scattered near field to a `.vtu`.
+///
+/// Independent of the eigenmode benchmark — does not write
+/// `results.toml`.
+fn export_field(path: &str) {
+    use burn::tensor::backend::BackendTypes;
+    let _device = <B as BackendTypes>::Device::default();
+
+    let f = read_sphere_fixture().expect("sphere fixture load for --export-field");
+    let omega = EXPORT_KA / R_SPHERE;
+    eprintln!(
+        "=== --export-field: driven scattered-field solve at ka = {EXPORT_KA} \
+         (omega = {omega:.5}), matched UPML sigma_0 = {EXPORT_SIGMA_0} ==="
+    );
+
+    let (_mask_edges, interior) = sphere_pec_interior_edges(&f.mesh, R_BUFFER);
+    let j_at = plane_wave_polarization_current(
+        &f.tet_physical_tags,
+        PHYS_SPHERE_INTERIOR,
+        N_INSIDE,
+        omega,
+    );
+    let sol = solve_scattered_field_matched_upml(
+        &f.mesh,
+        &f.tet_physical_tags,
+        PHYS_SPHERE_INTERIOR,
+        &interior,
+        N_INSIDE,
+        EXPORT_SIGMA_0,
+        omega,
+        j_at,
+    )
+    .expect("matched-UPML scattered-field solve for --export-field");
+    eprintln!(
+        "  solve residual_rel = {:.3e}; reconstructing per-node E (Whitney average)",
+        sol.residual_rel
+    );
+
+    let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&f.mesh, &sol.e_edges);
+
+    // Per-node eps_r: n² inside the sphere, 1 outside. Average the
+    // per-tet relative permittivity over the tets incident to each node.
+    let eps_inside = N_INSIDE * N_INSIDE;
+    let mut eps_sum = vec![0.0_f64; f.mesh.n_nodes()];
+    let mut eps_cnt = vec![0_u32; f.mesh.n_nodes()];
+    for (t, tet) in f.mesh.tets.iter().enumerate() {
+        let eps = if f.tet_physical_tags[t] == PHYS_SPHERE_INTERIOR {
+            eps_inside
+        } else {
+            1.0
+        };
+        for &v in tet.iter() {
+            eps_sum[v as usize] += eps;
+            eps_cnt[v as usize] += 1;
+        }
+    }
+    let eps_r: Vec<f64> = eps_sum
+        .iter()
+        .zip(eps_cnt.iter())
+        .map(|(&s, &c)| if c > 0 { s / c as f64 } else { 1.0 })
+        .collect();
+
+    let out = std::path::Path::new(path);
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
+        }
+    }
+    geode_core::viz_vtu::write_vtu(out, &f.mesh, &e_re, Some(&e_im), Some(&eps_r))
+        .expect("write --export-field .vtu");
+    eprintln!(
+        "  wrote {} ({} nodes, {} tets)",
+        out.display(),
+        f.mesh.n_nodes(),
+        f.mesh.n_tets()
+    );
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
+
+    // Opt-in field export (issue #287). Short-circuits the eigenmode
+    // benchmark so a normal run is byte-identical.
+    if let Some(path) = viz_export_helper::parse_export_field(&args) {
+        export_field(&path);
+        return;
+    }
+
     let use_dense = args.iter().any(|a| a == "--dense");
     let scalar_pml = args.iter().any(|a| a == "--scalar-pml");
 

--- a/crates/geode-core/examples/patch_antenna.rs
+++ b/crates/geode-core/examples/patch_antenna.rs
@@ -67,6 +67,25 @@
 //! cargo run -p geode-core --release --example patch_antenna -- pattern
 //! cargo run -p geode-core --release --example patch_antenna -- pattern-matched
 //! ```
+//!
+//! # Field export (Epic #276 Phase 2B, issue #287)
+//!
+//! Passing `--export-field <path.vtu>` is an opt-in side channel that
+//! does **not** touch the S11 sweep / NTFF above (the `results.toml` is
+//! byte-identical with or without it). When present, the benchmark
+//! fixture is solved once at the **committed FEM resonant frequency**
+//! (`2.274530` GHz, the same `f_res` the `pattern` subcommand uses — the
+//! S11-dip / matched operating point of the antenna) and the driven near
+//! field `E(r)` is dumped to `<path.vtu>` for ParaView inspection:
+//!
+//! ```sh
+//! cargo run -p geode-core --release --example patch_antenna -- --export-field artifacts/viz/E_patch.vtu
+//! ```
+//!
+//! The exported per-node `E` is the crude per-tet-vertex average of the
+//! Whitney interpolant (see `examples/viz_export_helper.rs`), with a
+//! per-node `eps_r` map (FR-4 ε_r in the substrate, 1 in air/UPML)
+//! averaged from the fixture's material regions.
 
 use std::fs;
 use std::path::PathBuf;
@@ -82,6 +101,9 @@ use geode_core::{
     read_patch_smoke_fixture, s11, to_db, CurrentSource, DefaultBackend, DrivenBcs,
     DrivenMaterials, PatchCavity, PatchFixture,
 };
+
+#[path = "common/viz_export_helper.rs"]
+mod viz_export_helper;
 
 /// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.
 const ETA_0: f64 = 376.730_313_668;
@@ -812,7 +834,115 @@ fn write_pattern_toml(
     eprintln!("wrote {}", path.display());
 }
 
+/// Committed FEM resonant frequency (GHz) of the benchmark fixture —
+/// the same `f_res` the `pattern` subcommand uses, the S11-dip operating
+/// point. Default frequency for `--export-field` (issue #287).
+const EXPORT_F_RES_GHZ: f64 = 2.274530;
+
+/// Opt-in `--export-field` (Epic #276 Phase 2B, issue #287): solve the
+/// benchmark fixture once at the committed resonant frequency and dump
+/// the driven near field to `<path>` as `.vtu`.
+///
+/// Independent of the S11 sweep / NTFF — does not write `results.toml`.
+fn export_field(path: &str) {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+    let device = <B as BackendTypes>::Device::default();
+
+    let fixture = read_patch_fixture().expect("bundled benchmark patch fixture for --export-field");
+    let pml_thick = pml_thick_for(FixtureChoice::Benchmark);
+    let omega = ghz_to_omega(EXPORT_F_RES_GHZ);
+    eprintln!(
+        "=== --export-field: driven solve at f_res = {EXPORT_F_RES_GHZ} GHz (omega = {omega:.5e} rad/mm) ==="
+    );
+
+    let edges = fixture.mesh.edges();
+    let patch = fixture.patch_triangles();
+    let ground = fixture.ground_triangles();
+    let outer = fixture.outer_boundary_triangles();
+    let mask = pec_interior_mask_from_triangles(
+        &edges,
+        &[patch.as_slice(), ground.as_slice(), outer.as_slice()],
+    );
+
+    let port = fixture.port();
+    let r_nat = R_PORT_OHM / ETA_0;
+    let lp = port.lumped_port(r_nat, c64::new(1.0, 0.0));
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; fixture.mesh.n_tets()],
+    };
+
+    let (air_lo, air_hi) = fixture.air_box(pml_thick);
+    let (eps_t, nu_t) =
+        fixture.matched_upml_materials(&FR4_MATERIALS, air_lo, air_hi, pml_thick, SIGMA_0, omega);
+    let sol = driven_solve_with_ports::<B>(
+        &fixture.mesh,
+        DrivenMaterials::MatchedUpml {
+            epsilon_tensor: &eps_t,
+            nu_tensor: &nu_t,
+        },
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&lp),
+        omega,
+        &source,
+        &device,
+    )
+    .expect("patch driven solve for --export-field");
+    eprintln!(
+        "  solve residual_rel = {:.3e}; reconstructing per-node E (Whitney average)",
+        sol.residual_rel
+    );
+
+    let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&fixture.mesh, &sol.e_edges);
+
+    // Per-node eps_r: real part of the per-tet FR-4/air permittivity
+    // (substrate eps_r in the slab, 1 in air/UPML), averaged over the
+    // tets incident to each node.
+    let eps_tet = fixture.epsilon_r_default();
+    let mut eps_sum = vec![0.0_f64; fixture.mesh.n_nodes()];
+    let mut eps_cnt = vec![0_u32; fixture.mesh.n_nodes()];
+    for (t, tet) in fixture.mesh.tets.iter().enumerate() {
+        let eps = eps_tet[t].re;
+        for &v in tet.iter() {
+            eps_sum[v as usize] += eps;
+            eps_cnt[v as usize] += 1;
+        }
+    }
+    let eps_r: Vec<f64> = eps_sum
+        .iter()
+        .zip(eps_cnt.iter())
+        .map(|(&s, &c)| if c > 0 { s / c as f64 } else { 1.0 })
+        .collect();
+
+    let out = std::path::Path::new(path);
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
+        }
+    }
+    geode_core::viz_vtu::write_vtu(out, &fixture.mesh, &e_re, Some(&e_im), Some(&eps_r))
+        .expect("write --export-field .vtu");
+    eprintln!(
+        "  wrote {} ({} nodes, {} tets)",
+        out.display(),
+        fixture.mesh.n_nodes(),
+        fixture.mesh.n_tets()
+    );
+}
+
 fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+
+    // Opt-in field export (issue #287). Short-circuits the S11 sweep so
+    // a normal run is byte-identical.
+    if let Some(path) = viz_export_helper::parse_export_field(&argv) {
+        export_field(&path);
+        return;
+    }
+
     let arg = std::env::args().nth(1);
     // `pattern` / `pattern-smoke` run the NTFF radiation-pattern
     // extraction instead of the S11 sweep.

--- a/crates/geode-core/examples/spiral_inductor.rs
+++ b/crates/geode-core/examples/spiral_inductor.rs
@@ -53,6 +53,26 @@
 //! ```sh
 //! cargo run -p geode-core --release --example spiral_inductor -- smoke
 //! ```
+//!
+//! # Field export (Epic #276 Phase 2B, issue #287)
+//!
+//! Passing `--export-field <path.vtu>` is an opt-in side channel that
+//! does **not** touch the extraction sweep above (the `results.toml` is
+//! byte-identical with or without it). When present, the benchmark
+//! fixture is solved once at the **low-frequency reference operating
+//! point** already used for the oracle comparison
+//! (`L_REF_GHZ = 1.0` GHz) and the driven near field `E(r)` is dumped to
+//! `<path.vtu>` for ParaView inspection:
+//!
+//! ```sh
+//! cargo run -p geode-core --release --example spiral_inductor -- --export-field artifacts/viz/E_spiral.vtu
+//! ```
+//!
+//! The exported per-node `E` is the crude per-tet-vertex average of the
+//! Whitney interpolant (see `examples/viz_export_helper.rs`). No
+//! per-node `eps_r` is exported for the spiral (the stack uses a
+//! per-region scalar permittivity that is not as cleanly nodal as the
+//! sphere/patch case) — `None` is passed.
 
 use std::fs;
 use std::path::PathBuf;
@@ -62,11 +82,14 @@ use faer::c64;
 
 use geode_core::mesh::spiral::CONDUCTOR_SIGMA_NATURAL;
 use geode_core::{
-    detect_srf, driven_frequency_sweep, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l,
-    pec_interior_mask_from_triangles, read_spiral_fixture, read_spiral_smoke_fixture,
-    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SpiralFixture, SquareSpiral,
-    SurfaceImpedanceBc, SurfaceImpedanceModel,
+    detect_srf, driven_frequency_sweep, driven_solve_with_ports, modified_wheeler_l,
+    mohan_current_sheet_l, monomial_fit_l, pec_interior_mask_from_triangles, read_spiral_fixture,
+    read_spiral_smoke_fixture, CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials,
+    SpiralFixture, SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel,
 };
+
+#[path = "common/viz_export_helper.rs"]
+mod viz_export_helper;
 
 /// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.
 const ETA_0: f64 = 376.730_313_668;
@@ -384,12 +407,90 @@ fn write_toml(rows: &[Row], path: &PathBuf, choice: FixtureChoice, srf_ghz: Opti
     eprintln!("wrote {}", path.display());
 }
 
+/// Opt-in `--export-field` (Epic #276 Phase 2B, issue #287): solve the
+/// benchmark fixture once at the low-frequency reference operating point
+/// (`L_REF_GHZ`) and dump the driven near field to `<path>` as `.vtu`.
+///
+/// Independent of the extraction sweep — does not write `results.toml`.
+fn export_field(path: &str) {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+    let device = <B as BackendTypes>::Device::default();
+
+    let fixture =
+        read_spiral_fixture().expect("bundled benchmark spiral fixture for --export-field");
+    let omega = ghz_to_omega(L_REF_GHZ);
+    eprintln!(
+        "=== --export-field: driven solve at {L_REF_GHZ} GHz (omega = {omega:.6e} rad/um) ==="
+    );
+
+    let edges = fixture.mesh.edges();
+    let eps = fixture.epsilon_r_default();
+    let outer = fixture.outer_boundary_triangles();
+    let mask = pec_interior_mask_from_triangles(&edges, &[outer.as_slice()]);
+    let port = fixture.port();
+    let r_nat = R_PORT_OHM / ETA_0;
+    let lp = port.lumped_port(r_nat, c64::new(1.0, 0.0));
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; fixture.mesh.n_tets()],
+    };
+
+    // The extraction sweep adds a Leontovich conductor-surface-impedance
+    // loss term; the public single-frequency `driven_solve_with_ports`
+    // does not take surface BCs, so the visualisation field is the
+    // PEC-walls + scalar-eps near field (a debugging visual, not the
+    // loss-loaded extraction operator — see issue #287 scope).
+    let sol = driven_solve_with_ports::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&lp),
+        omega,
+        &source,
+        &device,
+    )
+    .expect("port-driven solve for --export-field");
+    eprintln!(
+        "  solve residual_rel = {:.3e}; reconstructing per-node E (Whitney average)",
+        sol.residual_rel
+    );
+
+    let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&fixture.mesh, &sol.e_edges);
+
+    let out = std::path::Path::new(path);
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
+        }
+    }
+    geode_core::viz_vtu::write_vtu(out, &fixture.mesh, &e_re, Some(&e_im), None)
+        .expect("write --export-field .vtu");
+    eprintln!(
+        "  wrote {} ({} nodes, {} tets)",
+        out.display(),
+        fixture.mesh.n_nodes(),
+        fixture.mesh.n_tets()
+    );
+}
+
 fn main() {
-    let choice = match std::env::args().nth(1).as_deref() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Opt-in field export (issue #287). Short-circuits the extraction
+    // sweep so a normal run is byte-identical.
+    if let Some(path) = viz_export_helper::parse_export_field(&args) {
+        export_field(&path);
+        return;
+    }
+
+    let choice = match args.get(1).map(String::as_str) {
         None => FixtureChoice::Benchmark,
         Some("smoke") => FixtureChoice::Smoke,
         Some(other) => {
-            eprintln!("unknown argument {other:?} — expected `smoke` or no argument");
+            eprintln!("unknown argument {other:?} — expected `smoke`, `--export-field <path>`, or no argument");
             std::process::exit(2);
         }
     };


### PR DESCRIPTION
Closes #287

## Summary

Epic #276 **Phase 2B**: wires the Phase 2A VTK writer (`geode_core::viz_vtu::write_vtu`, #286) into the three driven/scattering benchmark examples as an **opt-in** `--export-field <path.vtu>` directive. This is the producer side of the Phase 2 pipeline (2C consumes the `.vtu`).

When the directive is present, the structure is solved once at a single default frequency and the near field `E(r)` is serialised to a `.vtu` for ParaView inspection. A run **without** the directive short-circuits before any export logic runs, so default benchmark behaviour (and the committed `results.toml`) is byte-identical — no benchmark output files are touched by this PR.

### Per-example wiring

| Example | Solve | Default frequency | `eps_r` |
|---|---|---|---|
| `mie_sphere` | scattered-field matched (Sacks) UPML (`solve_scattered_field_matched_upml`) | mid-`ka` point, `ka = 1.9` (between TE₁,₁ / TM₁,₁ resonances) | n² inside / 1 outside |
| `spiral_inductor` | port-driven (`driven_solve_with_ports`) | `L_REF_GHZ = 1.0` GHz (oracle reference point) | `None` (per-region scalar stack) |
| `patch_antenna` | matched box-UPML driven (`driven_solve_with_ports`) | committed FEM resonance `2.27453` GHz | FR-4 substrate / air |

The directive is recognised in both `--export-field <path>` and `--export-field=<path>` spellings (and the bare `export-field <path>` positional pair), matching each example's existing by-hand positional dispatch. No new arg-parsing crate, no new Cargo deps, no new public `geode-core` API.

### Nédélec → per-node E reconstruction

Shared examples-local helper `crates/geode-core/examples/common/viz_export_helper.rs`. For each tet it evaluates the lowest-order Whitney 1-form interpolant `E(x) = Σ_e d_e (λ_a ∇λ_b − λ_b ∇λ_a)` at each vertex and **averages** the contributions over the incident tets to produce one nodal value — a crude debugging visual (`TODO(viz)` left for higher-order sampling), not a quadrature-accurate reconstruction. It re-implements the `pub(crate)` Whitney evaluators from `geode_core::scattering` against the public mesh API rather than widening the crate surface. Placed in `examples/common/` (a subdir without `main.rs`) so Cargo does not treat it as a standalone example.

## Verification

- `cargo build -p geode-core --examples` — clean
- `cargo clippy -p geode-core --examples -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Each example writes a non-empty `.vtu` with `NumberOfPoints == mesh.n_nodes()` and `NumberOfCells == mesh.n_tets()`:
  - `mie_sphere`: 774 nodes / 3335 tets (residual 2.9e-14)
  - `spiral_inductor`: 8548 nodes / 42341 tets (residual 1.8e-8)
  - `patch_antenna`: 4750 nodes / 25452 tets (residual 1.1e-13)

### Evidence — `/tmp/E_patch.vtu` (`patch_antenna --export-field`)

File size: **2,694,292 bytes**. First 20 lines:

```xml
<?xml version="1.0"?>
<VTKFile type="UnstructuredGrid" version="1.0" byte_order="LittleEndian">
  <UnstructuredGrid>
    <Piece NumberOfPoints="4750" NumberOfCells="25452">
      <Points>
        <DataArray type="Float64" NumberOfComponents="3" format="ascii">
          0.0 5.7 0.0
          0.0 7.3 0.0
          0.0 7.3 1.6
          0.0 5.7 1.6
          -116.0 -111.5 86.6
          -116.0 -111.5 -85.0
          -116.0 111.5 86.6
          -116.0 111.5 -85.0
          116.0 -111.5 -85.0
          116.0 -111.5 86.6
          116.0 111.5 86.6
          116.0 111.5 -85.0
          -91.0 -86.5 61.59999999999999
          -91.0 -86.5 -60.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)