### PR TITLE
feat(viz): Phase 3B per-benchmark tearsheet PNG (composite figure)

### DIFF
--- a/tools/viz/geode_viz/plots/__init__.py
+++ b/tools/viz/geode_viz/plots/__init__.py
@@ -13,6 +13,10 @@ TOMLs loaded via :func:`geode_viz.io.load_results`.
 - Phase 1D (#280): :mod:`geode_viz.plots.pattern` — patch-antenna
   E-plane / H-plane radiation pattern polar cuts with the Balanis
   cavity-model oracle overlaid as a reference ring.
+- Phase 3B (#290): :mod:`geode_viz.plots.tearsheet` — per-benchmark
+  composite "tearsheet" PNG, combining the Phase 1 line plots (and an
+  optional pre-rendered field / lobe panel) into one glanceable
+  multi-panel figure per benchmark.
 
 Shared helpers (``iter_points`` / ``subtitle_from_notes`` /
 ``resolve_out``) live in :mod:`geode_viz.plots._common` so all
@@ -21,4 +25,4 @@ per-benchmark modules import them from one source of truth.
 
 from __future__ import annotations
 
-__all__ = ["s_params", "spiral", "mie", "pattern"]
+__all__ = ["s_params", "spiral", "mie", "pattern", "tearsheet"]

--- a/tools/viz/geode_viz/plots/mie.py
+++ b/tools/viz/geode_viz/plots/mie.py
@@ -72,42 +72,19 @@ def _sweep_arrays(
     }
 
 
-def plot_efficiency_vs_ka(
-    out: Path | None = None,
-    *,
-    fine: bool = False,
-) -> Path:
-    """Plot Q_ext / Q_sca / Q_abs vs ka for the driven-Mie benchmark.
+def _draw_efficiency(
+    ax_q: "plt.Axes",
+    ax_e: "plt.Axes",
+    results: dict[str, Any],
+) -> None:
+    """Draw the Q-vs-ka + relative-error panels onto two axes.
 
-    Two-panel figure:
-
-    - Upper (taller): Q_ext (FEM scatter + analytic line) and Q_sca
-      (FEM scatter + analytic line), plus Q_abs ≡ Q_ext − Q_sca for
-      the FEM and analytic series so the non-absorbing dielectric
-      sphere check is visible.
-    - Lower (thin): per-point relative error (|err| in percent) on a
-      log-scale y-axis so the 0.4 %–19 % spread on the coarse mesh
-      stays legible.
-
-    Parameters
-    ----------
-    out
-        Optional output PNG path. Defaults to
-        ``artifacts/viz/mie_sphere/q_vs_ka.png``.
-    fine
-        When ``True``, load ``driven_results_fine.toml`` (the ~5.9k
-        node fine fixture from issue #215). Default ``False`` loads
-        ``driven_results.toml`` (the 774-node coarse fixture).
-
-    Returns
-    -------
-    Path
-        The resolved PNG path (already written to disk).
+    The axis-only core shared by the standalone
+    :func:`plot_efficiency_vs_ka` and the tearsheet composer. ``ax_q``
+    is the (taller) efficiency panel; ``ax_e`` the (thinner) relative
+    error strip — they are expected to share the ka x-axis. No
+    figure-level scaffolding (suptitle / footer / savefig) is touched.
     """
-    apply_style("light")
-
-    filename = "driven_results_fine.toml" if fine else "driven_results.toml"
-    results = load_results("mie_sphere", filename=filename)
     arrays = _sweep_arrays(results)
 
     ka = arrays["ka"]
@@ -121,16 +98,6 @@ def plot_efficiency_vs_ka(
 
     err_ext = arrays["rel_err_q_ext"]
     err_sca = arrays["rel_err_q_sca"]
-
-    # Two panels: efficiency above, error below. ``height_ratios`` keeps
-    # the headline efficiency panel ~3x the relative-error strip.
-    fig, (ax_q, ax_e) = plt.subplots(
-        nrows=2,
-        ncols=1,
-        sharex=True,
-        figsize=(7.5, 6.5),
-        gridspec_kw={"height_ratios": [3.0, 1.2]},
-    )
 
     # --- Q panel: analytic lines + FEM scatter ----------------------------
     # Dense analytic curve via the recorded points only (the analytic
@@ -198,7 +165,6 @@ def plot_efficiency_vs_ka(
         label="Q_abs FEM (Q_ext − Q_sca)",
     )
 
-    fixture_tag = "fine" if fine else "coarse"
     ax_q.set_ylabel("Efficiency Q (dimensionless)")
     ax_q.legend(loc="best", fontsize=8)
 
@@ -234,6 +200,79 @@ def plot_efficiency_vs_ka(
     ax_e.legend(loc="best", fontsize=8)
     # A faint 5 % guide — the project's mid-band tolerance band.
     ax_e.axhline(5.0, color="#d62728", linewidth=0.7, linestyle=":", alpha=0.6)
+
+
+def plot_efficiency_vs_ka(
+    out: Path | None = None,
+    *,
+    fine: bool = False,
+    ax: "plt.Axes | None" = None,
+) -> Path | tuple["plt.Axes", "plt.Axes"]:
+    """Plot Q_ext / Q_sca / Q_abs vs ka for the driven-Mie benchmark.
+
+    Two-panel figure:
+
+    - Upper (taller): Q_ext (FEM scatter + analytic line) and Q_sca
+      (FEM scatter + analytic line), plus Q_abs ≡ Q_ext − Q_sca for
+      the FEM and analytic series so the non-absorbing dielectric
+      sphere check is visible.
+    - Lower (thin): per-point relative error (|err| in percent) on a
+      log-scale y-axis so the 0.4 %–19 % spread on the coarse mesh
+      stays legible.
+
+    Parameters
+    ----------
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/mie_sphere/q_vs_ka.png``. Ignored when ``ax``
+        is supplied.
+    fine
+        When ``True``, load ``driven_results_fine.toml`` (the ~5.9k
+        node fine fixture from issue #215). Default ``False`` loads
+        ``driven_results.toml`` (the 774-node coarse fixture).
+    ax
+        Optional pre-existing axes whose grid slot is subdivided into
+        the efficiency + relative-error rows (used by the tearsheet
+        composer). When supplied the panels are drawn into a 2-row
+        subgridspec carved from ``ax`` and the two new axes returned
+        without creating a standalone figure or writing a PNG. When
+        ``None`` the standalone two-panel figure is built exactly as
+        before.
+
+    Returns
+    -------
+    Path or tuple of matplotlib.axes.Axes
+        The resolved PNG path when ``ax is None``; otherwise the
+        ``(ax_q, ax_e)`` panel axes drawn into.
+    """
+    filename = "driven_results_fine.toml" if fine else "driven_results.toml"
+    results = load_results("mie_sphere", filename=filename)
+    fixture_tag = "fine" if fine else "coarse"
+
+    if ax is not None:
+        fig = ax.get_figure()
+        # Carve a 2-row sub-grid (3:1.2 height ratio) from the supplied
+        # slot; drop the placeholder axes so only the panels remain.
+        gridspec = ax.get_subplotspec().subgridspec(
+            2, 1, height_ratios=[3.0, 1.2], hspace=0.08
+        )
+        ax.remove()
+        ax_q = fig.add_subplot(gridspec[0])
+        ax_e = fig.add_subplot(gridspec[1], sharex=ax_q)
+        _draw_efficiency(ax_q, ax_e, results)
+        return ax_q, ax_e
+
+    apply_style("light")
+    # Two panels: efficiency above, error below. ``height_ratios`` keeps
+    # the headline efficiency panel ~3x the relative-error strip.
+    fig, (ax_q, ax_e) = plt.subplots(
+        nrows=2,
+        ncols=1,
+        sharex=True,
+        figsize=(7.5, 6.5),
+        gridspec_kw={"height_ratios": [3.0, 1.2]},
+    )
+    _draw_efficiency(ax_q, ax_e, results)
 
     # Figure-level title + italic subtitle from the first TOML note.
     subtitle = _subtitle_from_notes(results)

--- a/tools/viz/geode_viz/plots/pattern.py
+++ b/tools/viz/geode_viz/plots/pattern.py
@@ -242,55 +242,21 @@ def _plot_cut(
     )
 
 
-def plot_pattern_cut(
-    benchmark: str = "patch_antenna",
+def _draw_pattern_cut(
+    ax: "plt.Axes",
+    results: dict[str, Any],
     *,
-    variant: str = "matched",
-    out: Path | None = None,
-) -> Path:
-    """Plot the E-plane + H-plane radiation pattern on a polar axes.
+    label: str,
+) -> None:
+    """Draw the E-/H-plane cuts + cavity-model ring onto a polar ``ax``.
 
-    Loads ``pattern_matched.toml`` (default) or ``pattern.toml`` and
-    renders the two principal cuts on a single polar axes:
-
-    - E-plane (solid).
-    - H-plane (dashed).
-    - Balanis cavity-model oracle as a thin reference circle at
-      ``directivity_broadside_dbi`` relative to the FEM lobe peak (the
-      cavity model is a scalar oracle; the trace is a constant-D ring
-      annotated with the cavity D value).
-
-    The radial axis is dB (``20·log10|E|``) with a fixed −30 dB floor.
-    A corner annotation surfaces the FEM ``D_broadside`` /
-    ``G_broadside`` and the cavity-model ``D_broadside`` scalars.
-
-    Parameters
-    ----------
-    benchmark
-        Benchmark name (currently only ``"patch_antenna"`` is wired).
-        Kept as a parameter for symmetry with the other plot helpers.
-    variant
-        ``"matched"`` (default — the tuned-feed pattern) or
-        ``"unmatched"`` (the untuned ``pattern.toml``).
-    out
-        Optional output PNG path. Defaults to
-        ``artifacts/viz/<benchmark>/pattern_cuts.png``.
-
-    Returns
-    -------
-    Path
-        The resolved PNG path (already written to disk).
+    The axis-only core shared by the standalone
+    :func:`plot_pattern_cut` and the tearsheet composer. Sets the
+    antenna-convention orientation, radial dB ticks, angular grid and
+    the per-axes legend; the figure-level annotation block,
+    suptitle, axes repositioning and footer remain in the standalone
+    entry point so its output stays byte-stable.
     """
-    if benchmark != "patch_antenna":
-        raise ValueError(
-            f"plot_pattern_cut is only wired for patch_antenna; "
-            f"got benchmark {benchmark!r}"
-        )
-
-    apply_style("light")
-
-    results, label = _load_pattern_variant(variant)
-
     cuts = results.get("cut", {})
     if "e_plane" not in cuts or "h_plane" not in cuts:
         raise KeyError(
@@ -303,13 +269,6 @@ def plot_pattern_cut(
     e_db_e = _to_db(e_norm_e, floor_db=floor_db)
     e_db_h = _to_db(e_norm_h, floor_db=floor_db)
 
-    # Constrained-layout (enabled by ``apply_style``) does not always
-    # interact well with polar subplots; turn it off here so we can
-    # hand-tune the suptitle / annotation positions without the
-    # legend bouncing around.
-    fig = plt.figure(figsize=(8.0, 7.5))
-    fig.set_constrained_layout(False)
-    ax = fig.add_subplot(111, projection="polar")
     # Antenna-engineering convention: broadside (θ = 0) up, θ
     # increases clockwise.
     ax.set_theta_zero_location("N")
@@ -373,6 +332,81 @@ def plot_pattern_cut(
     # Constrain the angular grid to the standard antenna-convention
     # ticks (every 30°) so the polar backdrop matches Balanis Figs.
     ax.set_thetagrids(np.arange(0, 360, 30))
+    ax.legend(
+        loc="lower center", bbox_to_anchor=(0.5, -0.18), fontsize=8
+    )
+
+
+def plot_pattern_cut(
+    benchmark: str = "patch_antenna",
+    *,
+    variant: str = "matched",
+    out: Path | None = None,
+    ax: "plt.Axes | None" = None,
+) -> Path | "plt.Axes":
+    """Plot the E-plane + H-plane radiation pattern on a polar axes.
+
+    Loads ``pattern_matched.toml`` (default) or ``pattern.toml`` and
+    renders the two principal cuts on a single polar axes:
+
+    - E-plane (solid).
+    - H-plane (dashed).
+    - Balanis cavity-model oracle as a thin reference circle at
+      ``directivity_broadside_dbi`` relative to the FEM lobe peak (the
+      cavity model is a scalar oracle; the trace is a constant-D ring
+      annotated with the cavity D value).
+
+    The radial axis is dB (``20·log10|E|``) with a fixed −30 dB floor.
+    A corner annotation surfaces the FEM ``D_broadside`` /
+    ``G_broadside`` and the cavity-model ``D_broadside`` scalars.
+
+    Parameters
+    ----------
+    benchmark
+        Benchmark name (currently only ``"patch_antenna"`` is wired).
+        Kept as a parameter for symmetry with the other plot helpers.
+    variant
+        ``"matched"`` (default — the tuned-feed pattern) or
+        ``"unmatched"`` (the untuned ``pattern.toml``).
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/<benchmark>/pattern_cuts.png``. Ignored when
+        ``ax`` is supplied.
+    ax
+        Optional pre-existing *polar* axes to draw into (used by the
+        tearsheet composer). When supplied the cuts are drawn into
+        ``ax`` and the axes returned without creating a standalone
+        figure, the corner annotation block, or writing a PNG. When
+        ``None`` the standalone figure is built exactly as before.
+
+    Returns
+    -------
+    Path or matplotlib.axes.Axes
+        The resolved PNG path when ``ax is None``; otherwise the
+        ``ax`` that was drawn into.
+    """
+    if benchmark != "patch_antenna":
+        raise ValueError(
+            f"plot_pattern_cut is only wired for patch_antenna; "
+            f"got benchmark {benchmark!r}"
+        )
+
+    results, label = _load_pattern_variant(variant)
+
+    if ax is not None:
+        _draw_pattern_cut(ax, results, label=label)
+        return ax
+
+    apply_style("light")
+
+    # Constrained-layout (enabled by ``apply_style``) does not always
+    # interact well with polar subplots; turn it off here so we can
+    # hand-tune the suptitle / annotation positions without the
+    # legend bouncing around.
+    fig = plt.figure(figsize=(8.0, 7.5))
+    fig.set_constrained_layout(False)
+    ax = fig.add_subplot(111, projection="polar")
+    _draw_pattern_cut(ax, results, label=label)
 
     # --- Annotation block --------------------------------------------------
     # Anchored to the lower-left so the suptitle has the whole top

--- a/tools/viz/geode_viz/plots/s_params.py
+++ b/tools/viz/geode_viz/plots/s_params.py
@@ -191,45 +191,24 @@ def _set_db_ylim(ax: "plt.Axes", s11_db_arrays: Iterable[np.ndarray]) -> None:
     ax.set_ylim(lo, hi)
 
 
-def plot_s11_magnitude(
-    benchmark: str,
+def _draw_s11_magnitude(
+    ax: "plt.Axes",
     *,
-    out: Path | None = None,
-    variant: str = "matched",
-) -> Path:
-    """Plot |S11| in dB vs frequency for a port-driven benchmark.
+    primary: dict[str, Any],
+    secondary: dict[str, Any] | None,
+    primary_label: str,
+    benchmark: str,
+) -> None:
+    """Draw the |S11| dB trace(s) onto ``ax``.
 
-    Parameters
-    ----------
-    benchmark
-        Benchmark name — directory under ``benchmarks/``. Currently
-        wired for ``"spiral_inductor"`` and ``"patch_antenna"``.
-    out
-        Optional output PNG path. Defaults to
-        ``artifacts/viz/<benchmark>/s11_db.png``.
-    variant
-        Patch-antenna variant (``"matched"`` or ``"unmatched"``);
-        ignored for benchmarks with a single result file. When the
-        opposite variant exists on disk it is overlaid for comparison.
-
-    Returns
-    -------
-    Path
-        The resolved PNG path (already written to disk).
+    The axis-only core shared by the standalone
+    :func:`plot_s11_magnitude` and the composed tearsheet panel — all
+    the figure scaffolding (sizing, footer, savefig) stays in the
+    public entry point so standalone output is byte-stable.
     """
-    apply_style("light")
-
-    if benchmark == "patch_antenna":
-        primary, secondary, primary_label = _load_patch_pair(variant)
-    else:
-        primary = load_results(benchmark)
-        secondary = None
-        primary_label = benchmark.replace("_", " ")
-
     z0_primary = _resolve_z0(primary)
     f_p, db_p, _ = _sweep_arrays(primary, z0_ohm=z0_primary)
 
-    fig, ax = plt.subplots(figsize=(7.0, 4.5))
     ax.plot(f_p, db_p, marker="o", label=primary_label)
 
     db_arrays: list[np.ndarray] = [db_p]
@@ -278,6 +257,71 @@ def plot_s11_magnitude(
     ax.axhline(0.0, color="#888888", linewidth=0.6, alpha=0.5)
     if secondary is not None or srf is not None:
         ax.legend(loc="best")
+
+
+def plot_s11_magnitude(
+    benchmark: str,
+    *,
+    out: Path | None = None,
+    variant: str = "matched",
+    ax: "plt.Axes | None" = None,
+) -> Path | "plt.Axes":
+    """Plot |S11| in dB vs frequency for a port-driven benchmark.
+
+    Parameters
+    ----------
+    benchmark
+        Benchmark name — directory under ``benchmarks/``. Currently
+        wired for ``"spiral_inductor"`` and ``"patch_antenna"``.
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/<benchmark>/s11_db.png``. Ignored when ``ax``
+        is supplied.
+    variant
+        Patch-antenna variant (``"matched"`` or ``"unmatched"``);
+        ignored for benchmarks with a single result file. When the
+        opposite variant exists on disk it is overlaid for comparison.
+    ax
+        Optional pre-existing axes to draw into (used by the
+        tearsheet composer). When supplied, the trace is drawn into
+        ``ax`` and the axes is returned without creating a standalone
+        figure or writing a PNG. When ``None`` (the default) a
+        standalone figure is created, written to ``out``, and the
+        resolved path returned — byte-compatible with the pre-``ax``
+        behaviour.
+
+    Returns
+    -------
+    Path or matplotlib.axes.Axes
+        The resolved PNG path when ``ax is None``; otherwise the
+        ``ax`` that was drawn into.
+    """
+    if benchmark == "patch_antenna":
+        primary, secondary, primary_label = _load_patch_pair(variant)
+    else:
+        primary = load_results(benchmark)
+        secondary = None
+        primary_label = benchmark.replace("_", " ")
+
+    if ax is not None:
+        _draw_s11_magnitude(
+            ax,
+            primary=primary,
+            secondary=secondary,
+            primary_label=primary_label,
+            benchmark=benchmark,
+        )
+        return ax
+
+    apply_style("light")
+    fig, ax = plt.subplots(figsize=(7.0, 4.5))
+    _draw_s11_magnitude(
+        ax,
+        primary=primary,
+        secondary=secondary,
+        primary_label=primary_label,
+        benchmark=benchmark,
+    )
     footer(fig, primary)
 
     out_path = _resolve_out(benchmark, out, "s11_db.png")
@@ -367,50 +411,23 @@ def _add_smith_trace(
         )
 
 
-def plot_smith(
-    benchmark: str,
+def _draw_smith(
+    ax: "plt.Axes",
     *,
-    out: Path | None = None,
-    variant: str = "matched",
-) -> Path:
-    """Plot the S11 sweep on a polar Smith chart.
+    primary: dict[str, Any],
+    secondary: dict[str, Any] | None,
+    primary_label: str,
+    benchmark: str,
+) -> None:
+    """Draw the polar Smith chart trace(s) onto a polar ``ax``.
 
-    Uses matplotlib's polar projection — no ``scikit-rf`` dependency.
-    The Smith backdrop is a minimal constant-|Γ| ring overlay (0.25,
-    0.5, 0.75, 1.0). Markers are placed at the frequency where |S11|
-    is minimum (the "match" point) for each trace.
-
-    Parameters
-    ----------
-    benchmark
-        Benchmark name. ``"spiral_inductor"`` or ``"patch_antenna"``.
-    out
-        Optional output PNG path. Defaults to
-        ``artifacts/viz/<benchmark>/smith.png``.
-    variant
-        Patch-antenna variant (``"matched"`` or ``"unmatched"``);
-        ignored for single-result benchmarks. When the opposite
-        variant exists on disk, it is overlaid for comparison.
-
-    Returns
-    -------
-    Path
-        The resolved PNG path (already written to disk).
+    The supplied ``ax`` must be a polar projection axes (the
+    standalone entry point and the tearsheet composer both create
+    one via ``projection="polar"``).
     """
-    apply_style("light")
-
-    if benchmark == "patch_antenna":
-        primary, secondary, primary_label = _load_patch_pair(variant)
-    else:
-        primary = load_results(benchmark)
-        secondary = None
-        primary_label = benchmark.replace("_", " ")
-
     z0_primary = _resolve_z0(primary)
     f_p, _, s11_p = _sweep_arrays(primary, z0_ohm=z0_primary)
 
-    fig = plt.figure(figsize=(6.0, 6.0))
-    ax = fig.add_subplot(111, projection="polar")
     _draw_smith_grid(ax)
 
     _add_smith_trace(
@@ -440,8 +457,78 @@ def plot_smith(
     title_label = benchmark.replace("_", " ")
     if benchmark == "patch_antenna":
         title_label = f"{title_label} ({primary_label})"
-    ax.set_title(f"{title_label}: Smith chart (Z0 = {z0_primary:.0f} Ω)", pad=18.0)
+    ax.set_title(
+        f"{title_label}: Smith chart (Z0 = {z0_primary:.0f} Ω)", pad=18.0
+    )
     ax.legend(loc="lower center", bbox_to_anchor=(0.5, -0.12), fontsize=8)
+
+
+def plot_smith(
+    benchmark: str,
+    *,
+    out: Path | None = None,
+    variant: str = "matched",
+    ax: "plt.Axes | None" = None,
+) -> Path | "plt.Axes":
+    """Plot the S11 sweep on a polar Smith chart.
+
+    Uses matplotlib's polar projection — no ``scikit-rf`` dependency.
+    The Smith backdrop is a minimal constant-|Γ| ring overlay (0.25,
+    0.5, 0.75, 1.0). Markers are placed at the frequency where |S11|
+    is minimum (the "match" point) for each trace.
+
+    Parameters
+    ----------
+    benchmark
+        Benchmark name. ``"spiral_inductor"`` or ``"patch_antenna"``.
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/<benchmark>/smith.png``. Ignored when ``ax``
+        is supplied.
+    variant
+        Patch-antenna variant (``"matched"`` or ``"unmatched"``);
+        ignored for single-result benchmarks. When the opposite
+        variant exists on disk, it is overlaid for comparison.
+    ax
+        Optional pre-existing *polar* axes to draw into (used by the
+        tearsheet composer). When supplied the trace is drawn into
+        ``ax`` and the axes returned without creating a standalone
+        figure or writing a PNG. When ``None`` a standalone figure is
+        created exactly as before.
+
+    Returns
+    -------
+    Path or matplotlib.axes.Axes
+        The resolved PNG path when ``ax is None``; otherwise the
+        ``ax`` that was drawn into.
+    """
+    if benchmark == "patch_antenna":
+        primary, secondary, primary_label = _load_patch_pair(variant)
+    else:
+        primary = load_results(benchmark)
+        secondary = None
+        primary_label = benchmark.replace("_", " ")
+
+    if ax is not None:
+        _draw_smith(
+            ax,
+            primary=primary,
+            secondary=secondary,
+            primary_label=primary_label,
+            benchmark=benchmark,
+        )
+        return ax
+
+    apply_style("light")
+    fig = plt.figure(figsize=(6.0, 6.0))
+    ax = fig.add_subplot(111, projection="polar")
+    _draw_smith(
+        ax,
+        primary=primary,
+        secondary=secondary,
+        primary_label=primary_label,
+        benchmark=benchmark,
+    )
     footer(fig, primary)
 
     out_path = _resolve_out(benchmark, out, "smith.png")

--- a/tools/viz/geode_viz/plots/spiral.py
+++ b/tools/viz/geode_viz/plots/spiral.py
@@ -112,32 +112,20 @@ def _annotate_srf(ax: "plt.Axes", srf_ghz: float, *, label: bool) -> None:
     )
 
 
-def plot_lqr_vs_f(out: Path | None = None) -> Path:
-    """Plot the spiral inductor L / Q / R sweep vs frequency.
+def _draw_lqr(
+    ax_l: "plt.Axes",
+    ax_q: "plt.Axes",
+    ax_r: "plt.Axes",
+    results: dict[str, Any],
+) -> None:
+    """Draw the L / Q / R panels onto three pre-existing axes.
 
-    Three-panel figure (rows: L_eq, Q, R) sharing the frequency axis.
-    Overlays:
-
-    - Mohan L₀ horizontal band on the L panel.
-    - mom PEEC n=3 / n=4 shaded bracket on the L panel.
-    - SRF vertical guideline on every panel (from ``meta.srf_ghz``).
-    - Subtitle: first caveat from ``meta.notes``.
-    - Provenance footer: commit / fixture SHA / source TOML.
-
-    Parameters
-    ----------
-    out
-        Optional output PNG path. Defaults to
-        ``artifacts/viz/spiral_inductor/lqr_vs_f.png``.
-
-    Returns
-    -------
-    Path
-        The resolved PNG path (already written to disk).
+    The axis-only core shared by the standalone
+    :func:`plot_lqr_vs_f` and the tearsheet composer. The three axes
+    are expected to share the frequency x-axis (created with
+    ``sharex=True`` or an equivalent subgridspec). No figure-level
+    scaffolding (suptitle / footer / savefig) is touched here.
     """
-    apply_style("light")
-
-    results = load_results("spiral_inductor")
     f_ghz, l_nh, q_vals, r_ohm = _sweep_arrays(results)
 
     oracles = results.get("oracles", {})
@@ -145,10 +133,6 @@ def plot_lqr_vs_f(out: Path | None = None) -> Path:
     mom = _mom_peec_bracket(oracles)
     srf_ghz_raw = results.get("meta", {}).get("srf_ghz")
     srf_ghz = float(srf_ghz_raw) if srf_ghz_raw is not None else None
-
-    fig, (ax_l, ax_q, ax_r) = plt.subplots(
-        nrows=3, ncols=1, sharex=True, figsize=(7.5, 8.5)
-    )
 
     # --- L panel -----------------------------------------------------------
     # Split the FEM L into pre-SRF (physically meaningful inductance) and
@@ -293,6 +277,63 @@ def plot_lqr_vs_f(out: Path | None = None) -> Path:
     ax_r.set_xlabel("Frequency (GHz)")
     if use_log:
         ax_r.legend(loc="best", fontsize=8)
+
+
+def plot_lqr_vs_f(
+    out: Path | None = None,
+    *,
+    ax: "plt.Axes | None" = None,
+) -> Path | tuple["plt.Axes", "plt.Axes", "plt.Axes"]:
+    """Plot the spiral inductor L / Q / R sweep vs frequency.
+
+    Three-panel figure (rows: L_eq, Q, R) sharing the frequency axis.
+    Overlays:
+
+    - Mohan L₀ horizontal band on the L panel.
+    - mom PEEC n=3 / n=4 shaded bracket on the L panel.
+    - SRF vertical guideline on every panel (from ``meta.srf_ghz``).
+    - Subtitle: first caveat from ``meta.notes``.
+    - Provenance footer: commit / fixture SHA / source TOML.
+
+    Parameters
+    ----------
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/spiral_inductor/lqr_vs_f.png``. Ignored when
+        ``ax`` is supplied.
+    ax
+        Optional pre-existing axes whose grid slot is subdivided into
+        the three L / Q / R rows (used by the tearsheet composer).
+        When supplied the panels are drawn into a 3-row subgridspec
+        carved from ``ax`` and the three new axes returned without
+        creating a standalone figure or writing a PNG. When ``None``
+        the standalone three-panel figure is built exactly as before.
+
+    Returns
+    -------
+    Path or tuple of matplotlib.axes.Axes
+        The resolved PNG path when ``ax is None``; otherwise the
+        ``(ax_l, ax_q, ax_r)`` panel axes drawn into.
+    """
+    results = load_results("spiral_inductor")
+
+    if ax is not None:
+        fig = ax.get_figure()
+        # Carve a 3-row sub-grid from the supplied slot; drop the
+        # placeholder axes so only the panels remain.
+        gridspec = ax.get_subplotspec().subgridspec(3, 1, hspace=0.08)
+        ax.remove()
+        ax_l = fig.add_subplot(gridspec[0])
+        ax_q = fig.add_subplot(gridspec[1], sharex=ax_l)
+        ax_r = fig.add_subplot(gridspec[2], sharex=ax_l)
+        _draw_lqr(ax_l, ax_q, ax_r, results)
+        return ax_l, ax_q, ax_r
+
+    apply_style("light")
+    fig, (ax_l, ax_q, ax_r) = plt.subplots(
+        nrows=3, ncols=1, sharex=True, figsize=(7.5, 8.5)
+    )
+    _draw_lqr(ax_l, ax_q, ax_r, results)
 
     # Figure-level title + italic subtitle from the first TOML note,
     # placed above the constrained-layout L panel so they don't collide

--- a/tools/viz/geode_viz/plots/tearsheet.py
+++ b/tools/viz/geode_viz/plots/tearsheet.py
@@ -1,0 +1,256 @@
+"""Per-benchmark composite "tearsheet" figures (#290, Phase 3B).
+
+Phase 3B of Epic #276. Composes the Phase 1 line plots — |S11| dB +
+Smith (1B), L / Q / R + Q vs ka (1C), and the radiation-pattern polar
+cuts (1D) — into a single multi-panel PNG per benchmark, the figure a
+developer actually wants to paste into a PR description or release
+note: every headline view for a benchmark in one glance.
+
+The panels are *not* re-plotted from raw TOML here. Each per-family
+plot function in :mod:`geode_viz.plots` grew an optional ``ax=``
+parameter (the load-bearing 3B refactor); the composer simply hands
+each one a pre-positioned axes and lets the existing drawing code run.
+That keeps a single source of truth for every panel — the standalone
+PNGs and the tearsheet panels are pixel-for-pixel the same plot.
+
+Per-benchmark layouts:
+
+- ``spiral_inductor`` — |S11| dB (left) + L / Q / R vs f (right).
+- ``patch_antenna`` — |S11| dB + Smith (top row) + E/H-plane pattern
+  cuts (bottom).
+- ``mie_sphere`` — Q_ext / Q_sca / Q_abs vs ka (with the relative
+  error strip).
+
+An optional pre-rendered field-slice (Phase 2C) or 3D-lobe (Phase 3A)
+PNG is embedded as an extra image panel when ``field_png`` points at a
+file that exists, and silently omitted otherwise — so the tearsheet
+works from matplotlib-only data without the heavier ParaView pipeline.
+
+Single public entry point:
+
+- :func:`plot_tearsheet` — compose + write ``tearsheet.png`` for a
+  benchmark.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib.image as mpimg
+import matplotlib.pyplot as plt
+
+from geode_viz.io import load_results
+from geode_viz.plots._common import (
+    resolve_out as _resolve_out,
+    subtitle_from_notes as _subtitle_from_notes,
+)
+from geode_viz.plots.mie import plot_efficiency_vs_ka
+from geode_viz.plots.pattern import plot_pattern_cut
+from geode_viz.plots.s_params import plot_s11_magnitude, plot_smith
+from geode_viz.plots.spiral import plot_lqr_vs_f
+from geode_viz.style import apply_style, footer
+
+# Benchmarks the composer knows how to lay out. Mirrors the
+# per-benchmark plot families wired in
+# :mod:`geode_viz.scripts.plot_benchmark`.
+_TEARSHEET_BENCHMARKS: tuple[str, ...] = (
+    "spiral_inductor",
+    "patch_antenna",
+    "mie_sphere",
+)
+
+
+def _load_primary(
+    benchmark: str, *, variant: str, fine: bool
+) -> dict[str, Any]:
+    """Load the headline TOML used for the suptitle / footer provenance.
+
+    Picks the same source file the dominant panel reads so the
+    figure-level suptitle (fixture variant) and the provenance footer
+    agree with the rendered data.
+    """
+    if benchmark == "patch_antenna":
+        filename = (
+            "results_matched.toml"
+            if variant == "matched"
+            else "results.toml"
+        )
+        return load_results("patch_antenna", filename=filename)
+    if benchmark == "mie_sphere":
+        filename = (
+            "driven_results_fine.toml" if fine else "driven_results.toml"
+        )
+        return load_results("mie_sphere", filename=filename)
+    return load_results(benchmark)
+
+
+def _variant_tag(benchmark: str, *, variant: str, fine: bool) -> str:
+    """Human-readable fixture-variant tag for the suptitle."""
+    if benchmark == "patch_antenna":
+        return variant
+    if benchmark == "mie_sphere":
+        return "fine" if fine else "coarse"
+    return "default"
+
+
+def _embed_field_png(ax: "plt.Axes", field_png: Path) -> None:
+    """Draw a pre-rendered image into ``ax`` as a borderless panel."""
+    image = mpimg.imread(str(field_png))
+    ax.imshow(image)
+    ax.set_axis_off()
+    ax.set_title(f"field render: {field_png.name}", fontsize=9)
+
+
+def _compose_spiral(fig: "plt.Figure", *, has_field: bool) -> Any:
+    """Lay out the spiral-inductor panels; return the gridspec."""
+    ncols = 3 if has_field else 2
+    width_ratios = [1.0, 1.2, 1.0] if has_field else [1.0, 1.2]
+    gridspec = fig.add_gridspec(1, ncols, width_ratios=width_ratios)
+    ax_s11 = fig.add_subplot(gridspec[0, 0])
+    plot_s11_magnitude("spiral_inductor", ax=ax_s11)
+    ax_lqr = fig.add_subplot(gridspec[0, 1])
+    plot_lqr_vs_f(ax=ax_lqr)
+    return gridspec
+
+
+def _compose_patch(
+    fig: "plt.Figure", *, variant: str, has_field: bool
+) -> Any:
+    """Lay out the patch-antenna panels; return the gridspec."""
+    nrows = 3 if has_field else 2
+    height_ratios = [1.0, 1.3, 1.0] if has_field else [1.0, 1.3]
+    gridspec = fig.add_gridspec(nrows, 2, height_ratios=height_ratios)
+    ax_s11 = fig.add_subplot(gridspec[0, 0])
+    plot_s11_magnitude("patch_antenna", variant=variant, ax=ax_s11)
+    ax_smith = fig.add_subplot(gridspec[0, 1], projection="polar")
+    plot_smith("patch_antenna", variant=variant, ax=ax_smith)
+    ax_pattern = fig.add_subplot(gridspec[1, :], projection="polar")
+    plot_pattern_cut("patch_antenna", variant=variant, ax=ax_pattern)
+    return gridspec
+
+
+def _compose_mie(fig: "plt.Figure", *, fine: bool, has_field: bool) -> Any:
+    """Lay out the Mie-sphere panel; return the gridspec."""
+    if has_field:
+        gridspec = fig.add_gridspec(1, 2, width_ratios=[1.4, 1.0])
+    else:
+        gridspec = fig.add_gridspec(1, 1)
+    ax_q = fig.add_subplot(gridspec[0, 0])
+    plot_efficiency_vs_ka(fine=fine, ax=ax_q)
+    return gridspec
+
+
+def plot_tearsheet(
+    benchmark: str,
+    *,
+    out: Path | None = None,
+    variant: str = "matched",
+    fine: bool = False,
+    field_png: Path | None = None,
+) -> Path:
+    """Compose the per-benchmark tearsheet PNG.
+
+    Builds one multi-panel :class:`~matplotlib.figure.Figure` for the
+    chosen benchmark by handing each Phase 1 plot helper a
+    pre-positioned axes (via its ``ax=`` parameter) — no panel is
+    re-plotted from raw TOML. A figure suptitle names the benchmark +
+    fixture variant; a subtitle line echoes the first caveat from the
+    TOML ``meta.notes`` block. A provenance footer is stamped from the
+    headline TOML.
+
+    Parameters
+    ----------
+    benchmark
+        ``"spiral_inductor"``, ``"patch_antenna"`` or ``"mie_sphere"``.
+    out
+        Optional output PNG path. Defaults to
+        ``artifacts/viz/<benchmark>/tearsheet.png``.
+    variant
+        Patch-antenna fixture variant (``"matched"`` / ``"unmatched"``);
+        ignored for the other benchmarks.
+    fine
+        Mie-sphere fine-mesh fixture toggle; ignored for the others.
+    field_png
+        Optional path to a pre-rendered field-slice (Phase 2C) or 3D
+        lobe (Phase 3A) PNG. Embedded as an extra image panel when the
+        file exists; silently omitted otherwise so the tearsheet works
+        from matplotlib-only data.
+
+    Returns
+    -------
+    Path
+        The resolved PNG path (already written to disk).
+    """
+    if benchmark not in _TEARSHEET_BENCHMARKS:
+        raise ValueError(
+            f"unknown tearsheet benchmark {benchmark!r}; "
+            f"expected one of {sorted(_TEARSHEET_BENCHMARKS)}"
+        )
+
+    apply_style("light")
+
+    # Resolve the embedded-field panel up front so the layout knows
+    # whether to reserve a slot. A missing file degrades gracefully.
+    field_path = Path(field_png) if field_png is not None else None
+    has_field = field_path is not None and field_path.is_file()
+
+    # Constrained-layout (enabled by ``apply_style``) does not
+    # cooperate with the explicit ``subplots_adjust`` margins below nor
+    # with the polar subplots in the patch layout. Build the whole
+    # figure — including the panels each plot helper carves via its
+    # ``ax=`` hook — with the layout engine turned off so the margins
+    # take effect.
+    with plt.rc_context({"figure.constrained_layout.use": False}):
+        fig = plt.figure(figsize=(13.0, 8.0))
+
+        gridspec: Any
+        if benchmark == "spiral_inductor":
+            gridspec = _compose_spiral(fig, has_field=has_field)
+        elif benchmark == "patch_antenna":
+            gridspec = _compose_patch(
+                fig, variant=variant, has_field=has_field
+            )
+        else:  # mie_sphere
+            gridspec = _compose_mie(fig, fine=fine, has_field=has_field)
+
+        if has_field:
+            # The composer reserves a slot for the optional field panel
+            # when ``has_field`` is set. Patch reserves the bottom row;
+            # spiral / mie reserve the right column.
+            if benchmark == "patch_antenna":
+                ax_field = fig.add_subplot(gridspec[2, :])
+            elif benchmark == "spiral_inductor":
+                ax_field = fig.add_subplot(gridspec[0, 2])
+            else:  # mie_sphere
+                ax_field = fig.add_subplot(gridspec[0, 1])
+            _embed_field_png(ax_field, field_path)
+
+        primary = _load_primary(benchmark, variant=variant, fine=fine)
+        tag = _variant_tag(benchmark, variant=variant, fine=fine)
+        label = benchmark.replace("_", " ")
+        base_title = f"{label} tearsheet ({tag})"
+        subtitle = _subtitle_from_notes(primary)
+        if subtitle is None:
+            fig.suptitle(base_title, fontsize=15, y=0.99)
+        else:
+            fig.suptitle(base_title + "\n" + subtitle, fontsize=12, y=0.99)
+
+        # Reserve top headroom for the suptitle (no constrained-layout).
+        fig.subplots_adjust(
+            top=0.90,
+            bottom=0.08,
+            left=0.06,
+            right=0.97,
+            hspace=0.45,
+            wspace=0.30,
+        )
+        footer(fig, primary)
+
+    out_path = _resolve_out(benchmark, out, "tearsheet.png")
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+__all__ = ["plot_tearsheet"]

--- a/tools/viz/geode_viz/scripts/plot_benchmark.py
+++ b/tools/viz/geode_viz/scripts/plot_benchmark.py
@@ -23,6 +23,14 @@ By default every plot wired up for the chosen benchmark is rendered.
 Restrict to a single family with the ``--<plot>-only`` flags
 (``--s11-only`` / ``--smith-only`` / ``--lqr-only`` / ``--mie-only`` /
 ``--pattern-only``).
+
+Pass ``--tearsheet`` to instead compose the benchmark-appropriate
+panels into a single multi-panel ``tearsheet.png`` (Phase 3B, #290)::
+
+    python -m geode_viz.scripts.plot_benchmark spiral_inductor --tearsheet
+
+An optional pre-rendered field-slice / 3D-lobe PNG is embedded as an
+extra panel via ``--field-png <path>`` when the file exists.
 """
 
 from __future__ import annotations
@@ -36,6 +44,7 @@ from geode_viz.plots.mie import plot_efficiency_vs_ka
 from geode_viz.plots.pattern import plot_pattern_cut
 from geode_viz.plots.s_params import plot_s11_magnitude, plot_smith
 from geode_viz.plots.spiral import plot_lqr_vs_f
+from geode_viz.plots.tearsheet import plot_tearsheet
 
 # Benchmarks understood by the CLI. The mapping spells out which
 # plot families a benchmark exposes — used both by argparse
@@ -83,6 +92,35 @@ def _build_parser() -> argparse.ArgumentParser:
             "Mie sphere: load the fine-mesh fixture "
             "(driven_results_fine.toml, issue #215). "
             "Ignored for other benchmarks."
+        ),
+    )
+
+    parser.add_argument(
+        "--tearsheet",
+        action="store_true",
+        help=(
+            "Compose the benchmark-appropriate panels into a single "
+            "multi-panel tearsheet.png (Phase 3B). Overrides the "
+            "per-family --<plot>-only flags."
+        ),
+    )
+    parser.add_argument(
+        "--field-png",
+        type=Path,
+        default=None,
+        help=(
+            "Tearsheet only: path to a pre-rendered field-slice / 3D "
+            "lobe PNG to embed as an extra panel. Silently omitted when "
+            "the file does not exist."
+        ),
+    )
+    parser.add_argument(
+        "--tearsheet-out",
+        type=Path,
+        default=None,
+        help=(
+            "Override the tearsheet PNG output path. Defaults to "
+            "artifacts/viz/<benchmark>/tearsheet.png."
         ),
     )
 
@@ -194,6 +232,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI. Returns a POSIX-style exit code."""
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    if args.tearsheet:
+        # Tearsheet mode composes the per-benchmark panels into a single
+        # figure; the per-family --<plot>-only filters do not apply.
+        path = plot_tearsheet(
+            args.benchmark,
+            out=args.tearsheet_out,
+            variant=args.variant,
+            fine=args.fine,
+            field_png=args.field_png,
+        )
+        print(f"wrote {path}")
+        return 0
 
     available = set(_BENCHMARK_PLOTS[args.benchmark])
     requested = _plot_filter(args)


### PR DESCRIPTION
## Summary

Phase 3B of Epic #276: compose the Phase 1 per-family plots into a single multi-panel **tearsheet** PNG per benchmark — one glanceable figure with all the headline views, suitable for dropping into a PR description or release note.

`python -m geode_viz.scripts.plot_benchmark <benchmark> --tearsheet` writes `artifacts/viz/<benchmark>/tearsheet.png`.

## Load-bearing refactor (composability)

Each per-family plot function gained an optional `ax: matplotlib.axes.Axes | None = None`:

- `s_params.plot_s11_magnitude`, `s_params.plot_smith`
- `spiral.plot_lqr_vs_f` (3-panel) and `mie.plot_efficiency_vs_ka` (2-panel) — when `ax=` is given they carve a `subgridspec` from the supplied slot
- `pattern.plot_pattern_cut`

When `ax=None` the function builds its standalone figure **exactly as before** and returns the resolved `Path`; when `ax` is supplied it draws into the axes and returns the axes (no figure/footer/savefig). The drawing logic was lifted into private `_draw_*` cores so there is a single source of truth — the tearsheet does **not** re-plot from raw TOML.

**Byte-stability verified**: all seven standalone PNGs are pixel-for-pixel identical pre/post refactor (rendered from the original `main` code into `/tmp/viz_before`, from this branch into `/tmp/viz_after`, `cmp` → IDENTICAL for every file).

## New module

`geode_viz.plots.tearsheet.plot_tearsheet(benchmark, *, out, variant, fine, field_png)` lays out:

- **spiral_inductor**: |S11| dB (left) + L/Q/R vs f (right, 3 rows)
- **patch_antenna**: |S11| dB + Smith (top row) + E/H-plane pattern cuts (bottom)
- **mie_sphere**: Q_ext/Q_sca/Q_abs vs ka (+ relative-error strip)

Figure suptitle (benchmark + fixture variant) and a subtitle line from the TOML `meta.notes` via `plots._common.subtitle_from_notes`; provenance footer via `style.footer`. `--field-png <path>` embeds a pre-rendered 2C field-slice / 3A lobe panel **if the file exists**, silently omitted otherwise. Added `tearsheet` to `plots/__init__.py` `__all__`.

## CLI

`scripts/plot_benchmark.py` gains `--tearsheet` (overrides the per-family `--*-only` flags), `--field-png`, and `--tearsheet-out`; `--variant` / `--fine` propagate.

## Verification

```
$ ruff check geode_viz/
All checks passed!

$ python -m geode_viz.scripts.plot_benchmark spiral_inductor --tearsheet   # real 0.82s
$ python -m geode_viz.scripts.plot_benchmark patch_antenna  --tearsheet   # real 0.75s
$ python -m geode_viz.scripts.plot_benchmark mie_sphere     --tearsheet   # real 0.78s
```

All three write a single multi-panel `tearsheet.png` in < 1 s (well under the 5 s budget), with `-W error::UserWarning` clean. `--field-png` confirmed for both present (panel embedded) and missing (gracefully omitted) cases.

### Generated tearsheets

The three PNGs land under the gitignored `artifacts/viz/<benchmark>/tearsheet.png` (not committed). Layouts, confirmed by visual inspection:

- **spiral_inductor/tearsheet.png** — |S11| dB panel (left) beside the L_eq / Q / R three-row stack (Mohan band + mom PEEC bracket + SRF guideline), suptitle `spiral inductor tearsheet (default)`, notes subtitle + provenance footer.
- **patch_antenna/tearsheet.png** — |S11| dB (matched + unmatched overlay) and the polar Smith chart on the top row; full-width E-plane/H-plane polar cuts with the cavity-model ring below; suptitle `patch antenna tearsheet (matched)`.
- **mie_sphere/tearsheet.png** — Q_ext/Q_sca/Q_abs analytic lines + FEM scatter (upper) over the |rel err| % log strip (lower); suptitle `mie sphere tearsheet (coarse)`.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)