### PR TITLE
refactor(solver): add iterate_while / iterate_while_with_prev combinators and port self-consistent k₀ Newton

### DIFF
--- a/crates/geode-core/src/iterate.rs
+++ b/crates/geode-core/src/iterate.rs
@@ -1,0 +1,347 @@
+//! Generic convergence-loop combinators (issue #301).
+//!
+//! GEODE-FEM has several hand-rolled convergence loops — the
+//! self-consistent `k₀` Newton iteration
+//! ([`crate::silvermuller_self_consistent`]), the Lanczos restart loops
+//! ([`crate::lanczos`] / [`crate::complex_lanczos`]), and the
+//! bracketing/bisection root finder ([`crate::mie`]). This module
+//! provides two small combinators that capture the *shape* shared by the
+//! state-carry loops so the duplication collapses onto one tested
+//! primitive:
+//!
+//! * [`iterate_while`] — a state-update loop with a **scalar** continue
+//!   condition and a hard iteration cap. Each step maps the carried
+//!   state to either a continuing state or a terminal value.
+//! * [`iterate_while_with_prev`] — the same, but the step closure is
+//!   handed both the *current* and the *previous* carried state, so
+//!   recurrences (divergence guards, momentum, Aitken-style
+//!   acceleration) can be expressed without the caller threading the
+//!   history by hand.
+//!
+//! # Whiteroom L4 contract (the three graph-only restrictions)
+//!
+//! These combinators are deliberately shaped to match the firm
+//! whiteroom **L4 `iterate_while` / `iterate_while_with_prev`** surface,
+//! which survives a graph-only (trace-once) tensor backend *only* under
+//! three restrictions (Pass-1 friction artifact 11). They are the
+//! combinator's invariants — callers must honor them for the loop to be
+//! portable to a graph backend:
+//!
+//! 1. **Loop-invariant carried-state shapes.** The carried state `S`
+//!    must have the same logical shape on every iteration. A graph
+//!    backend traces the loop body once; a state slot whose tensor shape
+//!    changes between iterations cannot be expressed. (Concretely: do
+//!    not grow a `Vec` inside the carried state — that is what disqualifies
+//!    the Lanczos Krylov-basis loops; see the module-level note in
+//!    [`crate::lanczos`].)
+//! 2. **Scalar continue-condition.** The decision to continue or stop is
+//!    a single scalar predicate evaluated inside the step, not an
+//!    element-wise mask with a data-dependent reduction. There is no
+//!    per-element `break`.
+//! 3. **No data-dependent output counts.** The number of values the loop
+//!    ultimately produces is fixed by the carried-state type, not by the
+//!    data. The loop returns exactly one final state plus a report; it
+//!    does not emit a runtime-variable-length stream of outputs.
+//!
+//! The combinators do **not** enforce these at the type level (they are
+//! ordinary CPU control flow today); they document the contract so that
+//! the eventual L4 mapping is a *realization* of an already-conforming
+//! shape rather than a post-hoc retrofit.
+
+/// Report describing how an [`iterate_while`] /
+/// [`iterate_while_with_prev`] loop terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IterReport {
+    /// Number of step evaluations performed (`1..=max_iters`). A value
+    /// equal to `max_iters` together with `converged == false` means the
+    /// cap was hit.
+    pub iterations: usize,
+    /// `true` if the step returned [`Step::Done`] before the cap;
+    /// `false` if the loop exhausted `max_iters` while every step
+    /// returned [`Step::Continue`].
+    pub converged: bool,
+}
+
+/// Outcome of a single iteration step.
+///
+/// The step closure consumes the carried state and returns either a new
+/// carried state to iterate again, or a terminal value that stops the
+/// loop. Because the terminal type `T` is distinct from the carried type
+/// `S`, callers can model "ran to a definitive answer" (`Done`) versus
+/// "still refining" (`Continue`) without smuggling a sentinel into the
+/// state — this keeps the continue-condition a clean scalar decision
+/// (contract restriction 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Step<S, T> {
+    /// Keep iterating with this updated carried state.
+    Continue(S),
+    /// Stop now with this terminal value (the scalar predicate fired).
+    Done(T),
+}
+
+/// Result of running a combinator: either a terminal value produced by a
+/// step, or the final carried state when the iteration cap was reached
+/// first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IterOutcome<S, T> {
+    /// A step returned [`Step::Done`] before the cap.
+    Done(T),
+    /// `max_iters` steps all returned [`Step::Continue`]; this is the
+    /// last carried state.
+    MaxIters(S),
+}
+
+/// Drive `step` from `state0` until it returns [`Step::Done`] or until
+/// `max_iters` step evaluations have run, whichever comes first.
+///
+/// This is the state-update + scalar-predicate loop combinator. The
+/// per-iteration continue/stop decision lives *inside* `step` (it returns
+/// `Done(T)` when the scalar predicate fires); the combinator only owns
+/// the counter and the hard cap. See the [module docs](self) for the
+/// three graph-only contract restrictions the carried state must honor.
+///
+/// # Arguments
+///
+/// * `state0` — initial carried state.
+/// * `max_iters` — hard cap on step evaluations. Must be `> 0`.
+/// * `step` — maps the current iteration index (`1`-based) and the
+///   carried state to a [`Step`]. Returning [`Step::Done`] stops the
+///   loop immediately.
+///
+/// # Returns
+///
+/// `(outcome, report)` where `outcome` is [`IterOutcome::Done`] with the
+/// terminal value if a step finished, or [`IterOutcome::MaxIters`] with
+/// the final carried state if the cap was reached. `report.iterations`
+/// counts the step evaluations actually performed.
+///
+/// # Panics
+///
+/// Panics if `max_iters == 0`.
+pub fn iterate_while<S, T, F>(
+    state0: S,
+    max_iters: usize,
+    mut step: F,
+) -> (IterOutcome<S, T>, IterReport)
+where
+    F: FnMut(usize, S) -> Step<S, T>,
+{
+    assert!(max_iters > 0, "max_iters must be positive");
+
+    let mut state = state0;
+    for it in 1..=max_iters {
+        match step(it, state) {
+            Step::Done(value) => {
+                return (
+                    IterOutcome::Done(value),
+                    IterReport {
+                        iterations: it,
+                        converged: true,
+                    },
+                );
+            }
+            Step::Continue(next) => {
+                state = next;
+            }
+        }
+    }
+
+    (
+        IterOutcome::MaxIters(state),
+        IterReport {
+            iterations: max_iters,
+            converged: false,
+        },
+    )
+}
+
+/// Like [`iterate_while`], but the step closure also receives the
+/// *previous* carried state (`None` on the first iteration), enabling
+/// recurrences without the caller threading the history manually.
+///
+/// This is the recommended shape for fixed-point iterations that need to
+/// compare the latest update against the one before it — e.g. a
+/// divergence guard that aborts when the relative step *increases*
+/// between successive iterations. The combinator owns the one-step
+/// history; the carried state `S` must still be `Clone` and obey the
+/// loop-invariant-shape restriction (contract restriction 1).
+///
+/// # Arguments
+///
+/// * `state0` — initial carried state.
+/// * `max_iters` — hard cap on step evaluations. Must be `> 0`.
+/// * `step` — maps `(iteration_index, prev_state, current_state)` to a
+///   [`Step`]. `prev_state` is `None` for `iteration_index == 1` and
+///   `Some(previous_carried_state)` thereafter.
+///
+/// # Returns
+///
+/// Same `(outcome, report)` contract as [`iterate_while`].
+///
+/// # Panics
+///
+/// Panics if `max_iters == 0`.
+pub fn iterate_while_with_prev<S, T, F>(
+    state0: S,
+    max_iters: usize,
+    mut step: F,
+) -> (IterOutcome<S, T>, IterReport)
+where
+    S: Clone,
+    F: FnMut(usize, Option<&S>, S) -> Step<S, T>,
+{
+    assert!(max_iters > 0, "max_iters must be positive");
+
+    let mut state = state0;
+    let mut prev: Option<S> = None;
+    for it in 1..=max_iters {
+        let current = state.clone();
+        match step(it, prev.as_ref(), state) {
+            Step::Done(value) => {
+                return (
+                    IterOutcome::Done(value),
+                    IterReport {
+                        iterations: it,
+                        converged: true,
+                    },
+                );
+            }
+            Step::Continue(next) => {
+                prev = Some(current);
+                state = next;
+            }
+        }
+    }
+
+    (
+        IterOutcome::MaxIters(state),
+        IterReport {
+            iterations: max_iters,
+            converged: false,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iterate_while_runs_to_done() {
+        // Count up; stop when state reaches 5.
+        let (outcome, report) = iterate_while(0i32, 100, |_it, s| {
+            if s >= 5 {
+                Step::Done(s)
+            } else {
+                Step::Continue(s + 1)
+            }
+        });
+        assert_eq!(outcome, IterOutcome::Done(5));
+        // it=1 sees 0 -> 1, ... it=6 sees 5 -> Done. Six evaluations.
+        assert_eq!(
+            report,
+            IterReport {
+                iterations: 6,
+                converged: true,
+            }
+        );
+    }
+
+    #[test]
+    fn iterate_while_hits_cap() {
+        // Never finishes — should cap out and return final state.
+        let (outcome, report) = iterate_while(0i32, 4, |_it, s| Step::<i32, i32>::Continue(s + 1));
+        assert_eq!(outcome, IterOutcome::MaxIters(4));
+        assert_eq!(
+            report,
+            IterReport {
+                iterations: 4,
+                converged: false,
+            }
+        );
+    }
+
+    #[test]
+    fn iterate_while_iteration_index_is_one_based() {
+        let mut seen = Vec::new();
+        let (_outcome, _report) = iterate_while(0i32, 3, |it, s| {
+            seen.push(it);
+            Step::<i32, i32>::Continue(s + 1)
+        });
+        assert_eq!(seen, vec![1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_iters must be positive")]
+    fn iterate_while_rejects_zero_cap() {
+        let _ = iterate_while(0i32, 0, |_it, s| Step::<i32, i32>::Continue(s));
+    }
+
+    #[test]
+    fn with_prev_threads_previous_state() {
+        // On the first iter, prev is None. On subsequent iters prev is
+        // the state from one step earlier. Stop when current == 3 and
+        // return the (prev, current) pair we observed.
+        let (outcome, report) = iterate_while_with_prev(0i32, 100, |_it, prev, s| {
+            if s == 3 {
+                Step::Done((prev.copied(), s))
+            } else {
+                Step::Continue(s + 1)
+            }
+        });
+        // States visited as `current`: 0, 1, 2, 3. When current == 3,
+        // prev should be 2.
+        assert_eq!(outcome, IterOutcome::Done((Some(2), 3)));
+        assert_eq!(
+            report,
+            IterReport {
+                iterations: 4,
+                converged: true,
+            }
+        );
+    }
+
+    #[test]
+    fn with_prev_first_iter_prev_is_none() {
+        let (outcome, _report) = iterate_while_with_prev(42i32, 100, |it, prev, s| {
+            assert_eq!(it, 1);
+            assert!(prev.is_none(), "prev must be None on the first iteration");
+            Step::Done((prev.copied(), s))
+        });
+        assert_eq!(outcome, IterOutcome::Done((None, 42)));
+    }
+
+    #[test]
+    fn with_prev_divergence_guard_pattern() {
+        // Emulate the divergence guard from the self-consistent driver:
+        // carry a residual, abort if it increases between steps. Here the
+        // residual sequence is 8, 4, 6 (increases at step 3).
+        let residuals = [8.0_f64, 4.0, 6.0, 1.0];
+        let (outcome, report) = iterate_while_with_prev(0usize, 10, |_it, prev, idx| {
+            let r = residuals[idx];
+            if let Some(&prev_idx) = prev {
+                if r > residuals[prev_idx] {
+                    return Step::Done(format!("diverged at idx {idx}"));
+                }
+            }
+            Step::Continue(idx + 1)
+        });
+        assert_eq!(outcome, IterOutcome::Done("diverged at idx 2".to_string()));
+        assert_eq!(report.iterations, 3);
+        assert!(report.converged);
+    }
+
+    #[test]
+    fn with_prev_hits_cap() {
+        let (outcome, report) =
+            iterate_while_with_prev(0i32, 3, |_it, _prev, s| Step::<i32, i32>::Continue(s + 1));
+        assert_eq!(outcome, IterOutcome::MaxIters(3));
+        assert_eq!(
+            report,
+            IterReport {
+                iterations: 3,
+                converged: false,
+            }
+        );
+    }
+}

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod eigen;
 pub mod extraction;
 pub mod fe_assemble;
 pub mod fiber_lp;
+pub mod iterate;
 pub mod ksp_solve;
 pub mod lanczos;
 pub mod lumped_port;
@@ -69,6 +70,7 @@ pub use fiber_lp::{
     bessel_j, bessel_j0, bessel_j1, bessel_k, bessel_k0, bessel_k1, fiber_lp_neff, normalized_b,
     v_number,
 };
+pub use iterate::{iterate_while, iterate_while_with_prev, IterOutcome, IterReport, Step};
 pub use ksp_solve::{
     Cocg, IdentityPreconditioner, IluPreconditioner, JacobiPreconditioner, KspError, KspReport,
     KspSolve, Preconditioner,

--- a/crates/geode-core/src/silvermuller_self_consistent.rs
+++ b/crates/geode-core/src/silvermuller_self_consistent.rs
@@ -65,6 +65,7 @@ use faer::mat::MatRef;
 
 use crate::complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 use crate::eigen::EigenError;
+use crate::iterate::{iterate_while_with_prev, IterOutcome, Step};
 
 /// Outcome of [`self_consistent_k`].
 #[derive(Debug, Clone)]
@@ -161,66 +162,110 @@ pub fn self_consistent_k(
     assert!(max_iter > 0, "max_iter must be positive");
 
     let solver = FaerComplexEigensolver;
-    let mut k0 = initial_k0;
-    let mut last_k: Option<c64> = None;
-    let mut prev_dk_rel: Option<f64> = None;
 
-    for it in 1..=max_iter {
-        let lambdas = solver.smallest_complex_eigenvalues(k_mat, s_mat, m_mat, k0, n_eigs)?;
-        if lambdas.len() <= target_idx {
-            // Solver returned fewer eigenvalues than requested (e.g.
-            // mass-pencil singularities skipped). Treat as divergence
-            // at the last stable point.
-            return Ok(SelfConsistentResult::Diverged {
-                last_k: last_k.unwrap_or(c64::new(k0, 0.0)),
-                iterations: it,
-            });
-        }
+    // The carried state is the fixed-point's loop-invariant slot
+    // (contract restriction 1): the current seed `k₀`, the last stable
+    // `k_target` (`None` until the first successful solve), and this
+    // step's relative residual `|Δk₀| / k₀` (`None` on entry, used by
+    // the divergence guard via the combinator's `prev`). All scalars —
+    // the shape never changes across iterations.
+    //
+    // We use `iterate_while_with_prev` rather than `iterate_while` so the
+    // divergence guard reads the *previous* iteration's `dk_rel` from the
+    // combinator's one-step history instead of threading it by hand. The
+    // continue/stop decision inside the step is a single scalar predicate
+    // (`abs_dk < tol`, plus the guard / fewer-eigs branches), satisfying
+    // contract restriction 2; the loop yields exactly one terminal
+    // `SelfConsistentResult` (restriction 3).
+    let (outcome, report) = iterate_while_with_prev(
+        SelfConsistentState {
+            k0: initial_k0,
+            last_k: None,
+            dk_rel: None,
+        },
+        max_iter,
+        |it, prev, state| {
+            let SelfConsistentState { k0, last_k, .. } = state;
 
-        let lambda = lambdas[target_idx];
-        let k_target = principal_sqrt(lambda);
-        let re_k = k_target.re;
+            let lambdas = match solver.smallest_complex_eigenvalues(k_mat, s_mat, m_mat, k0, n_eigs)
+            {
+                Ok(l) => l,
+                Err(e) => return Step::Done(Err(e)),
+            };
+            if lambdas.len() <= target_idx {
+                // Solver returned fewer eigenvalues than requested (e.g.
+                // mass-pencil singularities skipped). Treat as divergence
+                // at the last stable point.
+                return Step::Done(Ok(SelfConsistentResult::Diverged {
+                    last_k: last_k.unwrap_or(c64::new(k0, 0.0)),
+                    iterations: it,
+                }));
+            }
 
-        let dk = re_k - k0;
-        let abs_dk = dk.abs();
-        let k0_mag = k0.abs().max(f64::EPSILON);
+            let lambda = lambdas[target_idx];
+            let k_target = principal_sqrt(lambda);
+            let re_k = k_target.re;
 
-        // Convergence check — measured against the **undamped** step,
-        // since `|Re(k) - k₀|` is the fixed-point residual.
-        if abs_dk < tol {
-            let q = q_factor(k_target);
-            return Ok(SelfConsistentResult::Converged {
-                k: k_target,
-                q,
-                iterations: it,
-            });
-        }
+            let dk = re_k - k0;
+            let abs_dk = dk.abs();
+            let k0_mag = k0.abs().max(f64::EPSILON);
 
-        // Divergence guard — only active *after* the damped phase, and
-        // we need at least one prior step to compare against.
-        let dk_rel = abs_dk / k0_mag;
-        if it > DAMPED_ITERATIONS {
-            if let Some(prev) = prev_dk_rel {
-                if dk_rel > prev {
-                    return Ok(SelfConsistentResult::Diverged {
-                        last_k: last_k.unwrap_or(k_target),
-                        iterations: it,
-                    });
+            // Convergence check — measured against the **undamped** step,
+            // since `|Re(k) - k₀|` is the fixed-point residual.
+            if abs_dk < tol {
+                let q = q_factor(k_target);
+                return Step::Done(Ok(SelfConsistentResult::Converged {
+                    k: k_target,
+                    q,
+                    iterations: it,
+                }));
+            }
+
+            // Divergence guard — only active *after* the damped phase, and
+            // we need at least one prior step to compare against.
+            let dk_rel = abs_dk / k0_mag;
+            if it > DAMPED_ITERATIONS {
+                if let Some(prev_dk_rel) = prev.and_then(|p| p.dk_rel) {
+                    if dk_rel > prev_dk_rel {
+                        return Step::Done(Ok(SelfConsistentResult::Diverged {
+                            last_k: last_k.unwrap_or(k_target),
+                            iterations: it,
+                        }));
+                    }
                 }
             }
-        }
-        prev_dk_rel = Some(dk_rel);
 
-        // Damped update.
-        let alpha = if it <= DAMPED_ITERATIONS { 0.5 } else { 1.0 };
-        k0 += alpha * dk;
-        last_k = Some(k_target);
+            // Damped update.
+            let alpha = if it <= DAMPED_ITERATIONS { 0.5 } else { 1.0 };
+            Step::Continue(SelfConsistentState {
+                k0: k0 + alpha * dk,
+                last_k: Some(k_target),
+                dk_rel: Some(dk_rel),
+            })
+        },
+    );
+
+    match outcome {
+        IterOutcome::Done(result) => result,
+        IterOutcome::MaxIters(state) => Ok(SelfConsistentResult::MaxIterations {
+            last_k: state.last_k.unwrap_or(c64::new(state.k0, 0.0)),
+            iterations: report.iterations,
+        }),
     }
+}
 
-    Ok(SelfConsistentResult::MaxIterations {
-        last_k: last_k.unwrap_or(c64::new(k0, 0.0)),
-        iterations: max_iter,
-    })
+/// Loop-invariant carried state for the self-consistent `k₀` fixed
+/// point (issue #301). All slots are scalars, so the shape is constant
+/// across iterations — the graph-only contract restriction 1.
+#[derive(Debug, Clone, Copy)]
+struct SelfConsistentState {
+    /// Current seed wavenumber for the next solve.
+    k0: f64,
+    /// Last stable `k = sqrt(λ_target)` (`None` before the first solve).
+    last_k: Option<c64>,
+    /// This step's relative residual `|Δk₀| / k₀` (`None` on entry).
+    /// Read from the combinator's `prev` by the divergence guard.
+    dk_rel: Option<f64>,
 }
 
 /// Minimum acceptable bilinear M-overlap between successive iterations'
@@ -677,6 +722,47 @@ mod tests {
                 assert!((1..=10).contains(&iterations));
             }
             other => panic!("expected Converged from a trivially diagonal pencil, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_consistent_k_bit_identical_regression_diagonal_pencil() {
+        // Issue #301: regression-lock the self-consistent k₀ Newton
+        // driver after refactoring it onto `iterate_while_with_prev`.
+        //
+        // A diagonal pencil K = diag(1, 4), M = I, S = 0 has exact
+        // eigenvalues {1, 4}; faer returns λ₀ = 1 + 0i bit-exactly, so
+        // `k_target = sqrt(1) = 1.0` on every solve and the damped
+        // fixed point is fully deterministic:
+        //   k₀: 0.5 →(α=.5) .75 →(α=.5) .875 →(α=.5) .9375 →(α=1) 1.0
+        //   →(Δ=0 < tol) Converged at k = 1.0 on iteration 5.
+        // Any drift in the iteration arithmetic (damping schedule,
+        // residual test, divergence-guard threading via `with_prev`)
+        // would move `k.re` off 1.0 or change the iteration count, so
+        // this asserts both to full precision.
+        let k = faer::Mat::<f64>::from_fn(2, 2, |i, j| {
+            if i == 0 && j == 0 {
+                1.0
+            } else if i == 1 && j == 1 {
+                4.0
+            } else {
+                0.0
+            }
+        });
+        let s = faer::Mat::<f64>::from_fn(2, 2, |_, _| 0.0);
+        let m = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 });
+
+        let r = self_consistent_k(k.as_ref(), s.as_ref(), m.as_ref(), 0.5, 0, 2, 1e-6, 20)
+            .expect("diagonal-pencil self-consistent solve");
+
+        match r {
+            SelfConsistentResult::Converged { k, q, iterations } => {
+                assert_eq!(k.re, 1.0, "converged k.re must be bit-exact 1.0");
+                assert_eq!(k.im, 0.0, "converged k.im must be bit-exact 0.0");
+                assert!(q.is_infinite(), "lossless real pencil → Q = inf");
+                assert_eq!(iterations, 5, "deterministic damped path → 5 solves");
+            }
+            other => panic!("expected Converged from diagonal pencil, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Standardizes the project's hand-rolled state-carry convergence loops onto a single tested primitive. Adds a small generic `iterate.rs` module with two combinators shaped to match the firm whiteroom **L4 `iterate_while` / `iterate_while_with_prev`** surface, and refactors the self-consistent k₀ Newton iteration onto it with bit-identical results.

## Changes

- **New `crates/geode-core/src/iterate.rs`**:
  - `iterate_while(state0, max_iters, step) -> (IterOutcome, IterReport)` — state-update loop with a scalar continue/stop decision (the step returns `Step::Done(T)` when the predicate fires) and a hard iteration cap.
  - `iterate_while_with_prev(...)` — same, but the step also receives the *previous* carried state (`None` on the first iteration), so recurrences (divergence guards, momentum) need not thread the history by hand.
  - Supporting types `Step<S, T>`, `IterOutcome<S, T>`, `IterReport { iterations, converged }`.
  - Module docs document the three graph-only L4 contract restrictions as the combinator's invariants: (1) loop-invariant carried-state shapes, (2) scalar continue-condition, (3) no data-dependent output counts.
  - 8 unit tests (run-to-done, cap, 1-based index, zero-cap panic, prev-threading, first-iter `None`, divergence-guard pattern).
- **`silvermuller_self_consistent::self_consistent_k`** refactored onto `iterate_while_with_prev`. New all-scalar carried `SelfConsistentState { k0, last_k, dk_rel }` honors restriction 1; the divergence guard now reads the previous step's `dk_rel` from the combinator's one-step history. Behavior unchanged.
- **`lib.rs`**: register `pub mod iterate;` and re-export the combinators + types.

## Why the other two sites were left as follow-ups

- **`lanczos.rs` / `complex_lanczos.rs`** — the carried Krylov basis grows by one vector per iteration, which violates contract restriction 1 (loop-invariant carried-state shapes). Documented in the `iterate` module docs; not refactored.
- **`mie::find_roots`** bisection — a clean `iterate_while` candidate (fixed-trip scalar predicate), left as a follow-up since this issue establishes the combinator + one realization.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `iterate_while` / `iterate_while_with_prev` exist with documented contract (3 restrictions) | ✅ | `iterate.rs` module docs enumerate restrictions 1–3; both functions implemented + doc-commented |
| At least one loop refactored with bit-identical results, regression-tested | ✅ | `self_consistent_k` ported; new test `self_consistent_k_bit_identical_regression_diagonal_pencil` asserts converged `k.re == 1.0` (bit-exact) in exactly 5 solves on a deterministic diagonal pencil |
| `cargo build/test/clippy/fmt` clean, no new deps | ✅ | `cargo test -p geode-core --no-default-features --features arpack,ndarray --lib`: 246 passed, 0 failed, 2 ignored. `cargo clippy --tests ... --features arpack,ndarray -- -D warnings` clean. `cargo fmt --all -- --check` clean. No `Cargo.toml` changes |

## Test Plan

- `cargo test -p geode-core --no-default-features --features arpack,ndarray --lib` → 246 passed / 0 failed / 2 ignored (the 2 ignored are pre-existing faer-gevd-under-debug cases, unrelated).
- `cargo clippy --tests -p geode-core --no-default-features --features arpack,ndarray -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- The pre-existing `#[ignore]`'d integration tests in `tests/silvermuller_self_consistent.rs` (which exercise the full eigensolve path) require `--release` due to a faer 0.24 gevd debug-assertion; the new in-crate regression test uses a diagonal pencil so it runs in the default debug suite and pins the refactored path bit-for-bit.

Closes #301