### PR TITLE
feat(viz): Phase 3C frequency-sweep animation (.pvd → ffmpeg → MP4) (#291)

### DIFF
--- a/crates/geode-core/examples/common/viz_export_helper.rs
+++ b/crates/geode-core/examples/common/viz_export_helper.rs
@@ -40,6 +40,15 @@
 //! averaging) if the crude per-tet-vertex average proves too noisy for
 //! the intended ParaView inspection.
 
+// This module is `#[path]`-included by three examples, but not every
+// example exercises every item: `parse_export_field` / `edge_field_to_nodes`
+// are used by all three, while the Phase 3C sweep helpers (`SweepSpec`,
+// `parse_export_sweep`, `write_pvd`) are only used by `patch_antenna`. The
+// unused-in-this-binary items would otherwise trip `-D warnings` dead-code
+// in the mie/spiral binaries, so allow it module-wide for this shared
+// example helper.
+#![allow(dead_code)]
+
 use faer::c64;
 
 use geode_core::TetMesh;
@@ -71,6 +80,125 @@ pub fn parse_export_field(args: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+/// A frequency-sweep field-export request parsed from the example argv
+/// (Epic #276 Phase 3C, issue #291).
+///
+/// The sweep writes one `E_<index>.vtu` per swept frequency into
+/// [`dir`] plus a ParaView `.pvd` collection ([`write_pvd`]) so
+/// `sweep_animate.py` can render the band as an MP4. It is the
+/// frequency-domain sibling of [`parse_export_field`]: one driven solve
+/// per source frequency `ω`, not a time-domain `E(r, t)`.
+pub struct SweepSpec {
+    /// Output directory for the `E_<index>.vtu` frames and the `.pvd`.
+    pub dir: String,
+    /// Sweep start frequency (GHz, inclusive).
+    pub f_start_ghz: f64,
+    /// Sweep stop frequency (GHz, inclusive).
+    pub f_stop_ghz: f64,
+    /// Number of swept frequencies (frames). Must be `>= 1`.
+    pub n: usize,
+}
+
+impl SweepSpec {
+    /// The swept frequencies (GHz), evenly spaced over
+    /// `[f_start_ghz, f_stop_ghz]` inclusive. A single-point sweep
+    /// (`n == 1`) returns just `f_start_ghz`.
+    pub fn freqs_ghz(&self) -> Vec<f64> {
+        if self.n <= 1 {
+            return vec![self.f_start_ghz];
+        }
+        let step = (self.f_stop_ghz - self.f_start_ghz) / (self.n - 1) as f64;
+        (0..self.n)
+            .map(|i| self.f_start_ghz + step * i as f64)
+            .collect()
+    }
+}
+
+/// Scan `args` (the full process argv) for the opt-in
+/// `--export-sweep <dir>` directive and its companion flags and return
+/// the parsed [`SweepSpec`] when present.
+///
+/// Spellings (matching the by-hand positional style the examples use):
+///
+/// * `--export-sweep <dir>` (flag + following token), or
+/// * `--export-sweep=<dir>`.
+///
+/// The band/count flags are `--f-start <ghz>`, `--f-stop <ghz>`, and
+/// `--n <count>` (each also accepts the `--flag=value` spelling).
+/// `--f-start` / `--f-stop` default to the patch S11-band 2.0 / 3.0 GHz
+/// and `--n` defaults to 11 when omitted, so `--export-sweep <dir>`
+/// alone is a usable invocation.
+///
+/// Returns `None` when `--export-sweep` is absent, leaving the example's
+/// default benchmark behaviour byte-for-byte unchanged.
+pub fn parse_export_sweep(args: &[String]) -> Option<SweepSpec> {
+    fn flag_value(args: &[String], name: &str) -> Option<String> {
+        let mut it = args.iter();
+        let eq = format!("{name}=");
+        while let Some(a) = it.next() {
+            if a == name {
+                return it.next().cloned();
+            }
+            if let Some(rest) = a.strip_prefix(&eq) {
+                return Some(rest.to_string());
+            }
+        }
+        None
+    }
+
+    let dir = flag_value(args, "--export-sweep")?;
+    let f_start_ghz = flag_value(args, "--f-start")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2.0);
+    let f_stop_ghz = flag_value(args, "--f-stop")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3.0);
+    let n = flag_value(args, "--n")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(11usize)
+        .max(1);
+    Some(SweepSpec {
+        dir,
+        f_start_ghz,
+        f_stop_ghz,
+        n,
+    })
+}
+
+/// Write a ParaView `.pvd` collection mapping each `E_<index>.vtu` frame
+/// to a `timestep` (the swept frequency in GHz), so ParaView (and
+/// `sweep_animate.py`) treats the frequency sweep as a time-series.
+///
+/// `frames` is `(timestep, file_name)` pairs where `file_name` is the
+/// frame's path **relative to the `.pvd`** (e.g. `E_0000.vtu`) — keeping
+/// it relative lets the collection move with its directory. The `.pvd`
+/// format is a tiny hand-rolled XML, consistent with the Phase 2A `.vtu`
+/// writer (no XML dependency):
+///
+/// ```xml
+/// <?xml version="1.0"?>
+/// <VTKFile type="Collection" version="0.1" byte_order="LittleEndian">
+///   <Collection>
+///     <DataSet timestep="2.0" group="" part="0" file="E_0000.vtu"/>
+///     ...
+///   </Collection>
+/// </VTKFile>
+/// ```
+pub fn write_pvd(path: &std::path::Path, frames: &[(f64, String)]) -> std::io::Result<()> {
+    let mut s = String::new();
+    s.push_str("<?xml version=\"1.0\"?>\n");
+    s.push_str("<VTKFile type=\"Collection\" version=\"0.1\" byte_order=\"LittleEndian\">\n");
+    s.push_str("  <Collection>\n");
+    for (timestep, file) in frames {
+        s.push_str(&format!(
+            "    <DataSet timestep=\"{timestep}\" group=\"\" part=\"0\" file=\"{file}\"/>\n"
+        ));
+    }
+    s.push_str("  </Collection>\n");
+    s.push_str("</VTKFile>\n");
+    std::fs::write(path, s)
 }
 
 /// Cross product of two 3-vectors.

--- a/crates/geode-core/examples/patch_antenna.rs
+++ b/crates/geode-core/examples/patch_antenna.rs
@@ -96,6 +96,24 @@
 //! Whitney interpolant (see `examples/viz_export_helper.rs`), with a
 //! per-node `eps_r` map (FR-4 ε_r in the substrate, 1 in air/UPML)
 //! averaged from the fixture's material regions.
+//!
+//! # Frequency-sweep export (Epic #276 Phase 3C, issue #291)
+//!
+//! Passing `--export-sweep <dir>` (optionally `--f-start`/`--f-stop` in
+//! GHz and `--n <count>`, defaulting to 2.0–3.0 GHz over 11 points) is
+//! the **frequency-domain** sibling of `--export-field`: it solves the
+//! benchmark fixture once per swept source frequency `ω` and dumps one
+//! `E_<index>.vtu` per frequency into `<dir>`, plus a ParaView `.pvd`
+//! collection (`sweep.pvd`) mapping each frame to a `timestep` = the
+//! swept frequency (GHz). Each frame is byte-for-byte the
+//! `--export-field` output at that frequency; the `.pvd` lets
+//! `tools/viz/geode_viz/scripts/sweep_animate.py` render the band to an
+//! MP4 (watch the resonance build and decay across the S11 band).
+//!
+//! ```sh
+//! cargo run -p geode-core --release --example patch_antenna -- \
+//!     --export-sweep artifacts/viz/patch_sweep --f-start 2.0 --f-stop 3.0 --n 11
+//! ```
 
 use std::fs;
 use std::path::PathBuf;
@@ -1158,8 +1176,137 @@ fn export_field(path: &str) {
     );
 }
 
+/// Opt-in `--export-sweep <dir>` (Epic #276 Phase 3C, issue #291): solve
+/// the benchmark fixture across the requested frequency band and dump one
+/// `E_<index>.vtu` per swept frequency `ω` into `<dir>`, plus a ParaView
+/// `.pvd` collection (`sweep.pvd`) mapping each frame to a `timestep` =
+/// the swept frequency (GHz). `sweep_animate.py` renders the collection
+/// to an MP4.
+///
+/// This is the **frequency-domain** sibling of [`export_field`] — one
+/// driven solve per source frequency, not a time-domain `E(r, t)`. It
+/// reuses the exact same per-node field-eval ([`viz_export_helper`]) and
+/// the same fixture / mask / port / box-UPML setup as the S11 sweep, so a
+/// frame is byte-for-byte the `--export-field` output at that frequency.
+///
+/// Independent of the S11 sweep / NTFF — does not write `results.toml`.
+fn export_sweep(spec: &viz_export_helper::SweepSpec) {
+    use burn::tensor::backend::BackendTypes;
+    type B = DefaultBackend;
+    let device = <B as BackendTypes>::Device::default();
+
+    let fixture = read_patch_fixture().expect("bundled benchmark patch fixture for --export-sweep");
+    let pml_thick = pml_thick_for(FixtureChoice::Benchmark);
+    let freqs = spec.freqs_ghz();
+    eprintln!(
+        "=== --export-sweep: {} frame(s) over {:.4}–{:.4} GHz into {} ===",
+        freqs.len(),
+        spec.f_start_ghz,
+        spec.f_stop_ghz,
+        spec.dir,
+    );
+
+    let edges = fixture.mesh.edges();
+    let patch = fixture.patch_triangles();
+    let ground = fixture.ground_triangles();
+    let outer = fixture.outer_boundary_triangles();
+    let mask = pec_interior_mask_from_triangles(
+        &edges,
+        &[patch.as_slice(), ground.as_slice(), outer.as_slice()],
+    );
+
+    let port = fixture.port();
+    let r_nat = R_PORT_OHM / ETA_0;
+    let lp = port.lumped_port(r_nat, c64::new(1.0, 0.0));
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; fixture.mesh.n_tets()],
+    };
+    let (air_lo, air_hi) = fixture.air_box(pml_thick);
+
+    // Per-node eps_r map (FR-4 in the slab, 1 in air/UPML) — ω-independent,
+    // so build it once and reuse for every frame.
+    let eps_tet = fixture.epsilon_r_default();
+    let mut eps_sum = vec![0.0_f64; fixture.mesh.n_nodes()];
+    let mut eps_cnt = vec![0_u32; fixture.mesh.n_nodes()];
+    for (t, tet) in fixture.mesh.tets.iter().enumerate() {
+        let eps = eps_tet[t].re;
+        for &v in tet.iter() {
+            eps_sum[v as usize] += eps;
+            eps_cnt[v as usize] += 1;
+        }
+    }
+    let eps_r: Vec<f64> = eps_sum
+        .iter()
+        .zip(eps_cnt.iter())
+        .map(|(&s, &c)| if c > 0 { s / c as f64 } else { 1.0 })
+        .collect();
+
+    let dir = std::path::Path::new(&spec.dir);
+    std::fs::create_dir_all(dir).expect("create --export-sweep output dir");
+
+    let mut frames: Vec<(f64, String)> = Vec::with_capacity(freqs.len());
+    for (i, &f_ghz) in freqs.iter().enumerate() {
+        let omega = ghz_to_omega(f_ghz);
+        // Box-UPML tensors are ω-dependent → rebuild per frequency.
+        let (eps_t, nu_t) = fixture.matched_upml_materials(
+            &FR4_MATERIALS,
+            air_lo,
+            air_hi,
+            pml_thick,
+            SIGMA_0,
+            omega,
+        );
+        let sol = driven_solve_with_ports::<B>(
+            &fixture.mesh,
+            DrivenMaterials::MatchedUpml {
+                epsilon_tensor: &eps_t,
+                nu_tensor: &nu_t,
+            },
+            None,
+            &DrivenBcs {
+                pec_interior_mask: &mask,
+            },
+            std::slice::from_ref(&lp),
+            omega,
+            &source,
+            &device,
+        )
+        .unwrap_or_else(|e| panic!("driven solve at {f_ghz} GHz for --export-sweep: {e}"));
+
+        let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&fixture.mesh, &sol.e_edges);
+        let file = format!("E_{i:04}.vtu");
+        let out = dir.join(&file);
+        geode_core::viz_vtu::write_vtu(&out, &fixture.mesh, &e_re, Some(&e_im), Some(&eps_r))
+            .expect("write --export-sweep frame .vtu");
+        eprintln!(
+            "  frame {i:>3}/{}: f = {f_ghz:6.4} GHz (res = {:.1e}) → {}",
+            freqs.len(),
+            sol.residual_rel,
+            file,
+        );
+        // `.pvd` DataSet paths are relative to the collection file.
+        frames.push((f_ghz, file));
+    }
+
+    let pvd = dir.join("sweep.pvd");
+    viz_export_helper::write_pvd(&pvd, &frames).expect("write --export-sweep .pvd collection");
+    eprintln!(
+        "  wrote {} ({} frames; render with tools/viz/geode_viz/scripts/sweep_animate.py)",
+        pvd.display(),
+        frames.len(),
+    );
+}
+
 fn main() {
     let argv: Vec<String> = std::env::args().collect();
+
+    // Opt-in frequency-sweep field export (issue #291). Short-circuits the
+    // S11 sweep so a normal run is byte-identical. Checked before
+    // `--export-field` so the more specific `--export-sweep` directive wins.
+    if let Some(spec) = viz_export_helper::parse_export_sweep(&argv) {
+        export_sweep(&spec);
+        return;
+    }
 
     // Opt-in field export (issue #287). Short-circuits the S11 sweep so
     // a normal run is byte-identical.

--- a/tools/viz/README.md
+++ b/tools/viz/README.md
@@ -249,6 +249,86 @@ module form or the `artifacts/viz/` default-path resolution fails. The
 output goes to the gitignored `artifacts/viz/` tree — never commit a
 rendered PNG.
 
+## Phase 3C: frequency-sweep animation (.pvd → ffmpeg → MP4) (#291)
+
+Phase 3C is the last item of Epic #276. It turns a frequency sweep of
+exported `.vtu` fields into an MP4 so a developer can watch a resonance
+build and decay as the source frequency steps across a band — the key
+debugging artifact for resonant structures (the patch antenna).
+
+> **Frequency-domain, not time-domain.** GEODE-FEM is a frequency-domain
+> solver: this is **not** an `E(r, t)` movie. "Animation" means one
+> rendered frame per *source frequency* `ω`, stitched into a video.
+
+The pipeline composes the 2B field export and the 2C render core (it does
+not introduce new field/render logic):
+
+1. **Sweep export (Rust).** `patch_antenna -- --export-sweep <dir>` solves
+   the benchmark fixture once per swept frequency and writes one
+   `E_<index>.vtu` per frequency into `<dir>`, plus a ParaView `.pvd`
+   collection (`sweep.pvd`) mapping each frame to a `timestep` = the swept
+   frequency (GHz). Each frame is byte-for-byte the `--export-field`
+   output at that frequency (same 2B per-node field eval). The `.pvd` is
+   hand-rolled XML (no deps), consistent with the Phase 2A `.vtu` writer.
+2. **Render + stitch (Python).**
+   `tools/viz/geode_viz/scripts/sweep_animate.py` reads the `.pvd`, renders
+   each frame with the **same** slice/colormap core as `pvbatch_render.py`
+   (refactored into the shared `geode_viz.scripts.render_core` so 2C and 3C
+   cannot diverge), then shells out to `ffmpeg` to stitch
+   `frame_%04d.png` → an MP4 (configurable fps, default 10).
+
+> **Neither ParaView nor ffmpeg is a CI/pip dependency.** Both are
+> local-only developer tools. The render step runs under ParaView's
+> bundled Python (`pvbatch`); a plain-`python` invocation fails with an
+> actionable "run under pvbatch" message. A missing `ffmpeg` binary fails
+> with a clear, actionable error too (and `--frames-only` lets you get the
+> PNG frames without it).
+
+End-to-end (3C):
+
+```bash
+# (1) Rust: export one .vtu per swept frequency + sweep.pvd.
+#     --f-start / --f-stop are GHz; --n is the frame count
+#     (defaults: 2.0–3.0 GHz over 11 points).
+cargo run -p geode-core --release --example patch_antenna -- \
+    --export-sweep artifacts/viz/patch_sweep --f-start 2.0 --f-stop 3.0 --n 11
+
+# (2) Python: render frames + stitch to MP4, under pvbatch (ParaView 5.x).
+#     Direct-path form (no PYTHONPATH needed):
+pvbatch tools/viz/geode_viz/scripts/sweep_animate.py \
+    artifacts/viz/patch_sweep/sweep.pvd \
+    --out artifacts/viz/patch_sweep.mp4 --fps 10
+
+# Module form, if pvbatch can see the editable-installed package:
+PYTHONPATH=tools/viz pvbatch -m geode_viz.scripts.sweep_animate \
+    artifacts/viz/patch_sweep/sweep.pvd --out artifacts/viz/patch_sweep.mp4
+
+# Render the PNG frames only (skip the ffmpeg stitch):
+pvbatch tools/viz/geode_viz/scripts/sweep_animate.py \
+    artifacts/viz/patch_sweep/sweep.pvd --frames-only
+```
+
+`sweep_animate.py` CLI flags:
+
+- `pvd` (positional, required): the `.pvd` collection from the sweep
+  export.
+- `--out`: output MP4. Default `artifacts/viz/animations/<name>.mp4` (name
+  from the `.pvd`'s parent dir) via `geode_viz.paths`, falling back to a
+  sibling `<dir>.mp4`.
+- `--frames-dir`: directory for the `frame_%04d.png` images. Default: a
+  `frames/` subdirectory next to the `.pvd`.
+- `--fps`: frames per second for the MP4 (default `10`).
+- `--frames-only`: render the PNG frames but skip the ffmpeg stitch.
+- `--ffmpeg`: ffmpeg binary name or path (default `ffmpeg` on `PATH`).
+- `--slice` / `--field` / `--colormap` / `--size`: identical to
+  `pvbatch_render.py` (shared `render_core`) — axis-aligned slice plane,
+  `PointData` array to colour by (default `|E|`), colormap preset (default
+  `"Viridis (matplotlib)"`), and frame size in pixels (default `1200 900`).
+
+The camera is reset once on the first frame and then frozen so the sweep
+doesn't jitter as the per-frame field range shifts. Output goes to the
+gitignored `artifacts/viz/` tree — never commit frames or MP4s.
+
 ## Adding a new plot module
 
 Phase 1B/1C/1D land plot scripts under

--- a/tools/viz/geode_viz/scripts/pvbatch_render.py
+++ b/tools/viz/geode_viz/scripts/pvbatch_render.py
@@ -7,6 +7,13 @@ by ``geode_core::viz_vtu`` (Phase 2A/2B), applies a single axis-aligned
 with a perceptually-uniform colormap, and writes a PNG — all without
 opening the ParaView GUI.
 
+The slice/colormap render core is shared with the Phase 3C
+frequency-sweep animator (``sweep_animate.py``) via
+``geode_viz.scripts.render_core`` — a single change there updates both
+render paths so 2C and 3C cannot diverge (refactor for #291). This
+script is the single-frame entry point; the sweep animator drives the
+same core once per swept frequency.
+
 It is a thin, well-commented wrapper over the ``paraview.simple`` API
 (``OpenDataFile`` / ``Slice`` / ``GetColorTransferFunction`` /
 ``SaveScreenshot``) intended as a developer debugging tool. **ParaView
@@ -46,97 +53,19 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-# --- ParaView import guard ------------------------------------------------
-#
-# ``paraview.simple`` only exists inside ParaView's bundled Python, which
-# you reach via ``pvbatch`` (or ``pvpython``). Plain ``python3 -m ...`` will
-# not find it. Rather than let an opaque ``ModuleNotFoundError`` traceback
-# escape, we catch it and surface an actionable message. We keep the import
-# lazy-ish here (module scope, but guarded) so that ``main`` can still parse
-# args and so importing the module for a smoke test produces the friendly
-# error, not a stack trace.
-_PARAVIEW_IMPORT_ERROR: ModuleNotFoundError | None = None
-try:  # pragma: no cover - depends on the runtime interpreter
-    from paraview import simple as pvsimple
-except ModuleNotFoundError as exc:  # pragma: no cover - exercised under plain python
-    pvsimple = None  # type: ignore[assignment]
-    _PARAVIEW_IMPORT_ERROR = exc
+# Shared render core (slice/colormap + ParaView import guard). Prefer the
+# package import; fall back to a sys.path insertion for the direct-path
+# pvbatch form (``pvbatch .../pvbatch_render.py``) where the editable
+# install is not on pvbatch's bundled-Python PYTHONPATH.
+try:
+    from geode_viz.scripts import render_core
+except ModuleNotFoundError:  # pragma: no cover - direct-path pvbatch form
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from geode_viz.scripts import render_core
 
-
-class ParaViewUnavailableError(RuntimeError):
-    """Raised when ``paraview.simple`` is not importable.
-
-    The message points the developer at ``pvbatch`` so a plain-``python``
-    invocation fails loudly and usefully instead of with a raw
-    ``ImportError`` traceback (acceptance criterion for #288).
-    """
-
-
-def _require_paraview() -> None:
-    """Fail with an actionable message if ``paraview.simple`` is missing."""
-    if pvsimple is None:
-        raise ParaViewUnavailableError(
-            "Could not import 'paraview.simple'. This renderer must run "
-            "under ParaView's bundled Python — use 'pvbatch', not plain "
-            "'python'/'python3'. Example:\n"
-            "    pvbatch tools/viz/geode_viz/scripts/pvbatch_render.py "
-            "artifacts/viz/E_patch.vtu --out artifacts/viz/E_patch.png\n"
-            "Install ParaView 5.x locally (https://www.paraview.org/download/). "
-            "ParaView is intentionally NOT a CI/pip dependency of geode_viz; "
-            "this is a local developer debugging tool.\n"
-            f"(underlying import error: {_PARAVIEW_IMPORT_ERROR})"
-        )
-
-
-# --- CLI helpers ----------------------------------------------------------
-
-_AXES: tuple[str, ...] = ("x", "y", "z")
-# Map each slice axis to its plane normal (axis-aligned cut).
-_AXIS_NORMAL: dict[str, tuple[float, float, float]] = {
-    "x": (1.0, 0.0, 0.0),
-    "y": (0.0, 1.0, 0.0),
-    "z": (0.0, 0.0, 1.0),
-}
-_AXIS_INDEX: dict[str, int] = {"x": 0, "y": 1, "z": 2}
-
-_DEFAULT_FIELD = "|E|"
-# A perceptually-uniform default. ParaView ships "Viridis (matplotlib)"
-# as a built-in preset name.
-_DEFAULT_COLORMAP = "Viridis (matplotlib)"
-
-
-def _parse_slice(spec: str) -> tuple[str, float]:
-    """Parse a ``--slice`` spec of the form ``<axis>=<value>``.
-
-    Returns ``(axis, value)`` where ``axis`` is one of ``x``/``y``/``z``.
-    Raises :class:`ValueError` on malformed input so argparse can surface
-    a clean error.
-    """
-    if "=" not in spec:
-        raise ValueError(
-            f"--slice must be '<axis>=<value>' (e.g. 'z=0.5'), got {spec!r}"
-        )
-    axis_raw, _, value_raw = spec.partition("=")
-    axis = axis_raw.strip().lower()
-    if axis not in _AXES:
-        raise ValueError(
-            f"--slice axis must be one of {_AXES}, got {axis_raw!r}"
-        )
-    try:
-        value = float(value_raw.strip())
-    except ValueError as exc:
-        raise ValueError(
-            f"--slice value must be a number, got {value_raw!r}"
-        ) from exc
-    return axis, value
-
-
-def _slice_arg(spec: str) -> tuple[str, float]:
-    """argparse ``type=`` adapter that re-raises as ``ArgumentTypeError``."""
-    try:
-        return _parse_slice(spec)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError(str(exc)) from exc
+ParaViewUnavailableError = render_core.ParaViewUnavailableError
+_DEFAULT_FIELD = render_core.DEFAULT_FIELD
+_DEFAULT_COLORMAP = render_core.DEFAULT_COLORMAP
 
 
 def _default_out(input_vtu: Path) -> Path:
@@ -185,7 +114,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--slice",
         dest="slice_spec",
-        type=_slice_arg,
+        type=render_core.slice_arg,
         default=None,
         metavar="AXIS=VALUE",
         help=(
@@ -217,86 +146,6 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-# --- Render ---------------------------------------------------------------
-
-
-def render(
-    input_vtu: Path,
-    out_png: Path,
-    *,
-    slice_spec: tuple[str, float] | None,
-    field: str,
-    colormap: str,
-    size: tuple[int, int],
-) -> Path:
-    """Render a single axis-aligned slice of ``input_vtu`` to ``out_png``.
-
-    Requires ``paraview.simple`` (run under ``pvbatch``). Returns the
-    written PNG path.
-    """
-    _require_paraview()
-
-    if not input_vtu.is_file():
-        raise FileNotFoundError(f"input .vtu not found: {input_vtu}")
-
-    # OpenDataFile auto-selects the XML UnstructuredGrid reader for .vtu.
-    reader = pvsimple.OpenDataFile(str(input_vtu))
-    if reader is None:
-        raise RuntimeError(f"ParaView could not open {input_vtu}")
-    pvsimple.UpdatePipeline(proxy=reader)
-
-    # Resolve the slice plane. The default cuts through the bbox centre on
-    # z; an explicit --slice overrides the chosen axis offset.
-    bounds = reader.GetDataInformation().GetBounds()  # (xmin,xmax,ymin,...)
-    centre = (
-        0.5 * (bounds[0] + bounds[1]),
-        0.5 * (bounds[2] + bounds[3]),
-        0.5 * (bounds[4] + bounds[5]),
-    )
-    if slice_spec is None:
-        axis, value = "z", centre[_AXIS_INDEX["z"]]
-    else:
-        axis, value = slice_spec
-
-    origin = list(centre)
-    origin[_AXIS_INDEX[axis]] = value
-
-    slice_filter = pvsimple.Slice(Input=reader)
-    slice_filter.SliceType = "Plane"
-    slice_filter.SliceType.Origin = origin
-    slice_filter.SliceType.Normal = list(_AXIS_NORMAL[axis])
-    pvsimple.UpdatePipeline(proxy=slice_filter)
-
-    # Display the slice and colour it by the requested PointData scalar.
-    view = pvsimple.GetActiveViewOrCreate("RenderView")
-    view.ViewSize = list(size)
-    view.OrientationAxesVisibility = 0
-
-    display = pvsimple.Show(slice_filter, view)
-    pvsimple.ColorBy(display, ("POINTS", field))
-
-    # Rescale the lookup table to the field range on the slice and apply
-    # the perceptually-uniform preset.
-    display.RescaleTransferFunctionToDataRange(True, False)
-    lut = pvsimple.GetColorTransferFunction(field)
-    try:
-        lut.ApplyPreset(colormap, True)
-    except Exception as exc:  # pragma: no cover - depends on PV preset table
-        print(
-            f"warning: could not apply colormap preset {colormap!r} ({exc}); "
-            "falling back to ParaView default.",
-            file=sys.stderr,
-        )
-    display.SetScalarBarVisibility(view, True)
-
-    pvsimple.ResetCamera(view)
-    pvsimple.Render(view)
-
-    out_png.parent.mkdir(parents=True, exist_ok=True)
-    pvsimple.SaveScreenshot(str(out_png), view, ImageResolution=list(size))
-    return out_png
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI. Returns a POSIX-style exit code."""
     parser = _build_parser()
@@ -305,7 +154,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Fail fast with the actionable message before doing any work — this is
     # the path hit when someone runs the script under plain python.
     try:
-        _require_paraview()
+        render_core.require_paraview()
     except ParaViewUnavailableError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -313,7 +162,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     out_png = args.out if args.out is not None else _default_out(args.input)
 
     try:
-        written = render(
+        written = render_core.render_slice(
             args.input,
             out_png,
             slice_spec=args.slice_spec,

--- a/tools/viz/geode_viz/scripts/render_core.py
+++ b/tools/viz/geode_viz/scripts/render_core.py
@@ -1,0 +1,236 @@
+"""Shared ParaView slice/colormap render core for the Phase 2/3 viz scripts.
+
+Epic #276 factors the single-``.vtu`` slice render out of the Phase 2C
+``pvbatch_render.py`` so the Phase 3C frequency-sweep animator
+(``sweep_animate.py``) renders each frame with *exactly* the same slice
+plane + colormap logic — a single change here updates both render paths
+and they cannot diverge (acceptance criterion for #291).
+
+It owns three pieces both scripts share:
+
+1. The ``paraview.simple`` import guard + :func:`require_paraview`, so a
+   plain-``python`` invocation fails with an actionable "run under
+   ``pvbatch``" message instead of a raw ``ImportError`` traceback.
+2. The ``--slice <axis>=<value>`` parsing (:func:`parse_slice` /
+   :func:`slice_arg`) and the axis → plane-normal tables.
+3. :func:`render_slice` — open a ``.vtu``, cut one axis-aligned slice,
+   colour it by a ``PointData`` scalar with a perceptually-uniform
+   colormap, and save a PNG. It takes an explicit ParaView ``view`` so a
+   caller can reuse a single view across many frames (the sweep case)
+   instead of recreating it per frame.
+
+**ParaView is intentionally NOT a CI/pip dependency** of ``geode_viz`` —
+this module must run under ParaView's bundled Python (``pvbatch`` /
+``pvpython``), not plain ``python``. Importing it without
+``paraview.simple`` is fine (the guard defers the failure to
+:func:`require_paraview`) so the friendly-error smoke test runs under
+plain ``python3``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# --- ParaView import guard ------------------------------------------------
+#
+# ``paraview.simple`` only exists inside ParaView's bundled Python, which
+# you reach via ``pvbatch`` (or ``pvpython``). Plain ``python3`` will not
+# find it. Rather than let an opaque ``ModuleNotFoundError`` traceback
+# escape, we catch it and surface an actionable message. The import is
+# module-scope-but-guarded so importing this module for a smoke test under
+# plain python produces the friendly error, not a stack trace.
+_PARAVIEW_IMPORT_ERROR: ModuleNotFoundError | None = None
+try:  # pragma: no cover - depends on the runtime interpreter
+    from paraview import simple as pvsimple
+except ModuleNotFoundError as exc:  # pragma: no cover - hit under plain python
+    pvsimple = None  # type: ignore[assignment]
+    _PARAVIEW_IMPORT_ERROR = exc
+
+
+class ParaViewUnavailableError(RuntimeError):
+    """Raised when ``paraview.simple`` is not importable.
+
+    The message points the developer at ``pvbatch`` so a plain-``python``
+    invocation fails loudly and usefully instead of with a raw
+    ``ImportError`` traceback.
+    """
+
+
+def paraview_available() -> bool:
+    """Return ``True`` when ``paraview.simple`` imported successfully."""
+    return pvsimple is not None
+
+
+def require_paraview() -> None:
+    """Fail with an actionable message if ``paraview.simple`` is missing."""
+    if pvsimple is None:
+        raise ParaViewUnavailableError(
+            "Could not import 'paraview.simple'. This renderer must run "
+            "under ParaView's bundled Python — use 'pvbatch', not plain "
+            "'python'/'python3'. Example:\n"
+            "    pvbatch tools/viz/geode_viz/scripts/pvbatch_render.py "
+            "artifacts/viz/E_patch.vtu --out artifacts/viz/E_patch.png\n"
+            "Install ParaView 5.x locally (https://www.paraview.org/download/). "
+            "ParaView is intentionally NOT a CI/pip dependency of geode_viz; "
+            "this is a local developer debugging tool.\n"
+            f"(underlying import error: {_PARAVIEW_IMPORT_ERROR})"
+        )
+
+
+# --- Slice CLI helpers ----------------------------------------------------
+
+AXES: tuple[str, ...] = ("x", "y", "z")
+# Map each slice axis to its plane normal (axis-aligned cut).
+AXIS_NORMAL: dict[str, tuple[float, float, float]] = {
+    "x": (1.0, 0.0, 0.0),
+    "y": (0.0, 1.0, 0.0),
+    "z": (0.0, 0.0, 1.0),
+}
+AXIS_INDEX: dict[str, int] = {"x": 0, "y": 1, "z": 2}
+
+DEFAULT_FIELD = "|E|"
+# A perceptually-uniform default. ParaView ships "Viridis (matplotlib)"
+# as a built-in preset name.
+DEFAULT_COLORMAP = "Viridis (matplotlib)"
+
+
+def parse_slice(spec: str) -> tuple[str, float]:
+    """Parse a ``--slice`` spec of the form ``<axis>=<value>``.
+
+    Returns ``(axis, value)`` where ``axis`` is one of ``x``/``y``/``z``.
+    Raises :class:`ValueError` on malformed input so argparse can surface
+    a clean error.
+    """
+    if "=" not in spec:
+        raise ValueError(
+            f"--slice must be '<axis>=<value>' (e.g. 'z=0.5'), got {spec!r}"
+        )
+    axis_raw, _, value_raw = spec.partition("=")
+    axis = axis_raw.strip().lower()
+    if axis not in AXES:
+        raise ValueError(
+            f"--slice axis must be one of {AXES}, got {axis_raw!r}"
+        )
+    try:
+        value = float(value_raw.strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"--slice value must be a number, got {value_raw!r}"
+        ) from exc
+    return axis, value
+
+
+def slice_arg(spec: str) -> tuple[str, float]:
+    """argparse ``type=`` adapter that re-raises as ``ArgumentTypeError``."""
+    try:
+        return parse_slice(spec)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+# --- Render core ----------------------------------------------------------
+
+
+def make_view(size: tuple[int, int]):
+    """Create (or fetch) a headless RenderView sized for the PNG output.
+
+    Returned so a caller can reuse one view across many frames (the
+    sweep case) instead of recreating it per render.
+    """
+    require_paraview()
+    view = pvsimple.GetActiveViewOrCreate("RenderView")
+    view.ViewSize = list(size)
+    view.OrientationAxesVisibility = 0
+    return view
+
+
+def render_slice(
+    input_vtu: Path,
+    out_png: Path,
+    *,
+    slice_spec: tuple[str, float] | None,
+    field: str,
+    colormap: str,
+    size: tuple[int, int],
+    view=None,
+    reset_camera: bool = True,
+) -> Path:
+    """Render a single axis-aligned slice of ``input_vtu`` to ``out_png``.
+
+    Requires ``paraview.simple`` (run under ``pvbatch``). The slice plane
+    defaults to the bbox centre on the z axis; an explicit ``slice_spec``
+    overrides the chosen axis offset. The slice is coloured by the
+    ``field`` ``PointData`` scalar with the ``colormap`` preset
+    (perceptually uniform by default).
+
+    ``view`` lets the caller pass a pre-built view to reuse across frames
+    (set ``reset_camera=False`` after the first frame so the sweep camera
+    stays put). Returns the written PNG path.
+    """
+    require_paraview()
+
+    if not input_vtu.is_file():
+        raise FileNotFoundError(f"input .vtu not found: {input_vtu}")
+
+    # OpenDataFile auto-selects the XML UnstructuredGrid reader for .vtu.
+    reader = pvsimple.OpenDataFile(str(input_vtu))
+    if reader is None:
+        raise RuntimeError(f"ParaView could not open {input_vtu}")
+    pvsimple.UpdatePipeline(proxy=reader)
+
+    # Resolve the slice plane. The default cuts through the bbox centre on
+    # z; an explicit slice_spec overrides the chosen axis offset.
+    bounds = reader.GetDataInformation().GetBounds()  # (xmin,xmax,ymin,...)
+    centre = (
+        0.5 * (bounds[0] + bounds[1]),
+        0.5 * (bounds[2] + bounds[3]),
+        0.5 * (bounds[4] + bounds[5]),
+    )
+    if slice_spec is None:
+        axis, value = "z", centre[AXIS_INDEX["z"]]
+    else:
+        axis, value = slice_spec
+
+    origin = list(centre)
+    origin[AXIS_INDEX[axis]] = value
+
+    slice_filter = pvsimple.Slice(Input=reader)
+    slice_filter.SliceType = "Plane"
+    slice_filter.SliceType.Origin = origin
+    slice_filter.SliceType.Normal = list(AXIS_NORMAL[axis])
+    pvsimple.UpdatePipeline(proxy=slice_filter)
+
+    if view is None:
+        view = make_view(size)
+
+    display = pvsimple.Show(slice_filter, view)
+    pvsimple.ColorBy(display, ("POINTS", field))
+
+    # Rescale the lookup table to the field range on the slice and apply
+    # the perceptually-uniform preset.
+    display.RescaleTransferFunctionToDataRange(True, False)
+    lut = pvsimple.GetColorTransferFunction(field)
+    try:
+        lut.ApplyPreset(colormap, True)
+    except Exception as exc:  # pragma: no cover - depends on PV preset table
+        print(
+            f"warning: could not apply colormap preset {colormap!r} ({exc}); "
+            "falling back to ParaView default.",
+            file=sys.stderr,
+        )
+    display.SetScalarBarVisibility(view, True)
+
+    if reset_camera:
+        pvsimple.ResetCamera(view)
+    pvsimple.Render(view)
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    pvsimple.SaveScreenshot(str(out_png), view, ImageResolution=list(size))
+
+    # Clean the pipeline so the next frame starts from a blank slate (the
+    # sweep renders many .vtu files through one process / view).
+    pvsimple.Delete(slice_filter)
+    pvsimple.Delete(reader)
+    return out_png

--- a/tools/viz/geode_viz/scripts/sweep_animate.py
+++ b/tools/viz/geode_viz/scripts/sweep_animate.py
@@ -1,0 +1,394 @@
+"""Frequency-sweep ``.pvd`` → PNG frames → ``ffmpeg`` → MP4 animation.
+
+Phase 3C of Epic #276 (the last item — closing it completes the epic).
+GEODE-FEM is a frequency-domain solver, so this is **not** a time-domain
+``E(r, t)`` movie: it stitches one rendered frame per *source frequency*
+``ω`` so a developer can watch a resonance build and decay as the drive
+frequency steps across a band (the key debugging artifact for resonant
+structures like the patch antenna).
+
+Pipeline:
+
+1. The Rust producer (``patch_antenna -- --export-sweep <dir>``) writes
+   one ``E_<index>.vtu`` per swept frequency plus a ParaView ``.pvd``
+   collection (``sweep.pvd``) mapping each frame to a ``timestep`` = the
+   swept frequency (GHz).
+2. This script reads the ``.pvd``, renders each frame with the **same**
+   slice/colormap core as the Phase 2C single-frame renderer
+   (``geode_viz.scripts.render_core`` — refactored so 2C and 3C cannot
+   diverge), writing ``frame_%04d.png`` into a frames directory.
+3. It shells out to ``ffmpeg`` to stitch the PNG sequence into an MP4
+   (configurable fps; default 10).
+
+**Neither ParaView nor ffmpeg is a CI/pip dependency** — both are
+local-only developer tools. The render step must run under ParaView's
+bundled Python (``pvbatch``); a plain-``python`` invocation fails with an
+actionable "run under pvbatch" message (via ``render_core``). A missing
+``ffmpeg`` binary likewise fails with a clear, actionable error rather
+than a raw ``FileNotFoundError`` traceback.
+
+Usage::
+
+    # Full pipeline, under pvbatch (ParaView 5.x). Direct-path form:
+    pvbatch tools/viz/geode_viz/scripts/sweep_animate.py \\
+        artifacts/viz/patch_sweep/sweep.pvd \\
+        --out artifacts/viz/patch_sweep.mp4 --fps 10
+
+    # Module form, if pvbatch can see the editable-installed package:
+    PYTHONPATH=tools/viz pvbatch -m geode_viz.scripts.sweep_animate \\
+        artifacts/viz/patch_sweep/sweep.pvd --out artifacts/viz/patch_sweep.mp4
+
+    # Render the PNG frames only (skip the ffmpeg stitch):
+    pvbatch tools/viz/geode_viz/scripts/sweep_animate.py \\
+        artifacts/viz/patch_sweep/sweep.pvd --frames-only
+
+The slice / field / colormap flags mirror ``pvbatch_render.py`` exactly
+(shared core). Output goes to the gitignored ``artifacts/viz/`` tree —
+never commit frames or MP4s.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from collections.abc import Sequence
+from pathlib import Path
+
+# Shared render core (slice/colormap + ParaView import guard), shared with
+# pvbatch_render.py so 2C and 3C cannot diverge. Prefer the package import;
+# fall back to a sys.path insertion for the direct-path pvbatch form where
+# the editable install is not on pvbatch's bundled-Python PYTHONPATH.
+try:
+    from geode_viz.scripts import render_core
+except ModuleNotFoundError:  # pragma: no cover - direct-path pvbatch form
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from geode_viz.scripts import render_core
+
+
+class FfmpegUnavailableError(RuntimeError):
+    """Raised when the ``ffmpeg`` binary is not on ``PATH``.
+
+    The message points the developer at an install + tells them they can
+    still get the PNG frames with ``--frames-only`` — so a missing
+    ``ffmpeg`` fails loudly and usefully instead of with a raw
+    ``FileNotFoundError`` traceback (acceptance criterion for #291).
+    """
+
+
+def _require_ffmpeg(ffmpeg: str) -> str:
+    """Resolve the ``ffmpeg`` binary or fail with an actionable message."""
+    resolved = shutil.which(ffmpeg)
+    if resolved is None:
+        raise FfmpegUnavailableError(
+            f"Could not find the ffmpeg binary {ffmpeg!r} on PATH. The "
+            "frame-stitching step needs ffmpeg — install it locally "
+            "(https://ffmpeg.org/download.html, e.g. 'brew install ffmpeg' "
+            "or 'apt install ffmpeg'). ffmpeg is intentionally NOT a "
+            "CI/pip dependency of geode_viz; this is a local developer "
+            "tool. To render just the PNG frames without stitching, re-run "
+            "with --frames-only."
+        )
+    return resolved
+
+
+def parse_pvd(pvd: Path) -> list[tuple[float, Path]]:
+    """Parse a ParaView ``.pvd`` collection into ordered frame entries.
+
+    Returns ``(timestep, vtu_path)`` pairs in document order. Each
+    ``<DataSet file="...">`` path is resolved relative to the ``.pvd``'s
+    directory (the producer writes relative ``E_<index>.vtu`` names).
+    Raises :class:`ValueError` / :class:`FileNotFoundError` with a clean
+    message on malformed or empty collections.
+    """
+    if not pvd.is_file():
+        raise FileNotFoundError(f".pvd collection not found: {pvd}")
+    try:
+        tree = ET.parse(pvd)  # noqa: S314 - trusted, locally-produced file
+    except ET.ParseError as exc:
+        raise ValueError(f"could not parse .pvd as XML: {pvd} ({exc})") from exc
+
+    root = tree.getroot()
+    datasets = root.findall(".//DataSet")
+    if not datasets:
+        raise ValueError(
+            f"no <DataSet> entries in {pvd} — is it a ParaView .pvd "
+            "collection (e.g. written by 'patch_antenna -- --export-sweep')?"
+        )
+
+    base = pvd.parent
+    frames: list[tuple[float, Path]] = []
+    for ds in datasets:
+        file_attr = ds.get("file")
+        if file_attr is None:
+            raise ValueError(f"a <DataSet> in {pvd} has no 'file' attribute")
+        ts_attr = ds.get("timestep")
+        # timestep is optional in the .pvd spec; fall back to the frame
+        # index so the ordering is still well-defined.
+        try:
+            timestep = float(ts_attr) if ts_attr is not None else float(len(frames))
+        except ValueError:
+            timestep = float(len(frames))
+        frames.append((timestep, (base / file_attr).resolve()))
+    return frames
+
+
+def render_frames(
+    frames: list[tuple[float, Path]],
+    frames_dir: Path,
+    *,
+    slice_spec: tuple[str, float] | None,
+    field: str,
+    colormap: str,
+    size: tuple[int, int],
+) -> list[Path]:
+    """Render each ``.pvd`` frame to ``frames_dir/frame_%04d.png``.
+
+    Uses one reused ParaView view across all frames (camera reset on the
+    first frame, frozen after) via the shared ``render_core.render_slice``
+    so every frame shares the 2C slice/colormap exactly. Returns the
+    written PNG paths in order.
+    """
+    render_core.require_paraview()
+    frames_dir.mkdir(parents=True, exist_ok=True)
+
+    view = render_core.make_view(size)
+    pngs: list[Path] = []
+    for i, (timestep, vtu) in enumerate(frames):
+        out_png = frames_dir / f"frame_{i:04d}.png"
+        render_core.render_slice(
+            vtu,
+            out_png,
+            slice_spec=slice_spec,
+            field=field,
+            colormap=colormap,
+            size=size,
+            view=view,
+            # Reset the camera once on the first frame, then freeze it so the
+            # sweep doesn't jitter as per-frame field ranges shift.
+            reset_camera=(i == 0),
+        )
+        print(f"frame {i:>4d}/{len(frames)}: timestep={timestep:g} → {out_png.name}")
+        pngs.append(out_png)
+    return pngs
+
+
+def stitch_mp4(
+    frames_dir: Path,
+    out_mp4: Path,
+    *,
+    fps: int,
+    ffmpeg: str,
+) -> Path:
+    """Stitch ``frames_dir/frame_%04d.png`` into ``out_mp4`` via ffmpeg.
+
+    Resolves (and validates) the ``ffmpeg`` binary first, then runs a
+    standard ``-framerate ... -i frame_%04d.png ... yuv420p`` encode.
+    Returns the written MP4 path. Raises :class:`FfmpegUnavailableError`
+    if ffmpeg is missing, or :class:`RuntimeError` if the encode fails.
+    """
+    resolved = _require_ffmpeg(ffmpeg)
+    out_mp4.parent.mkdir(parents=True, exist_ok=True)
+    pattern = str(frames_dir / "frame_%04d.png")
+    cmd = [
+        resolved,
+        "-y",  # overwrite the output without prompting
+        "-framerate",
+        str(fps),
+        "-i",
+        pattern,
+        # H.264 + yuv420p so the MP4 plays in browsers / QuickTime; pad to
+        # even dimensions (libx264 requires it).
+        "-vf",
+        "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        str(out_mp4),
+    ]
+    print(f"stitching {len(list(frames_dir.glob('frame_*.png')))} frames → {out_mp4}")
+    result = subprocess.run(cmd, check=False)  # noqa: S603 - resolved binary
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed (exit {result.returncode}) stitching {pattern} "
+            f"→ {out_mp4}. Command: {' '.join(cmd)}"
+        )
+    return out_mp4
+
+
+def _default_out(pvd: Path) -> Path:
+    """Resolve the default MP4 output path for a ``.pvd`` collection.
+
+    Prefer ``artifacts/viz/<name>.mp4`` via ``geode_viz.paths`` (name
+    taken from the ``.pvd`` parent directory); fall back to a sibling
+    ``<dir>.mp4`` next to the collection if that package is not importable
+    under pvbatch's bundled Python.
+    """
+    name = pvd.parent.name or pvd.stem
+    try:
+        from geode_viz.paths import artifacts_dir  # noqa: PLC0415
+    except Exception:
+        return pvd.parent.with_suffix(".mp4")
+    try:
+        return artifacts_dir("animations") / f"{name}.mp4"
+    except Exception:
+        return pvd.parent.with_suffix(".mp4")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pvbatch ... geode_viz.scripts.sweep_animate",
+        description=(
+            "Render a frequency-sweep .pvd collection to PNG frames and "
+            "stitch them into an MP4. Run under 'pvbatch' (ParaView), not "
+            "plain 'python'; the ffmpeg stitch needs a local ffmpeg."
+        ),
+    )
+    parser.add_argument(
+        "pvd",
+        type=Path,
+        help=(
+            "Input ParaView .pvd collection (from "
+            "'patch_antenna -- --export-sweep <dir>', e.g. <dir>/sweep.pvd)."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=(
+            "Output MP4 path. Default: artifacts/viz/animations/<name>.mp4 "
+            "(name from the .pvd's parent dir) via geode_viz.paths, or a "
+            "sibling <dir>.mp4 if that package is not importable."
+        ),
+    )
+    parser.add_argument(
+        "--frames-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory for the rendered frame_%%04d.png images. Default: a "
+            "'frames/' subdirectory next to the .pvd."
+        ),
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=10,
+        help="Frames per second for the stitched MP4 (default: 10).",
+    )
+    parser.add_argument(
+        "--frames-only",
+        action="store_true",
+        help="Render the PNG frames but skip the ffmpeg stitch step.",
+    )
+    parser.add_argument(
+        "--ffmpeg",
+        default="ffmpeg",
+        help="ffmpeg binary name or path (default: 'ffmpeg' on PATH).",
+    )
+    # Slice / field / colormap flags mirror pvbatch_render.py (shared core).
+    parser.add_argument(
+        "--slice",
+        dest="slice_spec",
+        type=render_core.slice_arg,
+        default=None,
+        metavar="AXIS=VALUE",
+        help=(
+            "Axis-aligned slice plane, e.g. 'z=0.5'. Default: a slice "
+            "through the mesh bounding-box centre on the z axis."
+        ),
+    )
+    parser.add_argument(
+        "--field",
+        default=render_core.DEFAULT_FIELD,
+        help=(
+            "PointData array to colour by "
+            f"(default: {render_core.DEFAULT_FIELD!r})."
+        ),
+    )
+    parser.add_argument(
+        "--colormap",
+        default=render_core.DEFAULT_COLORMAP,
+        help=(
+            "ParaView colormap preset name "
+            f"(default: {render_core.DEFAULT_COLORMAP!r}, perceptually "
+            "uniform)."
+        ),
+    )
+    parser.add_argument(
+        "--size",
+        nargs=2,
+        type=int,
+        default=(1200, 900),
+        metavar=("W", "H"),
+        help="Output frame size in pixels (default: 1200 900).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI. Returns a POSIX-style exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Fail fast with the actionable ParaView message before any work — this
+    # is the path hit when someone runs the script under plain python.
+    try:
+        render_core.require_paraview()
+    except render_core.ParaViewUnavailableError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    # If we'll stitch, validate ffmpeg up front so we don't render all the
+    # frames only to fail at the last step.
+    if not args.frames_only:
+        try:
+            _require_ffmpeg(args.ffmpeg)
+        except FfmpegUnavailableError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        frames = parse_pvd(args.pvd)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    frames_dir = (
+        args.frames_dir if args.frames_dir is not None else args.pvd.parent / "frames"
+    )
+
+    try:
+        render_frames(
+            frames,
+            frames_dir,
+            slice_spec=args.slice_spec,
+            field=args.field,
+            colormap=args.colormap,
+            size=tuple(args.size),
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.frames_only:
+        print(f"wrote {len(frames)} frames to {frames_dir} (--frames-only)")
+        return 0
+
+    out_mp4 = args.out if args.out is not None else _default_out(args.pvd)
+    try:
+        written = stitch_mp4(frames_dir, out_mp4, fps=args.fps, ffmpeg=args.ffmpeg)
+    except (FfmpegUnavailableError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"wrote {written}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
Closes #291.

Final item of Epic #276 (Phase 3C). Composes the Phase 2B field export and the Phase 2C render core into a frequency-sweep animation: **one rendered frame per source frequency ω**, stitched into an MP4 so a developer can watch a resonance build and decay as the drive frequency steps across the patch S11 band. This is frequency-domain (one driven solve per ω), **not** time-domain `E(r, t)` — per the epic's explicit non-goal.

## What changed

**Sweep export (Rust)**
- `examples/common/viz_export_helper.rs`: add `SweepSpec` + `parse_export_sweep` (the `--export-sweep <dir> --f-start .. --f-stop .. --n N` directive, defaults 2.0–3.0 GHz over 11 points), **reusing** the existing 2B per-node `edge_field_to_nodes` field-eval — not duplicated. Add a hand-rolled `.pvd` collection writer `write_pvd` (no XML deps, consistent with the 2A `.vtu` writer). Module-wide `allow(dead_code)` because this shared helper is `#[path]`-included by `mie_sphere`/`spiral_inductor` too, which don't use the new sweep items.
- `examples/patch_antenna.rs`: `export_sweep` solves the benchmark fixture once per swept frequency, writes `E_<index>.vtu` per frame + `sweep.pvd` mapping each frame to a `timestep` = frequency (GHz). Each frame is byte-for-byte the `--export-field` output at that frequency (same fixture/mask/port/box-UPML setup, same field eval). Wired into `main` ahead of `--export-field`; a normal run is byte-identical.

**Render + stitch (Python)**
- `tools/viz/geode_viz/scripts/render_core.py` (new): the 2C slice/colormap render core + ParaView import guard, **refactored out of** `pvbatch_render.py` so 2C and 3C share one code path and cannot diverge (acceptance criterion). Exposes `render_slice` (takes an optional reusable `view`), `make_view`, `require_paraview`/`ParaViewUnavailableError`, and the `--slice` parsing.
- `pvbatch_render.py`: now delegates to `render_core` (behaviour unchanged; CLI flags identical).
- `tools/viz/geode_viz/scripts/sweep_animate.py` (new): parse the `.pvd`, render each frame via the shared core (one reused view; camera reset on frame 0 then frozen so the sweep doesn't jitter), then shell to `ffmpeg` to stitch `frame_%04d.png` → MP4 (configurable `--fps`, default 10). Missing `pvbatch` **and** missing `ffmpeg` are each guarded with a clear, actionable error (not a raw traceback / `FileNotFoundError`); `--frames-only` renders PNGs without the stitch. No ParaView/ffmpeg CI dependency.
- `tools/viz/README.md`: end-to-end 3C flow documented.

## Verification

- `cargo build -p geode-core --examples` — clean.
- `cargo clippy -p geode-core --examples -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo run -p geode-core --release --example patch_antenna -- --export-sweep /tmp/patch_sweep291 --f-start 2.2 --f-stop 2.4 --n 3` — wrote 3 `E_000{0,1,2}.vtu` + `sweep.pvd` (residuals 8.5e-14 / 1.0e-13 / 4.6e-14); `sweep_animate.parse_pvd` round-trips the produced collection to `[(2.2, E_0000.vtu), (2.3, E_0001.vtu), (2.4, E_0002.vtu)]`.
- `ruff check tools/viz` — All checks passed (did not run `ruff format`; repo uses manual ~79-col wrapping).
- Guards (under plain `python3`, no ParaView): `sweep_animate` exits 2 with the actionable "run under pvbatch" message; `_require_ffmpeg("bogus")` and `stitch_mp4(..., ffmpeg="bogus")` raise `FfmpegUnavailableError` with an install hint + `--frames-only` suggestion; empty/missing `.pvd` → clean `ValueError`/`FileNotFoundError`.

## Manual local check (ParaView + ffmpeg — not in CI)

The actual MP4 render needs ParaView 5.x (`pvbatch`) + a local `ffmpeg`, neither of which is a CI/pip dependency. Exact commands:

```bash
# Rust: one .vtu per swept frequency + sweep.pvd (use a wider band / more frames for a real movie).
cargo run -p geode-core --release --example patch_antenna -- \
    --export-sweep artifacts/viz/patch_sweep --f-start 2.0 --f-stop 3.0 --n 11

# Python under pvbatch: render frames + stitch to MP4.
pvbatch tools/viz/geode_viz/scripts/sweep_animate.py \
    artifacts/viz/patch_sweep/sweep.pvd \
    --out artifacts/viz/patch_sweep.mp4 --fps 10
```

Representative frame: an axis-aligned z-slice through the patch substrate coloured by `|E|` (Viridis), scalar bar shown. Across the 11 frames `|E|` under the patch is weak at the band edges (2.0 / 3.0 GHz) and brightens to a strong standing-wave pattern near the ~2.27 GHz resonance, then fades — the resonance building and decaying as ω steps. Output is gitignored under `artifacts/viz/`; no frames or MP4s are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)