### PR TITLE
docs(lanczos): note growing Krylov basis disqualifies loops from iterate combinator

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 300
-# Branch: feature/issue-300
+# Issue: 342
+# Branch: feature/issue-342
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/complex_lanczos.rs
+++ b/crates/geode-core/src/complex_lanczos.rs
@@ -52,6 +52,16 @@
 //! as the real path — at the n ≈ 6000 / k ≈ 30 sizes we care about,
 //! basis storage is < 6 MB and the orthogonalization cost is negligible
 //! next to the sparse triangular solves.
+//!
+//! # Why this loop is not ported onto [`crate::iterate`]
+//!
+//! Like the real path ([`crate::lanczos`]), this complex-symmetric
+//! variant shares the growing-basis structure: full reorthogonalization
+//! keeps the whole history, so the Krylov basis gains one column per
+//! iteration. That violates [`crate::iterate`] **contract restriction 1**
+//! (loop-invariant carried-state shapes), so the loop is intentionally
+//! left off the `iterate_while` combinator. See [`crate::lanczos`] for the
+//! full rationale.
 
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, SparseColMatRef};

--- a/crates/geode-core/src/lanczos.rs
+++ b/crates/geode-core/src/lanczos.rs
@@ -26,6 +26,19 @@
 //!
 //! Convergence is declared when the residual norm
 //! `‖K x - λ M x‖_2 / ‖λ M x‖_2 < tol` for **every** requested mode.
+//!
+//! # Why this loop is not ported onto [`crate::iterate`]
+//!
+//! Full reorthogonalization keeps the **entire** basis history, so the
+//! Krylov basis `V_k` gains one column per Lanczos iteration — the
+//! carried state grows by one vector each step. That violates
+//! [`crate::iterate`] **contract restriction 1** (loop-invariant
+//! carried-state shapes): a trace-once graph backend traces the loop body
+//! once and cannot express a state slot whose tensor shape changes
+//! between iterations. This is exactly the "do not grow a `Vec` inside
+//! the carried state" anti-pattern. The restart loop is therefore
+//! intentionally **not** expressed via `iterate_while` /
+//! `iterate_while_with_prev`; it stays as a hand-rolled loop.
 
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, SparseColMatRef};


### PR DESCRIPTION
## Summary

Resolves the dangling forward intra-doc link in `iterate.rs` (added by PR #340), which points the reader at "the module-level note in [`crate::lanczos`]" — a note that did not exist. Adds module-level (`//!`) notes to both Lanczos modules documenting why their restart loops are intentionally not ported onto the `iterate_while` / `iterate_while_with_prev` combinators. Docs-only; no behavior change.

## Changes

- `crates/geode-core/src/lanczos.rs`: added a "Why this loop is not ported onto `[crate::iterate]`" module note — full reorthogonalization keeps the entire basis history, so the Krylov basis `V_k` grows one column per iteration, violating `iterate` contract restriction 1 (loop-invariant carried-state shapes). Includes a resolving back-link to `crate::iterate`.
- `crates/geode-core/src/complex_lanczos.rs`: added a short module note noting it shares the growing-basis structure with the real path and cross-referencing `crate::lanczos` for the full rationale, with a back-link to `crate::iterate`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `lanczos.rs` has `//!` note re: growing basis / restriction 1 / intentionally not ported | done | New "Why this loop is not ported" section |
| `lanczos.rs` note has resolving intra-doc link back to `iterate` | done | Rendered HTML: `lanczos/index.html` -> `../iterate/index.html` |
| `complex_lanczos.rs` has a module note matching/referencing the rationale | done | New section cross-referencing `crate::lanczos` |
| `iterate.rs` forward reference now points to content that exists | done | Rendered HTML: `iterate/index.html` -> `../lanczos/index.html` |
| No code/behavior changes — doc comments only | done | `git diff` is `//!` comments only |

## Test Plan

- `cargo fmt --all -- --check`: clean.
- `cargo build -p geode-core`: clean.
- `cargo clippy -p geode-core -- -D warnings`: clean.
- `cargo doc -p geode-core --no-deps`: no errors attributed to `lanczos.rs` / `iterate.rs` / `complex_lanczos.rs`. Verified the new intra-doc links resolve in the rendered HTML (forward `iterate -> lanczos`, back-links `lanczos -> iterate` and `complex_lanczos -> iterate`/`lanczos`). Note: the crate already emits ~41 pre-existing broken-intra-doc-link errors under `RUSTDOCFLAGS=-D warnings` on unmodified `main` (private-item links in `waveguide_modes.rs` and others); this PR adds none.

Closes #342