### PR TITLE
docs(geode-core): fix 40 broken intra-doc links + add doc-lint CI gate

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -1,0 +1,65 @@
+name: doc-lint
+
+# Issue #346 — enforce warning-free rustdoc so broken intra-doc links
+# can't accumulate.
+#
+# Before this gate existed, geode-core had drifted to ~40 broken
+# intra-doc-link warnings (mostly private-item links in
+# waveguide_modes.rs) that only surfaced under
+# `RUSTDOCFLAGS="-D warnings"`. Because docs were never built with
+# `-D warnings` in CI, the backlog grew silently. This gate builds the
+# crate docs with warnings-as-errors so any regression fails the PR.
+#
+# Like rustfmt.yml, this is a repo-wide lint gate (no path filter).
+#
+# Backend note (mirrors arpack.yml): the runner is headless
+# `ubuntu-latest` with no Vulkan/CUDA adapter, so we build against the
+# CPU `ndarray` backend (`--no-default-features --features ndarray`)
+# rather than the GPU-only `wgpu` default. The intra-doc links being
+# guarded are backend-independent doc comments, so the CPU backend
+# exercises the identical rustdoc surface. The `arpack,ndarray` combo
+# additionally needs libarpack2-dev.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  RUSTDOCFLAGS: "-D warnings"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  doc:
+    name: cargo doc -p geode-core (-D warnings)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libarpack2-dev and pkg-config
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarpack2-dev pkg-config
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build docs (--features ndarray, CPU backend)
+        run: |
+          cargo doc -p geode-core --no-deps \
+              --no-default-features --features ndarray
+
+      - name: Build docs (--features arpack,ndarray, CPU backend)
+        run: |
+          cargo doc -p geode-core --no-deps \
+              --no-default-features --features arpack,ndarray

--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 342
-# Branch: feature/issue-342
+# Issue: 346
+# Branch: feature/issue-346
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/complex_eigen.rs
+++ b/crates/geode-core/src/complex_eigen.rs
@@ -84,7 +84,7 @@ pub trait ComplexEigenSolver {
     ///
     /// The eigenvector storage is `Vec<c64>` of length `n_dofs` per
     /// returned pair. Pairs are sorted by `|Re(λ)|` ascending to match
-    /// [`smallest_complex_eigenvalues`].
+    /// [`ComplexEigenSolver::smallest_complex_eigenvalues`].
     ///
     /// Eigenvectors are **not** normalized — callers performing
     /// mode-tracking under the M-bilinear form should normalize via

--- a/crates/geode-core/src/complex_lanczos.rs
+++ b/crates/geode-core/src/complex_lanczos.rs
@@ -94,7 +94,7 @@ impl Default for SparseComplexShiftInvertLanczos {
     }
 }
 
-/// Parallel of [`crate::eigen::ComplexEigenSolver`] for sparse
+/// Parallel of [`crate::complex_eigen::ComplexEigenSolver`] for sparse
 /// complex-symmetric pencils. The dense `ComplexEigenSolver` runs full
 /// non-symmetric QZ; this trait exploits bilinear-symmetry of the
 /// pencil to run shift-and-invert Lanczos at a small constant factor

--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -178,7 +178,7 @@ pub enum DrivenError {
 /// Iteration counts depend on conditioning — high frequencies,
 /// ill-conditioned matrix-loaded structures, or evanescent-mode-rich
 /// wave-port problems can blow iteration counts up (the
-/// [`DrivenSweepReport::iters_per_rhs`] per-ω log surfaces this in the
+/// per-ω `iters_per_rhs` log surfaces this in the
 /// regression).
 ///
 /// # Default
@@ -732,8 +732,8 @@ fn driven_solve_impl<B: Backend>(
 ///
 /// Assembles the driven operator exactly as [`driven_solve`] does and
 /// dispatches to [`DrivenOperator::solve_at_iterative`] with the
-/// supplied [`KspSolve`] solver and Jacobi preconditioner. Returns
-/// both the solution and the Krylov [`KspReport`] (iteration count,
+/// supplied [`crate::ksp_solve::KspSolve`] solver and Jacobi preconditioner. Returns
+/// both the solution and the Krylov [`crate::ksp_solve::KspReport`] (iteration count,
 /// final relative residual) — the report is what issue #238's
 /// acceptance criteria call out as "iteration counts reported".
 ///
@@ -1524,8 +1524,8 @@ impl DrivenOperator {
     /// (issue #238). The iterative analog of
     /// [`DrivenOperator::solve_at`]: assembles the same interior
     /// `A(ω)` and `b(ω)` as the direct path (sharing
-    /// [`DrivenOperator::assemble_a_at`] and
-    /// [`DrivenOperator::assemble_b_at`]) and hands the pair off to
+    /// `DrivenOperator::assemble_a_at` and
+    /// `DrivenOperator::assemble_b_at`) and hands the pair off to
     /// `ksp` with `precond` as a left-preconditioner.
     ///
     /// The returned [`DrivenSolution`] has the same shape and
@@ -1546,7 +1546,7 @@ impl DrivenOperator {
     /// iteration breakdown or non-convergence. A zero RHS is treated
     /// as a trivial all-zero solution (one iteration recorded) rather
     /// than an error — to match the direct path's
-    /// [`zero_source_gives_zero_field`] semantics.
+    /// `zero_source_gives_zero_field` semantics.
     pub fn solve_at_iterative<K, P>(
         &self,
         omega: f64,
@@ -1792,7 +1792,7 @@ impl FactoredDrivenOperator<'_> {
 /// Per-RHS back-solve report — issue #264's "iteration counts reported
 /// per ω + per RHS" channel for the iterative path.
 ///
-/// Returned by [`DrivenLinearSolver::back_solve_report`] alongside the
+/// Returned by [`DrivenLinearSolver::back_solve`] alongside the
 /// solution. For [`SolverMode::Direct`] the count is always `0` (the
 /// triangular back-substitution has no Krylov iterations) and
 /// `residual_rel` is the LU back-substitution's own residual on this
@@ -1822,8 +1822,8 @@ pub struct BackSolveReport {
 /// ([`crate::extraction::s_parameter_frequency_sweep`],
 /// [`crate::wave_port::solve_wave_port_sweep`]) reuse one handle across
 /// every RHS; on the iterative path the Jacobi preconditioner is built
-/// once at construction and reused across every [`back_solve`] call
-/// (`DrivenLinearSolver::back_solve`).
+/// once at construction and reused across every
+/// [`DrivenLinearSolver::back_solve`] call.
 pub struct DrivenLinearSolver<'a> {
     op: &'a DrivenOperator,
     omega: f64,

--- a/crates/geode-core/src/extraction.rs
+++ b/crates/geode-core/src/extraction.rs
@@ -19,7 +19,7 @@
 //! plus self-resonance detection from the `Im Z(ω)` zero crossing when
 //! a sweep brackets it.
 //!
-//! Everything here is **post-processing over [`DrivenSolution`]** — no
+//! Everything here is **post-processing over [`crate::driven::DrivenSolution`]** — no
 //! new assembly physics. The field-to-circuit reduction reuses the
 //! lumped-port flux functional `f_i = ∮ N_i · ê dS` (the same discrete
 //! functional that drives the port, so the drive/measure pair is

--- a/crates/geode-core/src/lumped_port.rs
+++ b/crates/geode-core/src/lumped_port.rs
@@ -130,7 +130,7 @@ impl LumpedPort<'_> {
 ///
 /// Same kernel as
 /// [`crate::silvermuller::assemble_surface_mass_triplets`] — both are
-/// thin delegates to the shared [`crate::whitney_face`] module (3-point
+/// thin delegates to the shared `whitney_face` module (3-point
 /// edge-midpoint quadrature, degree-2 exact; issue #208), so the two
 /// entry points produce bit-identical triplet streams. The unit tests
 /// cross-validate this path against the dense Silver-Müller assembly as

--- a/crates/geode-core/src/mesh/patch.rs
+++ b/crates/geode-core/src/mesh/patch.rs
@@ -267,7 +267,7 @@ impl PatchFixture {
     /// air domain, for [`crate::DrivenMaterials::MatchedUpml`].
     ///
     /// The interior (substrate + air) carries the identity stretch with
-    /// the per-tet scalar permittivity from [`epsilon_r_for`]
+    /// the per-tet scalar permittivity from [`PatchFixture::epsilon_r_for`]
     /// (`ε = ε_r·I`, `ν = I`). Tets tagged [`PHYS_UPML`] get the
     /// Cartesian (box) UPML stretch [`box_upml_tensors`]: each axis is
     /// independently stretched by the quadratic σ ramp once the tet
@@ -468,8 +468,8 @@ pub fn read_patch_matched_fixture() -> Result<PatchFixture, MeshError> {
 ///
 /// Reuses the surface-tag-retaining `$Entities` / `$Elements`
 /// hand-scanners shared with the sphere/spiral loaders
-/// ([`parse_entities_physical_tags`] /
-/// [`parse_elements_with_entity_tags`]) — the base [`GmshReader`] drops
+/// (`parse_entities_physical_tags` /
+/// `parse_elements_with_entity_tags`) — the base [`crate::mesh::GmshReader`] drops
 /// triangle blocks, so without these the port/patch/ground/outer
 /// surface tags would be lost.
 pub fn read_patch_fixture_from_bytes(source: &[u8]) -> Result<PatchFixture, MeshError> {

--- a/crates/geode-core/src/mesh/sphere.rs
+++ b/crates/geode-core/src/mesh/sphere.rs
@@ -27,7 +27,7 @@
 //! The new fixture promotes this region to two layered groups; the
 //! `PHYS_VACUUM_BUFFER` alias is kept as a deprecated synonym for
 //! `PHYS_VACUUM_GAP` so older callers (e.g. the `vacuum_buffer` symbol
-//! in [`build_complex_epsilon_r_pml`]) continue to compile, but new
+//! in [`crate::nedelec_assembly::build_complex_epsilon_r_pml`]) continue to compile, but new
 //! code should branch on `PHYS_VACUUM_GAP` and `PHYS_PML_SHELL`.
 //!
 //! The fixture is shipped as bytes via `include_bytes!`, so callers don't

--- a/crates/geode-core/src/mie_open.rs
+++ b/crates/geode-core/src/mie_open.rs
@@ -49,7 +49,7 @@
 //! It seeds complex Newton iteration from PEC-cavity real roots at
 //! several outer-wall radii (and a coarse complex-plane grid) and keeps
 //! the unique converged roots with `Im(k) < 0`. Each catalog entry is
-//! re-verified at runtime via [`tests::catalog_residuals_are_small`].
+//! re-verified at runtime via `tests::catalog_residuals_are_small`.
 //!
 //! Reproducing the table:
 //!

--- a/crates/geode-core/src/silvermuller.rs
+++ b/crates/geode-core/src/silvermuller.rs
@@ -61,7 +61,7 @@
 //! unit test below.
 //!
 //! The per-face geometry and quadrature kernel live in the shared
-//! [`crate::whitney_face`] module (issue #208), which this module and
+//! `whitney_face` module (issue #208), which this module and
 //! [`crate::lumped_port`] both delegate to.
 //!
 //! # Why the BAC-CAB rank reduction is valid here
@@ -203,7 +203,7 @@ pub fn assemble_surface_mass(
 /// Same convention as
 /// [`crate::lumped_port::assemble_port_surface_mass`], which is the
 /// **same kernel** — both delegate to the shared
-/// [`crate::whitney_face`] module (issue #208), so the two entry points
+/// `whitney_face` module (issue #208), so the two entry points
 /// produce bit-identical triplet streams.
 ///
 /// # Panics

--- a/crates/geode-core/src/sparse.rs
+++ b/crates/geode-core/src/sparse.rs
@@ -3,7 +3,7 @@
 //!
 //! The dense `K` and `M` that come off [`crate::assembly::assemble_global_p1`]
 //! are full `[n_dof, n_dof]` Burn tensors but the underlying P1 stencil is
-//! sparse — every entry not in the assembled [`SparsityPattern`] is exactly
+//! sparse — every entry not in the assembled [`crate::assembly::SparsityPattern`] is exactly
 //! zero. We:
 //!
 //! 1. Pull the dense matrices to host f64 once (`burn_matrix_to_faer`).

--- a/crates/geode-core/src/waveguide_modes.rs
+++ b/crates/geode-core/src/waveguide_modes.rs
@@ -1023,7 +1023,7 @@ pub const REGION_PML: i32 = 2;
 /// `(mesh, region_tags)` where `region_tags[t] ∈ {REGION_CORE,
 /// REGION_CLADDING, REGION_PML}`. Feed the core/cladding tags into
 /// [`epsilon_r_from_region_tags`] for the per-triangle `ε_r`; feed the full
-/// tag vector into [`assemble_2d_nedelec2_pml_sparse_interior`] to flag the
+/// tag vector into `assemble_2d_nedelec2_pml_sparse_interior` to flag the
 /// PML-stretched triangles.
 ///
 /// # Panics
@@ -1702,7 +1702,7 @@ fn tri_nedelec2_dofs(
 /// ## Per-DOF orientation signs
 ///
 /// The scatter applies a per-DOF sign (`sign_i · sign_j` on entry `(i, j)`)
-/// taken from [`TRI_NEDELEC2_DOF_FLIPS`] via [`tri_nedelec2_dofs`]: the
+/// taken from `TRI_NEDELEC2_DOF_FLIPS` via `tri_nedelec2_dofs`: the
 /// three Whitney edge functions are *odd* and flip with the global edge
 /// orientation (exactly like the first-order Whitney DOF); the three
 /// gradient edge functions `Q` are *even* (symmetric under `a ↔ b`) and the
@@ -3329,7 +3329,7 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// # Sign / gauge convention (issue #300, superseding the #262 pin)
 ///
 /// Each returned eigenvector's sign is pinned by a **reference-integral
-/// gauge** ([`gauge_fix_eigenvector`]): the eigenvector is rotated so its
+/// gauge** (`gauge_fix_eigenvector`): the eigenvector is rotated so its
 /// projection onto a fixed continuous reference profile is real-positive.
 /// Concretely, a smooth reference vector field `F(x, y)` is sampled at
 /// each edge midpoint to form the Whitney DOF it would produce, and the
@@ -3339,7 +3339,7 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// This gives a gauge that is reproducible **across mesh refinements at
 /// the level of the raw complex S-matrix entries**, not merely
 /// deterministic per call. The earlier convention (issue #262,
-/// [`pin_eigenvector_sign`]) pinned on the single largest-magnitude DOF;
+/// `pin_eigenvector_sign`) pinned on the single largest-magnitude DOF;
 /// because that pivot DOF is a property of the discretization, it could
 /// jump to a different edge between meshes and flip the sign — so the C2
 /// mode-matching test had to compare gauge-invariant *magnitudes* (PR
@@ -3347,7 +3347,7 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// projection is a quadrature of the *continuous* functional `∫ e · F dS`,
 /// so it converges with the mesh instead of jumping, pinning both sign
 /// and (in the complex generalization) phase consistently regardless of
-/// mesh. See [`gauge_fix_eigenvector`] for the convention's rationale and
+/// mesh. See `gauge_fix_eigenvector` for the convention's rationale and
 /// the robustness handling for modes orthogonal to a given reference.
 ///
 /// All gauge-invariant observables — eigenvalues `λ = k_c²`, modal
@@ -3359,9 +3359,9 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// **Note**: this metallic path is real-valued, so the gauge reduces to
 /// a sign. The complex eigenvector paths (`complex_eigen.rs` /
 /// `complex_lanczos.rs`, and the [`DielectricMode`] solver) still use the
-/// [`pin_eigenvector_sign`] argmax pin; extending the reference-integral
+/// `pin_eigenvector_sign` argmax pin; extending the reference-integral
 /// phase gauge to them is the documented complex generalization in
-/// [`gauge_fix_eigenvector`] but is out of scope for issue #300.
+/// `gauge_fix_eigenvector` but is out of scope for issue #300.
 ///
 /// # Solver
 ///
@@ -3369,7 +3369,7 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// sparse shift-and-invert Lanczos via faer's sparse LU). The 2-D
 /// modal pencil is real-symmetric SPD after PEC reduction, and the
 /// gradient null cluster sits at λ ≈ 0; a small positive shift (see
-/// [`modal_shift`]) targets the lowest physical modes while keeping the
+/// `modal_shift`) targets the lowest physical modes while keeping the
 /// shifted pencil well-conditioned. This replaces the previous dense
 /// `faer::generalized_eigen` path (issue #249) which tripped a wrap-
 /// around-overflow inside faer-0.24's `gevd::qz_real` under debug
@@ -3419,7 +3419,7 @@ pub struct WaveguideSolveOpts {
     /// Explicit positive shift `σ` for the shift-invert Lanczos. When
     /// `None`, the solver runs a cheap probe Lanczos pass to estimate
     /// the smallest non-spurious eigenvalue and places `σ` halfway
-    /// between zero and that estimate (see [`estimate_modal_shift`]).
+    /// between zero and that estimate (see `estimate_modal_shift`).
     pub sigma: Option<f64>,
     /// Explicit absolute threshold below which an eigenvalue is
     /// classified as gradient-spurious. When `None`, the solver uses
@@ -3442,7 +3442,7 @@ pub struct WaveguideSolveOpts {
 /// `interior_edge_mask`. Unlike [`solve_rect_waveguide_modes`], this
 /// entry point makes no assumptions about cross-section geometry — the
 /// shift `σ` is estimated on the fly via a cheap probe Lanczos pass
-/// (see [`estimate_modal_shift`]) and the spurious-mode threshold is
+/// (see `estimate_modal_shift`) and the spurious-mode threshold is
 /// chosen relative to that shift.
 ///
 /// # Parameters
@@ -3462,7 +3462,7 @@ pub struct WaveguideSolveOpts {
 /// 1. Assemble and PEC-reduce the curl-curl pencil `(K_int, M_int)`.
 /// 2. Run a probe Lanczos pass with `σ = 0` to estimate the smallest
 ///    non-spurious eigenvalue `λ_min_phys` (see
-///    [`estimate_modal_shift`]). Set `σ = 0.5 · λ_min_phys`.
+///    `estimate_modal_shift`). Set `σ = 0.5 · λ_min_phys`.
 /// 3. Set the spurious-mode threshold to `0.1 · σ` (one decade of
 ///    slack below the shift; the gradient cluster sits many decades
 ///    below `σ`).
@@ -3707,7 +3707,7 @@ pub fn rect_waveguide_cutoff(m: u32, n: u32, a: f64, b: f64) -> f64 {
 /// `mesh.edges().len()`), with exact zeros on PEC-eliminated boundary
 /// edges. It is **M-orthonormalized** in the *unweighted* transverse
 /// mass `M₁` (`eᵀ M₁ e = 1`) and **sign-pinned** so the
-/// largest-magnitude component is non-negative ([`pin_eigenvector_sign`],
+/// largest-magnitude component is non-negative (`pin_eigenvector_sign`,
 /// issue #262), matching the metallic-mode gauge convention.
 #[derive(Debug, Clone)]
 pub struct DielectricMode {
@@ -3798,7 +3798,7 @@ pub struct DielectricMode {
 /// `n_core² k₀²` **that also carry curl energy**. We target the band by
 /// placing the shift-invert Lanczos shift `σ` just under the ceiling
 /// (`σ = (n_core² − δ) k₀²` with a small relative back-off `δ`; see
-/// [`estimate_modal_shift`] for the analogous metallic shift-placement
+/// `estimate_modal_shift` for the analogous metallic shift-placement
 /// strategy — here the band location is known a priori from `n_core`, so
 /// we use it directly).
 ///
@@ -3826,7 +3826,7 @@ pub struct DielectricMode {
 /// floors at `r ≈ 8.5×10⁻²`, leaving a clean ~5× gap above the
 /// weakly-resolved spurious ceiling (`≈ 1.7×10⁻²`). We therefore reject
 /// eigenpairs below a fixed floor centred in that gap (`3×10⁻²`); see
-/// [`physical_curl_floor`] for why a fixed floor is used rather than any
+/// `physical_curl_floor` for why a fixed floor is used rather than any
 /// adaptive gap-widening (an out-of-window spike can drive widening above
 /// the genuine band and return zero modes).
 ///
@@ -4218,10 +4218,10 @@ fn physical_curl_floor_p2() -> f64 {
 ///
 /// The eigenpencil `A = k₀²M_ε − K`, `A x = β² M₁ x`, the sparse
 /// shift-invert Lanczos path, the guided-band shift target, the
-/// bound-window classifier, the [`physical_index_ceiling`] geometry ceiling,
-/// and the [`pin_eigenvector_sign`] gauge are all **order-agnostic** and
+/// bound-window classifier, the `physical_index_ceiling` geometry ceiling,
+/// and the `pin_eigenvector_sign` gauge are all **order-agnostic** and
 /// reused verbatim; only the assembly order and the curl-energy floor
-/// ([`physical_curl_floor_p2`]) differ. Returns up to `n_modes` guided
+/// (`physical_curl_floor_p2`) differ. Returns up to `n_modes` guided
 /// [`DielectricMode`]s ordered fundamental-first (largest `n_eff`), with
 /// `e_edges` in the **p=2 DOF ordering** (length [`n_dof_2d_nedelec2`]).
 ///
@@ -4562,7 +4562,7 @@ fn physical_curl_floor_pml() -> f64 {
 /// LP₀₁ is therefore the eigenpair with the **smallest `|Im(β²)|`**
 /// (genuinely bound, lowest loss) whose `Re(β²)` lies inside the index
 /// window `(n_clad² k₀², n_eff_ceiling² k₀²)` and which carries curl energy
-/// above [`physical_curl_floor_p2`]. The core-energy fraction
+/// above `physical_curl_floor_p2`. The core-energy fraction
 /// ([`dielectric_mode_field_shape_pml`]) then **confirms** the selection
 /// (≳0.8 for a genuine LP₀₁) rather than driving it.
 ///
@@ -4909,7 +4909,7 @@ fn tri_nedelec2_basis_values(coords: &[[f64; 2]; 3], lam: [f64; 3]) -> [[f64; 2]
 /// `disk_tri_mesh` region tags (tag `1` = core, anything else = cladding).
 ///
 /// The transverse field is reconstructed per triangle from the mode's
-/// `e_edges` p=2 DOFs via [`tri_nedelec2_basis_values`] and the global
+/// `e_edges` p=2 DOFs via `tri_nedelec2_basis_values` and the global
 /// DOF map (the same numbering [`assemble_2d_nedelec2_with_epsilon`] uses),
 /// then `|E|²` is integrated with the degree-4 quadrature
 /// [`TRI_QUAD_DEG4`] and accumulated into core vs total buckets.
@@ -5101,7 +5101,7 @@ fn dielectric_raw_candidates_p2(
 /// regression and the manufactured order-of-convergence gate (Epic #318
 /// 2.5C). Assembles with [`assemble_2d_nedelec2_with_epsilon`] (uniform
 /// ε ≡ 1), PEC-reduces with the p=2 interior-DOF mask, estimates the shift
-/// via [`estimate_modal_shift`], and returns the lowest `n_modes` physical
+/// via `estimate_modal_shift`, and returns the lowest `n_modes` physical
 /// (`λ = k_c² > threshold`) eigenvalues, smallest first.
 ///
 /// Returns the bare eigenvalues `λ = k_c²` (the field profile is not needed


### PR DESCRIPTION
## Summary

`geode-core` emitted ~40 broken intra-doc-link warnings under `RUSTDOCFLAGS="-D warnings" cargo doc`, mostly private-item links in `waveguide_modes.rs` (around `solve_rect_waveguide_modes`) plus a scattering in `driven.rs`, `complex_eigen.rs`, `mesh/patch.rs`, `silvermuller.rs`, and others. These were pre-existing and accumulated silently because docs were never built with `-D warnings` in CI. This PR fixes every one (no blanket allow) and adds a CI gate so they can't return.

## Changes

- **Private items** (helpers, tests, `pub(crate)`/`pub(super)` fns and modules) that legitimately can't be doc-links → demoted to plain code-span backticks: `estimate_modal_shift`, `pin_eigenvector_sign`, `gauge_fix_eigenvector`, `modal_shift`, `physical_curl_floor`, `physical_curl_floor_p2`, `physical_index_ceiling`, `tri_nedelec2_basis_values`, `tri_nedelec2_dofs`, `TRI_NEDELEC2_DOF_FLIPS`, `assemble_2d_nedelec2_pml_sparse_interior`, `whitney_face`, `DrivenOperator::assemble_a_at`/`assemble_b_at`, `zero_source_gives_zero_field`, `tests::catalog_residuals_are_small`, the gmsh `parse_*` scanners.
- **Public items reached via the wrong/short path** → fully-qualified: `crate::complex_eigen::ComplexEigenSolver`, `crate::ksp_solve::{KspSolve, KspReport}`, `crate::assembly::SparsityPattern`, `crate::driven::DrivenSolution`, `crate::mesh::GmshReader`, `crate::nedelec_assembly::build_complex_epsilon_r_pml`, `PatchFixture::epsilon_r_for`, `ComplexEigenSolver::smallest_complex_eigenvalues`.
- **Stale links to nonexistent items** → repointed to the real API (`DrivenLinearSolver::back_solve_report` → `back_solve`) or demoted (`DrivenSweepReport::iters_per_rhs`).
- **New `.github/workflows/doc-lint.yml`** — repo-wide gate (modeled on `rustfmt.yml`) that builds `geode-core` docs with `-D warnings` on the headless CPU `ndarray` and `arpack,ndarray` combos.

No `#![allow(rustdoc::broken_intra_doc_links)]`. Doc-comment-only; no behavior change; no new deps.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` clean across CI feature combos | ✅ | `default`, `--features ndarray`, `--features arpack,ndarray`, plus the headless `--no-default-features --features ndarray` / `arpack,ndarray` combos all exit 0 with zero warnings (all 40 enumerated and fixed) |
| No blanket allow; private links fixed or demoted to code spans | ✅ | No `#![allow(...)]` added; private items use backticks, public items fully-qualified |
| `cargo build/test/clippy/fmt` still clean; no new deps | ✅ | `cargo build` exit 0; `cargo clippy -p geode-core --all-targets` exit 0; `cargo fmt --all -- --check` exit 0; `cargo test -p geode-core --lib` 256 passed / 0 failed; `--doc` 1 passed / 0 failed |
| Tighten/document CI doc command with `-D warnings` | ✅ | Added `doc-lint.yml` |

## Test Plan

- Enumerated all broken-link warnings per feature combo (identical 40 locations across `default` / `ndarray` / `arpack,ndarray`).
- Re-ran each doc build after fixes → exit 0, zero warnings.
- `cargo fmt --all -- --check`, `cargo clippy -p geode-core --all-targets`, `cargo build -p geode-core`, `cargo test -p geode-core --lib` (256 passed) and `--doc` (1 passed) all green.

Closes #346