### PR TITLE
refactor(workspace): centralize dependency versions in [workspace.dependencies] (#361)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,25 @@ repository = "https://github.com/rjwalters/geode-fem"
 rust-version = "1.92"
 
 [workspace.dependencies]
+# Third-party dependencies — all versions are defined here and referenced
+# from child crates via `dep = { workspace = true }` (issue #361). Per-crate
+# `features` / `optional` / `default-features` overrides live on the child
+# reference and are unioned with the base settings declared here.
 burn = { version = "0.21", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
+criterion = "0.5"
+# Base faer feature set shared by every consumer; geode-core additionally
+# enables `sparse-linalg` on its own reference.
+faer = { version = "0.24", default-features = false, features = ["std", "linalg"] }
+mshio = "0.4"
+num-complex = { version = "0.4", default-features = false, features = ["std"] }
+pkg-config = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+toml = "0.8"
+
+# Workspace-internal crates (path dependencies).
 geode-core = { path = "crates/geode-core" }
 
 [profile.release]

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -9,14 +9,16 @@ description = "GEODE-FEM solver primitives: tensor ops over Burn."
 
 [dependencies]
 burn = { workspace = true }
-faer = { version = "0.24", default-features = false, features = ["std", "linalg", "sparse-linalg"] }
-mshio = "0.4"
-thiserror = "2"
+# `sparse-linalg` is added on top of the workspace base feature set
+# (`std`, `linalg`) for the sparse shift-invert Lanczos eigensolver.
+faer = { workspace = true, features = ["sparse-linalg"] }
+mshio = { workspace = true }
+thiserror = { workspace = true }
 # Parses the [oracles.palace] block of the benchmark results TOMLs in
 # `src/palace.rs` (issue #239 — operator-assisted Palace 3D oracle
 # scaffolding). Same major as the existing dev-dep usage in the
 # benchmark tests.
-toml = "0.8"
+toml = { workspace = true }
 
 # Optional: link-time discovery of the system `libarpack` for the `arpack`
 # Cargo feature. Bindings to `dsaupd_c` / `dseupd_c` (the stable ARPACK
@@ -26,7 +28,7 @@ toml = "0.8"
 # `## System dependencies` in the README for the platform install
 # one-liners.
 [build-dependencies]
-pkg-config = { version = "0.3", optional = true }
+pkg-config = { workspace = true, optional = true }
 
 [features]
 default = ["wgpu"]
@@ -59,18 +61,18 @@ arpack = ["dep:pkg-config"]
 # feature selection (wgpu by default, or ndarray on CI).
 geode-core = { path = ".", default-features = false, features = ["autodiff"] }
 # Read regression-fixture TOML in `tests/cube_convergence_regression.rs`.
-toml = "0.8"
+toml = { workspace = true }
 # Performance benchmark harness (issue #50). Each `[[bench]]` below opts
 # out of the libtest harness and lets criterion own the entrypoint.
-criterion = "0.5"
+criterion = { workspace = true }
 # Benches/examples need direct faer access (the trait surface we're
-# benching takes `MatRef<f64>` and `SparseColMatRef`). Pinned to the
-# same minor as the regular dependency line above.
-faer = { version = "0.24", default-features = false, features = ["std", "linalg", "sparse-linalg"] }
+# benching takes `MatRef<f64>` and `SparseColMatRef`). Same feature set as
+# the regular dependency line above (workspace base + `sparse-linalg`).
+faer = { workspace = true, features = ["sparse-linalg"] }
 # Read criterion's JSON `estimates.json` outputs in
 # `examples/extract_baseline.rs` to produce `benchmarks/perf/baseline.toml`.
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [[bench]]
 name = "assembly_p1"

--- a/crates/geode-validation/Cargo.toml
+++ b/crates/geode-validation/Cargo.toml
@@ -8,14 +8,14 @@ rust-version.workspace = true
 description = "Cross-backend reference comparison harness for GEODE-FEM (Epic #88, Phase A)."
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 # Complex scalar type for c128 fixture fields (Phase H scaffolding,
 # issue #145). Already a transitive dep via faer + ndarray; pinned here
 # directly so the comparator API surface doesn't depend on which feature
 # combo pulls it in.
-num-complex = { version = "0.4", default-features = false, features = ["std"] }
+num-complex = { workspace = true }
 
 [dev-dependencies]
 # The cube-cavity cross-backend integration test (#92) runs the full Burn
@@ -31,9 +31,9 @@ burn = { workspace = true }
 # M_int interior matrices via `burn_matrix_to_faer`, then call
 # `generalized_eigen` directly to recover both eigenvalues AND
 # eigenvectors (the existing `EigenSolver` trait surface only returns
-# eigenvalues — extending it is tracked as a follow-up). Pinned to the
-# same minor as geode-core's dep above.
-faer = { version = "0.24", default-features = false, features = ["std", "linalg"] }
+# eigenvalues — extending it is tracked as a follow-up). Uses the
+# workspace base faer feature set (`std`, `linalg`); no `sparse-linalg`.
+faer = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## Summary

Hoists all directly-pinned third-party dependency versions out of child crates and into the workspace root `[workspace.dependencies]`, per issue #361. Child crates (`geode-core`, `geode-validation`) now reference them via `{ workspace = true }`, preserving per-crate `features` / `optional` / `default-features`.

This follows the convention already established by `clap` (merged in #366).

## Why it's safe

- **`Cargo.lock` is unchanged** — dependency resolution is byte-for-byte identical; this is a pure declaration-site relocation, not a version change.
- `cargo build --workspace`, `cargo fmt --all --check`, and `cargo clippy --workspace --all-targets -- -D warnings` all pass locally.
- The full `cargo test` workspace run is delegated to CI (the workspace test compile is very heavy locally); since `Cargo.lock` is identical and there are no source changes, runtime behavior cannot change.

## Changes

- `Cargo.toml` — added hoisted versions to `[workspace.dependencies]`
- `crates/geode-core/Cargo.toml` — `{ workspace = true }` references
- `crates/geode-validation/Cargo.toml` — `{ workspace = true }` references

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)