### PR TITLE
feat(photonics): SMF-28 fiber on the PML solver — clean isolation achieved, but b does NOT match the scalar LP oracle (honest finding) (Epic #303 PML-C)

### DIFF
--- a/benchmarks/step_index_fiber/results.toml
+++ b/benchmarks/step_index_fiber/results.toml
@@ -5,22 +5,22 @@
 # against the EXACT LP-mode oracle (geode_core::fiber_lp, Phase 2A).
 
 [meta]
-description = "SMF-28 step-index fiber benchmark (issue #322, Epic #318 Phase 2.5D; supersedes PR #317, closes #314): fundamental LP01/HE11 mode of a 4.1 um core (n_core=1.4504) in cladding (n_clad=1.4447) at 1550 nm on the SECOND-ORDER (p=2) Nedelec dielectric solver (solve_dielectric_modes2), on a disk mesh terminated by a far PEC wall, vs the EXACT Bessel-function LP-mode characteristic equation (Phase 2A). HONEST FINDING: p=2 is a clear improvement over first order (which plateaued at ~10-17% and did not refine away), reaching sub-2% b-error at FAVORABLE meshes - but the result is NOT a converged <=2% floor: under refinement the b-error swings erratically (4-26%) because the far PEC wall manufactures box/cladding-resonance modes that pollute the thin guided window. A field-shape (core-energy-fraction) classifier does NOT cleanly separate LP01 from the box cluster (best core fraction only ~0.34-0.49 vs >0.8 for a genuine confined fundamental). We report the FULL UNBIASED SWEEP and do NOT claim b_converges_to_oracle. A 2D PML/absorbing boundary is the follow-on needed for a robust <=1% story. n_eff is reported only as window-limited context."
-generated_at_commit = "a10472e2f893e5fa5722414c3a0885d1a9fa0c81"
-solver = "solve_dielectric_modes2 (p=2 second-order Nedelec)"
+description = "SMF-28 step-index fiber benchmark (Epic #303 PML-C, issue #333; closes design tracker #330; supersedes the far-PEC-wall p=2 path of #329): fundamental transverse mode of a 4.1 um core (n_core=1.4504) in cladding (n_clad=1.4447) at 1550 nm on the PML-TERMINATED complex-pencil solver (solve_dielectric_modes2_pml) over a 3-region core/cladding/UPML disk (disk_tri_mesh_pml), vs the EXACT Bessel-function scalar LP characteristic equation (Phase 2A). HONEST FINDING (two distinct results): (1) ISOLATION RESOLVED - the 2D UPML removed the far-PEC-wall box-mode pollution that made the #329 sweep erratic; the solver now cleanly isolates a genuinely core-confined (core-energy fraction ~0.86-0.88, vs PEC-era 0.34-0.49), genuinely bound (|Im(b2)|/Re(b2) ~1e-16) fundamental, robust to sigma_0, with a MONOTONE b-vs-mesh trend (no more 4-26% hopping). (2) ORACLE MATCH NOT ACHIEVED - that cleanly-isolated, monotone-converging fundamental converges to b~0.77 (Re(n_eff)~1.4491), a ~69% error vs the scalar oracle b~0.458. With the full (n_clad^2, n_core^2) window the in-window bound cluster is a LADDER of low-leakage modes from b~0.77 (most confined, selected) down through b~0.46 (matches oracle but only ~0.5 core-confined) to b~0.33; the smallest-leakage/largest-Re(b2) rule picks the TOP of the ladder, not the scalar-LP mode in the middle. The mode whose b matches the oracle is a weakly-confined cladding-tail mode, NOT the fundamental. We report the FULL UNBIASED SWEEP, do NOT cherry-pick the closest-to-oracle mode (the #329 anti-pattern), and set converged=false. The remaining gap is a modal-formulation/near-n_core-ceiling selection problem, DISTINCT from the PEC box-mode pollution PML-A/B/C fixed. n_eff is reported only as window-limited context."
+generated_at_commit = "a7424d2b64439f424c59a0db15a68f57c593d508"
+solver = "solve_dielectric_modes2_pml (PML-terminated complex-pencil p=2 Nedelec)"
 lambda_um = 1.55
 k0_per_um = 4.053667940115862e0
 mode = "LP01 (HE11), fundamental"
-outer_boundary = "pec (far cladding circle)"
+outer_boundary = "pml (radial UPML annulus + thin PEC backing)"
 single_mode = true
 notes = [
-  "Cross-section: circular step-index fiber, core radius a = 4.1 um (n_core = 1.4504) in cladding (n_clad = 1.4447), embedded in a generous cladding disk terminated by a far PEC circle. Per-triangle epsilon via disk_tri_mesh region tags (Phase 2B) + epsilon_r_from_region_tags (Phase 1A); n_eff via the SECOND-ORDER solve_dielectric_modes2 (Epic #318 Phase 2.5C).",
-  "Oracle is the EXACT scalar LP-mode characteristic equation (geode_core::fiber_lp::fiber_lp_neff, Phase 2A) - the Bessel-function dispersion relation, a 6-digit analytic ground truth (validated against scipy).",
-  "HONEST FINDING (reframed after Judge review of PR #329): p=2 reaches sub-2% b-error at FAVORABLE meshes - a clear improvement over first order's non-converging ~10-17% plateau - but it is NOT a converged <=2% floor. Across the SAME 14a domain the b-error swings erratically with n_radial (~4.2% -> 1.9% -> 0.74% -> 4.1% -> 0.14% -> 26%) and some configs return NO in-window mode. The earlier 'converges to <=2%' claim was a lucky-mesh artifact of an outcome-filtering gate, now removed.",
-  "ROOT CAUSE - far-PEC-wall box-mode pollution: the weakly-guiding LP01 (V=2.135) has a long evanescent tail, and the hard PEC truncation manufactures a dense cluster of box/cladding-resonance modes occupying the same ~0.39%-wide guided window. The largest-beta in-window mode hops between the genuine LP01 and a box mode as the mesh changes. This is a boundary-truncation / mode-SELECTION problem, NOT a p=2 element-accuracy floor.",
-  "FIELD-SHAPE CLASSIFIER (attempted, reported as core_energy_fraction): the genuine LP01 should be strongly core-confined (>0.8 of integral|E|^2 inside r<a); box modes peak near the wall. On this PEC-truncated domain the MOST core-confined returned mode is only ~0.34-0.49 confined, and it coincides with the largest-beta mode - so field-shape selection does NOT cleanly separate LP01 from the box cluster and adds no robustness. The genuine LP01 is genuinely mixed into the cluster, not merely mis-ordered.",
-  "WINDOW-LIMITED n_eff: the guided window (n_clad, n_core) is only ~0.39% wide, so ANY in-window n_eff is automatically <=0.4% from the oracle. The n_eff agreement is therefore a squeezed-window artifact and is NOT the validation. The discriminator is the normalized b.",
-  "FOLLOW-ON for a robust <=1% story: replace the far PEC wall with a 2D PML / absorbing (transparent) boundary to remove the box-mode cluster. Tracked as a follow-on; out of scope for p=2 element validation.",
+  "Cross-section: circular step-index fiber, core radius a = 4.1 um (n_core = 1.4504) in cladding (n_clad = 1.4447), on a 3-region disk_tri_mesh_pml: core (r<a), cladding (a<r<8a), UPML annulus (8a<r<11a) with a thin PEC backing. Per-triangle epsilon via region tags + epsilon_r_from_region_tags; complex n_eff via the PML-terminated complex-pencil solve_dielectric_modes2_pml (Epic #303 PML-B).",
+  "Oracle is the EXACT scalar LP-mode characteristic equation (geode_core::fiber_lp::fiber_lp_neff, Phase 2A) - the Bessel-function dispersion relation, a 6-digit analytic ground truth (validated against scipy). b_oracle ~ 0.458.",
+  "RESULT 1 (isolation, RESOLVED by the PML): the 2D UPML absorbs the cladding instead of truncating it with a far PEC wall, so the box/cladding-resonance cluster that polluted the #329 PEC window is gone. The smallest-leakage/lowest-order selection now returns a genuinely core-confined fundamental: core-energy fraction ~0.86-0.88 (PEC-era best was only 0.34-0.49) and relative leakage |Im(b2)|/Re(b2) ~ 1e-16 (a truly trapped mode; the PML adds no spurious loss). The selection is robust to sigma_0 (see [sigma_robustness]) and the b-vs-mesh trend is MONOTONE - no more 4-26% PEC hopping.",
+  "RESULT 2 (oracle match, NOT achieved): the cleanly-isolated, monotone-converging fundamental converges to b ~ 0.77 (Re(n_eff) ~ 1.4491), a ~69% error vs the scalar oracle b ~ 0.458. This is NOT box-mode hopping (the trend is smooth and monotone under refinement). With the full (n_clad^2, n_core^2) window (the PML path drops the PEC-era slab ceiling), the in-window bound cluster is a LADDER of low-leakage core-ish modes from b~0.77 (highest Re(b2), most confined) down through b~0.46 (matching the oracle but only ~0.5 core-confined) to b~0.33. The largest-Re(b2) rule selects the TOP of that ladder, not the scalar-LP mode in the middle.",
+  "HONESTY: the in-window mode whose b matches the oracle is a weakly-confined cladding-tail mode (core fraction ~0.5), NOT the most-confined fundamental - so we CANNOT honor both 'core-confined >=0.8' and 'b <= 1%' with the same mode. We report b_fem_closest_oracle and its core fraction per series purely as context, and do NOT select it (that would be the outcome-filtering anti-pattern the #329 Judge review caught). converged=false; b_converges_to_oracle=false.",
+  "WINDOW-LIMITED n_eff: the guided window (n_clad, n_core) is only ~0.39% wide, so ANY in-window Re(n_eff) is automatically <=0.4% from the oracle. The n_eff agreement is a squeezed-window artifact and is NOT the validation. The discriminator is the normalized b.",
+  "FOLLOW-ON for a robust <=1% story: a modal-formulation / near-n_core-ceiling fix (a physical near-n_core cutoff, a vector HE11 radial-profile classifier, or determining whether the top-of-ladder mode is a spurious near-n_core eigenvector). This is a DISTINCT problem from the far-PEC-wall box-mode pollution that PML-A/B/C set out to (and did) resolve.",
   "Single-mode: V < 2.405 (first zero of J0), so LP01 (no cutoff) guides and LP11 is below cutoff (the oracle returns None for LP11 here) - the defining property of single-mode telecom fiber.",
   "Genuine solver output - NOT fit to the oracle, NOT cherry-picked. The FULL unbiased sweep is reported below.",
 ]
@@ -34,6 +34,13 @@ eps_clad = 2.087158e0
 numerical_aperture = 1.284604e-1
 relative_index_difference = 3.922228e-3
 
+[pml]
+# PML parameters (reused from the PML-B headline test, #332).
+r_pml_inner_um = 3.280000e1  # cladding outer = 8*a
+r_outer_um = 4.510000e1  # PEC-backed termination = 11*a
+pml_thickness_um = 1.230000e1  # 3*a
+sigma_0 = 6
+
 [normalized]
 # Discriminator: normalized b stretches the 0.39%-wide window onto
 # (0,1). b_fem vs b_oracle is the real, window-independent test.
@@ -41,13 +48,29 @@ v_number = 2.135017e0
 v_single_mode_cutoff = 2.405
 single_mode = true
 b_oracle = 4.580943e-1
-b_fem_trend = [4.772573e-1, 4.667618e-1, 4.547210e-1, 4.394076e-1, 4.587215e-1, 3.378002e-1]
-b_rel_err_trend = [4.183193e-2, 1.892074e-2, 7.363782e-3, 4.079222e-2, 1.369096e-3, 2.625969e-1]
-best_case_b_rel_err = 1.369096e-3
-best_case_within_2pct = true  # best-case ONLY, NOT converged
-b_converges_to_oracle = false  # NOT a converged <=2% floor; erratic 4-26% under refinement (far-PEC-wall box-mode pollution)
+b_fem_trend = [7.593174e-1, 7.654005e-1, 7.687949e-1, 7.720051e-1, 7.732897e-1, 7.738734e-1]  # SELECTED (most-confined) fundamental
+b_rel_err_trend = [6.575570e-1, 6.708362e-1, 6.782459e-1, 6.852536e-1, 6.880579e-1, 6.893320e-1]
+core_energy_fraction_trend = [8.655457e-1, 8.709121e-1, 8.742168e-1, 8.776197e-1, 8.790846e-1, 8.797778e-1]  # selected mode; ~0.86-0.88 (clean LP01 isolation)
+rel_im_beta_sq_trend = [2.976431e-17, 1.163969e-17, 8.157679e-18, 1.028989e-17, 1.690805e-17, 2.982769e-18]  # |Im(b2)|/Re(b2); ~1e-16 (genuinely bound)
+b_trend_monotone = true  # PML killed the erratic PEC hopping (#329)
+b_converges_to_oracle = false  # converges MONOTONICALLY but to b~0.77 (~69% err), NOT the oracle 0.458
 converged = false
-limitation = "far-PEC-wall box-mode pollution; field-shape classifier does not separate LP01 from box cluster (best core fraction ~0.34-0.49); 2D PML/ABC is the follow-on"
+limitation = "PML resolved box-mode pollution (clean core-confined LP01, |Im(b2)|~1e-16, monotone) but b converges to ~0.77 not the oracle 0.458: the largest-Re(b2) selection picks the top of a near-n_core bound ladder; a modal-formulation/near-n_core-ceiling fix is the follow-on (distinct from the PEC box-mode problem)"
+
+# CONTEXT ONLY: the in-window mode whose b is CLOSEST to the oracle
+# at each mesh, with its core-energy fraction. It is a weakly-
+# confined cladding-tail mode (NOT the fundamental); we do NOT
+# select it (that is the #329 outcome-filtering anti-pattern).
+[closest_to_oracle]
+b_fem_closest_oracle = [4.873655e-1, 4.564386e-1, 4.407900e-1, 4.484682e-1, 4.532332e-1, 4.565118e-1]
+core_energy_fraction_closest_oracle = [5.448246e-1, 4.909772e-1, 4.632819e-1, 4.639319e-1, 4.645318e-1, 4.318559e-1]  # ~0.5: NOT core-confined
+
+[sigma_robustness]
+# Selected fundamental b at several PML strengths sigma_0 (fixed mesh).
+# The absorbed bound mode is insensitive to sigma_0 - the matched
+# layer is absorbing, not fitting.
+sigma_0 = [2.0, 4.0, 6.0, 10.0]
+b_fem = [7.687949e-1, 7.687949e-1, 7.687949e-1, 7.687949e-1]
 
 [oracles.lp]
 # Exact LP-mode characteristic equation (geode_core::fiber_lp, Phase 2A).
@@ -56,105 +79,114 @@ n_eff_lp01 = 1.447313923904518e0
 n_eff_lp11 = "none (below cutoff, V < 2.405)"
 lp11_below_cutoff = true
 
+# PEC reference (issue #329): the far-PEC-wall sweep this PML path
+# supersedes. Erratic b-error (box-mode pollution); best core
+# fraction only 0.34-0.49. Retained for before/after legibility.
+[pec_reference]
+solver = "solve_dielectric_modes2 (far-PEC-wall p=2)"
+b_rel_err_trend = [4.183193e-2, 1.892074e-2, 7.363782e-3, 4.079222e-2, 1.369096e-3, 2.625969e-1]
+erratic_under_refinement = true  # 4.2% -> 1.9% -> 0.74% -> 4.1% -> 0.14% -> 26%
+best_core_energy_fraction = 4.897955e-1  # box-mode pollution; never core-confined
+
 [series_0]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 26
-n_angular = 232
-n_dof = 119712
-n_eff = 1.447423166509370e0
-b_fem = 4.772573e-1
-neff_rel_err_vs_oracle = 7.547955e-5
-b_rel_err_vs_oracle = 4.183193e-2
-core_energy_fraction_top = 4.897955e-1
-core_energy_fraction_best = 4.897955e-1
-b_fem_most_core_confined = 4.772573e-1
-b_rel_err_most_core_confined = 4.183193e-2
-n_eff_all = [1.447423e0, 1.446637e0, 1.446225e0]
-solve_s = 1.582
+n_radial = 4
+n_angular = 48
+n_dof = 5568
+re_n_eff = 1.449030158254947e0
+im_n_eff = 0.000000e0
+b_fem = 7.593174e-1
+re_neff_rel_err_vs_oracle = 1.185807e-3
+b_rel_err_vs_oracle = 6.575570e-1
+core_energy_fraction = 8.655457e-1
+rel_im_beta_sq = 2.976431e-17
+b_fem_closest_oracle = 4.873655e-1
+b_rel_err_closest_oracle = 6.389784e-2
+core_energy_fraction_closest_oracle = 5.448246e-1
+re_n_eff_all = [1.449030e0, 1.449030e0, 1.448032e0, 1.448032e0, 1.447481e0, 1.447481e0, 1.447132e0, 1.446872e0, 1.446664e0, 1.446492e0, 1.446348e0, 1.444700e0]
+solve_s = 0.185
 
 [series_1]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 28
-n_angular = 240
-n_dof = 133440
-n_eff = 1.447363335784480e0
-b_fem = 4.667618e-1
-neff_rel_err_vs_oracle = 3.414040e-5
-b_rel_err_vs_oracle = 1.892074e-2
-core_energy_fraction_top = 4.724556e-1
-core_energy_fraction_best = 4.724556e-1
-b_fem_most_core_confined = 4.667618e-1
-b_rel_err_most_core_confined = 1.892074e-2
-n_eff_all = [1.447363e0, 1.447291e0, 1.447183e0, 1.447031e0]
-solve_s = 1.713
+n_radial = 5
+n_angular = 60
+n_dof = 8760
+re_n_eff = 1.449064796075384e0
+im_n_eff = 0.000000e0
+b_fem = 7.654005e-1
+re_neff_rel_err_vs_oracle = 1.209739e-3
+b_rel_err_vs_oracle = 6.708362e-1
+core_energy_fraction = 8.709121e-1
+rel_im_beta_sq = 1.163969e-17
+b_fem_closest_oracle = 4.564386e-1
+b_rel_err_closest_oracle = 3.614262e-3
+core_energy_fraction_closest_oracle = 4.909772e-1
+re_n_eff_all = [1.449065e0, 1.449065e0, 1.448117e0, 1.448117e0, 1.447615e0, 1.447615e0, 1.447304e0, 1.447071e0, 1.446878e0, 1.446713e0, 1.446569e0, 1.446445e0]
+solve_s = 0.305
 
 [series_2]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 30
-n_angular = 252
-n_dof = 150192
-n_eff = 1.447294692793184e0
-b_fem = 4.547210e-1
-neff_rel_err_vs_oracle = 1.328745e-5
-b_rel_err_vs_oracle = 7.363782e-3
-core_energy_fraction_top = 4.578473e-1
-core_energy_fraction_best = 4.578473e-1
-b_fem_most_core_confined = 4.547210e-1
-b_rel_err_most_core_confined = 7.363782e-3
-n_eff_all = [1.447295e0, 1.447178e0, 1.447018e0, 1.446798e0]
-solve_s = 2.126
+n_radial = 6
+n_angular = 72
+n_dof = 12672
+re_n_eff = 1.449084123470138e0
+im_n_eff = 0.000000e0
+b_fem = 7.687949e-1
+re_neff_rel_err_vs_oracle = 1.223093e-3
+b_rel_err_vs_oracle = 6.782459e-1
+core_energy_fraction = 8.742168e-1
+rel_im_beta_sq = 8.157679e-18
+b_fem_closest_oracle = 4.407900e-1
+b_rel_err_closest_oracle = 3.777466e-2
+core_energy_fraction_closest_oracle = 4.632819e-1
+re_n_eff_all = [1.449084e0, 1.449084e0, 1.448168e0, 1.448168e0, 1.447703e0, 1.447424e0, 1.447215e0, 1.447040e0, 1.446886e0, 1.446749e0, 1.446626e0, 1.447702e0]
+solve_s = 0.446
 
 [series_3]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 32
-n_angular = 264
-n_dof = 167904
-n_eff = 1.447207388504533e0
-b_fem = 4.394076e-1
-neff_rel_err_vs_oracle = 7.360905e-5
-b_rel_err_vs_oracle = 4.079222e-2
-core_energy_fraction_top = 4.412461e-1
-core_energy_fraction_best = 4.412461e-1
-b_fem_most_core_confined = 4.394076e-1
-b_rel_err_most_core_confined = 4.079222e-2
-n_eff_all = [1.447207e0, 1.447049e0, 1.446826e0, 1.446501e0]
-solve_s = 2.376
+n_radial = 8
+n_angular = 96
+n_dof = 22656
+re_n_eff = 1.449102402051902e0
+im_n_eff = 0.000000e0
+b_fem = 7.720051e-1
+re_neff_rel_err_vs_oracle = 1.235722e-3
+b_rel_err_vs_oracle = 6.852536e-1
+core_energy_fraction = 8.776197e-1
+rel_im_beta_sq = 1.028989e-17
+b_fem_closest_oracle = 4.484682e-1
+b_rel_err_closest_oracle = 2.101330e-2
+core_energy_fraction_closest_oracle = 4.639319e-1
+re_n_eff_all = [1.449102e0, 1.449102e0, 1.448221e0, 1.448221e0, 1.447801e0, 1.447568e0, 1.447401e0, 1.447259e0, 1.447131e0, 1.447012e0, 1.446902e0, 1.446801e0]
+solve_s = 0.845
 
 [series_4]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 34
-n_angular = 276
-n_dof = 186576
-n_eff = 1.447317499380780e0
-b_fem = 4.587215e-1
-neff_rel_err_vs_oracle = 2.470422e-6
-b_rel_err_vs_oracle = 1.369096e-3
-core_energy_fraction_top = 4.614352e-1
-core_energy_fraction_best = 4.614352e-1
-b_fem_most_core_confined = 4.587215e-1
-b_rel_err_most_core_confined = 1.369096e-3
-n_eff_all = [1.447317e0, 1.447182e0, 1.446994e0, 1.446728e0]
-solve_s = 2.557
+n_radial = 10
+n_angular = 120
+n_dof = 35520
+re_n_eff = 1.449109716793205e0
+im_n_eff = 0.000000e0
+b_fem = 7.732897e-1
+re_neff_rel_err_vs_oracle = 1.240776e-3
+b_rel_err_vs_oracle = 6.880579e-1
+core_energy_fraction = 8.790846e-1
+rel_im_beta_sq = 1.690805e-17
+b_fem_closest_oracle = 4.532332e-1
+b_rel_err_closest_oracle = 1.061156e-2
+core_energy_fraction_closest_oracle = 4.645318e-1
+re_n_eff_all = [1.449110e0, 1.449110e0, 1.448245e0, 1.448245e0, 1.447849e0, 1.447645e0, 1.447506e0, 1.447391e0, 1.447286e0, 1.447187e0, 1.447092e0, 1.447002e0]
+solve_s = 1.470
 
 [series_5]
-radius_mult = 14.000
-outer_um = 5.740000e1
-n_radial = 36
-n_angular = 288
-n_dof = 206208
-n_eff = 1.446627972816210e0
-b_fem = 3.378002e-1
-neff_rel_err_vs_oracle = 4.739477e-4
-b_rel_err_vs_oracle = 2.625969e-1
-core_energy_fraction_top = 3.417282e-1
-core_energy_fraction_best = 3.417282e-1
-b_fem_most_core_confined = 3.378002e-1
-b_rel_err_most_core_confined = 2.625969e-1
-n_eff_all = [1.446628e0, 1.446241e0]
-solve_s = 3.357
+n_radial = 12
+n_angular = 144
+n_dof = 51264
+re_n_eff = 1.449113040005120e0
+im_n_eff = -0.000000e0
+b_fem = 7.738734e-1
+re_neff_rel_err_vs_oracle = 1.243072e-3
+b_rel_err_vs_oracle = 6.893320e-1
+core_energy_fraction = 8.797778e-1
+rel_im_beta_sq = 2.982769e-18
+b_fem_closest_oracle = 4.565118e-1
+b_rel_err_closest_oracle = 3.454518e-3
+core_energy_fraction_closest_oracle = 4.318559e-1
+re_n_eff_all = [1.449113e0, 1.449113e0, 1.448256e0, 1.448256e0, 1.447874e0, 1.447687e0, 1.447568e0, 1.447473e0, 1.447387e0, 1.447305e0, 1.447225e0, 1.447147e0]
+solve_s = 2.271
 

--- a/crates/geode-core/examples/step_index_fiber.rs
+++ b/crates/geode-core/examples/step_index_fiber.rs
@@ -1,98 +1,97 @@
 //! SMF-28 step-index circular-fiber benchmark vs the **exact** LP-mode
-//! oracle, on the **second-order (p=2) Nédélec** dielectric mode solver
-//! (Epic #318 Phase 2.5D; supersedes the parked first-order PR #317, closes
-//! #314).
+//! oracle, on the **PML-terminated complex-pencil** dielectric mode solver
+//! ([`solve_dielectric_modes2_pml`], Epic #303 PML-C; supersedes the
+//! far-PEC-wall p=2 path of #329, closes #330 / #333).
 //!
-//! Solves for the **fundamental LP₀₁/HE₁₁ mode** of a standard single-mode
-//! telecom fiber (SMF-28-like) with [`solve_dielectric_modes2`] (p=2) and
-//! compares against the **exact** Bessel-function characteristic equation
-//! ([`fiber_lp_neff`], Phase 2A).
+//! Solves for the fundamental transverse mode of a standard single-mode
+//! telecom fiber (SMF-28-like) on a 3-region (core / cladding / UPML) disk
+//! ([`disk_tri_mesh_pml`]) with the complex UPML absorbing boundary, and
+//! compares against the **exact** Bessel-function scalar LP characteristic
+//! equation ([`fiber_lp_neff`], Phase 2A).
 //!
 //! # The real discriminator: normalized b, NOT n_eff
 //!
 //! The guided window `(n_clad, n_core)` is only ~0.39 % wide, so **any**
-//! in-window `n_eff` is automatically ≤0.4 % from the oracle — the n_eff
+//! in-window `Re(n_eff)` is automatically ≤0.4 % from the oracle — the n_eff
 //! "agreement" is a squeezed-window artifact and cannot discriminate the
 //! mode. The honest, window-independent discriminator is the **normalized
 //! propagation constant**
 //!
 //! ```text
-//!   b = (n_eff² − n_clad²) / (n_core² − n_clad²)  ∈ (0, 1),
+//!   b = (Re(n_eff)² − n_clad²) / (n_core² − n_clad²)  ∈ (0, 1),
 //! ```
 //!
 //! which stretches the thin window onto `(0, 1)`. The oracle LP₀₁ has
-//! `b ≈ 0.458`. We report **both** `n_eff` and `b`, surface `b_fem` next to
-//! `b_oracle`, and discuss the result on `b` — the n_eff figure is reported
-//! only as window-limited context.
+//! `b ≈ 0.458`. We report **both** `Re(n_eff)` and `b`, surface `b_fem` next
+//! to `b_oracle`, and discuss the result on `b`.
 //!
-//! # HONEST FINDING — what this benchmark actually shows (and does NOT)
+//! # HONEST FINDING — what the PML actually resolved, and what it did NOT
 //!
-//! **p=2 is a clear improvement over first order, but ≤2 % is NOT robustly
-//! converged on this PEC-truncated geometry.** This is an honest reframe of
-//! the earlier "converges to ≤2 %" claim, which the Judge correctly
-//! identified as a *lucky-mesh* artifact of an outcome-filtering gate.
+//! The PML did exactly what PML-A/PML-B promised on the **selection /
+//! isolation** front, and the convergence study here exposes a **second,
+//! distinct** problem that the PEC sweep had hidden:
 //!
-//! At **first order** (PR #317) the genuine LP₀₁ plateaued at `b ≈ 0.50…0.54`,
-//! ~10–17 % above the oracle, and that bias did **not** refine away. At
-//! **second order** the largest-β in-window mode lands much closer to the
-//! oracle band at favorable meshes (`b_err` reaching 0.14–1.9 %) — a genuine
-//! qualitative improvement. **But the result is not monotone under
-//! refinement**: at the SAME 14·a domain the b-error swings erratically with
-//! `n_radial` (e.g. ≈4.2 % → 1.9 % → 0.74 % → 4.1 % → 0.14 % → 26 % across
-//! adjacent meshes) and is additionally sensitive to how many eigenpairs are
-//! requested. A result that lands ≤2 % at one mesh and 4–26 % one step finer
-//! is **not** a converged ≤2 % floor.
+//! 1. **Clean isolation — RESOLVED.** With the cladding absorbed by the 2D
+//!    UPML (no far PEC wall), the box / cladding-resonance cluster that
+//!    polluted the #329 PEC window is gone. The solver's smallest-leakage /
+//!    lowest-order selection returns a **genuinely core-confined, genuinely
+//!    bound** fundamental: core-energy fraction ≈ **0.86–0.88** (PEC-era best
+//!    was only 0.34–0.49) and relative leakage `|Im(β²)|/Re(β²) ≈ 10⁻¹⁶`
+//!    (a truly trapped mode — the PML adds no spurious loss). The selection is
+//!    also **robust to σ₀** (the absorbed mode is insensitive to PML strength)
+//!    and the b-vs-mesh trend is now **MONOTONE** (no more 4 %→26 % hopping).
 //!
-//! ## Why: far-PEC-wall box-mode pollution (a SELECTION/truncation problem)
+//! 2. **b does NOT converge to the scalar LP oracle — UNRESOLVED.** The
+//!    cleanly-isolated, monotone-converging fundamental converges to
+//!    **b ≈ 0.77** (`Re(n_eff) ≈ 1.4491`), a ~**69 %** error vs the scalar
+//!    oracle `b ≈ 0.458`. This is NOT box-mode hopping (the trend is smooth
+//!    and monotone under refinement); it is a genuine, reproducible
+//!    **mode-selection discrepancy**: with the full `(n_clad², n_core²)`
+//!    window (the PML path drops the PEC-era slab ceiling), the in-window
+//!    bound cluster is a *ladder* of low-leakage core-ish modes running from
+//!    `b ≈ 0.77` (highest `Re(β²)`, most confined) down through `b ≈ 0.46`
+//!    (matching the oracle, but only **~0.5** core-confined) to `b ≈ 0.33`.
+//!    The smallest-leakage / largest-`Re(β²)` rule picks the **top** of that
+//!    ladder, NOT the scalar-LP-oracle mode in the middle. The mode whose b
+//!    *matches* the oracle is a weakly-confined cladding-tail mode (core
+//!    fraction ~0.5), not the most-confined fundamental — so we CANNOT honor
+//!    both "≳0.8 core-confined" and "b ≤ 1 %" with the same mode.
 //!
-//! The weakly-guiding LP₀₁ (V = 2.135) has a **long** evanescent cladding
-//! tail. The computational disk is truncated by a far PEC circle, and that
-//! hard wall manufactures a dense cluster of **box / cladding-resonance
-//! modes** that populate the same ~0.39 %-wide guided window as the genuine
-//! LP₀₁. The mode the solver returns first (largest β in-window) hops between
-//! the genuine LP₀₁ and a nearby box mode as the mesh changes.
+//! ## What this means (honest, NOT cherry-picked)
 //!
-//! We attempted a **field-shape classifier** to disambiguate: the genuine
-//! LP₀₁ should be strongly **core-confined** (a high fraction of `∫|E|²`
-//! inside `r < a`), while box modes peak out near the wall. We compute the
-//! core-energy fraction of every returned mode via
-//! [`dielectric_mode_field_shape`]. **It does not cleanly separate the
-//! modes**: on this PEC-truncated domain the most core-confined returned mode
-//! is only ~0.34–0.49 core-confined (a genuine well-confined fundamental
-//! would be ≳0.8), and the maximum-core-fraction mode coincides with the
-//! largest-β mode — so field-shape selection gives the *same* answer as
-//! largest-β and adds no robustness. The genuine LP₀₁ is **genuinely mixed
-//! into the box-mode cluster**, not merely mis-ordered.
+//! The headline ≤1 % b convergence Epic #303 targeted is **NOT achieved** by
+//! this PML solver path. The PML resolved the box-mode *pollution* that made
+//! the #329 PEC sweep erratic, and the fundamental is now cleanly isolated and
+//! its b converges monotonically — but it converges to ≈0.77, not to the
+//! oracle 0.458. We report the full unbiased sweep (every mesh, both the
+//! selected mode and the closest-to-oracle in-window mode and its core
+//! fraction) and set `converged = false`, `b_converges_to_oracle = false`.
+//! Picking the closest-to-oracle in-window mode would be exactly the
+//! outcome-filtering anti-pattern the #329 Judge review caught, and that mode
+//! is not even core-confined — so we do not do it.
 //!
-//! ## What we report — and the test gate
-//!
-//! We report the **full, unbiased mesh sweep** (every config, including the
-//! 4–26 % configs and the NO-in-window-mode configs), with the core-energy
-//! fraction of the selected mode. We do **not** cherry-pick a headline mesh
-//! and we do **not** claim `b_converges_to_oracle`. The benchmark records the
-//! best-case b-error reached anywhere in the sweep purely as context.
-//!
-//! The follow-on needed for a fully-robust ≤1 % story is a **2-D PML /
-//! absorbing boundary** (or a transparent boundary condition) replacing the
-//! far PEC wall, which would remove the box-mode cluster that pollutes the
-//! window. That is tracked as a follow-on; it is out of scope for p=2
-//! element validation (the p=2 *element accuracy* is fine — the per-mesh
-//! error reaches sub-percent when the genuine mode happens to be the one
-//! selected; the failure is boundary-truncation mode selection).
+//! The remaining gap is a **modal-formulation / ceiling-selection** problem,
+//! not a boundary-truncation one: the near-`n_core` end of the index window
+//! admits a more-confined-than-LP₀₁ bound mode that outranks the genuine
+//! fundamental under the largest-`Re(β²)` rule. Resolving it (a physical
+//! near-`n_core` cutoff, a vector-mode classifier that recognizes the true
+//! HE₁₁ radial profile, or an analysis of whether the top-of-ladder mode is
+//! a spurious near-`n_core` eigenvector) is the genuine follow-on. It is a
+//! distinct problem from the PEC box-mode pollution PML-A/B/C set out to fix.
 //!
 //! # Geometry / fiber parameters (SMF-28-like, λ = 1550 nm)
 //!
 //! - Core radius `a = 4.1 µm`, `n_core = 1.4504`, `n_clad = 1.4447`
 //!   (NA = √(n_core² − n_clad²) ≈ 0.129, Δ ≈ 0.39 %).
-//! - V-number `V = k₀·a·√(n_core² − n_clad²) ≈ 2.14 < 2.405` ⇒ the fiber is
-//!   **single-mode**: LP₀₁ (no cutoff) guides; LP₁₁ (cutoff `V = 2.405`) is
-//!   below cutoff and absent (the oracle returns `None` for LP₁₁ here).
+//! - V-number `V ≈ 2.14 < 2.405` ⇒ **single-mode**: LP₀₁ (no cutoff) guides;
+//!   LP₁₁ (cutoff `V = 2.405`) is below cutoff (the oracle returns `None`).
 //!
-//! # Validation oracle — the EXACT LP characteristic equation
+//! # PML parameters (reused from the PML-B headline test, #332)
 //!
-//! Compared to `fiber_lp_neff(n_core, n_clad, a, k0, 0, 1)` (Phase 2A), the
-//! exact LP₀₁ root of the scalar Bessel dispersion relation (validated to 6
-//! digits against scipy).
+//! - Cladding outer radius `r_pml_inner = 8·a` (the LP₀₁ evanescent tail is
+//!   well inside this), PML thickness `3·a` (`r_outer = 11·a`), UPML strength
+//!   `σ₀ = 6`. The selected bound mode is insensitive to σ₀ (verified below)
+//!   and to thickness — the matched layer is absorbing, not fitting.
 //!
 //! Writes `benchmarks/step_index_fiber/results.toml`.
 //!
@@ -107,9 +106,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use geode_core::{
-    dielectric_mode_field_shape, disk_pec_interior_dofs2, disk_tri_mesh,
+    dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
     epsilon_r_from_region_tags, fiber_lp_neff, n_dof_2d_nedelec2, normalized_b,
-    solve_dielectric_modes2, v_number, TriMesh,
+    solve_dielectric_modes2_pml, v_number, TriMesh, REGION_CORE,
 };
 
 /// Core refractive index (SMF-28-like, λ = 1550 nm).
@@ -124,126 +123,177 @@ const LAMBDA_UM: f64 = 1.55;
 /// Single-mode cutoff V-number (first zero of `J₀`); LP₁₁ turns on here.
 const V_SINGLE_MODE: f64 = 2.405;
 
-/// Best-case **normalized-b** band reached at *favorable* meshes. This is
-/// reported as context, NOT asserted as a convergence floor: the sweep shows
-/// the b-error swinging to 4–26 % at adjacent / finer meshes (far-PEC-wall
-/// box-mode pollution), so ≤2 % is a best-case, not a converged result.
-const B_BESTCASE: f64 = 0.02;
+/// PML inner radius (cladding outer) as a multiple of the core radius `a`.
+/// The LP₀₁ evanescent tail is well decayed inside `8·a`.
+const CLAD_MULT: f64 = 8.0;
+/// PML outer radius (PEC-backed termination) as a multiple of `a`. Thickness
+/// `(11 − 8)·a = 3·a`.
+const PML_MULT: f64 = 11.0;
+/// UPML strength σ₀ (reused from the PML-B headline test). The selected bound
+/// mode is insensitive to this (verified by the σ₀-robustness check).
+const SIGMA_0: f64 = 6.0;
 
-/// Coarse-recovery sanity band. p=2 recovers an in-window guided mode at the
-/// favorable meshes far below first order's ~10–17 % plateau; this band
-/// (much wider than the best case) is the honest "p=2 is in the right
-/// regime, not garbage" guard, NOT a validation tolerance.
-const B_RECOVERY: f64 = 0.30;
+/// Lower bound on the selected fundamental's core-energy fraction. The PML
+/// cleanly isolates a fundamental with core fraction ≈0.86–0.88 (PEC-era best
+/// was 0.34–0.49); this is the genuine isolation win.
+const CORE_FRAC_FLOOR: f64 = 0.8;
 
-/// Number of modes to request per config. The window is polluted by a dense
-/// box-mode cluster; the returned set (after the curl-floor / window
-/// rejection inside [`solve_dielectric_modes2`]) is reported in full, and we
-/// report the largest-β mode AND the most core-confined mode.
-const N_MODES: usize = 4;
+/// Number of modes to inspect per config. We report the selected (top-of-
+/// ladder, most-confined) mode AND the closest-to-oracle in-window mode and
+/// its core fraction, so the full ladder is legible.
+const N_MODES: usize = 12;
 
-/// Unbiased p=2 refinement sweep at a generous (14·a) open-boundary domain:
-/// the weakly-guiding LP₀₁ tail needs the large domain (smaller domains
-/// return only box modes), and `(n_radial, n_angular)` is refined uniformly.
-/// We report EVERY config — no filtering, no headline pin.
-const SERIES: &[(f64, usize, usize)] = &[
-    (14.0, 26, 232),
-    (14.0, 28, 240),
-    (14.0, 30, 252),
-    (14.0, 32, 264),
-    (14.0, 34, 276),
-    (14.0, 36, 288),
-];
+/// Unbiased PML refinement sweep at the fixed PML geometry (8·a cladding,
+/// 3·a PML). Each region gets `n_radial` subdivisions, so the core is refined
+/// uniformly with the cladding/PML. We report EVERY config — no filtering, no
+/// headline pin.
+const SERIES: &[(usize, usize)] = &[(4, 48), (5, 60), (6, 72), (8, 96), (10, 120), (12, 144)];
 
 fn k0() -> f64 {
     2.0 * std::f64::consts::PI / LAMBDA_UM
 }
 
-/// One solved sweep configuration.
+/// One solved sweep configuration on the PML-terminated disk.
 struct FiberResult {
-    /// Computational (far-wall) radius as a multiple of the core radius `a`.
-    radius_mult: f64,
-    /// Computational radius (µm).
-    outer_um: f64,
-    /// Mesh resolution `(n_radial, n_angular)`.
+    /// Mesh resolution `(n_radial, n_angular)` (per region).
     res: (usize, usize),
     /// p=2 DOF count (system size).
     n_dof: usize,
-    /// Largest-β in-window guided `n_eff` (`modes.first()`), or `None` if the
-    /// config returned no in-window guided mode.
-    n_eff: Option<f64>,
-    /// Normalized b of the largest-β mode.
+    /// Selected fundamental `Re(n_eff)` (smallest-leakage / lowest-order), or
+    /// `None` if the config returned no in-window guided mode.
+    re_n_eff: Option<f64>,
+    /// Selected fundamental `Im(n_eff)` (modal loss; tiny for a bound mode).
+    im_n_eff: Option<f64>,
+    /// Relative leakage `|Im(β²)|/Re(β²)` of the selected mode.
+    rel_im_beta_sq: Option<f64>,
+    /// Normalized b of the selected fundamental.
     b: Option<f64>,
-    /// Core-energy fraction `∫_core|E|²/∫|E|²` of the largest-β mode (a
-    /// genuine confined LP₀₁ would be ≳0.8; box-polluted modes are low).
+    /// Core-energy fraction of the selected fundamental (a genuine confined
+    /// LP₀₁ is ≳0.8 — the PML isolation win).
     core_frac: Option<f64>,
-    /// Core-energy fraction of the MOST core-confined returned mode.
-    best_core_frac: Option<f64>,
-    /// b of the most core-confined returned mode.
-    b_best_core: Option<f64>,
-    /// All recovered guided `n_eff` (largest-β first).
-    n_eff_all: Vec<f64>,
+    /// b of the in-window mode whose b is *closest* to the oracle (reported
+    /// as context — NOT the selected mode; it is weakly confined).
+    b_closest_oracle: Option<f64>,
+    /// Core-energy fraction of that closest-to-oracle mode (the honesty
+    /// point: it is NOT core-confined, so it is not the genuine LP₀₁).
+    core_frac_closest_oracle: Option<f64>,
+    /// All recovered guided `Re(n_eff)` (selection order).
+    re_n_eff_all: Vec<f64>,
     /// Wall-clock solve time (s).
     solve_s: f64,
 }
 
-/// Build the circular step-index fiber cross-section at computational radius
-/// `outer_um` with mesh resolution `(n_radial, n_angular)`.
+/// Build the PML-terminated step-index fiber cross-section.
 ///
-/// Returns `(mesh, region_tags, eps_r, p=2 interior-DOF mask)`.
-fn build_fiber(outer_um: f64, res: (usize, usize)) -> (TriMesh, Vec<i32>, Vec<f64>, Vec<bool>) {
+/// Returns `(mesh, region_tags, eps_r, p=2 interior-DOF mask, r_pml_inner,
+/// r_outer)`.
+#[allow(clippy::type_complexity)]
+fn build_fiber(res: (usize, usize)) -> (TriMesh, Vec<i32>, Vec<f64>, Vec<bool>, f64, f64) {
     let (n_radial, n_angular) = res;
-    let (mesh, region_tags) = disk_tri_mesh(A_UM, outer_um, n_radial, n_angular);
+    let clad_r = CLAD_MULT * A_UM;
+    let outer_r = PML_MULT * A_UM;
+    let (mesh, region_tags) = disk_tri_mesh_pml(A_UM, clad_r, outer_r, n_radial, n_angular);
     let eps_core = N_CORE * N_CORE;
     let eps_clad = N_CLAD * N_CLAD;
-    // tag 1 = core, tag 0 = cladding (disk_tri_mesh convention).
-    let eps_r =
-        epsilon_r_from_region_tags(&region_tags, |t| if t == 1 { eps_core } else { eps_clad });
-    let interior = disk_pec_interior_dofs2(&mesh, outer_um);
-    (mesh, region_tags, eps_r, interior)
+    let eps_r = epsilon_r_from_region_tags(&region_tags, |t| {
+        if t == REGION_CORE {
+            eps_core
+        } else {
+            eps_clad
+        }
+    });
+    let interior = disk_pec_interior_dofs2(&mesh, outer_r);
+    (mesh, region_tags, eps_r, interior, clad_r, outer_r)
 }
 
-fn solve_config(radius_mult: f64, res: (usize, usize)) -> FiberResult {
+fn solve_config(res: (usize, usize), b_oracle: f64) -> FiberResult {
     let k0 = k0();
-    let outer_um = A_UM * radius_mult;
-    let (mesh, region_tags, eps_r, interior) = build_fiber(outer_um, res);
+    let (mesh, region_tags, eps_r, interior, clad_r, outer_r) = build_fiber(res);
     let n_dof = n_dof_2d_nedelec2(&mesh);
     let t0 = std::time::Instant::now();
-    let modes = solve_dielectric_modes2(&mesh, &eps_r, &interior, k0, N_MODES)
-        .expect("step-index fiber p=2 dielectric mode solve");
+    let modes = solve_dielectric_modes2_pml(
+        &mesh,
+        &eps_r,
+        &region_tags,
+        &interior,
+        clad_r,
+        outer_r,
+        SIGMA_0,
+        k0,
+        N_MODES,
+    )
+    .expect("step-index fiber PML dielectric mode solve");
     let solve_s = t0.elapsed().as_secs_f64();
-    let n_eff_all: Vec<f64> = modes.iter().map(|m| m.n_eff).collect();
+    let re_n_eff_all: Vec<f64> = modes.iter().map(|m| m.n_eff.re).collect();
 
-    let n_eff = n_eff_all.first().copied();
-    let b = n_eff.map(|n| normalized_b(n, N_CORE, N_CLAD));
-    let core_frac = modes
-        .first()
-        .map(|m| dielectric_mode_field_shape(&mesh, &region_tags, m).core_energy_fraction);
+    // Selected fundamental = modes[0] (smallest-leakage / lowest-order).
+    let top = modes.first();
+    let re_n_eff = top.map(|m| m.n_eff.re);
+    let im_n_eff = top.map(|m| m.n_eff.im);
+    let rel_im_beta_sq = top.map(|m| m.beta_sq.im.abs() / m.beta_sq.re.abs().max(1.0));
+    let b = re_n_eff.map(|n| normalized_b(n, N_CORE, N_CLAD));
+    let core_frac =
+        top.map(|m| dielectric_mode_field_shape_pml(&mesh, &region_tags, m).core_energy_fraction);
 
-    // Most core-confined returned mode (the field-shape classifier's pick).
-    let best = modes
+    // Closest-to-oracle in-window mode (context only — NOT selected; it is
+    // weakly confined). Reporting it surfaces the ladder honestly: the b that
+    // matches the oracle belongs to a cladding-tail mode, not the fundamental.
+    let closest = modes
         .iter()
         .map(|m| {
-            let cf = dielectric_mode_field_shape(&mesh, &region_tags, m).core_energy_fraction;
-            (cf, m.n_eff)
+            let bb = normalized_b(m.n_eff.re, N_CORE, N_CLAD);
+            let cf = dielectric_mode_field_shape_pml(&mesh, &region_tags, m).core_energy_fraction;
+            (bb, cf)
         })
-        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-    let best_core_frac = best.map(|(cf, _)| cf);
-    let b_best_core = best.map(|(_, n)| normalized_b(n, N_CORE, N_CLAD));
+        .min_by(|a, b| {
+            (a.0 - b_oracle)
+                .abs()
+                .partial_cmp(&(b.0 - b_oracle).abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    let b_closest_oracle = closest.map(|(bb, _)| bb);
+    let core_frac_closest_oracle = closest.map(|(_, cf)| cf);
 
     FiberResult {
-        radius_mult,
-        outer_um,
         res,
         n_dof,
-        n_eff,
+        re_n_eff,
+        im_n_eff,
+        rel_im_beta_sq,
         b,
         core_frac,
-        best_core_frac,
-        b_best_core,
-        n_eff_all,
+        b_closest_oracle,
+        core_frac_closest_oracle,
+        re_n_eff_all,
         solve_s,
     }
+}
+
+/// σ₀-robustness probe: re-solve a fixed mesh at several PML strengths and
+/// report the selected fundamental's b. The absorbed bound mode should be
+/// insensitive to σ₀ (the matched layer is doing its job, not fitting).
+fn sigma_robustness(res: (usize, usize)) -> Vec<(f64, f64)> {
+    let k0 = k0();
+    let (mesh, region_tags, eps_r, interior, clad_r, outer_r) = build_fiber(res);
+    let mut out = Vec::new();
+    for &s0 in &[2.0_f64, 4.0, 6.0, 10.0] {
+        let modes = solve_dielectric_modes2_pml(
+            &mesh,
+            &eps_r,
+            &region_tags,
+            &interior,
+            clad_r,
+            outer_r,
+            s0,
+            k0,
+            1,
+        )
+        .expect("σ₀-robustness PML solve");
+        if let Some(m) = modes.first() {
+            out.push((s0, normalized_b(m.n_eff.re, N_CORE, N_CLAD)));
+        }
+    }
+    out
 }
 
 fn current_commit() -> String {
@@ -270,24 +320,32 @@ fn results_path() -> PathBuf {
         .join("results.toml")
 }
 
-/// Best-case b-error reached anywhere in the (unfiltered) sweep — reported as
-/// context only. This is NOT a converged figure and NOT used to pick a
-/// "headline" mesh; the full sweep is what the benchmark reports.
-fn best_case_b_err(results: &[FiberResult], b_oracle: f64) -> Option<f64> {
-    results
-        .iter()
-        .filter_map(|r| r.b.map(|b| (b - b_oracle).abs() / b_oracle))
-        .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+/// Is the selected-mode b-trend monotone? (We do not need it to point at the
+/// oracle — the trend is monotone but converges to ≈0.77; this just records
+/// that the PML killed the erratic PEC hopping.)
+fn is_monotone(results: &[FiberResult]) -> bool {
+    let bs: Vec<f64> = results.iter().filter_map(|r| r.b).collect();
+    if bs.len() < 3 {
+        return false;
+    }
+    let inc = bs.windows(2).all(|w| w[1] >= w[0] - 1e-9);
+    let dec = bs.windows(2).all(|w| w[1] <= w[0] + 1e-9);
+    inc || dec
 }
 
-fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
+fn write_toml(
+    results: &[FiberResult],
+    oracle: f64,
+    oracle11: Option<f64>,
+    sigma_rob: &[(f64, f64)],
+) {
     let commit = current_commit();
     let k0 = k0();
     let v = v_number(N_CORE, N_CLAD, A_UM, k0);
     let na_aperture = (N_CORE * N_CORE - N_CLAD * N_CLAD).sqrt();
     let delta = (N_CORE * N_CORE - N_CLAD * N_CLAD) / (2.0 * N_CORE * N_CORE);
     let b_oracle = normalized_b(oracle, N_CORE, N_CLAD);
-    let best_b_err = best_case_b_err(results, b_oracle);
+    let monotone = is_monotone(results);
 
     let mut s = String::new();
     s.push_str("# Auto-generated by `cargo run -p geode-core --release \\\n");
@@ -299,23 +357,25 @@ fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
 
     s.push_str("[meta]\n");
     s.push_str(
-        "description = \"SMF-28 step-index fiber benchmark (issue #322, Epic #318 Phase 2.5D; supersedes PR #317, closes #314): fundamental LP01/HE11 mode of a 4.1 um core (n_core=1.4504) in cladding (n_clad=1.4447) at 1550 nm on the SECOND-ORDER (p=2) Nedelec dielectric solver (solve_dielectric_modes2), on a disk mesh terminated by a far PEC wall, vs the EXACT Bessel-function LP-mode characteristic equation (Phase 2A). HONEST FINDING: p=2 is a clear improvement over first order (which plateaued at ~10-17% and did not refine away), reaching sub-2% b-error at FAVORABLE meshes - but the result is NOT a converged <=2% floor: under refinement the b-error swings erratically (4-26%) because the far PEC wall manufactures box/cladding-resonance modes that pollute the thin guided window. A field-shape (core-energy-fraction) classifier does NOT cleanly separate LP01 from the box cluster (best core fraction only ~0.34-0.49 vs >0.8 for a genuine confined fundamental). We report the FULL UNBIASED SWEEP and do NOT claim b_converges_to_oracle. A 2D PML/absorbing boundary is the follow-on needed for a robust <=1% story. n_eff is reported only as window-limited context.\"\n",
+        "description = \"SMF-28 step-index fiber benchmark (Epic #303 PML-C, issue #333; closes design tracker #330; supersedes the far-PEC-wall p=2 path of #329): fundamental transverse mode of a 4.1 um core (n_core=1.4504) in cladding (n_clad=1.4447) at 1550 nm on the PML-TERMINATED complex-pencil solver (solve_dielectric_modes2_pml) over a 3-region core/cladding/UPML disk (disk_tri_mesh_pml), vs the EXACT Bessel-function scalar LP characteristic equation (Phase 2A). HONEST FINDING (two distinct results): (1) ISOLATION RESOLVED - the 2D UPML removed the far-PEC-wall box-mode pollution that made the #329 sweep erratic; the solver now cleanly isolates a genuinely core-confined (core-energy fraction ~0.86-0.88, vs PEC-era 0.34-0.49), genuinely bound (|Im(b2)|/Re(b2) ~1e-16) fundamental, robust to sigma_0, with a MONOTONE b-vs-mesh trend (no more 4-26% hopping). (2) ORACLE MATCH NOT ACHIEVED - that cleanly-isolated, monotone-converging fundamental converges to b~0.77 (Re(n_eff)~1.4491), a ~69% error vs the scalar oracle b~0.458. With the full (n_clad^2, n_core^2) window the in-window bound cluster is a LADDER of low-leakage modes from b~0.77 (most confined, selected) down through b~0.46 (matches oracle but only ~0.5 core-confined) to b~0.33; the smallest-leakage/largest-Re(b2) rule picks the TOP of the ladder, not the scalar-LP mode in the middle. The mode whose b matches the oracle is a weakly-confined cladding-tail mode, NOT the fundamental. We report the FULL UNBIASED SWEEP, do NOT cherry-pick the closest-to-oracle mode (the #329 anti-pattern), and set converged=false. The remaining gap is a modal-formulation/near-n_core-ceiling selection problem, DISTINCT from the PEC box-mode pollution PML-A/B/C fixed. n_eff is reported only as window-limited context.\"\n",
     );
     s.push_str(&format!("generated_at_commit = \"{commit}\"\n"));
-    s.push_str("solver = \"solve_dielectric_modes2 (p=2 second-order Nedelec)\"\n");
+    s.push_str(
+        "solver = \"solve_dielectric_modes2_pml (PML-terminated complex-pencil p=2 Nedelec)\"\n",
+    );
     s.push_str(&format!("lambda_um = {LAMBDA_UM}\n"));
     s.push_str(&format!("k0_per_um = {k0:.15e}\n"));
     s.push_str("mode = \"LP01 (HE11), fundamental\"\n");
-    s.push_str("outer_boundary = \"pec (far cladding circle)\"\n");
+    s.push_str("outer_boundary = \"pml (radial UPML annulus + thin PEC backing)\"\n");
     s.push_str("single_mode = true\n");
     s.push_str("notes = [\n");
-    s.push_str("  \"Cross-section: circular step-index fiber, core radius a = 4.1 um (n_core = 1.4504) in cladding (n_clad = 1.4447), embedded in a generous cladding disk terminated by a far PEC circle. Per-triangle epsilon via disk_tri_mesh region tags (Phase 2B) + epsilon_r_from_region_tags (Phase 1A); n_eff via the SECOND-ORDER solve_dielectric_modes2 (Epic #318 Phase 2.5C).\",\n");
-    s.push_str("  \"Oracle is the EXACT scalar LP-mode characteristic equation (geode_core::fiber_lp::fiber_lp_neff, Phase 2A) - the Bessel-function dispersion relation, a 6-digit analytic ground truth (validated against scipy).\",\n");
-    s.push_str("  \"HONEST FINDING (reframed after Judge review of PR #329): p=2 reaches sub-2% b-error at FAVORABLE meshes - a clear improvement over first order's non-converging ~10-17% plateau - but it is NOT a converged <=2% floor. Across the SAME 14a domain the b-error swings erratically with n_radial (~4.2% -> 1.9% -> 0.74% -> 4.1% -> 0.14% -> 26%) and some configs return NO in-window mode. The earlier 'converges to <=2%' claim was a lucky-mesh artifact of an outcome-filtering gate, now removed.\",\n");
-    s.push_str("  \"ROOT CAUSE - far-PEC-wall box-mode pollution: the weakly-guiding LP01 (V=2.135) has a long evanescent tail, and the hard PEC truncation manufactures a dense cluster of box/cladding-resonance modes occupying the same ~0.39%-wide guided window. The largest-beta in-window mode hops between the genuine LP01 and a box mode as the mesh changes. This is a boundary-truncation / mode-SELECTION problem, NOT a p=2 element-accuracy floor.\",\n");
-    s.push_str("  \"FIELD-SHAPE CLASSIFIER (attempted, reported as core_energy_fraction): the genuine LP01 should be strongly core-confined (>0.8 of integral|E|^2 inside r<a); box modes peak near the wall. On this PEC-truncated domain the MOST core-confined returned mode is only ~0.34-0.49 confined, and it coincides with the largest-beta mode - so field-shape selection does NOT cleanly separate LP01 from the box cluster and adds no robustness. The genuine LP01 is genuinely mixed into the cluster, not merely mis-ordered.\",\n");
-    s.push_str("  \"WINDOW-LIMITED n_eff: the guided window (n_clad, n_core) is only ~0.39% wide, so ANY in-window n_eff is automatically <=0.4% from the oracle. The n_eff agreement is therefore a squeezed-window artifact and is NOT the validation. The discriminator is the normalized b.\",\n");
-    s.push_str("  \"FOLLOW-ON for a robust <=1% story: replace the far PEC wall with a 2D PML / absorbing (transparent) boundary to remove the box-mode cluster. Tracked as a follow-on; out of scope for p=2 element validation.\",\n");
+    s.push_str("  \"Cross-section: circular step-index fiber, core radius a = 4.1 um (n_core = 1.4504) in cladding (n_clad = 1.4447), on a 3-region disk_tri_mesh_pml: core (r<a), cladding (a<r<8a), UPML annulus (8a<r<11a) with a thin PEC backing. Per-triangle epsilon via region tags + epsilon_r_from_region_tags; complex n_eff via the PML-terminated complex-pencil solve_dielectric_modes2_pml (Epic #303 PML-B).\",\n");
+    s.push_str("  \"Oracle is the EXACT scalar LP-mode characteristic equation (geode_core::fiber_lp::fiber_lp_neff, Phase 2A) - the Bessel-function dispersion relation, a 6-digit analytic ground truth (validated against scipy). b_oracle ~ 0.458.\",\n");
+    s.push_str("  \"RESULT 1 (isolation, RESOLVED by the PML): the 2D UPML absorbs the cladding instead of truncating it with a far PEC wall, so the box/cladding-resonance cluster that polluted the #329 PEC window is gone. The smallest-leakage/lowest-order selection now returns a genuinely core-confined fundamental: core-energy fraction ~0.86-0.88 (PEC-era best was only 0.34-0.49) and relative leakage |Im(b2)|/Re(b2) ~ 1e-16 (a truly trapped mode; the PML adds no spurious loss). The selection is robust to sigma_0 (see [sigma_robustness]) and the b-vs-mesh trend is MONOTONE - no more 4-26% PEC hopping.\",\n");
+    s.push_str("  \"RESULT 2 (oracle match, NOT achieved): the cleanly-isolated, monotone-converging fundamental converges to b ~ 0.77 (Re(n_eff) ~ 1.4491), a ~69% error vs the scalar oracle b ~ 0.458. This is NOT box-mode hopping (the trend is smooth and monotone under refinement). With the full (n_clad^2, n_core^2) window (the PML path drops the PEC-era slab ceiling), the in-window bound cluster is a LADDER of low-leakage core-ish modes from b~0.77 (highest Re(b2), most confined) down through b~0.46 (matching the oracle but only ~0.5 core-confined) to b~0.33. The largest-Re(b2) rule selects the TOP of that ladder, not the scalar-LP mode in the middle.\",\n");
+    s.push_str("  \"HONESTY: the in-window mode whose b matches the oracle is a weakly-confined cladding-tail mode (core fraction ~0.5), NOT the most-confined fundamental - so we CANNOT honor both 'core-confined >=0.8' and 'b <= 1%' with the same mode. We report b_fem_closest_oracle and its core fraction per series purely as context, and do NOT select it (that would be the outcome-filtering anti-pattern the #329 Judge review caught). converged=false; b_converges_to_oracle=false.\",\n");
+    s.push_str("  \"WINDOW-LIMITED n_eff: the guided window (n_clad, n_core) is only ~0.39% wide, so ANY in-window Re(n_eff) is automatically <=0.4% from the oracle. The n_eff agreement is a squeezed-window artifact and is NOT the validation. The discriminator is the normalized b.\",\n");
+    s.push_str("  \"FOLLOW-ON for a robust <=1% story: a modal-formulation / near-n_core-ceiling fix (a physical near-n_core cutoff, a vector HE11 radial-profile classifier, or determining whether the top-of-ladder mode is a spurious near-n_core eigenvector). This is a DISTINCT problem from the far-PEC-wall box-mode pollution that PML-A/B/C set out to (and did) resolve.\",\n");
     s.push_str("  \"Single-mode: V < 2.405 (first zero of J0), so LP01 (no cutoff) guides and LP11 is below cutoff (the oracle returns None for LP11 here) - the defining property of single-mode telecom fiber.\",\n");
     s.push_str("  \"Genuine solver output - NOT fit to the oracle, NOT cherry-picked. The FULL unbiased sweep is reported below.\",\n");
     s.push_str("]\n");
@@ -329,6 +389,24 @@ fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
     s.push_str(&format!("eps_clad = {:.6e}\n", N_CLAD * N_CLAD));
     s.push_str(&format!("numerical_aperture = {na_aperture:.6e}\n"));
     s.push_str(&format!("relative_index_difference = {delta:.6e}\n"));
+    s.push('\n');
+
+    s.push_str("[pml]\n");
+    s.push_str("# PML parameters (reused from the PML-B headline test, #332).\n");
+    s.push_str(&format!(
+        "r_pml_inner_um = {:.6e}  # cladding outer = {CLAD_MULT}*a\n",
+        CLAD_MULT * A_UM
+    ));
+    s.push_str(&format!(
+        "r_outer_um = {:.6e}  # PEC-backed termination = {PML_MULT}*a\n",
+        PML_MULT * A_UM
+    ));
+    s.push_str(&format!(
+        "pml_thickness_um = {:.6e}  # {}*a\n",
+        (PML_MULT - CLAD_MULT) * A_UM,
+        PML_MULT - CLAD_MULT
+    ));
+    s.push_str(&format!("sigma_0 = {SIGMA_0}\n"));
     s.push('\n');
 
     s.push_str("[normalized]\n");
@@ -345,7 +423,10 @@ fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
             None => "nan".to_string(),
         })
         .collect();
-    s.push_str(&format!("b_fem_trend = [{}]\n", b_trend.join(", ")));
+    s.push_str(&format!(
+        "b_fem_trend = [{}]  # SELECTED (most-confined) fundamental\n",
+        b_trend.join(", ")
+    ));
     let b_err_trend: Vec<String> = results
         .iter()
         .map(|r| match r.b {
@@ -354,19 +435,70 @@ fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
         })
         .collect();
     s.push_str(&format!("b_rel_err_trend = [{}]\n", b_err_trend.join(", ")));
-    match best_b_err {
-        Some(e) => {
-            s.push_str(&format!("best_case_b_rel_err = {e:.6e}\n"));
-            s.push_str(&format!(
-                "best_case_within_2pct = {}  # best-case ONLY, NOT converged\n",
-                e < B_BESTCASE
-            ));
-        }
-        None => s.push_str("best_case_b_rel_err = \"none (no in-window mode at any config)\"\n"),
-    }
-    s.push_str("b_converges_to_oracle = false  # NOT a converged <=2% floor; erratic 4-26% under refinement (far-PEC-wall box-mode pollution)\n");
+    let cf_trend: Vec<String> = results
+        .iter()
+        .map(|r| match r.core_frac {
+            Some(c) => format!("{c:.6e}"),
+            None => "nan".to_string(),
+        })
+        .collect();
+    s.push_str(&format!(
+        "core_energy_fraction_trend = [{}]  # selected mode; ~0.86-0.88 (clean LP01 isolation)\n",
+        cf_trend.join(", ")
+    ));
+    let im_trend: Vec<String> = results
+        .iter()
+        .map(|r| match r.rel_im_beta_sq {
+            Some(x) => format!("{x:.6e}"),
+            None => "nan".to_string(),
+        })
+        .collect();
+    s.push_str(&format!(
+        "rel_im_beta_sq_trend = [{}]  # |Im(b2)|/Re(b2); ~1e-16 (genuinely bound)\n",
+        im_trend.join(", ")
+    ));
+    s.push_str(&format!(
+        "b_trend_monotone = {monotone}  # PML killed the erratic PEC hopping (#329)\n"
+    ));
+    s.push_str("b_converges_to_oracle = false  # converges MONOTONICALLY but to b~0.77 (~69% err), NOT the oracle 0.458\n");
     s.push_str("converged = false\n");
-    s.push_str("limitation = \"far-PEC-wall box-mode pollution; field-shape classifier does not separate LP01 from box cluster (best core fraction ~0.34-0.49); 2D PML/ABC is the follow-on\"\n");
+    s.push_str("limitation = \"PML resolved box-mode pollution (clean core-confined LP01, |Im(b2)|~1e-16, monotone) but b converges to ~0.77 not the oracle 0.458: the largest-Re(b2) selection picks the top of a near-n_core bound ladder; a modal-formulation/near-n_core-ceiling fix is the follow-on (distinct from the PEC box-mode problem)\"\n");
+    s.push('\n');
+
+    s.push_str("# CONTEXT ONLY: the in-window mode whose b is CLOSEST to the oracle\n");
+    s.push_str("# at each mesh, with its core-energy fraction. It is a weakly-\n");
+    s.push_str("# confined cladding-tail mode (NOT the fundamental); we do NOT\n");
+    s.push_str("# select it (that is the #329 outcome-filtering anti-pattern).\n");
+    s.push_str("[closest_to_oracle]\n");
+    let bco: Vec<String> = results
+        .iter()
+        .map(|r| match r.b_closest_oracle {
+            Some(b) => format!("{b:.6e}"),
+            None => "nan".to_string(),
+        })
+        .collect();
+    s.push_str(&format!("b_fem_closest_oracle = [{}]\n", bco.join(", ")));
+    let cfco: Vec<String> = results
+        .iter()
+        .map(|r| match r.core_frac_closest_oracle {
+            Some(c) => format!("{c:.6e}"),
+            None => "nan".to_string(),
+        })
+        .collect();
+    s.push_str(&format!(
+        "core_energy_fraction_closest_oracle = [{}]  # ~0.5: NOT core-confined\n",
+        cfco.join(", ")
+    ));
+    s.push('\n');
+
+    s.push_str("[sigma_robustness]\n");
+    s.push_str("# Selected fundamental b at several PML strengths sigma_0 (fixed mesh).\n");
+    s.push_str("# The absorbed bound mode is insensitive to sigma_0 - the matched\n");
+    s.push_str("# layer is absorbing, not fitting.\n");
+    let s0s: Vec<String> = sigma_rob.iter().map(|(s0, _)| format!("{s0:.1}")).collect();
+    let bs: Vec<String> = sigma_rob.iter().map(|(_, b)| format!("{b:.6e}")).collect();
+    s.push_str(&format!("sigma_0 = [{}]\n", s0s.join(", ")));
+    s.push_str(&format!("b_fem = [{}]\n", bs.join(", ")));
     s.push('\n');
 
     s.push_str("[oracles.lp]\n");
@@ -380,38 +512,58 @@ fn write_toml(results: &[FiberResult], oracle: f64, oracle11: Option<f64>) {
     s.push_str(&format!("lp11_below_cutoff = {}\n", oracle11.is_none()));
     s.push('\n');
 
+    s.push_str("# PEC reference (issue #329): the far-PEC-wall sweep this PML path\n");
+    s.push_str("# supersedes. Erratic b-error (box-mode pollution); best core\n");
+    s.push_str("# fraction only 0.34-0.49. Retained for before/after legibility.\n");
+    s.push_str("[pec_reference]\n");
+    s.push_str("solver = \"solve_dielectric_modes2 (far-PEC-wall p=2)\"\n");
+    s.push_str("b_rel_err_trend = [4.183193e-2, 1.892074e-2, 7.363782e-3, 4.079222e-2, 1.369096e-3, 2.625969e-1]\n");
+    s.push_str(
+        "erratic_under_refinement = true  # 4.2% -> 1.9% -> 0.74% -> 4.1% -> 0.14% -> 26%\n",
+    );
+    s.push_str(
+        "best_core_energy_fraction = 4.897955e-1  # box-mode pollution; never core-confined\n",
+    );
+    s.push('\n');
+
     for (i, r) in results.iter().enumerate() {
         s.push_str(&format!("[series_{i}]\n"));
-        s.push_str(&format!("radius_mult = {:.3}\n", r.radius_mult));
-        s.push_str(&format!("outer_um = {:.6e}\n", r.outer_um));
         s.push_str(&format!("n_radial = {}\n", r.res.0));
         s.push_str(&format!("n_angular = {}\n", r.res.1));
         s.push_str(&format!("n_dof = {}\n", r.n_dof));
-        match (r.n_eff, r.b) {
-            (Some(n_eff), Some(b)) => {
-                let rel = (n_eff - oracle).abs() / oracle;
+        match (r.re_n_eff, r.b) {
+            (Some(re_n_eff), Some(b)) => {
+                let rel = (re_n_eff - oracle).abs() / oracle;
                 let b_rel = (b - b_oracle).abs() / b_oracle;
-                s.push_str(&format!("n_eff = {n_eff:.15e}\n"));
+                s.push_str(&format!("re_n_eff = {re_n_eff:.15e}\n"));
+                if let Some(im) = r.im_n_eff {
+                    s.push_str(&format!("im_n_eff = {im:.6e}\n"));
+                }
                 s.push_str(&format!("b_fem = {b:.6e}\n"));
-                s.push_str(&format!("neff_rel_err_vs_oracle = {rel:.6e}\n"));
+                s.push_str(&format!("re_neff_rel_err_vs_oracle = {rel:.6e}\n"));
                 s.push_str(&format!("b_rel_err_vs_oracle = {b_rel:.6e}\n"));
                 if let Some(cf) = r.core_frac {
-                    s.push_str(&format!("core_energy_fraction_top = {cf:.6e}\n"));
+                    s.push_str(&format!("core_energy_fraction = {cf:.6e}\n"));
                 }
-                if let (Some(cf), Some(bb)) = (r.best_core_frac, r.b_best_core) {
-                    let bb_rel = (bb - b_oracle).abs() / b_oracle;
-                    s.push_str(&format!("core_energy_fraction_best = {cf:.6e}\n"));
-                    s.push_str(&format!("b_fem_most_core_confined = {bb:.6e}\n"));
-                    s.push_str(&format!("b_rel_err_most_core_confined = {bb_rel:.6e}\n"));
+                if let Some(ri) = r.rel_im_beta_sq {
+                    s.push_str(&format!("rel_im_beta_sq = {ri:.6e}\n"));
+                }
+                if let (Some(bc), Some(cfc)) = (r.b_closest_oracle, r.core_frac_closest_oracle) {
+                    let bc_rel = (bc - b_oracle).abs() / b_oracle;
+                    s.push_str(&format!("b_fem_closest_oracle = {bc:.6e}\n"));
+                    s.push_str(&format!("b_rel_err_closest_oracle = {bc_rel:.6e}\n"));
+                    s.push_str(&format!(
+                        "core_energy_fraction_closest_oracle = {cfc:.6e}\n"
+                    ));
                 }
             }
             _ => {
-                s.push_str("n_eff = \"none (no in-window guided mode at this config)\"\n");
+                s.push_str("re_n_eff = \"none (no in-window guided mode at this config)\"\n");
                 s.push_str("b_fem = \"none\"\n");
             }
         }
-        let all: Vec<String> = r.n_eff_all.iter().map(|v| format!("{v:.6e}")).collect();
-        s.push_str(&format!("n_eff_all = [{}]\n", all.join(", ")));
+        let all: Vec<String> = r.re_n_eff_all.iter().map(|v| format!("{v:.6e}")).collect();
+        s.push_str(&format!("re_n_eff_all = [{}]\n", all.join(", ")));
         s.push_str(&format!("solve_s = {:.3}\n", r.solve_s));
         s.push('\n');
     }
@@ -431,8 +583,14 @@ fn main() {
     let oracle11 = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 1, 1);
     let b_oracle = normalized_b(oracle, N_CORE, N_CLAD);
 
-    println!("SMF-28 step-index fiber benchmark (p=2 Nédélec, Epic #318 Phase 2.5D)");
+    println!("SMF-28 step-index fiber benchmark (PML-terminated, Epic #303 PML-C)");
     println!("  λ = {LAMBDA_UM} µm, a = {A_UM} µm, n_core = {N_CORE}, n_clad = {N_CLAD}");
+    println!(
+        "  PML: r_pml_inner = {}·a, r_outer = {}·a (thickness {}·a), σ₀ = {SIGMA_0}",
+        CLAD_MULT,
+        PML_MULT,
+        PML_MULT - CLAD_MULT
+    );
     println!(
         "  V = {v:.4}  (single-mode: {}, cutoff {V_SINGLE_MODE}); LP11 = {}",
         v < V_SINGLE_MODE,
@@ -443,51 +601,67 @@ fn main() {
     );
     println!("  EXACT oracle: n_eff_LP01 = {oracle:.8}, b_oracle = {b_oracle:.6}");
     println!();
-    println!("  UNBIASED p=2 refinement sweep at 14·a (no filtering, no headline pin):");
+    println!("  UNBIASED PML refinement sweep (selected = smallest-leakage / lowest-order):");
     println!(
-        "  (TOP = largest-β in-window mode; cf = core-energy fraction; best-cf = most core-confined mode's b)"
+        "  (b = SELECTED mode's b; cf = its core-energy fraction; closest = in-window mode whose b is nearest the oracle + its cf)"
     );
 
     let mut results = Vec::new();
-    for &(mult, nr, na) in SERIES {
-        let r = solve_config(mult, (nr, na));
-        match (r.n_eff, r.b) {
-            (Some(n_eff), Some(b)) => {
+    for &(nr, na) in SERIES {
+        let r = solve_config((nr, na), b_oracle);
+        match (r.re_n_eff, r.b) {
+            (Some(re_n_eff), Some(b)) => {
                 let b_err = 100.0 * (b - b_oracle).abs() / b_oracle;
                 let cf = r.core_frac.unwrap_or(f64::NAN);
-                let bcf = r.b_best_core.unwrap_or(f64::NAN);
-                let bcf_err = 100.0 * (bcf - b_oracle).abs() / b_oracle;
+                let im = r.im_n_eff.unwrap_or(f64::NAN);
+                let bco = r.b_closest_oracle.unwrap_or(f64::NAN);
+                let cfco = r.core_frac_closest_oracle.unwrap_or(f64::NAN);
                 println!(
-                    "    {mult:>4.1}·a  ({nr:>2},{na:>3})  dof={:>6}  n_eff={n_eff:.7}  b={b:.5}  b_err={b_err:>6.2}%  cf={cf:.3}  | best-cf b={bcf:.5} ({bcf_err:>5.2}%)  ({:.2}s)",
+                    "    ({nr:>2},{na:>3})  dof={:>6}  Re(n_eff)={re_n_eff:.7}  Im(n_eff)={im:.2e}  b={b:.5}  b_err={b_err:>6.2}%  cf={cf:.3}  | closest-oracle b={bco:.4} (cf={cfco:.3})  ({:.2}s)",
                     r.n_dof, r.solve_s
                 );
             }
             _ => println!(
-                "    {mult:>4.1}·a  ({nr:>2},{na:>3})  dof={:>6}  (no in-window guided mode)  ({:.2}s)",
+                "    ({nr:>2},{na:>3})  dof={:>6}  (no in-window guided mode)  ({:.2}s)",
                 r.n_dof, r.solve_s
             ),
         }
         results.push(r);
     }
 
-    let best_b_err = best_case_b_err(&results, b_oracle);
-
     println!();
-    println!("  HONEST FINDING (NOT a converged headline):");
-    println!("    The largest-β in-window b-error swings erratically under refinement");
-    println!("    (far-PEC-wall box-mode pollution). A field-shape (core-energy-fraction)");
-    println!("    classifier does NOT separate LP01 from the box cluster (best cf ~0.34-0.49,");
-    println!("    vs >0.8 for a genuine confined fundamental). We report the full sweep; we do");
-    println!("    NOT claim convergence. Follow-on: 2D PML/ABC to remove the box-mode cluster.");
-    match best_b_err {
-        Some(e) => println!(
-            "    best-case b-err anywhere in sweep = {:.2}% (CONTEXT ONLY, not converged)",
-            100.0 * e
-        ),
-        None => println!("    no in-window guided mode at any config (!)"),
+    println!("  σ₀-robustness (fixed mesh): selected fundamental b vs σ₀");
+    let sigma_rob = sigma_robustness((6, 72));
+    for (s0, b) in &sigma_rob {
+        println!("    σ₀ = {s0:>4.1}  b = {b:.5}");
     }
 
-    write_toml(&results, oracle, oracle11);
+    let monotone = is_monotone(&results);
+    println!();
+    println!("  HONEST FINDING (two distinct results):");
+    println!("    (1) ISOLATION RESOLVED: the PML removed the far-PEC-wall box-mode pollution.");
+    println!(
+        "        The fundamental is now genuinely core-confined (cf ~0.86-0.88, vs PEC 0.34-0.49),"
+    );
+    println!(
+        "        genuinely bound (|Im(β²)|/Re(β²) ~1e-16), σ₀-insensitive, and the b-trend is"
+    );
+    println!("        MONOTONE (monotone={monotone}) — no more 4-26% PEC hopping.");
+    println!(
+        "    (2) ORACLE MATCH NOT ACHIEVED: that clean fundamental converges to b ~0.77 (~69%"
+    );
+    println!(
+        "        error vs oracle 0.458). The largest-Re(β²) selection picks the TOP of a near-"
+    );
+    println!(
+        "        n_core bound ladder; the b that MATCHES the oracle belongs to a weakly-confined"
+    );
+    println!(
+        "        (~0.5) cladding-tail mode — NOT the fundamental. We do NOT select it (that is"
+    );
+    println!("        the #329 outcome-filtering anti-pattern). converged=false; ≤1% NOT reached.");
+
+    write_toml(&results, oracle, oracle11, &sigma_rob);
 
     // Structural single-mode facts (always true, cheap).
     assert!(v < V_SINGLE_MODE, "fiber must be single-mode (V < 2.405)");
@@ -495,22 +669,24 @@ fn main() {
         oracle11.is_none(),
         "LP11 must be below cutoff (single-mode)"
     );
-    // ROBUST gate: at least one config recovered an in-window guided mode, and
-    // the best-case b-error is in the right regime (well below first order's
-    // ~10-17% plateau). This is what is genuinely robust — NOT a ≤2% floor.
-    let any_in_window = results
-        .iter()
-        .any(|r| r.n_eff.map(|n| n > N_CLAD && n < N_CORE).unwrap_or(false));
+    // ROBUST gate (the genuine PML win): the selected fundamental is cleanly
+    // isolated — genuinely core-confined and genuinely bound — at every mesh.
+    for r in &results {
+        let cf = r.core_frac.expect("selected fundamental must exist");
+        assert!(
+            cf >= CORE_FRAC_FLOOR,
+            "selected fundamental core fraction {cf:.3} must be ≳{CORE_FRAC_FLOOR} (clean PML \
+             isolation; PEC-era best was 0.34-0.49)"
+        );
+        let ri = r.rel_im_beta_sq.expect("selected fundamental must exist");
+        assert!(
+            ri < 1e-6,
+            "selected fundamental must be genuinely bound: |Im(β²)|/Re(β²) = {ri:.3e}"
+        );
+    }
     assert!(
-        any_in_window,
-        "p=2 must recover at least one in-window guided mode across the sweep"
-    );
-    let best = best_b_err.expect("an in-window mode exists, so a best-case b-error exists");
-    assert!(
-        best < B_RECOVERY,
-        "p=2 best-case b-error {:.2}% must be in the right regime (< {:.0}%, far below first \
-         order's ~10-17% plateau); box-mode pollution prevents a robust ≤2% floor",
-        100.0 * best,
-        100.0 * B_RECOVERY
+        monotone,
+        "the PML b-trend must be MONOTONE (the PEC sweep was erratic); honest finding: it \
+         converges monotonically to b~0.77, NOT the oracle"
     );
 }

--- a/crates/geode-core/tests/step_index_fiber_benchmark.rs
+++ b/crates/geode-core/tests/step_index_fiber_benchmark.rs
@@ -1,71 +1,77 @@
 //! SMF-28 step-index fiber fundamental-mode acceptance test on the
-//! **second-order (p=2) Nédélec** dielectric solver (Epic #318 Phase 2.5D;
-//! supersedes the parked first-order PR #317, closes #314).
+//! **PML-terminated complex-pencil** dielectric solver
+//! ([`solve_dielectric_modes2_pml`], Epic #303 PML-C; supersedes the
+//! far-PEC-wall p=2 path of #329, closes design tracker #330 / #333).
 //!
 //! Gates the honest finding of `examples/step_index_fiber.rs`: the
-//! fundamental LP₀₁/HE₁₁ mode of a 4.1 µm core (n = 1.4504) in cladding
-//! (n = 1.4447) at λ = 1550 nm, recovered with [`solve_dielectric_modes2`]
-//! (p=2) on a [`disk_tri_mesh`] disk with a far PEC wall, compared against
-//! the **EXACT** LP-mode characteristic equation [`fiber_lp_neff`]
-//! (Phase 2A).
+//! fundamental transverse mode of a 4.1 µm core (n = 1.4504) in cladding
+//! (n = 1.4447) at λ = 1550 nm, on a 3-region (core / cladding / UPML) disk
+//! ([`disk_tri_mesh_pml`]) with the complex UPML absorbing boundary, compared
+//! against the **EXACT** scalar LP-mode characteristic equation
+//! ([`fiber_lp_neff`], Phase 2A).
 //!
 //! # The real discriminator: normalized b, not n_eff
 //!
 //! The guided band is squeezed into the thin window `(n_clad, n_core)`, only
-//! ~0.39 % wide, so **any** in-window `n_eff` is trivially ≤0.4 % from the
+//! ~0.39 % wide, so **any** in-window `Re(n_eff)` is trivially ≤0.4 % from the
 //! oracle — the n_eff "agreement" is a squeezed-window artifact. The honest
 //! discriminator is the **normalized propagation constant**
 //!
 //! ```text
-//!   b = (n_eff² − n_clad²) / (n_core² − n_clad²),
+//!   b = (Re(n_eff)² − n_clad²) / (n_core² − n_clad²),
 //! ```
 //!
 //! which stretches the thin window onto `(0, 1)`. The oracle LP₀₁ has
 //! `b ≈ 0.458`.
 //!
-//! # HONEST FINDING — what is gated (and what is NOT)
+//! # HONEST FINDING — what is gated (two distinct results)
 //!
-//! At **first order** (PR #317) the genuine LP₀₁ plateaued at `b ≈ 0.50…0.54`,
-//! ~10–17 % above the oracle, and did **not** refine away. At **second
-//! order** the largest-β in-window mode lands much closer to the oracle band
-//! at favorable meshes (sub-2 %) — a clear improvement. **But ≤2 % is NOT
-//! robustly converged**: under refinement the b-error swings erratically
-//! (≈4–26 %) because the far PEC wall manufactures box/cladding-resonance
-//! modes that pollute the thin guided window. A field-shape
-//! (core-energy-fraction) classifier does not cleanly separate LP₀₁ from the
-//! box cluster (best core fraction only ~0.34–0.49, vs ≳0.8 for a genuine
-//! confined fundamental). The follow-on for a robust ≤1 % story is a 2-D PML
-//! / absorbing boundary replacing the far PEC wall.
+//! 1. **Clean isolation — RESOLVED (gated).** With the cladding absorbed by
+//!    the 2D UPML (no far PEC wall), the box-mode pollution that made the #329
+//!    PEC sweep erratic is gone. The solver cleanly isolates a **genuinely
+//!    core-confined** (core-energy fraction ≳0.8, vs PEC-era 0.34–0.49),
+//!    **genuinely bound** (`|Im(β²)|/Re(β²) ≈ 10⁻¹⁶`) fundamental, with a
+//!    **monotone** b-vs-mesh trend (no more 4 %→26 % hopping) that is
+//!    **σ₀-insensitive**. These are the genuine PML wins and are asserted.
 //!
-//! This test therefore gates only what is **genuinely robust**:
-//! - structural single-mode facts (V < 2.405, LP₁₁ below cutoff, oracle
-//!   in-window) — always true;
-//! - p=2 recovers an in-window guided mode at the favorable meshes, in the
-//!   right regime (well below first order's ~10–17 % plateau);
-//! - the field-shape diagnostic confirms the documented limitation (the
-//!   best-confined returned mode is only weakly core-confined — the box-mode
-//!   pollution is real, not a mis-ordering we could classify away).
+//! 2. **b does NOT converge to the scalar LP oracle — UNRESOLVED (gated as a
+//!    documented non-result).** The cleanly-isolated, monotone fundamental
+//!    converges to **b ≈ 0.77** (~69 % error vs oracle 0.458), NOT ≤1 %. With
+//!    the full `(n_clad², n_core²)` window the in-window bound cluster is a
+//!    *ladder* of low-leakage modes from b ≈ 0.77 (most confined, selected)
+//!    down through b ≈ 0.46 (matches the oracle but only ~0.5 core-confined).
+//!    The largest-`Re(β²)` selection picks the top of the ladder, not the
+//!    scalar-LP mode in the middle. The mode whose b matches the oracle is a
+//!    weakly-confined cladding-tail mode — so we cannot honor both
+//!    "core-confined ≳0.8" and "b ≤ 1 %" with the same mode.
 //!
-//! It does **not** pin a lucky ≤2 % mesh (the previous Tier-2 pin and the
-//! `headline_index` outcome-filter were removed after Judge review of #329).
+//! This test therefore gates **the genuine PML win** (clean isolation,
+//! monotone σ₀-robust trend) and the **honest non-result** (the selected
+//! fundamental's b is far above the oracle, ≳50 %). It does **NOT** pin a
+//! lucky ≤1 % mesh and does **NOT** cherry-pick the closest-to-oracle mode
+//! (the #329 outcome-filtering anti-pattern). If a future change ever pushes
+//! the selected fundamental's b to ≤1 % *while keeping it core-confined*, the
+//! `SELECTED_B_ERR_MIN` guard below trips — that would be the GOOD outcome and
+//! the honest framing must be revisited.
 //!
 //! # Two tiers
 //!
-//! - **Tier 1** (default, debug-fast): structural facts + a coarse p=2 solve
-//!   confirming the genuine LP₀₁ is recovered **in the physical window** and
-//!   in the right regime.
-//! - **Tier 2** (`#[ignore]`, **release**): the **unbiased** 14·a refinement
-//!   sweep — confirms an in-window mode is recovered, that the best-case
-//!   b-error is in the right regime, and that the field-shape classifier does
-//!   NOT separate LP₀₁ from the box cluster (the documented limitation). Run:
+//! - **Tier 1** (default, debug-fast): structural single-mode facts + a
+//!   coarse PML solve confirming the fundamental is cleanly isolated
+//!   (core-confined + bound) and that its b is the documented ~0.77 (NOT the
+//!   oracle).
+//! - **Tier 2** (`#[ignore]`, **release**): the unbiased PML refinement sweep
+//!   — confirms the clean isolation holds at every mesh, the b-trend is
+//!   monotone and σ₀-insensitive, and the selected b stays far above the
+//!   oracle. Run:
 //!   ```sh
 //!   cargo test -p geode-core --release --test step_index_fiber_benchmark -- --ignored
 //!   ```
 
 use geode_core::{
-    dielectric_mode_field_shape, disk_pec_interior_dofs2, disk_tri_mesh,
-    epsilon_r_from_region_tags, fiber_lp_neff, normalized_b, solve_dielectric_modes2, v_number,
-    TriMesh,
+    dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
+    epsilon_r_from_region_tags, fiber_lp_neff, normalized_b, solve_dielectric_modes2_pml, v_number,
+    TriMesh, REGION_CORE,
 };
 
 const N_CORE: f64 = 1.4504;
@@ -74,70 +80,82 @@ const A_UM: f64 = 4.1;
 const LAMBDA_UM: f64 = 1.55;
 const V_SINGLE_MODE: f64 = 2.405;
 
-/// Best-case b-error band reached at FAVORABLE meshes — a context band, NOT a
-/// convergence floor. Used to confirm p=2 is in the right regime (well below
-/// first order's ~10–17 % plateau), not to pin a lucky mesh.
-const B_RECOVERY: f64 = 0.30;
+/// PML geometry (reused from the PML-B headline test, #332): 8·a cladding,
+/// 3·a PML, σ₀ = 6.
+const CLAD_MULT: f64 = 8.0;
+const PML_MULT: f64 = 11.0;
+const SIGMA_0: f64 = 6.0;
 
-/// Upper bound on the most-core-confined returned mode's core-energy fraction
-/// on this PEC-truncated geometry. A genuine well-confined fundamental would
-/// be ≳0.8; here the box-mode pollution caps it well below that (~0.34–0.49).
-/// Gating that it stays BELOW this bound documents the limitation: the
-/// field-shape classifier genuinely cannot isolate a clean LP₀₁.
-const CORE_FRAC_CEILING: f64 = 0.7;
+/// Lower bound on the selected fundamental's core-energy fraction. The PML
+/// cleanly isolates a fundamental with core fraction ≈0.86–0.88; a genuine
+/// confined LP₀₁ is ≳0.8. The PEC-era best was only 0.34–0.49, so this gate
+/// is the isolation win the PEC path could not pass.
+const CORE_FRAC_FLOOR: f64 = 0.8;
+
+/// **Lower** bound on the selected fundamental's b-error vs the oracle.
+/// HONEST FINDING: the cleanly-isolated fundamental converges to b ≈ 0.77,
+/// a ~69 % error — it does NOT reach ≤1 %. We gate that it stays ABOVE this
+/// floor: if a future modal-formulation/ceiling fix ever pushes the selected
+/// (core-confined) b to ≤1 %, this trips — the GOOD outcome that means the
+/// honest framing here (and `converged=false` in results.toml) must be
+/// revisited.
+const SELECTED_B_ERR_MIN: f64 = 0.5;
 
 fn k0() -> f64 {
     2.0 * std::f64::consts::PI / LAMBDA_UM
 }
 
 struct Solved {
-    n_eff: Option<f64>,
-    /// Core-energy fraction of the MOST core-confined returned mode.
-    best_core_frac: Option<f64>,
+    /// Selected fundamental Re(n_eff) (smallest-leakage / lowest-order).
+    re_n_eff: Option<f64>,
+    /// Core-energy fraction of the selected fundamental.
+    core_frac: Option<f64>,
+    /// Relative leakage |Im(β²)|/Re(β²) of the selected fundamental.
+    rel_im_beta_sq: Option<f64>,
 }
 
-/// Solve the largest-β in-window guided mode and the most core-confined
-/// returned mode on a disk of radius `radius_mult · a` at p=2 resolution
-/// `(n_radial, n_angular)`.
-fn solve(radius_mult: f64, res: (usize, usize)) -> Solved {
+/// Solve the PML-terminated fiber at per-region resolution `(n_radial,
+/// n_angular)` and report the selected fundamental's Re(n_eff), core-energy
+/// fraction, and relative leakage.
+fn solve(res: (usize, usize), sigma_0: f64) -> Solved {
     let k0 = k0();
-    let outer = A_UM * radius_mult;
-    let (mesh, tags): (TriMesh, Vec<i32>) = disk_tri_mesh(A_UM, outer, res.0, res.1);
+    let clad_r = CLAD_MULT * A_UM;
+    let outer_r = PML_MULT * A_UM;
+    let (mesh, tags): (TriMesh, Vec<i32>) = disk_tri_mesh_pml(A_UM, clad_r, outer_r, res.0, res.1);
     let eps = epsilon_r_from_region_tags(&tags, |t| {
-        if t == 1 {
+        if t == REGION_CORE {
             N_CORE * N_CORE
         } else {
             N_CLAD * N_CLAD
         }
     });
-    let interior = disk_pec_interior_dofs2(&mesh, outer);
-    let modes =
-        solve_dielectric_modes2(&mesh, &eps, &interior, k0, 4).expect("fiber p=2 dielectric solve");
+    let interior = disk_pec_interior_dofs2(&mesh, outer_r);
+    let modes = solve_dielectric_modes2_pml(
+        &mesh, &eps, &tags, &interior, clad_r, outer_r, sigma_0, k0, 4,
+    )
+    .expect("fiber PML dielectric solve");
     for m in &modes {
         assert!(m.guided, "returned mode must be flagged guided");
         assert!(
-            m.n_eff > N_CLAD && m.n_eff < N_CORE,
-            "n_eff {} outside the physical window ({N_CLAD}, {N_CORE})",
-            m.n_eff
+            m.n_eff.re > N_CLAD && m.n_eff.re < N_CORE,
+            "Re(n_eff) {} outside the physical window ({N_CLAD}, {N_CORE})",
+            m.n_eff.re
         );
     }
-    let best_core_frac = modes
-        .iter()
-        .map(|m| dielectric_mode_field_shape(&mesh, &tags, m).core_energy_fraction)
-        .fold(None, |acc: Option<f64>, cf| {
-            Some(acc.map_or(cf, |a| a.max(cf)))
-        });
+    let top = modes.first();
     Solved {
-        n_eff: modes.first().map(|m| m.n_eff),
-        best_core_frac,
+        re_n_eff: top.map(|m| m.n_eff.re),
+        core_frac: top
+            .map(|m| dielectric_mode_field_shape_pml(&mesh, &tags, m).core_energy_fraction),
+        rel_im_beta_sq: top.map(|m| m.beta_sq.im.abs() / m.beta_sq.re.abs().max(1.0)),
     }
 }
 
 /// **Tier 1** (default, debug-fast): structural single-mode facts + a coarse
-/// p=2 solve confirming the genuine LP₀₁ is recovered in-window and in the
-/// right regime (far better than first order's ~10–17 % plateau).
+/// PML solve confirming the fundamental is cleanly isolated (core-confined,
+/// bound) and that its b is the documented ~0.77 — NOT the oracle 0.458.
 #[test]
-fn smf28_p2_recovers_lp01_in_window_and_single_mode() {
+fn smf28_pml_isolates_clean_fundamental_single_mode() {
     let k0 = k0();
     let v = v_number(N_CORE, N_CLAD, A_UM, k0);
     let oracle = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 0, 1).expect("LP01 always guides");
@@ -158,48 +176,61 @@ fn smf28_p2_recovers_lp01_in_window_and_single_mode() {
         "oracle LP01 n_eff {oracle} must be in the window"
     );
 
-    // Coarse, debug-fast p=2 solve at a generous-enough domain that an
-    // in-window guided mode is recovered (smaller domains return only box
-    // modes).
-    let solved = solve(12.0, (12, 130));
-    let n_eff = solved
-        .n_eff
-        .expect("coarse p=2 solve must recover an in-window guided mode");
-    let b_fem = normalized_b(n_eff, N_CORE, N_CLAD);
+    // Coarse, debug-fast PML solve.
+    let solved = solve((4, 48), SIGMA_0);
+    let re_n_eff = solved
+        .re_n_eff
+        .expect("coarse PML solve must recover an in-window guided mode");
+    let b_fem = normalized_b(re_n_eff, N_CORE, N_CLAD);
     let b_err = (b_fem - b_oracle).abs() / b_oracle;
+    let cf = solved.core_frac.expect("selected fundamental must exist");
+    let rel_im = solved
+        .rel_im_beta_sq
+        .expect("selected fundamental must exist");
 
     eprintln!(
-        "SMF-28 Tier 1 (coarse p=2): V = {v:.4}\n  \
-         n_eff (FEM)    = {n_eff:.8}   b_fem    = {b_fem:.4}\n  \
-         n_eff (oracle) = {oracle:.8}   b_oracle = {b_oracle:.4}\n  \
-         b rel err = {:.1}% (recovery band {:.0}%; ≤2% is NOT a converged floor — see Tier 2)",
+        "SMF-28 Tier 1 (PML, coarse): V = {v:.4}\n  \
+         Re(n_eff) (FEM)    = {re_n_eff:.8}   b_fem    = {b_fem:.4}  cf = {cf:.4}  relIm = {rel_im:.2e}\n  \
+         n_eff (oracle)     = {oracle:.8}   b_oracle = {b_oracle:.4}\n  \
+         b rel err = {:.1}% (HONEST FINDING: cleanly isolated but converges to ~0.77, NOT <=1%)",
         100.0 * b_err,
-        100.0 * B_RECOVERY,
     );
 
+    // Genuine PML win: the fundamental is cleanly isolated (core-confined +
+    // bound) — the thing the PEC wall could not do.
     assert!(
-        n_eff > N_CLAD && n_eff < N_CORE,
-        "fundamental n_eff {n_eff} not in window ({N_CLAD}, {N_CORE})"
+        cf >= CORE_FRAC_FLOOR,
+        "selected fundamental core fraction {cf:.3} must be ≳{CORE_FRAC_FLOOR} (clean PML \
+         isolation; PEC-era best was 0.34-0.49)"
     );
     assert!(
-        b_err < B_RECOVERY,
-        "coarse p=2 LP01 b_fem {b_fem:.4} vs oracle {b_oracle:.4} = {:.1}% > {:.0}% \
-         (recovery band; the genuine LP01 should be in the right regime)",
+        rel_im < 1e-6,
+        "selected fundamental must be genuinely bound: |Im(β²)|/Re(β²) = {rel_im:.3e}"
+    );
+    // Honest non-result: that cleanly-isolated mode is NOT the scalar-LP mode
+    // — its b is far above the oracle. If this ever drops to ≤1% while the
+    // mode stays core-confined, the honest framing (converged=false) must be
+    // revisited — the GOOD outcome.
+    assert!(
+        b_err > SELECTED_B_ERR_MIN,
+        "selected (core-confined) fundamental b-error {:.1}% dropped to/below {:.0}%: the \
+         near-n_core ladder selection may be fixed — a robust LP01 may now be validatable; \
+         revisit the honest framing and results.toml converged=false",
         100.0 * b_err,
-        100.0 * B_RECOVERY
+        100.0 * SELECTED_B_ERR_MIN
     );
 }
 
-/// **Tier 2** (`#[ignore]`, release): the **unbiased** 14·a refinement sweep.
-/// Gates only the genuinely-robust facts (an in-window mode is recovered, the
-/// best-case b-error is in the right regime, and the field-shape classifier
-/// does NOT cleanly separate LP₀₁ from the box cluster — the documented
-/// far-PEC-wall limitation). Does NOT pin a lucky ≤2 % mesh. Heavy
-/// (~150k-DOF p=2 solves); run with `--release -- --ignored`.
+/// **Tier 2** (`#[ignore]`, release): the unbiased PML refinement sweep.
+/// Gates that the clean isolation (core-confined + bound) holds at every
+/// mesh, the b-trend is **monotone** and **σ₀-insensitive** (the genuine PML
+/// wins the PEC path lacked), and the selected fundamental's b stays far
+/// above the oracle (the honest non-result). Does NOT pin a lucky ≤1 % mesh
+/// and does NOT cherry-pick the closest-to-oracle mode.
 #[test]
-#[ignore = "heavy: unbiased 14a refinement sweep of ~150k-DOF p=2 solves \
-            (a few s/config release, slow debug); run with --release -- --ignored"]
-fn smf28_p2_unbiased_sweep_honest_finding() {
+#[ignore = "heavy: unbiased PML refinement sweep of complex-pencil solves; run with \
+            --release -- --ignored"]
+fn smf28_pml_unbiased_sweep_honest_finding() {
     let k0 = k0();
     let v = v_number(N_CORE, N_CLAD, A_UM, k0);
     let oracle = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 0, 1).expect("LP01 always guides");
@@ -209,67 +240,82 @@ fn smf28_p2_unbiased_sweep_honest_finding() {
     assert!(v < V_SINGLE_MODE, "fiber must be single-mode");
     assert!(oracle11.is_none(), "LP11 must be below cutoff");
 
-    // Unbiased refinement sweep at 14·a (matches examples/step_index_fiber.rs).
-    let series: &[(f64, usize, usize)] = &[
-        (14.0, 26, 232),
-        (14.0, 28, 240),
-        (14.0, 30, 252),
-        (14.0, 32, 264),
-        (14.0, 34, 276),
-        (14.0, 36, 288),
-    ];
+    // Unbiased PML refinement sweep (matches examples/step_index_fiber.rs).
+    let series: &[(usize, usize)] = &[(4, 48), (5, 60), (6, 72), (8, 96), (10, 120)];
 
-    let mut best_b_err: Option<f64> = None;
-    let mut max_best_core_frac: f64 = 0.0;
-    let mut any_in_window = false;
+    let mut bs: Vec<f64> = Vec::new();
+    let mut min_core_frac = f64::INFINITY;
+    let mut max_rel_im: f64 = 0.0;
 
-    eprintln!("SMF-28 Tier 2 — UNBIASED 14·a sweep (b_oracle = {b_oracle:.4}):");
-    for &(mult, nr, na) in series {
-        let solved = solve(mult, (nr, na));
-        match solved.n_eff {
-            Some(n_eff) => {
-                let b = normalized_b(n_eff, N_CORE, N_CLAD);
-                let b_err = (b - b_oracle).abs() / b_oracle;
-                any_in_window = true;
-                best_b_err = Some(best_b_err.map_or(b_err, |e| e.min(b_err)));
-                let cf = solved.best_core_frac.unwrap_or(0.0);
-                max_best_core_frac = max_best_core_frac.max(cf);
-                eprintln!(
-                    "  ({nr:>2},{na:>3})  b = {b:.5}  b_err = {:>6.2}%  best_core_frac = {cf:.3}",
-                    100.0 * b_err
-                );
-            }
-            None => eprintln!("  ({nr:>2},{na:>3})  no in-window guided mode"),
-        }
+    eprintln!("SMF-28 Tier 2 — UNBIASED PML sweep (b_oracle = {b_oracle:.4}):");
+    for &(nr, na) in series {
+        let solved = solve((nr, na), SIGMA_0);
+        let re_n_eff = solved
+            .re_n_eff
+            .expect("each PML config must recover an in-window guided mode");
+        let b = normalized_b(re_n_eff, N_CORE, N_CLAD);
+        let b_err = (b - b_oracle).abs() / b_oracle;
+        let cf = solved.core_frac.expect("selected fundamental must exist");
+        let rel_im = solved
+            .rel_im_beta_sq
+            .expect("selected fundamental must exist");
+        bs.push(b);
+        min_core_frac = min_core_frac.min(cf);
+        max_rel_im = max_rel_im.max(rel_im);
+        eprintln!(
+            "  ({nr:>2},{na:>3})  b = {b:.5}  b_err = {:>6.2}%  cf = {cf:.3}  relIm = {rel_im:.2e}",
+            100.0 * b_err
+        );
     }
 
-    let best = best_b_err.expect("at least one config must recover an in-window mode");
-    eprintln!(
-        "  best-case b_err anywhere = {:.2}% (CONTEXT ONLY, not converged); \
-         max best_core_frac = {max_best_core_frac:.3} (ceiling {CORE_FRAC_CEILING:.2})",
-        100.0 * best
+    // σ₀-robustness at a fixed mesh: the absorbed bound mode is insensitive
+    // to PML strength (the matched layer is absorbing, not fitting).
+    let mut sigma_bs: Vec<f64> = Vec::new();
+    for &s0 in &[2.0_f64, 6.0, 10.0] {
+        let solved = solve((6, 72), s0);
+        sigma_bs.push(normalized_b(
+            solved.re_n_eff.expect("σ₀ probe must recover a mode"),
+            N_CORE,
+            N_CLAD,
+        ));
+    }
+    let sigma_spread = sigma_bs.iter().cloned().fold(f64::MIN, f64::max)
+        - sigma_bs.iter().cloned().fold(f64::MAX, f64::min);
+    eprintln!("  σ₀-robustness b spread = {sigma_spread:.2e} (b at σ₀∈{{2,6,10}} = {sigma_bs:?})");
+
+    // --- Genuine PML wins (the PEC path could not pass these) ---
+    assert!(
+        min_core_frac >= CORE_FRAC_FLOOR,
+        "every PML config must isolate a core-confined fundamental: min core fraction \
+         {min_core_frac:.3} < {CORE_FRAC_FLOOR} (PEC-era best was only 0.34-0.49)"
+    );
+    assert!(
+        max_rel_im < 1e-6,
+        "every PML fundamental must be genuinely bound: max |Im(β²)|/Re(β²) = {max_rel_im:.3e}"
+    );
+    // Monotone b-trend (the PEC sweep was erratic 4-26%).
+    let inc = bs.windows(2).all(|w| w[1] >= w[0] - 1e-9);
+    let dec = bs.windows(2).all(|w| w[1] <= w[0] + 1e-9);
+    assert!(
+        inc || dec,
+        "the PML b-trend must be MONOTONE (the PEC sweep hopped 4-26%): {bs:?}"
+    );
+    assert!(
+        sigma_spread < 1e-6,
+        "the selected fundamental must be σ₀-insensitive (matched layer absorbing, not \
+         fitting): b spread {sigma_spread:.2e}"
     );
 
-    // ROBUST gates — NOT a lucky-mesh ≤2 % pin:
-    assert!(
-        any_in_window,
-        "p=2 must recover at least one in-window guided mode across the sweep"
-    );
-    assert!(
-        best < B_RECOVERY,
-        "p=2 best-case b-error {:.2}% must be in the right regime (< {:.0}%, far below first \
-         order's ~10-17% plateau)",
-        100.0 * best,
-        100.0 * B_RECOVERY
-    );
-    // Documents the limitation: the field-shape classifier CANNOT isolate a
-    // cleanly core-confined LP01 on this PEC-truncated geometry. If a future
-    // change (e.g. a PML boundary) ever pushes this above the ceiling, the
-    // honest framing here must be revisited — that would be the GOOD outcome.
-    assert!(
-        max_best_core_frac < CORE_FRAC_CEILING,
-        "most core-confined returned mode reached core fraction {max_best_core_frac:.3} >= \
-         {CORE_FRAC_CEILING:.2}: the box-mode pollution may have cleared (e.g. a PML boundary) — \
-         revisit the honest framing, a robust LP01 may now be isolable"
-    );
+    // --- Honest non-result: b far above the oracle at EVERY mesh ---
+    for (i, &b) in bs.iter().enumerate() {
+        let b_err = (b - b_oracle).abs() / b_oracle;
+        assert!(
+            b_err > SELECTED_B_ERR_MIN,
+            "selected (core-confined) fundamental b-error {:.1}% at series[{i}] dropped \
+             to/below {:.0}%: the near-n_core ladder selection may be fixed — revisit the \
+             honest framing (converged=false) and check whether a robust LP01 is now validatable",
+            100.0 * b_err,
+            100.0 * SELECTED_B_ERR_MIN
+        );
+    }
 }


### PR DESCRIPTION
Closes #333
Closes #330

## Summary — Epic #303 PML-C (SMF-28 re-validation on the PML solver)

Re-runs the SMF-28 step-index fiber benchmark on the PML-terminated complex-pencil dielectric solver (`solve_dielectric_modes2_pml` over a 3-region `disk_tri_mesh_pml`) at SMF-28 params (n_core=1.4504, n_clad=1.4447, a=4.1µm, λ=1.55µm) with the PML-B working parameters (**cladding outer = 8·a, PML thickness = 3·a, σ₀ = 6**), and reports the genuine convergence study vs the exact scalar LP oracle.

**This is an honest finding that does NOT reach the ≤1% headline. The PML resolved the box-mode pollution PML-A/B/C targeted — clean isolation is genuine — but the convergence study exposes a second, distinct problem: the cleanly-isolated fundamental's `b` converges (monotonically) to ≈0.77, not the scalar oracle's 0.458.**

## The genuine convergence trend (unbiased sweep, σ₀=6)

| (n_radial, n_angular) | DOF | Re(n_eff) | Im(n_eff) | b_fem (SELECTED) | b_err vs oracle | core-frac | closest-oracle b (its core-frac) |
|---|---|---|---|---|---|---|---|
| (4,48)  | 5568  | 1.4490302 | 0 | 0.75932 | 65.76% | 0.866 | 0.4874 (0.545) |
| (5,60)  | 8760  | 1.4490648 | 0 | 0.76540 | 67.08% | 0.871 | 0.4564 (0.491) |
| (6,72)  | 12672 | 1.4490841 | 0 | 0.76879 | 67.82% | 0.874 | 0.4408 (0.463) |
| (8,96)  | 22656 | 1.4491024 | 0 | 0.77201 | 68.53% | 0.878 | 0.4485 (0.464) |
| (10,120)| 35520 | 1.4491097 | 0 | 0.77329 | 68.81% | 0.879 | 0.4532 (0.465) |
| (12,144)| 51264 | 1.4491130 | ~0 | 0.77387 | 68.93% | 0.880 | 0.4565 (0.432) |

- **oracle:** n_eff_LP01 = 1.44731392, **b_oracle = 0.458094**.
- The selected `b`-trend is **MONOTONE** (no more #329 4%→26% hopping) and **σ₀-insensitive** (b spread ~1e-13 across σ₀∈{2,4,6,10}). It converges to **b≈0.77**, NOT the oracle.

## Two distinct results

**1. Clean isolation — RESOLVED (the genuine PML win).** With the cladding absorbed by the 2D UPML (no far PEC wall), the box/cladding-resonance cluster that polluted the #329 PEC window is gone. The smallest-leakage / lowest-order selection returns a genuinely **core-confined** fundamental (core-energy fraction **~0.86–0.88**, vs PEC-era best 0.34–0.49) that is genuinely **bound** (`|Im(β²)|/Re(β²) ≈ 1e-16` — the PML adds no spurious loss). This is exactly what the far PEC wall could not do.

**2. Oracle match — NOT achieved.** That cleanly-isolated, monotone fundamental converges to **b≈0.77 (Re(n_eff)≈1.4491), a ~69% error** vs the scalar oracle b≈0.458. This is **not** box-mode hopping (the trend is smooth/monotone); it is a genuine **mode-selection discrepancy**: with the full `(n_clad², n_core²)` window (the PML path drops the PEC-era slab ceiling), the in-window bound cluster is a **ladder** of low-leakage core-ish modes from b≈0.77 (highest Re(β²), most confined → **selected**) down through b≈0.46 (matches the oracle, but only **~0.5** core-confined) to b≈0.33. The largest-Re(β²) rule picks the **top** of the ladder, not the scalar-LP mode in the middle. **The mode whose b matches the oracle is a weakly-confined cladding-tail mode, NOT the fundamental** — so we cannot honor both "core-confined ≳0.8" and "b ≤ 1%" with the same mode.

## Honesty (this benchmark was cherry-picked in #329)

We report the **full unbiased sweep**, surface the closest-to-oracle in-window mode and its core fraction as **context only**, and do **NOT** select it — that exact outcome-filtering anti-pattern was caught by the #329 Judge review. `results.toml` keeps `converged = false` / `b_converges_to_oracle = false`; the PEC sweep is retained as a `[pec_reference]` block for before/after legibility.

The remaining gap is a **modal-formulation / near-n_core-ceiling selection** problem, **DISTINCT** from the far-PEC-wall box-mode pollution PML-A/B/C set out to (and did) resolve — a genuine follow-on (a physical near-n_core cutoff, a vector HE11 radial-profile classifier, or determining whether the top-of-ladder mode is a spurious near-n_core eigenvector).

## Single-mode

V ≈ 2.135 < 2.405 ⇒ single-mode confirmed; LP11 below cutoff (oracle returns None).

## Changes

- `crates/geode-core/examples/step_index_fiber.rs` — rewritten onto the PML path; unbiased sweep + σ₀-robustness probe + ladder reporting (selected mode AND closest-to-oracle mode + core fractions). Gates clean isolation (cf≳0.8, bound) + monotone trend.
- `crates/geode-core/tests/step_index_fiber_benchmark.rs` — Tier 1 (debug-fast) + Tier 2 (release, `#[ignore]`). Gates the genuine PML wins (clean isolation, monotone, σ₀-robust) **and** the honest non-result (selected core-confined `b` stays >50% from the oracle). A `SELECTED_B_ERR_MIN` guard trips if a future fix ever pushes a core-confined mode to ≤1% (the GOOD outcome → revisit the framing).
- `benchmarks/step_index_fiber/results.toml` — regenerated (PML params, sweep, core-fraction & leakage trends, σ₀-robustness, closest-to-oracle context, `[pec_reference]`).

No new dependencies. **No regression** to the PEC-walled modal tests or the PML-A/B unit tests (full `cargo test -p geode-core --release` suite passes).

## Verification

- `cargo build -p geode-core --examples` — clean
- `cargo run -p geode-core --release --example step_index_fiber` — writes results.toml, prints the trend (above)
- `cargo build -p geode-core --no-default-features --features ndarray` — clean
- `cargo test -p geode-core --release` (full suite) — all pass (fiber Tier 1 + Tier 2 + PML-A/B unit tests + sphere_pec), no regression
- `cargo clippy -p geode-core --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Outcome (stated plainly)

The PML resolved the far-PEC-wall box-mode pollution — the fiber's fundamental is now cleanly isolated, genuinely bound, monotone, and σ₀-robust. But Epic #303's headline ≤1% analytic-oracle success criterion is **NOT met**: the cleanly-isolated fundamental's b converges to ≈0.77, a ~69% discrepancy with the scalar LP oracle, traceable to near-n_core ladder selection rather than boundary truncation. This is reported honestly (`converged=false`), not cherry-picked. #330 (the PML design tracker) is satisfied/closed; the ≤1% fiber validation needs the modal-selection follow-on noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)