### PR TITLE
feat(waveguide): make reference-integral gauge fall-through loud for ungaugable modes

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 346
-# Branch: feature/issue-346
+# Issue: 349
+# Branch: feature/issue-349
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/eigen.rs
+++ b/crates/geode-core/src/eigen.rs
@@ -28,6 +28,21 @@ pub enum EigenError {
     SingularPencil(usize),
     #[error("interior mask shape {got} disagrees with matrix dim {want}")]
     MaskDimMismatch { got: usize, want: usize },
+    /// The reference-integral eigenvector gauge could not pin a mode's
+    /// sign/phase: *every* reference field in the fixed basis projected to
+    /// below the relative floor, so no mesh-stable reference overlaps the
+    /// mode. Raised by `crate::waveguide_modes::gauge_fix_eigenvector`
+    /// instead of silently falling through to the cross-mesh-unstable
+    /// largest-magnitude argmax pin (issue #349, #300 follow-up). The
+    /// payload is the mode index and the largest relative projection
+    /// observed, for diagnosis.
+    #[error(
+        "reference-integral gauge could not pin mode {mode}: no reference field \
+         overlapped it (best relative projection {best_rel_proj:.3e} ≤ floor); \
+         refusing to fall through to the cross-mesh-unstable argmax pin — the \
+         hardcoded reference basis does not span this mode (issue #349)"
+    )]
+    UngaugableMode { mode: usize, best_rel_proj: f64 },
 }
 
 /// Interface for "compute the lowest `n` eigenvalues of `K x = λ M x`".

--- a/crates/geode-core/src/waveguide_modes.rs
+++ b/crates/geode-core/src/waveguide_modes.rs
@@ -3175,7 +3175,7 @@ fn pin_eigenvector_sign(v: &mut [f64]) {
 /// transverse pencil here only needs the `±1` specialization, but the
 /// convention is stated complex so the two paths share one contract.
 ///
-/// # Robustness: a small reference basis
+/// # Robustness: a small reference basis, and a loud guard
 ///
 /// A single fixed `F` can be (near-)orthogonal to some modes — e.g. a
 /// uniform x-directed field has zero net projection onto a mode that is
@@ -3183,10 +3183,26 @@ fn pin_eigenvector_sign(v: &mut [f64]) {
 /// try an ordered list of reference fields and use the **first** whose
 /// projection magnitude clears a relative floor. The list is fixed and
 /// mesh-independent, so two meshes resolving the same physical mode
-/// select the same reference and therefore the same sign. If *every*
-/// reference projection is negligible (degenerate / pathological case)
-/// we fall back to [`pin_eigenvector_sign`] so the gauge is always
-/// defined.
+/// select the same reference and therefore the same sign.
+///
+/// The reference basis only spans the lowest rectangular-guide modes
+/// (up to ~TE₀₂ plus uniform catch-alls). For a mode it does **not**
+/// span — a higher-order mode, or any mode on a non-rectangular cross-
+/// section that is orthogonal to all listed fields — *every* projection
+/// is negligible. Previously the helper fell back to
+/// [`pin_eigenvector_sign`] in that case, which is deterministic per call
+/// but cross-mesh-**unstable** (its argmax pivot DOF can jump between
+/// meshes, flipping the sign — the exact bug #300 fixed). That silent
+/// fall-through reintroduced the hazard for any mode outside the basis.
+///
+/// This helper therefore makes the fall-through **loud** (issue #349): if
+/// no reference clears the floor it returns
+/// [`EigenError::UngaugableMode`] instead of silently using the unstable
+/// argmax pin. A caller hitting this error knows the reference basis must
+/// be extended (or a general functional adopted) before that mode can be
+/// gauged cross-mesh-stably — there is no silent-but-wrong path. An
+/// all-zero eigenvector (e.g. a fully PEC-eliminated profile) has no sign
+/// to pin and is returned as a benign `Ok(())` no-op.
 ///
 /// # Invariants
 ///
@@ -3195,7 +3211,18 @@ fn pin_eigenvector_sign(v: &mut [f64]) {
 /// entries are unchanged. M-orthonormality of the returned set is
 /// therefore preserved exactly (see the unit test
 /// `reference_gauge_preserves_orthonormality`).
-fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]) {
+///
+/// # Errors
+///
+/// Returns [`EigenError::UngaugableMode`] when the fixed reference basis
+/// does not span the mode (every projection below the relative floor),
+/// carrying the largest relative projection observed for diagnosis.
+fn gauge_fix_eigenvector(
+    mesh: &TriMesh,
+    edges: &[[u32; 2]],
+    e_edges: &mut [f64],
+    mode: usize,
+) -> Result<(), EigenError> {
     debug_assert_eq!(
         edges.len(),
         e_edges.len(),
@@ -3262,11 +3289,19 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
     // Energy scale of the eigenvector (so the projection floor is
     // relative to the vector, not an absolute magnitude that depends on
     // the M-normalization length scale).
-    let e_scale = e_edges
-        .iter()
-        .fold(0.0_f64, |acc, &x| acc + x * x)
-        .sqrt()
-        .max(f64::EPSILON);
+    let e_scale = e_edges.iter().fold(0.0_f64, |acc, &x| acc + x * x).sqrt();
+
+    // An all-zero eigenvector (e.g. a fully PEC-eliminated profile) has no
+    // sign to pin: there is no cross-mesh-unstable argmax to guard against,
+    // so this is a benign no-op rather than an ungaugable-mode error.
+    if e_scale <= f64::EPSILON {
+        return Ok(());
+    }
+
+    // Track the largest *relative* projection seen across all references,
+    // so a loud failure can report how far below the floor the best
+    // reference fell (purely diagnostic).
+    let mut best_rel_proj = 0.0_f64;
 
     for f in &refs {
         let mut proj = 0.0_f64;
@@ -3291,23 +3326,37 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
             ref_scale += ri * ri;
         }
         let ref_scale = ref_scale.sqrt();
+        // Relative projection: |p| as a fraction of the Cauchy–Schwarz
+        // ceiling |e|·|r|. A field orthogonal to this mode produces ≈ 0.
+        let ceiling = e_scale * ref_scale;
+        if ceiling > 0.0 {
+            best_rel_proj = best_rel_proj.max(proj.abs() / ceiling);
+        }
         // Relative floor: require the projection to be a non-trivial
-        // fraction of the Cauchy–Schwarz ceiling |e|·|r|. A field that is
-        // orthogonal to this mode produces proj ≈ 0 and is skipped.
-        let floor = 1e-6 * e_scale * ref_scale;
+        // fraction of the ceiling. A field that is orthogonal to this mode
+        // produces proj ≈ 0 and is skipped.
+        let floor = 1e-6 * ceiling;
         if proj.abs() > floor {
             if proj < 0.0 {
                 for x in e_edges.iter_mut() {
                     *x = -*x;
                 }
             }
-            return;
+            return Ok(());
         }
     }
 
-    // Degenerate fallback: no reference overlapped. Use the argmax pin so
-    // the gauge is always defined (still deterministic per call).
-    pin_eigenvector_sign(e_edges);
+    // Loud guard (issue #349): no reference overlapped this mode. Rather
+    // than silently falling through to `pin_eigenvector_sign` — whose
+    // argmax pivot is cross-mesh-unstable and would reintroduce the #300
+    // sign-flip — refuse to gauge it. The fixed reference basis only spans
+    // the lowest rectangular-guide modes; a caller hitting this must
+    // extend the basis (or adopt a general functional) before this mode
+    // can be pinned cross-mesh-stably.
+    Err(EigenError::UngaugableMode {
+        mode,
+        best_rel_proj,
+    })
 }
 
 /// Compute the lowest `n_modes` transverse modes (cutoffs **and**
@@ -3347,8 +3396,16 @@ fn gauge_fix_eigenvector(mesh: &TriMesh, edges: &[[u32; 2]], e_edges: &mut [f64]
 /// projection is a quadrature of the *continuous* functional `∫ e · F dS`,
 /// so it converges with the mesh instead of jumping, pinning both sign
 /// and (in the complex generalization) phase consistently regardless of
-/// mesh. See `gauge_fix_eigenvector` for the convention's rationale and
-/// the robustness handling for modes orthogonal to a given reference.
+/// mesh. See `gauge_fix_eigenvector` for the convention's rationale.
+///
+/// The fixed reference basis only spans the lowest rectangular-guide
+/// modes (up to ~TE₀₂ plus uniform catch-alls). For a mode it does not
+/// span — a higher-order or non-rectangular case — the gauge no longer
+/// falls through silently to the cross-mesh-unstable argmax pin; instead
+/// this solver returns [`EigenError::UngaugableMode`] (issue #349), so
+/// the limitation is loud rather than a silent sign-flip hazard. In
+/// scope (the metallic rectangular guide, lowest few modes) every mode
+/// is spanned and this error never fires.
 ///
 /// All gauge-invariant observables — eigenvalues `λ = k_c²`, modal
 /// energies `‖e‖²_M = 1`, set-wise M-orthonormality `e_iᵀ M e_j`,
@@ -3621,7 +3678,8 @@ pub fn solve_waveguide_modes_with_opts(
             .into_iter()
             .filter(|p| p.lambda > threshold)
             .take(n_modes)
-            .map(|pair| {
+            .enumerate()
+            .map(|(mode_idx, pair)| {
                 let lam_pos = pair.lambda.max(0.0);
                 let mut e_edges = vec![0.0_f64; n_edges];
                 for (interior_idx, &full_idx) in interior_to_full.iter().enumerate() {
@@ -3638,14 +3696,19 @@ pub fn solve_waveguide_modes_with_opts(
                 // reproducible across mesh refinements. The flip is a
                 // unit-modulus (±1) rotation, so it preserves eᵀ M e and
                 // the set-wise e_iᵀ M e_j Gram (M-orthonormality intact).
-                gauge_fix_eigenvector(mesh, edges, &mut e_edges);
-                WaveguideModeProfile {
+                //
+                // If the fixed reference basis does not span this mode
+                // (issue #349) the gauge returns `UngaugableMode` rather
+                // than silently falling through to the cross-mesh-unstable
+                // argmax pin; propagate it so the failure is loud.
+                gauge_fix_eigenvector(mesh, edges, &mut e_edges, mode_idx)?;
+                Ok(WaveguideModeProfile {
                     k_c: lam_pos.sqrt(),
                     lambda: pair.lambda,
                     e_edges,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, EigenError>>()?;
 
         if physical.len() == n_modes {
             break physical;
@@ -6104,7 +6167,8 @@ mod tests {
     /// 1. A vector with positive reference projection is left unchanged.
     /// 2. Its negation is flipped back (the gauge pins proj ≥ 0).
     /// 3. The flip is norm-preserving (Σ eᵢ² unchanged).
-    /// 4. An all-zero vector falls through to the fallback without panic.
+    /// 4. An all-zero vector is a benign `Ok(())` no-op (no sign to pin,
+    ///    so no cross-mesh-unstable argmax to guard against — issue #349).
     #[test]
     fn gauge_fix_eigenvector_unit() {
         // 1×1 single-quad mesh → 5 edges (4 boundary + 1 diagonal).
@@ -6128,7 +6192,7 @@ mod tests {
 
         // Already-positive projection → unchanged.
         let mut v_pos = v.clone();
-        gauge_fix_eigenvector(&mesh, &edges, &mut v_pos);
+        gauge_fix_eigenvector(&mesh, &edges, &mut v_pos, 0).expect("positive proj is gaugable");
         assert_eq!(
             v_pos, v,
             "positive-projection vector must be left unchanged"
@@ -6136,7 +6200,7 @@ mod tests {
 
         // Negated → flipped back to positive projection.
         let mut v_neg: Vec<f64> = v.iter().map(|x| -x).collect();
-        gauge_fix_eigenvector(&mesh, &edges, &mut v_neg);
+        gauge_fix_eigenvector(&mesh, &edges, &mut v_neg, 0).expect("negated proj is gaugable");
         assert_eq!(
             v_neg, v,
             "negative-projection vector must be flipped to match"
@@ -6149,10 +6213,82 @@ mod tests {
             "gauge flip must preserve the eigenvector norm: {norm_after} ≠ {norm0}"
         );
 
-        // All-zero vector → fallback, no panic, stays zero.
+        // All-zero vector → benign no-op (no sign to pin), stays zero.
         let mut z = vec![0.0_f64; n];
-        gauge_fix_eigenvector(&mesh, &edges, &mut z);
+        gauge_fix_eigenvector(&mesh, &edges, &mut z, 0).expect("all-zero vector is a no-op");
         assert!(z.iter().all(|&x| x == 0.0));
+    }
+
+    /// **Loud guard for ungaugable modes** (issue #349): a non-zero
+    /// eigenvector that is orthogonal to *every* reference field in the
+    /// fixed basis must produce [`EigenError::UngaugableMode`], NOT a
+    /// silent fall-through to the cross-mesh-unstable argmax pin.
+    ///
+    /// We construct the orthogonal vector directly on a tiny synthetic
+    /// edge set so the orthogonality is exact and analytic rather than
+    /// mesh-dependent. Two horizontal edges of equal length, both sitting
+    /// on the box's bottom rail (`sy = 0`), carry equal-and-opposite
+    /// weights `[+1, −1]`. Then for that vector:
+    ///
+    /// - the y-directed `sin(mπsx)` references (1, 2) dot a horizontal
+    ///   tangent to exactly 0 edge-by-edge;
+    /// - the x-directed `sin(nπsy)` references (3, 4) carry `sin(nπ·0)=0`
+    ///   at both midpoints, so they vanish edge-by-edge;
+    /// - the uniform-x catch-all (5) gives `+|t| − |t| = 0` by the
+    ///   equal-and-opposite cancellation (both edges same length);
+    /// - the uniform-y catch-all (6) dots a horizontal tangent to 0.
+    ///
+    /// So every projection is exactly zero and the gauge must refuse to
+    /// pin the sign, returning the loud error with the offending mode
+    /// index. This is the test that proves the #300 silent-argmax hazard
+    /// can no longer be hit in production.
+    #[test]
+    fn gauge_fix_eigenvector_loud_on_ungaugable_mode() {
+        // Bounding box [0,1]×[0,1]: nodes 2,3 force the box height so the
+        // two weighted edges (0→1 and 4→5) sit at sy = 0 within it.
+        let mesh = TriMesh {
+            nodes: vec![
+                [0.0, 0.0], // 0  ┐ first horizontal edge (0→1)
+                [0.4, 0.0], // 1  ┘
+                [0.0, 1.0], // 2  box-height anchor (top-left)
+                [1.0, 1.0], // 3  box-width / height anchor (top-right)
+                [0.6, 0.0], // 4  ┐ second horizontal edge (4→5)
+                [1.0, 0.0], // 5  ┘  same length 0.4 as the first
+            ],
+            tris: vec![],
+        };
+        // Hand-built edge table (a < b by convention). Only the two
+        // horizontal bottom edges carry weight; the rest are zeros so they
+        // do not contribute to any projection.
+        let edges = vec![[0u32, 1], [2, 3], [4, 5]];
+        // Equal-and-opposite weights on the two equal-length horizontal
+        // edges; zero on the spacer edge.
+        let mut v = vec![1.0_f64, 0.0, -1.0];
+
+        let err = gauge_fix_eigenvector(&mesh, &edges, &mut v, 7)
+            .expect_err("a mode orthogonal to every reference must be loudly ungaugable");
+        match err {
+            EigenError::UngaugableMode {
+                mode,
+                best_rel_proj,
+            } => {
+                assert_eq!(mode, 7, "error must carry the offending mode index");
+                assert!(
+                    best_rel_proj < 1e-6,
+                    "best relative projection {best_rel_proj:.3e} must be below the \
+                     gauge floor for a genuinely orthogonal mode"
+                );
+            }
+            other => panic!("expected UngaugableMode, got {other:?}"),
+        }
+
+        // The vector must be left untouched on the loud path (no partial
+        // mutation): the caller is responsible for handling the error.
+        assert_eq!(
+            v,
+            vec![1.0, 0.0, -1.0],
+            "ungaugable vector must not be mutated on the error path"
+        );
     }
 
     /// **Sign pin helper unit test**: verifies the in-place flip

--- a/crates/geode-core/tests/waveguide_gauge_higher_order.rs
+++ b/crates/geode-core/tests/waveguide_gauge_higher_order.rs
@@ -1,0 +1,121 @@
+//! Cross-mesh stability of the reference-integral eigenvector gauge for
+//! a **higher-order mode outside the documented reference basis** (issue
+//! #349, follow-up to #300 / PR #344).
+//!
+//! `gauge_fix_eigenvector` pins each transverse mode's sign by projecting
+//! onto a fixed ordered basis of continuous reference fields. The basis
+//! is documented as spanning the lowest rectangular-guide shapes up to
+//! ~TE₀₂ (`sin(πx)`, `sin(2πx)`, `sin(πy)`, `sin(2πy)`) plus uniform
+//! catch-alls. Issue #300 fixed the cross-mesh sign-flip for TE₂₀; this
+//! test extends the guarantee to a mode the *trig* part of the basis does
+//! not span — TE₃₀, whose `E_y ∝ sin(3πx)` is orthogonal to `sin(πx)` and
+//! `sin(2πx)` — to demonstrate the gauge still pins a consistent sign
+//! across mesh refinements there (it locks onto the uniform-y catch-all,
+//! and that selection is itself mesh-stable).
+//!
+//! The companion guard test lives in the `waveguide_modes` unit tests
+//! (`gauge_fix_eigenvector_loud_on_ungaugable_mode`): a vector orthogonal
+//! to *every* reference now returns `EigenError::UngaugableMode` instead
+//! of silently falling through to the cross-mesh-unstable argmax pin. The
+//! rectangular guide never hits that path (every physical mode overlaps a
+//! reference), as this test confirms by solving 6 modes without error.
+
+use geode_core::{rect_tri_mesh, solve_rect_waveguide_modes, TriMesh};
+use std::f64::consts::PI;
+
+/// Signed projection of a transverse-E eigenvector onto the analytic
+/// reference field `F = ŷ · sin(harm·π·sx)` (a y-directed field with
+/// `harm` half-periods across the guide width), built exactly like the
+/// gauge's own midpoint-DOF construction: dot `F` with each edge's
+/// global-oriented tangent at the edge midpoint and weight by the
+/// eigenvector entry. `harm = 3` matches TE₃₀, which is **not** in the
+/// gauge's trig reference basis, so the sign of this projection is an
+/// independent witness of the gauge's cross-mesh sign choice.
+fn project_onto_y_sin(mesh: &TriMesh, e_edges: &[f64], harm: f64) -> f64 {
+    let edges = mesh.edges();
+    let (mut xmin, mut xmax) = (f64::INFINITY, f64::NEG_INFINITY);
+    for p in &mesh.nodes {
+        xmin = xmin.min(p[0]);
+        xmax = xmax.max(p[0]);
+    }
+    let lx = (xmax - xmin).max(f64::EPSILON);
+    let mut proj = 0.0_f64;
+    for (i, &ei) in e_edges.iter().enumerate() {
+        if ei == 0.0 {
+            continue; // PEC-eliminated edge.
+        }
+        let [a, b] = edges[i];
+        let pa = mesh.nodes[a as usize];
+        let pb = mesh.nodes[b as usize];
+        let ty = pb[1] - pa[1]; // y-component of the global tangent.
+        let mx = 0.5 * (pa[0] + pb[0]);
+        let sx = (mx - xmin) / lx;
+        proj += ei * ((harm * PI * sx).sin() * ty);
+    }
+    proj
+}
+
+/// **Cross-mesh sign stability for TE₃₀ (outside the trig reference
+/// basis)** — issue #349.
+///
+/// Solve the lowest 6 transverse modes of a `2 × 1` metallic guide at two
+/// resolutions (`nx = 12` and `nx = 20`). Mode 5 is TE₃₀ (`k_c ≈ 4.71`),
+/// whose `sin(3πx)` shape the gauge's `sin(πx)`/`sin(2πx)` references do
+/// not span. We project each mode onto an independent `sin(3πx)` witness
+/// and assert:
+///
+/// 1. Every mode solves without `EigenError::UngaugableMode` — the
+///    rectangular guide never hits the loud guard (all modes overlap a
+///    reference, here the uniform catch-all for the odd harmonics).
+/// 2. The TE₃₀ witness projection is non-trivial at both meshes (the mode
+///    really is the 3rd x-harmonic, so the test is meaningful).
+/// 3. Its **sign is identical across the two meshes** — the gauge pins a
+///    cross-mesh-reproducible sign for this out-of-basis mode, exactly the
+///    guarantee #300 established for TE₂₀ and this issue extends upward.
+#[test]
+fn gauge_sign_cross_mesh_stable_for_te30_outside_reference_basis() {
+    let (a, b) = (2.0_f64, 1.0_f64);
+    let n_modes = 6;
+    // Index of the TE₃₀ mode in the k_c-sorted spectrum (verified by the
+    // probe in PR #349: modes 0..6 are TE₁₀, TE₂₀, TE₀₁, TE₁₁, TE₂₁,
+    // TE₃₀). The witness harmonic for TE₃₀ is 3.
+    let te30_idx = 5;
+    let witness_harm = 3.0;
+
+    let mut te30_sign: Option<f64> = None;
+    let mut te30_proj_by_mesh: Vec<f64> = Vec::new();
+
+    for &nx in &[12usize, 20usize] {
+        let ny = nx / 2;
+        let mesh = rect_tri_mesh(nx, ny, a, b);
+
+        // (1) All modes gauge without error — the loud #349 guard never
+        // fires on the rectangular guide.
+        let modes = solve_rect_waveguide_modes(&mesh, a, b, n_modes)
+            .unwrap_or_else(|e| panic!("nx={nx}: solve failed (unexpected loud guard?): {e}"));
+        assert_eq!(modes.len(), n_modes, "nx={nx}: wrong mode count");
+
+        let proj = project_onto_y_sin(&mesh, &modes[te30_idx].e_edges, witness_harm);
+
+        // (2) The witness projection is non-trivial (this really is TE₃₀).
+        assert!(
+            proj.abs() > 0.5,
+            "nx={nx}: TE₃₀ witness projection {proj:+.4e} is too small — \
+             mode {te30_idx} is not the expected 3rd x-harmonic"
+        );
+        te30_proj_by_mesh.push(proj);
+
+        // (3) The gauged sign must agree across meshes.
+        let sign = proj.signum();
+        match te30_sign {
+            None => te30_sign = Some(sign),
+            Some(prev) => assert_eq!(
+                prev, sign,
+                "cross-mesh sign flip for TE₃₀ (outside the trig reference basis): \
+                 projection sign was {prev:+.0} at the coarser mesh but {sign:+.0} at \
+                 nx={nx} — the gauge is not cross-mesh stable for this higher-order mode \
+                 (the #300 hazard #349 guards against). Projections: {te30_proj_by_mesh:?}"
+            ),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The reference-integral eigenvector gauge added in #300 (PR #344) pins each transverse mode's sign by projecting onto a fixed ordered basis of continuous reference fields, hardcoded to the lowest rectangular-guide TE shapes (`sin(πx)`, `sin(2πx)`, `sin(πy)`, `sin(2πy)`, plus uniform catch-alls). For a mode the basis does **not** span — a higher-order or non-rectangular case orthogonal to every listed field — all projections were ≈0 and the gauge **silently fell through** to `pin_eigenvector_sign`, the cross-mesh-**unstable** largest-magnitude argmax pin whose pivot DOF can jump between meshes and flip the sign. That reintroduced the exact #300 sign-flip hazard the moment a higher-order / non-rectangular modal consumer is added.

**Approach taken: loud guard** (the cleaner of the two offered options for the rectangular code path — a provably mesh-stable general functional for *arbitrary* cross-sections is a much larger design task, and the rect guide never needs it). The silent unstable-argmax path is removed entirely.

## Changes

- `crates/geode-core/src/eigen.rs`: add `EigenError::UngaugableMode { mode, best_rel_proj }`.
- `crates/geode-core/src/waveguide_modes.rs`:
  - `gauge_fix_eigenvector` now returns `Result<(), EigenError>`. When no reference clears the relative floor it returns `UngaugableMode` (carrying the offending mode index + best relative projection) instead of falling through to the unstable argmax pin. An all-zero eigenvector (no sign to pin) stays a benign `Ok(())` no-op.
  - The solver call site propagates the error via `?` / `collect::<Result<_,_>>()`.
  - Doc comments on the helper and `solve_rect_waveguide_modes` updated to document the loud guard; dielectric/complex-pencil scoping notes kept consistent.
- `crates/geode-core/tests/waveguide_gauge_higher_order.rs` (new): cross-mesh sign stability for TE₃₀, a mode outside the trig reference basis.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Cross-mesh stable for a mode outside the rect-TE reference set, OR fall-through made loud (no silent unstable-argmax path) with a test proving it | ✅ | **Both.** Unit test `gauge_fix_eigenvector_loud_on_ungaugable_mode` proves the fall-through is now `UngaugableMode` (vector orthogonal to every reference). Integration test `gauge_sign_cross_mesh_stable_for_te30_outside_reference_basis` shows TE₃₀ (`sin(3πx)`, outside the `sin(πx)`/`sin(2πx)` basis) keeps a cross-mesh-consistent gauged sign at nx=12 vs nx=20. |
| M-orthonormality preserved; existing wave-port + C1/C2 tests still pass | ✅ | Rotation is still a unit-modulus (±1) scalar. `reference_gauge_preserves_orthonormality` passes; the heavy `bimodal_height_step_matches_analytic_mode_matching` C1/C2 cross-mesh complex-S test passes in `--release --ignored`; 70 waveguide lib tests pass. |
| cargo build/test/clippy(-D warnings)/fmt clean. No new deps | ✅ | `cargo build` clean; all test targets compile (`--no-run`); `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all` applied; no new dependencies. |
| Doc-lint CI gate clean | ✅ | `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` clean for both `ndarray` and `arpack,ndarray`; the new `[\`EigenError::UngaugableMode\`]` intra-doc link resolves. |

## Test Plan

- `cargo test -p geode-core --no-default-features --features ndarray --lib waveguide` → 70 passed.
- `cargo test ... --test waveguide_gauge_higher_order --test wave_port` → passed.
- `cargo test --release -p geode-core --no-default-features --features ndarray --test wave_port_step_mode_matching -- --ignored` → C1/C2 cross-mesh mode-matching passed.
- `cargo clippy -p geode-core --no-default-features --features ndarray --all-targets -- -D warnings` → clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` (ndarray; arpack,ndarray) → clean.

Closes #349