### PR TITLE
feat(cli): clap-derive argument parsing for the geode binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,10 +91,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -1002,6 +1046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1010,8 +1055,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1036,6 +1095,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -2553,6 +2618,7 @@ dependencies = [
 name = "geode-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "geode-core",
 ]
 
@@ -3132,6 +3198,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -4003,6 +4075,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneshot"
@@ -5855,6 +5933,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.92"
 
 [workspace.dependencies]
 burn = { version = "0.21", default-features = false, features = ["std"] }
+clap = { version = "4", features = ["derive"] }
 geode-core = { path = "crates/geode-core" }
 
 [profile.release]

--- a/crates/geode-cli/Cargo.toml
+++ b/crates/geode-cli/Cargo.toml
@@ -12,6 +12,7 @@ name = "geode"
 path = "src/main.rs"
 
 [dependencies]
+clap = { workspace = true }
 geode-core = { workspace = true }
 
 [lints.rust]

--- a/crates/geode-cli/src/main.rs
+++ b/crates/geode-cli/src/main.rs
@@ -1,6 +1,37 @@
 use std::process::ExitCode;
 
+use clap::{Parser, Subcommand};
+
+/// GEODE-FEM command-line entry point.
+#[derive(Parser)]
+#[command(
+    name = "geode",
+    version,
+    about = "GEODE-FEM: a Burn-based FEM/DG electromagnetics solver",
+    long_about = None
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run a backend smoke check (verify the tensor backend is reachable).
+    Smoke,
+}
+
 fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    // Default to the smoke check when no subcommand is given so the
+    // bare `geode` invocation keeps its existing behavior.
+    match cli.command.unwrap_or(Command::Smoke) {
+        Command::Smoke => run_smoke(),
+    }
+}
+
+fn run_smoke() -> ExitCode {
     println!("geode-fem {}", env!("CARGO_PKG_VERSION"));
 
     match geode_core::smoke_add() {


### PR DESCRIPTION
## Summary
Makes `geode-cli` a `clap`-based application. Adds the `clap` crate (with the `derive` feature) as a workspace dependency and rewrites the `geode` binary entry point around a `#[derive(Parser)]` `Cli` struct with subcommand dispatch. The command still does very little, but the parsing scaffold is now in place to grow modular subcommands.

## Changes
- Add `clap = { version = "4", features = ["derive"] }` to `[workspace.dependencies]` in the root `Cargo.toml`, following the existing workspace-deps convention.
- Add `clap = { workspace = true }` to `crates/geode-cli/Cargo.toml`.
- Rewrite `crates/geode-cli/src/main.rs`:
  - Top-level `Cli` struct with `#[derive(Parser)]`, `name = "geode"`, `version`, and an `about` string.
  - `Command` enum (`#[derive(Subcommand)]`) with a `smoke` subcommand that runs the backend smoke check.
  - `main()` parses args; a bare `geode` invocation defaults to `smoke`, preserving prior behavior.
- `Cargo.lock` updated for the new dependency.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `clap` dependency added (with `derive`) | done | Present in `[workspace.dependencies]` and consumed by `geode-cli` via `workspace = true` |
| Basic arg/parse added | done | `Cli` derives `Parser`; `Command::Smoke` subcommand; `Cli::parse()` in `main()` |
| Existing behavior preserved | done | `cargo run -p geode-cli` (no args) still prints version + backend smoke result |

## Test Plan
- `cargo fmt --check -p geode-cli` — clean
- `cargo build -p geode-cli` — success
- `cargo clippy -p geode-cli` — no warnings
- `cargo test -p geode-cli` — passes (0 tests)
- Manual runs:
  - `geode` -> prints `geode-fem 0.1.0` + backend smoke (default == smoke)
  - `geode smoke` -> same smoke output
  - `geode --help` -> usage with `smoke` subcommand listed
  - `geode --version` -> `geode 0.1.0`

Closes #362