### PR TITLE
chore: migrate workspace to Rust edition 2024 (rust-version 1.94.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/rjwalters/geode-fem"
-rust-version = "1.92"
+rust-version = "1.94.1"
 
 [workspace.dependencies]
 # Third-party dependencies — all versions are defined here and referenced

--- a/crates/geode-core/benches/assembly_nedelec.rs
+++ b/crates/geode-core/benches/assembly_nedelec.rs
@@ -14,11 +14,11 @@
 use std::time::Duration;
 
 use burn::tensor::backend::BackendTypes;
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use geode_core::{
-    assemble_global_nedelec, assemble_global_nedelec_with_complex_epsilon, burn_matrix_to_faer,
-    cube_tet_mesh, upload_mesh, DefaultBackend,
+    DefaultBackend, assemble_global_nedelec, assemble_global_nedelec_with_complex_epsilon,
+    burn_matrix_to_faer, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/benches/assembly_p1.rs
+++ b/crates/geode-core/benches/assembly_p1.rs
@@ -19,10 +19,10 @@
 use std::time::Duration;
 
 use burn::tensor::backend::BackendTypes;
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use geode_core::{
-    assemble_global_p1, burn_matrix_to_faer, cube_tet_mesh, upload_mesh, DefaultBackend,
+    DefaultBackend, assemble_global_p1, burn_matrix_to_faer, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/benches/eigensolve_dense.rs
+++ b/crates/geode-core/benches/eigensolve_dense.rs
@@ -14,11 +14,11 @@
 use std::time::Duration;
 
 use burn::tensor::backend::BackendTypes;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/benches/eigensolve_sparse.rs
+++ b/crates/geode-core/benches/eigensolve_sparse.rs
@@ -8,11 +8,11 @@
 use std::time::Duration;
 
 use burn::tensor::backend::BackendTypes;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use geode_core::{
-    assemble_global_p1, cube_interior_mask, cube_tet_mesh, global_system_to_sparse, upload_mesh,
-    DefaultBackend, SparseEigenSolver, SparseShiftInvertLanczos,
+    DefaultBackend, SparseEigenSolver, SparseShiftInvertLanczos, assemble_global_p1,
+    cube_interior_mask, cube_tet_mesh, global_system_to_sparse, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/benches/mie_end_to_end.rs
+++ b/crates/geode-core/benches/mie_end_to_end.rs
@@ -19,14 +19,15 @@
 use std::time::Duration;
 
 use burn::tensor::backend::BackendTypes;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use faer::sparse::{SparseColMat, Triplet};
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, R_BUFFER, SparseComplexEigenSolver,
+    SparseComplexShiftInvertLanczos, apply_dirichlet_bc,
+    assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
     burn_complex_mass_to_faer, burn_matrix_to_faer, read_sphere_fixture, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, SparseComplexEigenSolver, SparseComplexShiftInvertLanczos, R_BUFFER,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/examples/eigen_convergence.rs
+++ b/crates/geode-core/examples/eigen_convergence.rs
@@ -4,8 +4,8 @@
 //! Run with:  `cargo run -p geode-core --release --example eigen_convergence`
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 
 use burn::tensor::backend::BackendTypes;

--- a/crates/geode-core/examples/extract_baseline.rs
+++ b/crates/geode-core/examples/extract_baseline.rs
@@ -123,10 +123,10 @@ fn collect_rows(criterion_dir: &Path) -> Vec<Row> {
                 continue;
             }
             let est = input_path.join("new").join("estimates.json");
-            if est.is_file() {
-                if let Some(row) = parse_estimates(&est, &group_name, Some(input_name)) {
-                    rows.push(row);
-                }
+            if est.is_file()
+                && let Some(row) = parse_estimates(&est, &group_name, Some(input_name))
+            {
+                rows.push(row);
             }
         }
     }

--- a/crates/geode-core/examples/mie_driven_scattering.rs
+++ b/crates/geode-core/examples/mie_driven_scattering.rs
@@ -56,10 +56,10 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use geode_core::{
-    extinction_power, mie_efficiencies, plane_wave_polarization_current, q_from_power,
-    read_sphere_fine_fixture, read_sphere_fixture, scattered_flux_power,
-    solve_scattered_field_matched_upml, sphere_pec_interior_edges, SphereFixture,
-    PHYS_SPHERE_INTERIOR, R_BUFFER, R_PML_INNER, R_SPHERE,
+    PHYS_SPHERE_INTERIOR, R_BUFFER, R_PML_INNER, R_SPHERE, SphereFixture, extinction_power,
+    mie_efficiencies, plane_wave_polarization_current, q_from_power, read_sphere_fine_fixture,
+    read_sphere_fixture, scattered_flux_power, solve_scattered_field_matched_upml,
+    sphere_pec_interior_edges,
 };
 
 /// Which bundled fixture the sweep runs on (selected by the optional

--- a/crates/geode-core/examples/mie_open_quasimode.rs
+++ b/crates/geode-core/examples/mie_open_quasimode.rs
@@ -71,12 +71,11 @@ use burn::tensor::backend::BackendTypes;
 use faer::sparse::{SparseColMat, Triplet};
 
 use geode_core::{
-    assemble_global_nedelec_with_full_tensors, build_matched_upml_materials,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, MieRootComplex,
+    PHYS_SPHERE_INTERIOR, R_BUFFER, SparseComplexEigenSolver, SparseComplexShiftInvertLanczos,
+    SphereFixture, assemble_global_nedelec_with_full_tensors, build_matched_upml_materials,
     burn_complex_mass_to_faer, open_space_wgm_roots_n15, read_sphere_fixture,
-    sphere_n_interior_nodes, sphere_pec_interior_edges, upload_mesh, ComplexEigenSolver,
-    DefaultBackend, FaerComplexEigensolver, MiePolarisation, MieRootComplex,
-    SparseComplexEigenSolver, SparseComplexShiftInvertLanczos, SphereFixture, PHYS_SPHERE_INTERIOR,
-    R_BUFFER,
+    sphere_n_interior_nodes, sphere_pec_interior_edges, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/examples/mie_sphere.rs
+++ b/crates/geode-core/examples/mie_sphere.rs
@@ -98,14 +98,15 @@ use burn::tensor::backend::BackendTypes;
 use faer::sparse::{SparseColMat, Triplet};
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
-    assemble_global_nedelec_with_complex_epsilon, build_anisotropic_pml_tensor_diag,
-    build_complex_epsilon_r_pml, burn_complex_mass_to_faer, burn_matrix_to_faer, mie_roots_catalog,
-    open_space_wgm_roots_n15, plane_wave_polarization_current, read_sphere_fixture,
-    solve_scattered_field_matched_upml, sphere_n_interior_nodes, sphere_pec_interior_edges,
-    tet_centroid_radii, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, MieRoot, SparseComplexEigenSolver,
-    SparseComplexShiftInvertLanczos, PHYS_SPHERE_INTERIOR, R_BUFFER, R_SPHERE,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, MieRoot,
+    PHYS_SPHERE_INTERIOR, R_BUFFER, R_SPHERE, SparseComplexEigenSolver,
+    SparseComplexShiftInvertLanczos, apply_dirichlet_bc,
+    assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
+    build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, burn_complex_mass_to_faer,
+    burn_matrix_to_faer, mie_roots_catalog, open_space_wgm_roots_n15,
+    plane_wave_polarization_current, read_sphere_fixture, solve_scattered_field_matched_upml,
+    sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii, tet_centroids,
+    upload_mesh,
 };
 
 #[path = "common/viz_export_helper.rs"]
@@ -737,10 +738,10 @@ fn export_field(path: &str) {
         .collect();
 
     let out = std::path::Path::new(path);
-    if let Some(parent) = out.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
-        }
+    if let Some(parent) = out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).expect("create --export-field parent dir");
     }
     geode_core::viz_vtu::write_vtu(out, &f.mesh, &e_re, Some(&e_im), Some(&eps_r))
         .expect("write --export-field .vtu");

--- a/crates/geode-core/examples/patch_antenna.rs
+++ b/crates/geode-core/examples/patch_antenna.rs
@@ -124,11 +124,11 @@ use faer::c64;
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::viz_vtu::write_vtu_surface;
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, PatchCavity, PatchFixture,
     broadside_directivity, directivity, driven_solve_with_ports, flux_power_box, gain,
     im_z_zero_crossings, ntff_far_field, pec_interior_mask_from_triangles, port_current,
     port_voltage, principal_plane_cuts, read_patch_fixture, read_patch_matched_fixture,
-    read_patch_smoke_fixture, s11, to_db, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, PatchCavity, PatchFixture,
+    read_patch_smoke_fixture, s11, to_db,
 };
 
 #[path = "common/viz_export_helper.rs"]
@@ -261,15 +261,13 @@ fn fixture_sha256(choice: FixtureChoice) -> String {
             cmd.args(["-a", "256"]);
         }
         cmd.arg(&path);
-        if let Ok(out) = cmd.output() {
-            if out.status.success() {
-                if let Some(hash) = String::from_utf8_lossy(&out.stdout)
-                    .split_whitespace()
-                    .next()
-                {
-                    return hash.to_string();
-                }
-            }
+        if let Ok(out) = cmd.output()
+            && out.status.success()
+            && let Some(hash) = String::from_utf8_lossy(&out.stdout)
+                .split_whitespace()
+                .next()
+        {
+            return hash.to_string();
         }
     }
     let _ = bytes;
@@ -419,7 +417,7 @@ fn run_sweep(fixture: &PatchFixture, freqs_ghz: &[f64], pml_thick: f64) -> Vec<R
 #[allow(clippy::needless_range_loop)]
 fn bandwidth_10db(rows: &[Row]) -> Option<(f64, f64)> {
     let thresh = (0.1_f64).sqrt(); // |S11| at −10 dB return loss
-                                   // Index of the |S11| minimum.
+    // Index of the |S11| minimum.
     let i_min = rows
         .iter()
         .enumerate()
@@ -1161,10 +1159,10 @@ fn export_field(path: &str) {
         .collect();
 
     let out = std::path::Path::new(path);
-    if let Some(parent) = out.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
-        }
+    if let Some(parent) = out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).expect("create --export-field parent dir");
     }
     geode_core::viz_vtu::write_vtu(out, &fixture.mesh, &e_re, Some(&e_im), Some(&eps_r))
         .expect("write --export-field .vtu");

--- a/crates/geode-core/examples/regen_cube_convergence_fixture.rs
+++ b/crates/geode-core/examples/regen_cube_convergence_fixture.rs
@@ -29,8 +29,8 @@ use std::process::Command;
 
 use burn::tensor::backend::BackendTypes;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/examples/slcfet_3hp_spiral.rs
+++ b/crates/geode-core/examples/slcfet_3hp_spiral.rs
@@ -58,11 +58,10 @@ use std::process::Command;
 use faer::c64;
 
 use geode_core::{
-    detect_srf, driven_frequency_sweep, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l,
-    pec_interior_mask_from_triangles, read_spiral_slcfet_3hp_fixture,
-    read_spiral_slcfet_3hp_smoke_fixture, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, SpiralFixture, SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel,
-    SLCFET_3HP_MATERIALS,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SLCFET_3HP_MATERIALS, SpiralFixture,
+    SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel, detect_srf, driven_frequency_sweep,
+    modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l, pec_interior_mask_from_triangles,
+    read_spiral_slcfet_3hp_fixture, read_spiral_slcfet_3hp_smoke_fixture,
 };
 
 /// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.

--- a/crates/geode-core/examples/soi_waveguide.rs
+++ b/crates/geode-core/examples/soi_waveguide.rs
@@ -61,8 +61,8 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use geode_core::{
-    epsilon_r_from_region_tags, rect_pec_interior_edges, rect_tri_mesh, slab_te0_neff,
-    solve_dielectric_modes, TriMesh,
+    TriMesh, epsilon_r_from_region_tags, rect_pec_interior_edges, rect_tri_mesh, slab_te0_neff,
+    solve_dielectric_modes,
 };
 
 /// Silicon core refractive index at λ = 1550 nm.

--- a/crates/geode-core/examples/spiral_inductor.rs
+++ b/crates/geode-core/examples/spiral_inductor.rs
@@ -82,10 +82,10 @@ use faer::c64;
 
 use geode_core::mesh::spiral::CONDUCTOR_SIGMA_NATURAL;
 use geode_core::{
-    detect_srf, driven_frequency_sweep, driven_solve_with_ports, modified_wheeler_l,
-    mohan_current_sheet_l, monomial_fit_l, pec_interior_mask_from_triangles, read_spiral_fixture,
-    read_spiral_smoke_fixture, CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials,
-    SpiralFixture, SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SpiralFixture, SquareSpiral,
+    SurfaceImpedanceBc, SurfaceImpedanceModel, detect_srf, driven_frequency_sweep,
+    driven_solve_with_ports, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l,
+    pec_interior_mask_from_triangles, read_spiral_fixture, read_spiral_smoke_fixture,
 };
 
 #[path = "common/viz_export_helper.rs"]
@@ -461,10 +461,10 @@ fn export_field(path: &str) {
     let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&fixture.mesh, &sol.e_edges);
 
     let out = std::path::Path::new(path);
-    if let Some(parent) = out.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).expect("create --export-field parent dir");
-        }
+    if let Some(parent) = out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).expect("create --export-field parent dir");
     }
     geode_core::viz_vtu::write_vtu(out, &fixture.mesh, &e_re, Some(&e_im), None)
         .expect("write --export-field .vtu");
@@ -490,7 +490,9 @@ fn main() {
         None => FixtureChoice::Benchmark,
         Some("smoke") => FixtureChoice::Smoke,
         Some(other) => {
-            eprintln!("unknown argument {other:?} — expected `smoke`, `--export-field <path>`, or no argument");
+            eprintln!(
+                "unknown argument {other:?} — expected `smoke`, `--export-field <path>`, or no argument"
+            );
             std::process::exit(2);
         }
     };

--- a/crates/geode-core/examples/step_index_fiber.rs
+++ b/crates/geode-core/examples/step_index_fiber.rs
@@ -106,9 +106,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use geode_core::{
-    dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
-    epsilon_r_from_region_tags, fiber_lp_neff, n_dof_2d_nedelec2, normalized_b,
-    solve_dielectric_modes2_pml, v_number, TriMesh, REGION_CORE,
+    REGION_CORE, TriMesh, dielectric_mode_field_shape_pml, disk_pec_interior_dofs2,
+    disk_tri_mesh_pml, epsilon_r_from_region_tags, fiber_lp_neff, n_dof_2d_nedelec2, normalized_b,
+    solve_dielectric_modes2_pml, v_number,
 };
 
 /// Core refractive index (SMF-28-like, λ = 1550 nm).
@@ -196,11 +196,7 @@ fn build_fiber(res: (usize, usize)) -> (TriMesh, Vec<i32>, Vec<f64>, Vec<bool>, 
     let eps_core = N_CORE * N_CORE;
     let eps_clad = N_CLAD * N_CLAD;
     let eps_r = epsilon_r_from_region_tags(&region_tags, |t| {
-        if t == REGION_CORE {
-            eps_core
-        } else {
-            eps_clad
-        }
+        if t == REGION_CORE { eps_core } else { eps_clad }
     });
     let interior = disk_pec_interior_dofs2(&mesh, outer_r);
     (mesh, region_tags, eps_r, interior, clad_r, outer_r)

--- a/crates/geode-core/src/arpack.rs
+++ b/crates/geode-core/src/arpack.rs
@@ -422,7 +422,7 @@ impl SparseEigenSolver for ArpackEigensolver {
         let select: Vec<c_int> = vec![0; ncv];
         let howmny = b"A\0";
         let rvec: c_int = 0; // 0 = eigenvalues only
-                             // z and ldz are unused when rvec=0; pass a valid but trivial buffer.
+        // z and ldz are unused when rvec=0; pass a valid but trivial buffer.
         let mut z_dummy = vec![0.0_f64; n.max(1)];
         let ldz: c_int = n_c.max(1);
         let mut info_eup: c_int = 0;

--- a/crates/geode-core/src/assembly.rs
+++ b/crates/geode-core/src/assembly.rs
@@ -28,13 +28,13 @@
 
 use std::collections::BTreeSet;
 
-use burn::tensor::backend::Backend;
 use burn::tensor::ElementConversion;
 use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
 use burn::tensor::{IndexingUpdateOp, Int, TensorData};
 
-use crate::p1::batched_p1_local_matrices;
 use crate::TetMesh;
+use crate::p1::batched_p1_local_matrices;
 
 /// Assembled global linear system in dense Burn-tensor form.
 #[derive(Debug, Clone)]

--- a/crates/geode-core/src/complex_eigen.rs
+++ b/crates/geode-core/src/complex_eigen.rs
@@ -26,7 +26,7 @@
 //!   method on [`ComplexEigenSolver`] without changing this one.
 
 use faer::mat::MatRef;
-use faer::{c64, Mat};
+use faer::{Mat, c64};
 
 use crate::eigen::EigenError;
 

--- a/crates/geode-core/src/complex_lanczos.rs
+++ b/crates/geode-core/src/complex_lanczos.rs
@@ -65,7 +65,7 @@
 
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, SparseColMatRef};
-use faer::{c64, Mat, MatMut};
+use faer::{Mat, MatMut, c64};
 
 use crate::eigen::EigenError;
 

--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -107,16 +107,15 @@ use faer::c64;
 use faer::sparse::linalg::solvers::Lu;
 use faer::sparse::{SparseColMat, Triplet};
 
+use crate::TetMesh;
 use crate::complex_lanczos::{solve_with_lu, spmv};
-use crate::lumped_port::{assemble_port_flux, assemble_port_surface_mass, LumpedPort};
+use crate::lumped_port::{LumpedPort, assemble_port_flux, assemble_port_surface_mass};
 use crate::nedelec_assembly::{
-    assemble_global_nedelec_with_anisotropic_epsilon_sparse,
+    NedelecScatterMap, assemble_global_nedelec_with_anisotropic_epsilon_sparse,
     assemble_global_nedelec_with_complex_epsilon_sparse,
     assemble_global_nedelec_with_full_tensors_sparse, assemble_nedelec_current_rhs,
     assemble_nedelec_current_rhs_quad4, assemble_nedelec_sigma_damping_sparse, tet_centroids,
-    NedelecScatterMap,
 };
-use crate::TetMesh;
 
 /// Errors produced by the driven-solve layer.
 #[derive(Debug, thiserror::Error)]
@@ -964,13 +963,13 @@ impl DrivenOperator {
                 want: n_tets,
             });
         }
-        if let Some(sigma) = sigma_tet {
-            if sigma.len() != n_tets {
-                return Err(DrivenError::SigmaDimMismatch {
-                    got: sigma.len(),
-                    want: n_tets,
-                });
-            }
+        if let Some(sigma) = sigma_tet
+            && sigma.len() != n_tets
+        {
+            return Err(DrivenError::SigmaDimMismatch {
+                got: sigma.len(),
+                want: n_tets,
+            });
         }
         for (index, port) in ports.iter().enumerate() {
             let invalid = |reason: &str| DrivenError::InvalidPort {
@@ -2049,7 +2048,7 @@ impl DrivenOperator {
 mod tests {
     use super::*;
     use crate::nedelec_assembly::cube_pec_interior_edges;
-    use crate::{cube_tet_mesh, DefaultBackend};
+    use crate::{DefaultBackend, cube_tet_mesh};
     use burn::tensor::backend::BackendTypes;
 
     type B = DefaultBackend;
@@ -2171,10 +2170,11 @@ mod tests {
                 assert_eq!(sol.e_edges[i], c64::new(0.0, 0.0));
             }
         }
-        assert!(sol
-            .e_edges
-            .iter()
-            .all(|e| e.re.is_finite() && e.im.is_finite()));
+        assert!(
+            sol.e_edges
+                .iter()
+                .all(|e| e.re.is_finite() && e.im.is_finite())
+        );
     }
 
     /// An isotropic DiagTensor material must agree with the Scalar
@@ -2529,10 +2529,7 @@ mod tests {
         // criteria. Printed at INFO level (cargo test --nocapture).
         eprintln!(
             "[issue #238] cube cavity grid=3, n_interior={}, COCG iters={}, residual_rel={:.3e}, rel_diff_vs_LU={:.3e}",
-            sol_ksp.n_interior,
-            report.iters,
-            report.residual_rel,
-            rel_diff,
+            sol_ksp.n_interior, report.iters, report.residual_rel, rel_diff,
         );
     }
 

--- a/crates/geode-core/src/eigen.rs
+++ b/crates/geode-core/src/eigen.rs
@@ -12,10 +12,10 @@
 //! intentional and matches the curator's #3 plan ("dense for v0 as a
 //! correctness oracle").
 
-use burn::tensor::backend::Backend;
 use burn::tensor::Tensor;
-use faer::mat::MatRef;
+use burn::tensor::backend::Backend;
 use faer::Mat;
+use faer::mat::MatRef;
 
 /// Errors produced by the eigensolver layer.
 #[derive(Debug, thiserror::Error)]

--- a/crates/geode-core/src/extraction.rs
+++ b/crates/geode-core/src/extraction.rs
@@ -61,12 +61,12 @@
 use burn::tensor::backend::Backend;
 use faer::c64;
 
+use crate::TetMesh;
 use crate::driven::{
     CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
     SurfaceImpedanceBc,
 };
-use crate::lumped_port::{port_current, port_voltage, LumpedPort};
-use crate::TetMesh;
+use crate::lumped_port::{LumpedPort, port_current, port_voltage};
 
 /// Circuit quantities of one port at one frequency, read off a driven
 /// solution.
@@ -653,11 +653,12 @@ pub fn im_z_zero_crossings(omegas: &[f64], zs: &[c64]) -> Vec<f64> {
             prev = Some((omega, z.im));
             continue;
         }
-        if let Some((w1, im1)) = prev {
-            if im1 != 0.0 && im1.signum() != z.im.signum() {
-                // Linear interpolation of the bracketed zero.
-                crossings.push(w1 + (omega - w1) * im1 / (im1 - z.im));
-            }
+        if let Some((w1, im1)) = prev
+            && im1 != 0.0
+            && im1.signum() != z.im.signum()
+        {
+            // Linear interpolation of the bracketed zero.
+            crossings.push(w1 + (omega - w1) * im1 / (im1 - z.im));
         }
         prev = Some((omega, z.im));
     }

--- a/crates/geode-core/src/fe_assemble.rs
+++ b/crates/geode-core/src/fe_assemble.rs
@@ -38,10 +38,10 @@
 use burn::tensor::backend::Backend;
 use faer::Mat;
 
-use crate::assembly::{assemble_global_p1, upload_mesh};
-use crate::eigen::{apply_dirichlet_bc, burn_matrix_to_faer, EigenError};
-use crate::nedelec_assembly::assemble_global_nedelec_with_epsilon;
 use crate::TetMesh;
+use crate::assembly::{assemble_global_p1, upload_mesh};
+use crate::eigen::{EigenError, apply_dirichlet_bc, burn_matrix_to_faer};
+use crate::nedelec_assembly::assemble_global_nedelec_with_epsilon;
 
 /// Selector for the finite element type passed to [`fe_assemble`].
 ///

--- a/crates/geode-core/src/fiber_lp.rs
+++ b/crates/geode-core/src/fiber_lp.rs
@@ -147,11 +147,7 @@ pub fn bessel_j1(x: f64) -> f64 {
                 + y * (0.844_919_987_6e-5 + y * (-0.882_898_967_0e-6 + y * 0.105_787_412_0e-6)));
         let ans = (std::f64::consts::FRAC_2_PI / ax).sqrt() * (xx.cos() * p1 - z * xx.sin() * p2);
         // J₁ is odd; the asymptotic form above is for ax = |x|.
-        if x < 0.0 {
-            -ans
-        } else {
-            ans
-        }
+        if x < 0.0 { -ans } else { ans }
     }
 }
 
@@ -355,11 +351,7 @@ fn bessel_i1(x: f64) -> f64 {
                 + y * (-0.362_018e-2 + y * (0.163_801e-2 + y * (-0.103_155_55e-1 + y * ans))));
         ans * (ax.exp() / ax.sqrt())
     };
-    if x < 0.0 {
-        -ans
-    } else {
-        ans
-    }
+    if x < 0.0 { -ans } else { ans }
 }
 
 /// Normalized frequency (V-number) of a step-index fiber,

--- a/crates/geode-core/src/iterate.rs
+++ b/crates/geode-core/src/iterate.rs
@@ -319,10 +319,10 @@ mod tests {
         let residuals = [8.0_f64, 4.0, 6.0, 1.0];
         let (outcome, report) = iterate_while_with_prev(0usize, 10, |_it, prev, idx| {
             let r = residuals[idx];
-            if let Some(&prev_idx) = prev {
-                if r > residuals[prev_idx] {
-                    return Step::Done(format!("diverged at idx {idx}"));
-                }
+            if let Some(&prev_idx) = prev
+                && r > residuals[prev_idx]
+            {
+                return Step::Done(format!("diverged at idx {idx}"));
             }
             Step::Continue(idx + 1)
         });

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -42,7 +42,7 @@ pub(crate) mod whitney_face;
 pub mod arpack;
 
 pub use assembly::{
-    assemble_global_p1, gather_tet_coords, upload_mesh, GlobalSystem, SparsityPattern,
+    GlobalSystem, SparsityPattern, assemble_global_p1, gather_tet_coords, upload_mesh,
 };
 pub use complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 pub use complex_lanczos::{
@@ -50,71 +50,74 @@ pub use complex_lanczos::{
 };
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
 pub use driven::{
-    driven_solve, driven_solve_iterative, driven_solve_quad, driven_solve_with_ports,
-    driven_solve_with_sigma, driven_solve_with_sigma_quad, driven_solve_with_surface_impedance,
     BackSolveReport, CurrentSource, DrivenBcs, DrivenError, DrivenLinearSolver, DrivenMaterials,
     DrivenOperator, DrivenSolution, FactoredDrivenOperator, IterativeSettings, QuadCurrentSource,
-    SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel,
+    SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel, driven_solve, driven_solve_iterative,
+    driven_solve_quad, driven_solve_with_ports, driven_solve_with_sigma,
+    driven_solve_with_sigma_quad, driven_solve_with_surface_impedance,
 };
 pub use eigen::{
-    apply_dirichlet_bc, burn_matrix_to_faer, cube_interior_mask, EigenError, EigenPair,
-    EigenSolver, FaerDenseEigensolver,
+    EigenError, EigenPair, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc,
+    burn_matrix_to_faer, cube_interior_mask,
 };
 pub use extraction::{
-    detect_srf, driven_frequency_sweep, driven_frequency_sweep_with_mode, extract_port_circuit,
-    im_z_zero_crossings, inductance, quality_factor, s11, s_parameter_frequency_sweep,
-    s_parameter_frequency_sweep_with_mode, PortCircuit, SMatrix, SParameterSweepPoint, SweepPoint,
+    PortCircuit, SMatrix, SParameterSweepPoint, SweepPoint, detect_srf, driven_frequency_sweep,
+    driven_frequency_sweep_with_mode, extract_port_circuit, im_z_zero_crossings, inductance,
+    quality_factor, s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode, s11,
 };
-pub use fe_assemble::{fe_assemble, DirichletBc, ElementType, FeAssembleResult};
+pub use fe_assemble::{DirichletBc, ElementType, FeAssembleResult, fe_assemble};
 pub use fiber_lp::{
     bessel_j, bessel_j0, bessel_j1, bessel_k, bessel_k0, bessel_k1, fiber_lp_neff, normalized_b,
     v_number,
 };
-pub use iterate::{iterate_while, iterate_while_with_prev, IterOutcome, IterReport, Step};
+pub use iterate::{IterOutcome, IterReport, Step, iterate_while, iterate_while_with_prev};
 pub use ksp_solve::{
     ChebyshevConfig, ChebyshevKind, ChebyshevPreconditioner, Cocg, IdentityPreconditioner,
     IluPreconditioner, JacobiPreconditioner, KspError, KspReport, KspSolve, Preconditioner,
 };
 pub use lanczos::{SparseEigenSolver, SparseShiftInvertLanczos};
 pub use lumped_port::{
-    assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
-    port_voltage, LumpedPort,
+    LumpedPort, assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
+    port_voltage,
 };
 #[allow(deprecated)]
 pub use mesh::PHYS_VACUUM_BUFFER;
 pub use mesh::{
-    cube_tet_mesh, pec_interior_mask_from_triangles, read_patch_fixture,
-    read_patch_fixture_from_bytes, read_patch_matched_fixture, read_patch_smoke_fixture,
-    read_sphere_fine_fixture, read_sphere_fixture, read_sphere_fixture_from_bytes,
-    read_spiral_fixture, read_spiral_fixture_from_bytes, read_spiral_slcfet_3hp_fixture,
-    read_spiral_slcfet_3hp_smoke_fixture, read_spiral_smoke_fixture, GmshReader, MeshError,
-    MeshReader, PatchFixture, PatchMaterials, PatchPort, SphereFixture, SpiralFixture,
-    SpiralMaterials, SpiralPort, TetMesh, FR4_MATERIALS, GENERIC_MATERIALS, PHYS_OUTER_BOUNDARY,
+    FR4_MATERIALS, GENERIC_MATERIALS, GmshReader, MeshError, MeshReader, PHYS_OUTER_BOUNDARY,
     PHYS_PML_INTERFACE, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR, PHYS_SPHERE_SURFACE, PHYS_VACUUM_GAP,
-    R_BUFFER, R_PML_INNER, R_SPHERE, SLCFET_3HP_MATERIALS,
+    PatchFixture, PatchMaterials, PatchPort, R_BUFFER, R_PML_INNER, R_SPHERE, SLCFET_3HP_MATERIALS,
+    SphereFixture, SpiralFixture, SpiralMaterials, SpiralPort, TetMesh, cube_tet_mesh,
+    pec_interior_mask_from_triangles, read_patch_fixture, read_patch_fixture_from_bytes,
+    read_patch_matched_fixture, read_patch_smoke_fixture, read_sphere_fine_fixture,
+    read_sphere_fixture, read_sphere_fixture_from_bytes, read_spiral_fixture,
+    read_spiral_fixture_from_bytes, read_spiral_slcfet_3hp_fixture,
+    read_spiral_slcfet_3hp_smoke_fixture, read_spiral_smoke_fixture,
 };
 pub use mie::{
-    characteristic_te, characteristic_tm, chi, chi_prime, merged_roots, mie_roots_catalog, psi,
-    psi_prime, resonance_roots, spherical_j, spherical_j_pair, spherical_j_prime, spherical_y,
-    spherical_y_prime, MiePolarisation, MieRoot,
+    MiePolarisation, MieRoot, characteristic_te, characteristic_tm, chi, chi_prime, merged_roots,
+    mie_roots_catalog, psi, psi_prime, resonance_roots, spherical_j, spherical_j_pair,
+    spherical_j_prime, spherical_y, spherical_y_prime,
 };
 pub use mie_open::{
+    MieRootComplex, OPEN_SPACE_WGM_N, OPEN_SPACE_WGM_R_S, OPEN_SPACE_WGM_TABLE_N15,
     characteristic_te_open, characteristic_tm_open, open_space_wgm_roots_n15, spherical_h1_c,
-    spherical_j_c, spherical_y_c, MieRootComplex, OPEN_SPACE_WGM_N, OPEN_SPACE_WGM_R_S,
-    OPEN_SPACE_WGM_TABLE_N15,
+    spherical_j_c, spherical_y_c,
 };
 pub use mie_scattering::{
-    mie_a_b, mie_coefficients, mie_efficiencies, mie_series_order, MieCoefficients, MieEfficiencies,
+    MieCoefficients, MieEfficiencies, mie_a_b, mie_coefficients, mie_efficiencies, mie_series_order,
 };
-pub use mohan::{modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l, SquareSpiral};
+pub use mohan::{SquareSpiral, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l};
 pub use nedelec::{
-    batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_mass_anisotropic_full,
-    batched_nedelec_local_matrices, batched_nedelec_local_rhs, batched_nedelec_local_rhs_quad4,
-    batched_nedelec_local_stiffness_weighted, tet_edges, NedelecLocalMatrices, TET_QUAD4_A,
-    TET_QUAD4_B,
+    NedelecLocalMatrices, TET_QUAD4_A, TET_QUAD4_B, batched_nedelec_local_mass_anisotropic_diag,
+    batched_nedelec_local_mass_anisotropic_full, batched_nedelec_local_matrices,
+    batched_nedelec_local_rhs, batched_nedelec_local_rhs_quad4,
+    batched_nedelec_local_stiffness_weighted, tet_edges,
 };
 pub use nedelec_assembly::{
-    assemble_global_nedelec, assemble_global_nedelec_with_anisotropic_epsilon,
+    DERHAM_RANK_THRESHOLD_REL, NedelecComplexGlobalSystem, NedelecFullTensorGlobalSystem,
+    NedelecGlobalSystem, NedelecScatterMap, NedelecSparseComplexSystem,
+    NedelecSparseFullTensorSystem, assemble_global_nedelec,
+    assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_anisotropic_epsilon_sparse,
     assemble_global_nedelec_with_complex_epsilon,
     assemble_global_nedelec_with_complex_epsilon_sparse, assemble_global_nedelec_with_epsilon,
@@ -125,15 +128,13 @@ pub use nedelec_assembly::{
     build_epsilon_r, burn_complex_mass_to_faer, cube_pec_interior_edges, pec_interior_edge_mask,
     rank_via_svd, restrict_gradient_dense, sparsity_pattern_from_tet_edges,
     sphere_n_interior_nodes, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, tet_centroid_radii, tet_centroids, NedelecComplexGlobalSystem,
-    NedelecFullTensorGlobalSystem, NedelecGlobalSystem, NedelecScatterMap,
-    NedelecSparseComplexSystem, NedelecSparseFullTensorSystem, DERHAM_RANK_THRESHOLD_REL,
+    spurious_dim_from_derham, tet_centroid_radii, tet_centroids,
 };
 pub use ntff::{
-    broadside_directivity, directivity, gain, ntff_far_field, principal_plane_cuts, to_db,
-    FarField, PatternCut,
+    FarField, PatternCut, broadside_directivity, directivity, gain, ntff_far_field,
+    principal_plane_cuts, to_db,
 };
-pub use p1::{batched_p1_local_matrices, P1LocalMatrices};
+pub use p1::{P1LocalMatrices, batched_p1_local_matrices};
 pub use patch_cavity::PatchCavity;
 pub use scattering::{
     build_matched_upml_materials, extinction_power, flux_power_box, mie_polarization_source,
@@ -144,40 +145,40 @@ pub use silvermuller::{
     assemble_silver_muller_surface, assemble_surface_mass, assemble_surface_mass_triplets,
 };
 pub use silvermuller_self_consistent::{
-    self_consistent_k, self_consistent_k_vector_tracked, SelfConsistentResult,
+    SelfConsistentResult, self_consistent_k, self_consistent_k_vector_tracked,
 };
-pub use sparse::{global_system_to_sparse, SparseError, SparseSystem};
+pub use sparse::{SparseError, SparseSystem, global_system_to_sparse};
 pub use wave_port::{
+    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort, WavePortSweepPoint,
     extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
     map_mode_profile_to_full_mesh, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
-    waveguide_mode_reduce, ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort,
-    WavePortSweepPoint,
+    waveguide_mode_reduce,
 };
 pub use waveguide_modes::{
-    apply_pec_2d, assemble_2d_nedelec, assemble_2d_nedelec2_with_epsilon,
-    assemble_2d_nedelec_with_epsilon, beta_outgoing, dielectric_mode_field_shape,
-    dielectric_mode_field_shape_pml, dielectric_mode_radial_profile_pml, disk_boundary_nodes,
-    disk_pec_interior_dofs2, disk_pec_interior_edges, disk_pec_interior_nodes, disk_tri_mesh,
-    disk_tri_mesh_graded, disk_tri_mesh_graded_checked, disk_tri_mesh_pml,
-    disk_tri_mesh_pml_graded, disk_tri_mesh_pml_graded_checked, epsilon_r_from_region_tags,
-    lp01_template_correlation, n_dof_2d_nedelec2, pml_stretch_tensor_2d, rect_pec_interior_dofs2,
-    rect_pec_interior_edges, rect_pec_interior_nodes, rect_tri_mesh, rect_tri_mesh_graded,
-    rect_waveguide_cutoff, restrict_gradient_dense_2d, slab_te0_neff, solve_dielectric_modes,
-    solve_dielectric_modes2, solve_dielectric_modes2_pml,
-    solve_dielectric_modes2_pml_profile_selected, solve_rect_waveguide_modes,
-    solve_rect_waveguide_modes2_cutoffs, solve_waveguide_modes, solve_waveguide_modes_with_opts,
-    spurious_dim_2d, spurious_dim_2d_p2, tri_nedelec2_local, tri_nedelec_local, worst_aspect_ratio,
-    DielectricMode, DielectricModePml, Lp01ProfileScore, Lp01RadialTemplate, ModeFieldShape,
-    ModeRadialProfile, RadialGrading, ScoredDielectricModePml, TriMesh, WaveguideModeProfile,
-    WaveguideSolveOpts, ASPECT_RATIO_SLIVER_BOUND, REGION_CLADDING, REGION_CORE, REGION_PML,
-    TRI_LOCAL_EDGES,
+    ASPECT_RATIO_SLIVER_BOUND, DielectricMode, DielectricModePml, Lp01ProfileScore,
+    Lp01RadialTemplate, ModeFieldShape, ModeRadialProfile, REGION_CLADDING, REGION_CORE,
+    REGION_PML, RadialGrading, ScoredDielectricModePml, TRI_LOCAL_EDGES, TriMesh,
+    WaveguideModeProfile, WaveguideSolveOpts, apply_pec_2d, assemble_2d_nedelec,
+    assemble_2d_nedelec_with_epsilon, assemble_2d_nedelec2_with_epsilon, beta_outgoing,
+    dielectric_mode_field_shape, dielectric_mode_field_shape_pml,
+    dielectric_mode_radial_profile_pml, disk_boundary_nodes, disk_pec_interior_dofs2,
+    disk_pec_interior_edges, disk_pec_interior_nodes, disk_tri_mesh, disk_tri_mesh_graded,
+    disk_tri_mesh_graded_checked, disk_tri_mesh_pml, disk_tri_mesh_pml_graded,
+    disk_tri_mesh_pml_graded_checked, epsilon_r_from_region_tags, lp01_template_correlation,
+    n_dof_2d_nedelec2, pml_stretch_tensor_2d, rect_pec_interior_dofs2, rect_pec_interior_edges,
+    rect_pec_interior_nodes, rect_tri_mesh, rect_tri_mesh_graded, rect_waveguide_cutoff,
+    restrict_gradient_dense_2d, slab_te0_neff, solve_dielectric_modes, solve_dielectric_modes2,
+    solve_dielectric_modes2_pml, solve_dielectric_modes2_pml_profile_selected,
+    solve_rect_waveguide_modes, solve_rect_waveguide_modes2_cutoffs, solve_waveguide_modes,
+    solve_waveguide_modes_with_opts, spurious_dim_2d, spurious_dim_2d_p2, tri_nedelec_local,
+    tri_nedelec2_local, worst_aspect_ratio,
 };
 
 #[cfg(feature = "arpack")]
 pub use arpack::ArpackEigensolver;
 
-use burn::tensor::backend::{Backend, BackendTypes};
 use burn::tensor::Tensor;
+use burn::tensor::backend::{Backend, BackendTypes};
 
 // Backend selection is feature-driven, with a precedence policy:
 // `ndarray` > `cuda` > `wgpu`. The native GPU backends `wgpu` and

--- a/crates/geode-core/src/lumped_port.rs
+++ b/crates/geode-core/src/lumped_port.rs
@@ -77,8 +77,8 @@
 
 use faer::c64;
 
-use crate::whitney_face::{self, dot3, edge_lookup, face_geometry, scale3, sub3, TRI_LOCAL_EDGES};
 use crate::TetMesh;
+use crate::whitney_face::{self, TRI_LOCAL_EDGES, dot3, edge_lookup, face_geometry, scale3, sub3};
 
 /// Palace-style uniform lumped port specification.
 ///
@@ -266,7 +266,7 @@ pub fn port_input_impedance(
 mod tests {
     use super::*;
     use crate::silvermuller::assemble_silver_muller_surface;
-    use crate::{cube_tet_mesh, TetMesh};
+    use crate::{TetMesh, cube_tet_mesh};
     use std::collections::BTreeMap;
 
     fn unit_triangle_mesh() -> (TetMesh, Vec<[u32; 3]>) {

--- a/crates/geode-core/src/mesh/mod.rs
+++ b/crates/geode-core/src/mesh/mod.rs
@@ -18,25 +18,25 @@ pub mod spiral;
 #[allow(deprecated)]
 pub use sphere::PHYS_VACUUM_BUFFER;
 pub use sphere::{
-    read_sphere_fine_fixture, read_sphere_fixture, read_sphere_fixture_from_bytes, SphereFixture,
     PHYS_OUTER_BOUNDARY, PHYS_PML_INTERFACE, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR,
-    PHYS_SPHERE_SURFACE, PHYS_VACUUM_GAP, R_BUFFER, R_PML_INNER, R_SPHERE,
+    PHYS_SPHERE_SURFACE, PHYS_VACUUM_GAP, R_BUFFER, R_PML_INNER, R_SPHERE, SphereFixture,
+    read_sphere_fine_fixture, read_sphere_fixture, read_sphere_fixture_from_bytes,
 };
 // The spiral fixture's PHYS_* tag constants stay namespaced under
 // `mesh::spiral` — several names (e.g. `PHYS_OUTER_BOUNDARY`) would
 // collide with the sphere fixture's crate-root re-exports above.
 pub use spiral::{
+    GENERIC_MATERIALS, SLCFET_3HP_MATERIALS, SpiralFixture, SpiralMaterials, SpiralPort,
     pec_interior_mask_from_triangles, read_spiral_fixture, read_spiral_fixture_from_bytes,
     read_spiral_slcfet_3hp_fixture, read_spiral_slcfet_3hp_smoke_fixture,
-    read_spiral_smoke_fixture, SpiralFixture, SpiralMaterials, SpiralPort, GENERIC_MATERIALS,
-    SLCFET_3HP_MATERIALS,
+    read_spiral_smoke_fixture,
 };
 // The patch fixture's PHYS_* tag constants stay namespaced under
 // `mesh::patch` — like the spiral, several names (e.g.
 // `PHYS_OUTER_BOUNDARY`) would collide with the sphere re-exports above.
 pub use patch::{
-    read_patch_fixture, read_patch_fixture_from_bytes, read_patch_matched_fixture,
-    read_patch_smoke_fixture, PatchFixture, PatchMaterials, PatchPort, FR4_MATERIALS,
+    FR4_MATERIALS, PatchFixture, PatchMaterials, PatchPort, read_patch_fixture,
+    read_patch_fixture_from_bytes, read_patch_matched_fixture, read_patch_smoke_fixture,
 };
 
 /// CPU-side tetrahedral mesh produced by a `MeshReader`.
@@ -290,11 +290,7 @@ fn triple_permutation_sign(local: &[u32; 3]) -> i8 {
     if local[1] > local[2] {
         inv += 1;
     }
-    if inv.is_multiple_of(2) {
-        1
-    } else {
-        -1
-    }
+    if inv.is_multiple_of(2) { 1 } else { -1 }
 }
 
 /// Generate a tetrahedralized cube `[0, side]^3` with `n` hexes per side,

--- a/crates/geode-core/src/mie.rs
+++ b/crates/geode-core/src/mie.rs
@@ -41,7 +41,7 @@
 //! recurrence for `y_l`) for higher `l`. Roots are extracted by dense
 //! sampling + sign-change bracketing + bisection refinement.
 
-use crate::iterate::{iterate_while, IterOutcome, Step};
+use crate::iterate::{IterOutcome, Step, iterate_while};
 
 /// Polarisation of an electromagnetic resonance in the spherical
 /// cavity.

--- a/crates/geode-core/src/nedelec.rs
+++ b/crates/geode-core/src/nedelec.rs
@@ -94,8 +94,8 @@
 //! against a CPU reference, (c) rigid-motion / dilation invariants,
 //! and (d) symmetry / sign-flip behavior on a two-tet shared-edge mesh.
 
-use burn::tensor::backend::Backend;
 use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
 
 /// Canonical local edge → (local vertex pair) ordering on a tet.
 ///

--- a/crates/geode-core/src/nedelec_assembly.rs
+++ b/crates/geode-core/src/nedelec_assembly.rs
@@ -19,18 +19,18 @@
 
 use std::collections::BTreeSet;
 
-use burn::tensor::backend::Backend;
 use burn::tensor::ElementConversion;
 use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
 use burn::tensor::{IndexingUpdateOp, Int, TensorData};
 use faer::Mat;
 
-use crate::assembly::{gather_tet_coords, SparsityPattern};
+use crate::TetMesh;
+use crate::assembly::{SparsityPattern, gather_tet_coords};
 use crate::nedelec::{
     batched_nedelec_local_mass_anisotropic_diag, batched_nedelec_local_mass_anisotropic_full,
     batched_nedelec_local_matrices, batched_nedelec_local_stiffness_weighted,
 };
-use crate::TetMesh;
 
 /// Assembled global Nédélec linear system in dense Burn-tensor form.
 #[derive(Debug, Clone)]

--- a/crates/geode-core/src/ntff.rs
+++ b/crates/geode-core/src/ntff.rs
@@ -54,8 +54,8 @@ use std::f64::consts::PI;
 
 use faer::c64;
 
-use crate::scattering::{box_surface_samples, BoxFaceSample};
 use crate::TetMesh;
+use crate::scattering::{BoxFaceSample, box_surface_samples};
 
 /// Free-space impedance in the codebase's natural units (`η₀ = 1`).
 const ETA_0_NATURAL: f64 = 1.0;
@@ -419,7 +419,7 @@ mod tests {
         let ct = p[2] / r; // cosθ
         let rho = (p[0] * p[0] + p[1] * p[1]).sqrt();
         let st = rho / r; // sinθ
-                          // Azimuth basis.
+        // Azimuth basis.
         let (cp, sp) = if rho > 1e-14 {
             (p[0] / rho, p[1] / rho)
         } else {

--- a/crates/geode-core/src/p1.rs
+++ b/crates/geode-core/src/p1.rs
@@ -30,8 +30,8 @@
 //! M_{ij} = (V / 20) (1 + δ_{ij})    (consistent mass).
 //! ```
 
-use burn::tensor::backend::Backend;
 use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
 
 /// Batched P1 element-local matrices.
 #[derive(Debug, Clone)]

--- a/crates/geode-core/src/scattering.rs
+++ b/crates/geode-core/src/scattering.rs
@@ -115,9 +115,9 @@
 use faer::c64;
 use faer::sparse::{SparseColMat, Triplet};
 
+use crate::TetMesh;
 use crate::driven::{CurrentSource, DrivenError, DrivenSolution};
 use crate::mesh::{TET_LOCAL_EDGES, TET_LOCAL_FACES};
-use crate::TetMesh;
 
 /// Incident plane wave `E_inc(x) = x̂ · exp(−i ω z)` (unit amplitude,
 /// `x̂`-polarized, propagating along `+z` under `exp(+jωt)`).

--- a/crates/geode-core/src/silvermuller.rs
+++ b/crates/geode-core/src/silvermuller.rs
@@ -146,7 +146,7 @@ pub fn assemble_silver_muller_surface(
     let selected: Vec<[u32; 3]> = boundary_triangles
         .iter()
         .zip(boundary_tags.iter())
-        .filter(|(_, &tag)| tag == outer_tag)
+        .filter(|&(_, &tag)| tag == outer_tag)
         .map(|(tri, _)| *tri)
         .collect();
     assemble_surface_mass(mesh, &selected, edges)

--- a/crates/geode-core/src/silvermuller_self_consistent.rs
+++ b/crates/geode-core/src/silvermuller_self_consistent.rs
@@ -65,7 +65,7 @@ use faer::mat::MatRef;
 
 use crate::complex_eigen::{ComplexEigenSolver, FaerComplexEigensolver};
 use crate::eigen::EigenError;
-use crate::iterate::{iterate_while_with_prev, IterOutcome, Step};
+use crate::iterate::{IterOutcome, Step, iterate_while_with_prev};
 
 /// Outcome of [`self_consistent_k`].
 #[derive(Debug, Clone)]
@@ -224,15 +224,14 @@ pub fn self_consistent_k(
             // Divergence guard — only active *after* the damped phase, and
             // we need at least one prior step to compare against.
             let dk_rel = abs_dk / k0_mag;
-            if it > DAMPED_ITERATIONS {
-                if let Some(prev_dk_rel) = prev.and_then(|p| p.dk_rel) {
-                    if dk_rel > prev_dk_rel {
-                        return Step::Done(Ok(SelfConsistentResult::Diverged {
-                            last_k: last_k.unwrap_or(k_target),
-                            iterations: it,
-                        }));
-                    }
-                }
+            if it > DAMPED_ITERATIONS
+                && let Some(prev_dk_rel) = prev.and_then(|p| p.dk_rel)
+                && dk_rel > prev_dk_rel
+            {
+                return Step::Done(Ok(SelfConsistentResult::Diverged {
+                    last_k: last_k.unwrap_or(k_target),
+                    iterations: it,
+                }));
             }
 
             // Damped update.
@@ -494,15 +493,14 @@ pub fn self_consistent_k_vector_tracked(
         }
 
         let dk_rel = abs_dk / k0_mag;
-        if it > DAMPED_ITERATIONS {
-            if let Some(prev) = prev_dk_rel {
-                if dk_rel > prev {
-                    return Ok(SelfConsistentResult::Diverged {
-                        last_k: last_k.unwrap_or(k_target),
-                        iterations: it,
-                    });
-                }
-            }
+        if it > DAMPED_ITERATIONS
+            && let Some(prev) = prev_dk_rel
+            && dk_rel > prev
+        {
+            return Ok(SelfConsistentResult::Diverged {
+                last_k: last_k.unwrap_or(k_target),
+                iterations: it,
+            });
         }
         prev_dk_rel = Some(dk_rel);
 

--- a/crates/geode-core/src/sparse.rs
+++ b/crates/geode-core/src/sparse.rs
@@ -128,7 +128,7 @@ pub fn global_system_to_sparse<B: Backend>(
 mod tests {
     use super::*;
     use crate::{
-        assemble_global_p1, cube_interior_mask, cube_tet_mesh, upload_mesh, DefaultBackend,
+        DefaultBackend, assemble_global_p1, cube_interior_mask, cube_tet_mesh, upload_mesh,
     };
     use burn::tensor::backend::BackendTypes;
 

--- a/crates/geode-core/src/wave_port.rs
+++ b/crates/geode-core/src/wave_port.rs
@@ -111,13 +111,13 @@
 
 use faer::c64;
 
+use crate::TetMesh;
 use crate::driven::{
     CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
     SurfaceImpedanceBc,
 };
 use crate::lumped_port::LumpedPort;
 use crate::silvermuller::assemble_surface_mass_triplets;
-use crate::TetMesh;
 
 /// One mode of a [`WavePort`]: the modal eigenvector over the 3-D mesh
 /// edge table, the cutoff wavenumber `k_c`, and the incident modal
@@ -1335,7 +1335,7 @@ impl ExtrudedHeightStepMesh {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::waveguide_modes::{rect_tri_mesh, solve_rect_waveguide_modes, TriMesh};
+    use crate::waveguide_modes::{TriMesh, rect_tri_mesh, solve_rect_waveguide_modes};
 
     #[test]
     fn extruded_waveguide_mesh_shapes_are_consistent() {

--- a/crates/geode-core/src/waveguide_modes.rs
+++ b/crates/geode-core/src/waveguide_modes.rs
@@ -70,9 +70,9 @@
 //! nodes after PEC reduction. This mirrors the 3-D path in
 //! `nedelec_assembly::spurious_dim_from_derham`.
 
+use faer::Mat;
 use faer::c64;
 use faer::sparse::{SparseColMat, SparseColMatRef, Triplet};
-use faer::Mat;
 
 use crate::complex_lanczos::SparseComplexShiftInvertLanczos;
 use crate::eigen::EigenError;
@@ -946,11 +946,11 @@ fn build_disk_mesh(
             let b = ring_node(g, s + 1); // inner, sector s+1
             let c = ring_node(g + 1, s + 1); // outer, sector s+1
             let d = ring_node(g + 1, s); // outer, sector s
-                                         // Cell corners: a = inner sector s, b = inner sector s+1,
-                                         // c = outer sector s+1, d = outer sector s. Traversed
-                                         // a → d → c → b (out a radial spoke, CCW along the outer arc,
-                                         // back in, CW along the inner arc) the quad is CCW; split on
-                                         // the a→c diagonal into two CCW triangles.
+            // Cell corners: a = inner sector s, b = inner sector s+1,
+            // c = outer sector s+1, d = outer sector s. Traversed
+            // a → d → c → b (out a radial spoke, CCW along the outer arc,
+            // back in, CW along the inner arc) the quad is CCW; split on
+            // the a→c diagonal into two CCW triangles.
             tris.push([a, d, c]);
             tris.push([a, c, b]);
         }
@@ -7093,11 +7093,7 @@ mod tests {
                     + mesh.nodes[t[1] as usize][1]
                     + mesh.nodes[t[2] as usize][1])
                     / 3.0;
-                if yc < h / 2.0 {
-                    1
-                } else {
-                    0
-                }
+                if yc < h / 2.0 { 1 } else { 0 }
             })
             .collect();
         let eps_r =
@@ -7243,22 +7239,14 @@ mod tests {
                     + mesh.nodes[t[1] as usize][1]
                     + mesh.nodes[t[2] as usize][1])
                     / 3.0;
-                if (yc - 0.5 * h).abs() < 0.5 * d {
-                    1
-                } else {
-                    0
-                }
+                if (yc - 0.5 * h).abs() < 0.5 * d { 1 } else { 0 }
             })
             .collect();
         let eps_r =
             epsilon_r_from_region_tags(
                 &region_tags,
                 |tag| {
-                    if tag == 1 {
-                        eps_core
-                    } else {
-                        eps_clad
-                    }
+                    if tag == 1 { eps_core } else { eps_clad }
                 },
             );
         let (_edges, interior) = rect_pec_interior_edges(&mesh, w, h);
@@ -7289,9 +7277,9 @@ mod tests {
         // bound mode. W small (invariant direction); H tall.
         let w = 0.20_f64;
         let h = 4.0_f64; // many µm of cladding each side
-                         // Keep elements near-isotropic to suppress spurious edge-element
-                         // modes (anisotropic slivers from a tall thin domain pollute the
-                         // spectrum). Element size ≈ w/nx ≈ h/ny.
+        // Keep elements near-isotropic to suppress spurious edge-element
+        // modes (anisotropic slivers from a tall thin domain pollute the
+        // spectrum). Element size ≈ w/nx ≈ h/ny.
         let nx = 4;
         let ny = 80;
         let (mesh, eps_r, interior) = slab_fixture(nx, ny, w, h, d, eps_core, eps_clad);
@@ -7705,11 +7693,7 @@ mod tests {
             epsilon_r_from_region_tags(
                 &region_tags,
                 |tag| {
-                    if tag == 1 {
-                        eps_core
-                    } else {
-                        eps_clad
-                    }
+                    if tag == 1 { eps_core } else { eps_clad }
                 },
             );
         let (_edges, interior) = rect_pec_interior_edges(&mesh, w, h);

--- a/crates/geode-core/tests/assembly.rs
+++ b/crates/geode-core/tests/assembly.rs
@@ -14,11 +14,11 @@
 //!      probe at a single picked node within a coarse tolerance.
 
 use burn::backend::Autodiff;
-use burn::tensor::backend::BackendTypes;
 use burn::tensor::ElementConversion;
+use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Int, Tensor, TensorData};
 
-use geode_core::{assemble_global_p1, cube_tet_mesh, upload_mesh, DefaultBackend};
+use geode_core::{DefaultBackend, assemble_global_p1, cube_tet_mesh, upload_mesh};
 
 mod common;
 use common::readback_f64;

--- a/crates/geode-core/tests/circular_waveguide_modes.rs
+++ b/crates/geode-core/tests/circular_waveguide_modes.rs
@@ -47,7 +47,7 @@
 //! cargo test -p geode-core --test circular_waveguide_modes
 //! ```
 
-use geode_core::{solve_waveguide_modes, TriMesh};
+use geode_core::{TriMesh, solve_waveguide_modes};
 
 /// Hard-coded Bessel-zero table for the analytic oracle. Values from
 /// Abramowitz & Stegun Table 9.5 (J_m zeros) and 9.6 (J'_m zeros),

--- a/crates/geode-core/tests/cube_convergence_regression.rs
+++ b/crates/geode-core/tests/cube_convergence_regression.rs
@@ -36,8 +36,8 @@ use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/derham_curl.rs
+++ b/crates/geode-core/tests/derham_curl.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 
 use faer::sparse::SparseColMat;
-use geode_core::{cube_tet_mesh, curl_map, gradient_map, TetMesh};
+use geode_core::{TetMesh, cube_tet_mesh, curl_map, gradient_map};
 
 /// A single tet on nodes 0..4. Connectivity is all that matters for
 /// `d¹`; the coordinates below form a unit reference tet for good

--- a/crates/geode-core/tests/derham_divergence.rs
+++ b/crates/geode-core/tests/derham_divergence.rs
@@ -27,7 +27,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use geode_core::{apply_divergence, cube_tet_mesh, curl_map, divergence_map, TetMesh};
+use geode_core::{TetMesh, apply_divergence, cube_tet_mesh, curl_map, divergence_map};
 
 /// A single tet on nodes 0..4. Connectivity is all that matters for
 /// `d²`; the coordinates below form a unit reference tet for good

--- a/crates/geode-core/tests/derham_exact_sequence.rs
+++ b/crates/geode-core/tests/derham_exact_sequence.rs
@@ -44,7 +44,7 @@
 
 use faer::sparse::SparseColMat;
 use geode_core::{
-    cube_tet_mesh, curl_map, divergence_map, gradient_map, read_sphere_fixture, TetMesh,
+    TetMesh, cube_tet_mesh, curl_map, divergence_map, gradient_map, read_sphere_fixture,
 };
 
 /// Assert that `&a * &b` is bit-exactly the zero matrix of shape

--- a/crates/geode-core/tests/derham_gauge_invariance.rs
+++ b/crates/geode-core/tests/derham_gauge_invariance.rs
@@ -97,12 +97,12 @@
 //! ```
 
 use burn::tensor::backend::BackendTypes;
-use faer::linalg::solvers::Solve;
 use faer::Mat;
+use faer::linalg::solvers::Solve;
 
 use geode_core::{
-    apply_dirichlet_bc, apply_gradient, assemble_global_nedelec, burn_matrix_to_faer,
-    cube_interior_mask, cube_pec_interior_edges, cube_tet_mesh, upload_mesh, DefaultBackend,
+    DefaultBackend, apply_dirichlet_bc, apply_gradient, assemble_global_nedelec,
+    burn_matrix_to_faer, cube_interior_mask, cube_pec_interior_edges, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/derham_gradient.rs
+++ b/crates/geode-core/tests/derham_gradient.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use geode_core::{apply_gradient, cube_tet_mesh, gradient_map, TetMesh};
+use geode_core::{TetMesh, apply_gradient, cube_tet_mesh, gradient_map};
 
 /// A single tet on nodes 0..4. Connectivity is all that matters for `d⁰`;
 /// the coordinates below form a unit reference tet for good measure.

--- a/crates/geode-core/tests/derham_gradient_kernel.rs
+++ b/crates/geode-core/tests/derham_gradient_kernel.rs
@@ -79,10 +79,10 @@ use burn::tensor::backend::BackendTypes;
 use faer::Mat;
 
 use geode_core::{
-    apply_dirichlet_bc, apply_gradient, assemble_global_nedelec,
+    DefaultBackend, R_BUFFER, TetMesh, apply_dirichlet_bc, apply_gradient, assemble_global_nedelec,
     assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml, burn_matrix_to_faer,
     cube_interior_mask, cube_pec_interior_edges, cube_tet_mesh, read_sphere_fixture,
-    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh, DefaultBackend, TetMesh, R_BUFFER,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/derham_kernel_dim.rs
+++ b/crates/geode-core/tests/derham_kernel_dim.rs
@@ -84,12 +84,12 @@ use burn::tensor::backend::BackendTypes;
 use faer::Mat;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec, assemble_global_nedelec_with_complex_epsilon,
-    build_complex_epsilon_r_pml, burn_complex_mass_to_faer, burn_matrix_to_faer,
-    cube_interior_mask, cube_pec_interior_edges, cube_tet_mesh, gradient_map, read_sphere_fixture,
-    restrict_gradient_dense, sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
     ComplexEigenSolver, DefaultBackend, EigenSolver, FaerComplexEigensolver, FaerDenseEigensolver,
-    TetMesh, R_BUFFER,
+    R_BUFFER, TetMesh, apply_dirichlet_bc, assemble_global_nedelec,
+    assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
+    burn_complex_mass_to_faer, burn_matrix_to_faer, cube_interior_mask, cube_pec_interior_edges,
+    cube_tet_mesh, gradient_map, read_sphere_fixture, restrict_gradient_dense,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/driven_manufactured.rs
+++ b/crates/geode-core/tests/driven_manufactured.rs
@@ -48,9 +48,9 @@ use faer::c64;
 use std::f64::consts::PI;
 
 use geode_core::{
-    assemble_global_nedelec, batched_nedelec_local_rhs, burn_matrix_to_faer,
-    cube_pec_interior_edges, cube_tet_mesh, driven_solve, upload_mesh, CurrentSource,
-    DefaultBackend, DrivenBcs, DrivenMaterials,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, assemble_global_nedelec,
+    batched_nedelec_local_rhs, burn_matrix_to_faer, cube_pec_interior_edges, cube_tet_mesh,
+    driven_solve, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/driven_upml.rs
+++ b/crates/geode-core/tests/driven_upml.rs
@@ -28,9 +28,9 @@ use burn::tensor::backend::BackendTypes;
 use faer::c64;
 
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, R_BUFFER, R_PML_INNER, R_SPHERE,
     build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, driven_solve,
     read_sphere_fixture, sphere_pec_interior_edges, tet_centroid_radii, tet_centroids,
-    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, R_BUFFER, R_PML_INNER, R_SPHERE,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/eigensolver.rs
+++ b/crates/geode-core/tests/eigensolver.rs
@@ -51,8 +51,8 @@
 //! standard) would lift this restriction (deferred to v2).
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 
 use burn::tensor::backend::BackendTypes;

--- a/crates/geode-core/tests/extraction.rs
+++ b/crates/geode-core/tests/extraction.rs
@@ -43,11 +43,10 @@ use std::collections::BTreeMap;
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
-    detect_srf, driven_frequency_sweep, driven_solve_with_ports,
-    driven_solve_with_surface_impedance, extract_port_circuit, port_input_impedance, s11,
-    s_parameter_frequency_sweep, CurrentSource, DefaultBackend, DrivenBcs, DrivenError,
-    DrivenMaterials, DrivenOperator, LumpedPort, SurfaceImpedanceBc, SurfaceImpedanceModel,
-    TetMesh,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator,
+    LumpedPort, SurfaceImpedanceBc, SurfaceImpedanceModel, TetMesh, detect_srf,
+    driven_frequency_sweep, driven_solve_with_ports, driven_solve_with_surface_impedance,
+    extract_port_circuit, port_input_impedance, s_parameter_frequency_sweep, s11,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/fe_assemble.rs
+++ b/crates/geode-core/tests/fe_assemble.rs
@@ -8,9 +8,9 @@ use burn::tensor::backend::BackendTypes;
 
 use geode_core::fe_assemble::fe_assemble;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, assemble_global_p1, build_epsilon_r,
-    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, read_sphere_fixture,
-    sphere_pec_interior_edges, upload_mesh, DefaultBackend, DirichletBc, ElementType, R_BUFFER,
+    DefaultBackend, DirichletBc, ElementType, R_BUFFER, apply_dirichlet_bc,
+    assemble_global_nedelec_with_epsilon, assemble_global_p1, build_epsilon_r, burn_matrix_to_faer,
+    cube_interior_mask, cube_tet_mesh, read_sphere_fixture, sphere_pec_interior_edges, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/high_contrast_fiber_benchmark.rs
+++ b/crates/geode-core/tests/high_contrast_fiber_benchmark.rs
@@ -72,9 +72,9 @@
 //!   ```
 
 use geode_core::{
-    dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
-    epsilon_r_from_region_tags, fiber_lp_neff, normalized_b, solve_dielectric_modes2_pml, v_number,
-    TriMesh, REGION_CORE,
+    REGION_CORE, TriMesh, dielectric_mode_field_shape_pml, disk_pec_interior_dofs2,
+    disk_tri_mesh_pml, epsilon_r_from_region_tags, fiber_lp_neff, normalized_b,
+    solve_dielectric_modes2_pml, v_number,
 };
 
 /// Cladding index (SMF-28 reuse) and a ~3 % higher core index. The step

--- a/crates/geode-core/tests/iterative_sweep.rs
+++ b/crates/geode-core/tests/iterative_sweep.rs
@@ -26,11 +26,11 @@
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
-    cube_tet_mesh, driven_frequency_sweep, driven_frequency_sweep_with_mode,
-    extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh, rect_tri_mesh,
-    s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode, solve_rect_waveguide_modes,
-    solve_wave_port_sweep, solve_wave_port_sweep_with_mode, CurrentSource, DefaultBackend,
-    DrivenBcs, DrivenMaterials, IterativeSettings, LumpedPort, SolverMode, TetMesh, WavePort,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, IterativeSettings, LumpedPort,
+    SolverMode, TetMesh, WavePort, cube_tet_mesh, driven_frequency_sweep,
+    driven_frequency_sweep_with_mode, extruded_rect_waveguide_mesh, map_mode_profile_to_full_mesh,
+    rect_tri_mesh, s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode,
+    solve_rect_waveguide_modes, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
 };
 
 type B = DefaultBackend;
@@ -306,11 +306,7 @@ fn build_te10_port(
         .iter()
         .map(|e| {
             let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
-            if a3 < b3 {
-                [a3, b3]
-            } else {
-                [b3, a3]
-            }
+            if a3 < b3 { [a3, b3] } else { [b3, a3] }
         })
         .collect();
     let modes = solve_rect_waveguide_modes(&port_mesh, a, b, 1).expect("2-D modal solve");

--- a/crates/geode-core/tests/leontovich_surface_impedance.rs
+++ b/crates/geode-core/tests/leontovich_surface_impedance.rs
@@ -40,19 +40,19 @@
 //! conductor thickness (2δ → `e^{−4}` ≈ 2% residual reflection off the
 //! backing PEC wall).
 
-use burn::tensor::backend::BackendTypes;
 use burn::tensor::Tensor;
+use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use std::collections::BTreeMap;
 use std::f64::consts::PI;
 
 use geode_core::mesh::TET_LOCAL_EDGES;
 use geode_core::{
-    assemble_global_nedelec_with_complex_epsilon, assemble_nedelec_current_rhs,
-    assemble_nedelec_sigma_damping, assemble_silver_muller_surface, assemble_surface_mass,
-    cube_pec_interior_edges, cube_tet_mesh, driven_solve, driven_solve_with_sigma,
-    driven_solve_with_surface_impedance, upload_mesh, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, SurfaceImpedanceBc, SurfaceImpedanceModel, TetMesh,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SurfaceImpedanceBc,
+    SurfaceImpedanceModel, TetMesh, assemble_global_nedelec_with_complex_epsilon,
+    assemble_nedelec_current_rhs, assemble_nedelec_sigma_damping, assemble_silver_muller_surface,
+    assemble_surface_mass, cube_pec_interior_edges, cube_tet_mesh, driven_solve,
+    driven_solve_with_sigma, driven_solve_with_surface_impedance, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/lp01_profile_selector_benchmark.rs
+++ b/crates/geode-core/tests/lp01_profile_selector_benchmark.rs
@@ -68,10 +68,10 @@
 //!   ```
 
 use geode_core::{
+    Lp01RadialTemplate, REGION_CORE, ScoredDielectricModePml, TriMesh,
     dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
     epsilon_r_from_region_tags, fiber_lp_neff, normalized_b,
-    solve_dielectric_modes2_pml_profile_selected, v_number, Lp01RadialTemplate,
-    ScoredDielectricModePml, TriMesh, REGION_CORE,
+    solve_dielectric_modes2_pml_profile_selected, v_number,
 };
 
 const N_CORE: f64 = 1.4504;
@@ -408,7 +408,9 @@ fn smf28_profile_selector_unbiased_sweep_honest_negative() {
     }
     let sigma_spread = sigma_bs.iter().cloned().fold(f64::MIN, f64::max)
         - sigma_bs.iter().cloned().fold(f64::MAX, f64::min);
-    eprintln!("  σ₀-robustness selected-b spread = {sigma_spread:.2e} (b at σ₀∈{{2,6,10}} = {sigma_bs:?})");
+    eprintln!(
+        "  σ₀-robustness selected-b spread = {sigma_spread:.2e} (b at σ₀∈{{2,6,10}} = {sigma_bs:?})"
+    );
 
     // --- Structural invariants across the sweep (UNRELAXED) ---
     assert!(

--- a/crates/geode-core/tests/lumped_port.rs
+++ b/crates/geode-core/tests/lumped_port.rs
@@ -21,10 +21,10 @@
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
-    assemble_nedelec_current_rhs, cube_tet_mesh, driven_solve, driven_solve_with_ports,
-    port_current, port_input_impedance, port_voltage, s_parameter_frequency_sweep, upload_mesh,
     CurrentSource, DefaultBackend, DrivenBcs, DrivenError, DrivenMaterials, LumpedPort,
-    SParameterSweepPoint, TetMesh,
+    SParameterSweepPoint, TetMesh, assemble_nedelec_current_rhs, cube_tet_mesh, driven_solve,
+    driven_solve_with_ports, port_current, port_input_impedance, port_voltage,
+    s_parameter_frequency_sweep, upload_mesh,
 };
 
 type B = DefaultBackend;
@@ -511,10 +511,11 @@ fn pec_backed_cavity_with_port_composes() {
             );
         }
     }
-    assert!(sol
-        .e_edges
-        .iter()
-        .all(|e| e.re.is_finite() && e.im.is_finite()));
+    assert!(
+        sol.e_edges
+            .iter()
+            .all(|e| e.re.is_finite() && e.im.is_finite())
+    );
 
     let v = port_voltage(&mesh, &port, &edges, &sol.e_edges);
     let i = port_current(&port, v);

--- a/crates/geode-core/tests/matched_upml_burn.rs
+++ b/crates/geode-core/tests/matched_upml_burn.rs
@@ -28,12 +28,12 @@ use burn::tensor::{Int, Tensor, TensorData};
 use faer::c64;
 
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenError, DrivenMaterials, PHYS_PML_SHELL,
+    PHYS_SPHERE_INTERIOR, PHYS_VACUUM_GAP, R_PML_INNER, R_SPHERE, TetMesh,
     assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
     assemble_global_nedelec_with_full_tensors, assemble_nedelec_sigma_damping,
     build_matched_upml_materials, cube_pec_interior_edges, cube_tet_mesh, driven_solve,
-    tet_centroids, upload_mesh, CurrentSource, DefaultBackend, DrivenBcs, DrivenError,
-    DrivenMaterials, TetMesh, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR, PHYS_VACUUM_GAP, R_PML_INNER,
-    R_SPHERE,
+    tet_centroids, upload_mesh,
 };
 
 type B = DefaultBackend;
@@ -413,7 +413,7 @@ fn full_tensor_assembly_preserves_autodiff() {
 /// (`A + 3B = 1`).
 #[test]
 fn quad_source_reduces_to_constant_source_for_constant_j() {
-    use geode_core::{driven_solve_quad, QuadCurrentSource};
+    use geode_core::{QuadCurrentSource, driven_solve_quad};
 
     let mesh = cube_tet_mesh(2, 1.0);
     let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);

--- a/crates/geode-core/tests/mie_driven_scattering.rs
+++ b/crates/geode-core/tests/mie_driven_scattering.rs
@@ -50,11 +50,11 @@
 use faer::c64;
 
 use geode_core::{
-    build_matched_upml_materials, driven_solve, driven_solve_quad, extinction_power,
-    mie_efficiencies, mie_polarization_source, plane_wave_polarization_current, q_from_power,
-    scattered_flux_power, solve_scattered_field_matched_upml, sphere_pec_interior_edges,
-    DefaultBackend, DrivenBcs, DrivenMaterials, QuadCurrentSource, PHYS_SPHERE_INTERIOR, R_BUFFER,
-    R_PML_INNER, R_SPHERE,
+    DefaultBackend, DrivenBcs, DrivenMaterials, PHYS_SPHERE_INTERIOR, QuadCurrentSource, R_BUFFER,
+    R_PML_INNER, R_SPHERE, build_matched_upml_materials, driven_solve, driven_solve_quad,
+    extinction_power, mie_efficiencies, mie_polarization_source, plane_wave_polarization_current,
+    q_from_power, scattered_flux_power, solve_scattered_field_matched_upml,
+    sphere_pec_interior_edges,
 };
 
 const N_INSIDE: f64 = 1.5;

--- a/crates/geode-core/tests/mie_sphere.rs
+++ b/crates/geode-core/tests/mie_sphere.rs
@@ -42,11 +42,11 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     build_anisotropic_pml_tensor_diag, burn_complex_mass_to_faer, burn_matrix_to_faer,
     merged_roots, open_space_wgm_roots_n15, read_sphere_fixture, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, R_BUFFER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroids, upload_mesh,
 };
 
 /// Q-factor band lower bound for the lowest TM_1,1 triplet (issue #40).

--- a/crates/geode-core/tests/nedelec.rs
+++ b/crates/geode-core/tests/nedelec.rs
@@ -14,8 +14,8 @@ use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Int, Tensor, TensorData};
 
 use geode_core::{
-    assemble_global_nedelec, batched_nedelec_local_matrices, cube_pec_interior_edges,
-    cube_tet_mesh, tet_edges, upload_mesh, DefaultBackend, TetMesh,
+    DefaultBackend, TetMesh, assemble_global_nedelec, batched_nedelec_local_matrices,
+    cube_pec_interior_edges, cube_tet_mesh, tet_edges, upload_mesh,
 };
 
 mod common;

--- a/crates/geode-core/tests/nedelec_cavity.rs
+++ b/crates/geode-core/tests/nedelec_cavity.rs
@@ -78,9 +78,8 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec, burn_matrix_to_faer, cube_interior_mask,
-    cube_pec_interior_edges, cube_tet_mesh, upload_mesh, DefaultBackend, EigenSolver,
-    FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_nedelec,
+    burn_matrix_to_faer, cube_interior_mask, cube_pec_interior_edges, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/nedelec_sparse.rs
+++ b/crates/geode-core/tests/nedelec_sparse.rs
@@ -25,13 +25,13 @@ use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Int, Tensor, TensorData};
 use faer::c64;
 use geode_core::{
+    DefaultBackend, NedelecScatterMap, SparsityPattern, TetMesh,
     assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_anisotropic_epsilon_sparse,
     assemble_global_nedelec_with_complex_epsilon,
     assemble_global_nedelec_with_complex_epsilon_sparse, assemble_global_nedelec_with_full_tensors,
     assemble_global_nedelec_with_full_tensors_sparse, assemble_nedelec_sigma_damping,
-    assemble_nedelec_sigma_damping_sparse, cube_tet_mesh, upload_mesh, DefaultBackend,
-    NedelecScatterMap, SparsityPattern, TetMesh,
+    assemble_nedelec_sigma_damping_sparse, cube_tet_mesh, upload_mesh,
 };
 
 type B = DefaultBackend;
@@ -311,7 +311,7 @@ fn scatter_map_slot_lookup_is_consistent() {
         .rows
         .iter()
         .zip(pattern.cols.iter())
-        .filter(|(&r, _)| r == 0)
+        .filter(|&(&r, _)| r == 0)
         .map(|(_, &c)| c)
         .collect();
     let absent = (0..n_edges)

--- a/crates/geode-core/tests/p1_local_matrices.rs
+++ b/crates/geode-core/tests/p1_local_matrices.rs
@@ -12,7 +12,7 @@
 use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Tensor, TensorData};
 
-use geode_core::{batched_p1_local_matrices, DefaultBackend, GmshReader, MeshReader};
+use geode_core::{DefaultBackend, GmshReader, MeshReader, batched_p1_local_matrices};
 
 mod common;
 use common::readback_f64;

--- a/crates/geode-core/tests/palace_ingestion.rs
+++ b/crates/geode-core/tests/palace_ingestion.rs
@@ -15,7 +15,7 @@
 
 use std::path::PathBuf;
 
-use geode_core::palace::{PalaceOracleSlot, PalaceResults, PALACE_DEFAULT_PORT_OHM};
+use geode_core::palace::{PALACE_DEFAULT_PORT_OHM, PalaceOracleSlot, PalaceResults};
 
 fn fixtures_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/palace")

--- a/crates/geode-core/tests/patch_antenna_benchmark.rs
+++ b/crates/geode-core/tests/patch_antenna_benchmark.rs
@@ -24,8 +24,8 @@ use faer::c64;
 
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::{
-    driven_frequency_sweep, pec_interior_mask_from_triangles, read_patch_smoke_fixture,
-    DefaultBackend, DrivenBcs, DrivenMaterials, PatchFixture, SweepPoint,
+    DefaultBackend, DrivenBcs, DrivenMaterials, PatchFixture, SweepPoint, driven_frequency_sweep,
+    pec_interior_mask_from_triangles, read_patch_smoke_fixture,
 };
 
 /// Free-space impedance η₀ (Ω).

--- a/crates/geode-core/tests/patch_antenna_extraction.rs
+++ b/crates/geode-core/tests/patch_antenna_extraction.rs
@@ -59,9 +59,9 @@ use faer::c64;
 
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, PatchCavity, PatchFixture,
     driven_solve_with_ports, flux_power_box, pec_interior_mask_from_triangles, port_current,
-    port_voltage, read_patch_smoke_fixture, s11, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, PatchCavity, PatchFixture,
+    port_voltage, read_patch_smoke_fixture, s11,
 };
 
 /// Free-space impedance η₀ (Ω).

--- a/crates/geode-core/tests/patch_antenna_matched.rs
+++ b/crates/geode-core/tests/patch_antenna_matched.rs
@@ -42,9 +42,9 @@ use faer::c64;
 
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, PatchCavity, PatchFixture,
     driven_solve_with_ports, flux_power_box, pec_interior_mask_from_triangles, port_current,
-    port_voltage, read_patch_matched_fixture, s11, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, PatchCavity, PatchFixture,
+    port_voltage, read_patch_matched_fixture, s11,
 };
 
 /// Free-space impedance η₀ (Ω).

--- a/crates/geode-core/tests/patch_antenna_radiation.rs
+++ b/crates/geode-core/tests/patch_antenna_radiation.rs
@@ -62,10 +62,10 @@ use faer::c64;
 
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, PatchCavity, PatchFixture,
     broadside_directivity, directivity, driven_solve_with_ports, flux_power_box, gain,
     ntff_far_field, pec_interior_mask_from_triangles, port_current, port_voltage,
-    read_patch_smoke_fixture, CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials,
-    PatchCavity, PatchFixture,
+    read_patch_smoke_fixture,
 };
 
 const ETA_0: f64 = 376.730_313_668;

--- a/crates/geode-core/tests/patch_mesh.rs
+++ b/crates/geode-core/tests/patch_mesh.rs
@@ -33,7 +33,7 @@ use geode_core::mesh::patch::{
     PHYS_AIR, PHYS_GROUND, PHYS_OUTER_BOUNDARY, PHYS_PATCH, PHYS_PORT, PHYS_SUBSTRATE, PHYS_UPML,
 };
 use geode_core::{
-    read_patch_fixture, read_patch_matched_fixture, read_patch_smoke_fixture, PatchFixture,
+    PatchFixture, read_patch_fixture, read_patch_matched_fixture, read_patch_smoke_fixture,
 };
 
 /// All seven expected physical groups: `(dim, tag, name)`.

--- a/crates/geode-core/tests/rect_waveguide_modes.rs
+++ b/crates/geode-core/tests/rect_waveguide_modes.rs
@@ -41,9 +41,9 @@
 //! needs the `rustflags = ["-C", "overflow-checks=off"]` workaround.
 
 use geode_core::{
-    apply_pec_2d, assemble_2d_nedelec, rect_pec_interior_edges, rect_pec_interior_nodes,
-    rect_tri_mesh, rect_waveguide_cutoff, solve_rect_waveguide_modes, spurious_dim_2d, EigenSolver,
-    FaerDenseEigensolver,
+    EigenSolver, FaerDenseEigensolver, apply_pec_2d, assemble_2d_nedelec, rect_pec_interior_edges,
+    rect_pec_interior_nodes, rect_tri_mesh, rect_waveguide_cutoff, solve_rect_waveguide_modes,
+    spurious_dim_2d,
 };
 
 /// Two-step sanity: PEC reduction and de-Rham nullspace dimension agree

--- a/crates/geode-core/tests/sigma_conductivity.rs
+++ b/crates/geode-core/tests/sigma_conductivity.rs
@@ -26,10 +26,10 @@ use std::collections::HashMap;
 use std::f64::consts::PI;
 
 use geode_core::{
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenError, DrivenMaterials, TetMesh,
     assemble_global_nedelec_with_complex_epsilon, assemble_nedelec_sigma_damping,
     build_complex_epsilon_eff, cube_pec_interior_edges, cube_tet_mesh, driven_solve,
-    driven_solve_with_sigma, tet_centroids, upload_mesh, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenError, DrivenMaterials, TetMesh,
+    driven_solve_with_sigma, tet_centroids, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/silvermuller_self_consistent.rs
+++ b/crates/geode-core/tests/silvermuller_self_consistent.rs
@@ -17,10 +17,10 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    assemble_global_nedelec_with_epsilon, assemble_silver_muller_surface, build_epsilon_r,
-    burn_matrix_to_faer, read_sphere_fixture, self_consistent_k, sphere_n_interior_nodes,
-    upload_mesh, ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, SelfConsistentResult,
-    PHYS_OUTER_BOUNDARY,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, PHYS_OUTER_BOUNDARY,
+    SelfConsistentResult, assemble_global_nedelec_with_epsilon, assemble_silver_muller_surface,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, self_consistent_k,
+    sphere_n_interior_nodes, upload_mesh,
 };
 
 type B = DefaultBackend;
@@ -295,7 +295,9 @@ fn frozen_target_idx_prevents_mode_hop() {
             assert!(
                 k.re >= mid - 1e-6 || k.re >= k_target - 0.5 * (k_target - k_first).abs(),
                 "frozen target_idx hopped: converged at {:.4} but expected ≈ {:.4} (neighbour {:.4})",
-                k.re, k_target, k_first
+                k.re,
+                k_target,
+                k_first
             );
             // Q-of-target sanity: positive and finite.
             assert!(q.is_finite() && q > 0.0, "Q invalid: {q}");

--- a/crates/geode-core/tests/silvermuller_self_consistent_vector_tracking.rs
+++ b/crates/geode-core/tests/silvermuller_self_consistent_vector_tracking.rs
@@ -19,10 +19,10 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    assemble_global_nedelec_with_epsilon, assemble_silver_muller_surface, build_epsilon_r,
-    burn_matrix_to_faer, read_sphere_fixture, self_consistent_k, self_consistent_k_vector_tracked,
-    sphere_n_interior_nodes, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, SelfConsistentResult, PHYS_OUTER_BOUNDARY,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, PHYS_OUTER_BOUNDARY,
+    SelfConsistentResult, assemble_global_nedelec_with_epsilon, assemble_silver_muller_surface,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, self_consistent_k,
+    self_consistent_k_vector_tracked, sphere_n_interior_nodes, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/slcfet_3hp_benchmark.rs
+++ b/crates/geode-core/tests/slcfet_3hp_benchmark.rs
@@ -51,10 +51,10 @@ use std::fs;
 use std::path::PathBuf;
 
 use geode_core::{
-    driven_frequency_sweep, mohan_current_sheet_l, pec_interior_mask_from_triangles,
-    read_spiral_slcfet_3hp_fixture, read_spiral_slcfet_3hp_smoke_fixture, CurrentSource,
-    DefaultBackend, DrivenBcs, DrivenMaterials, SpiralFixture, SquareSpiral, SurfaceImpedanceBc,
-    SurfaceImpedanceModel, SweepPoint, SLCFET_3HP_MATERIALS,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SLCFET_3HP_MATERIALS, SpiralFixture,
+    SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel, SweepPoint, driven_frequency_sweep,
+    mohan_current_sheet_l, pec_interior_mask_from_triangles, read_spiral_slcfet_3hp_fixture,
+    read_spiral_slcfet_3hp_smoke_fixture,
 };
 
 /// Free-space impedance η₀ (Ω).

--- a/crates/geode-core/tests/soi_waveguide_benchmark.rs
+++ b/crates/geode-core/tests/soi_waveguide_benchmark.rs
@@ -23,8 +23,8 @@
 //!    a tight reference. We do NOT fit to it.
 
 use geode_core::{
-    epsilon_r_from_region_tags, rect_pec_interior_edges, rect_tri_mesh, slab_te0_neff,
-    solve_dielectric_modes, TriMesh,
+    TriMesh, epsilon_r_from_region_tags, rect_pec_interior_edges, rect_tri_mesh, slab_te0_neff,
+    solve_dielectric_modes,
 };
 
 const N_SI: f64 = 3.48;

--- a/crates/geode-core/tests/sparse_complex_eigensolver.rs
+++ b/crates/geode-core/tests/sparse_complex_eigensolver.rs
@@ -27,10 +27,11 @@
 use burn::tensor::backend::BackendTypes;
 use faer::sparse::{SparseColMat, Triplet};
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, R_BUFFER, SparseComplexEigenSolver,
+    SparseComplexShiftInvertLanczos, apply_dirichlet_bc,
+    assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
     burn_complex_mass_to_faer, burn_matrix_to_faer, read_sphere_fixture, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, SparseComplexEigenSolver, SparseComplexShiftInvertLanczos, R_BUFFER,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/sparse_eigensolver.rs
+++ b/crates/geode-core/tests/sparse_eigensolver.rs
@@ -34,9 +34,9 @@
 //! ```
 
 use geode_core::{
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, SparseEigenSolver, SparseShiftInvertLanczos,
     apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    global_system_to_sparse, upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
-    SparseEigenSolver, SparseShiftInvertLanczos,
+    global_system_to_sparse, upload_mesh,
 };
 
 use burn::tensor::backend::BackendTypes;

--- a/crates/geode-core/tests/sphere_matched_upml_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_matched_upml_eigenmode.rs
@@ -53,12 +53,12 @@ use faer::c64;
 
 use faer::sparse::{SparseColMat, Triplet};
 use geode_core::{
+    DefaultBackend, MiePolarisation, MieRootComplex, PHYS_SPHERE_INTERIOR, R_BUFFER,
+    SparseComplexEigenSolver, SparseComplexShiftInvertLanczos, TetMesh,
     assemble_global_nedelec_with_complex_epsilon, assemble_global_nedelec_with_full_tensors,
     build_complex_epsilon_r_pml, build_matched_upml_materials, burn_complex_mass_to_faer,
     burn_matrix_to_faer, open_space_wgm_roots_n15, read_sphere_fixture, sphere_pec_interior_edges,
-    tet_centroid_radii, upload_mesh, DefaultBackend, MiePolarisation, MieRootComplex,
-    SparseComplexEigenSolver, SparseComplexShiftInvertLanczos, TetMesh, PHYS_SPHERE_INTERIOR,
-    R_BUFFER,
+    tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/sphere_mesh.rs
+++ b/crates/geode-core/tests/sphere_mesh.rs
@@ -19,8 +19,8 @@
 //! - All tets have positive signed volume (right-handed).
 
 use geode_core::{
-    read_sphere_fixture, PHYS_OUTER_BOUNDARY, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR,
-    PHYS_SPHERE_SURFACE, PHYS_VACUUM_GAP, R_BUFFER, R_PML_INNER, R_SPHERE,
+    PHYS_OUTER_BOUNDARY, PHYS_PML_SHELL, PHYS_SPHERE_INTERIOR, PHYS_SPHERE_SURFACE,
+    PHYS_VACUUM_GAP, R_BUFFER, R_PML_INNER, R_SPHERE, read_sphere_fixture,
 };
 
 /// Surface tolerance for the radius check: vertices sitting on the

--- a/crates/geode-core/tests/sphere_pec_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pec_eigenmode.rs
@@ -57,10 +57,10 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    merged_roots, read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
-    R_BUFFER, R_SPHERE,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, R_BUFFER, R_SPHERE, apply_dirichlet_bc,
+    assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer, merged_roots,
+    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
+    spurious_dim_from_derham, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/sphere_pml_anisotropic_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pml_anisotropic_eigenmode.rs
@@ -34,12 +34,12 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     assemble_global_nedelec_with_complex_epsilon, build_anisotropic_pml_tensor_diag,
     build_complex_epsilon_r_pml, burn_complex_mass_to_faer, burn_matrix_to_faer, merged_roots,
     read_sphere_fixture, sphere_n_interior_nodes, sphere_pec_interior_edges, tet_centroid_radii,
-    tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver,
-    MiePolarisation, R_BUFFER, R_SPHERE,
+    tet_centroids, upload_mesh,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/sphere_pml_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_pml_eigenmode.rs
@@ -58,10 +58,10 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, R_BUFFER, R_PML_INNER, R_SPHERE,
     apply_dirichlet_bc, assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
     burn_complex_mass_to_faer, burn_matrix_to_faer, read_sphere_fixture, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, R_BUFFER, R_PML_INNER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroid_radii, upload_mesh,
 };
 
 type B = DefaultBackend;
@@ -84,7 +84,7 @@ fn pml_profile_is_real_inside_imag_in_buffer() {
     let n_interior_real_only = eps
         .iter()
         .zip(f.tet_physical_tags.iter())
-        .filter(|(c, &t)| {
+        .filter(|&(c, &t)| {
             t == geode_core::PHYS_SPHERE_INTERIOR
                 && c.im.abs() < 1e-12
                 && (c.re - 2.25).abs() < 1e-9
@@ -100,7 +100,7 @@ fn pml_profile_is_real_inside_imag_in_buffer() {
     let n_gap_real_one = eps
         .iter()
         .zip(f.tet_physical_tags.iter())
-        .filter(|(c, &t)| {
+        .filter(|&(c, &t)| {
             t == geode_core::PHYS_VACUUM_GAP && c.im.abs() < 1e-12 && (c.re - 1.0).abs() < 1e-12
         })
         .count();
@@ -114,7 +114,7 @@ fn pml_profile_is_real_inside_imag_in_buffer() {
     let n_pml_lossy = eps
         .iter()
         .zip(f.tet_physical_tags.iter())
-        .filter(|(c, &t)| t == geode_core::PHYS_PML_SHELL && c.im < 0.0)
+        .filter(|&(c, &t)| t == geode_core::PHYS_PML_SHELL && c.im < 0.0)
         .count();
     assert_eq!(
         n_pml_lossy,

--- a/crates/geode-core/tests/sphere_silvermuller_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_silvermuller_eigenmode.rs
@@ -59,9 +59,9 @@
 use burn::tensor::backend::BackendTypes;
 
 use geode_core::{
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, PHYS_OUTER_BOUNDARY,
     assemble_global_nedelec_with_epsilon, assemble_silver_muller_surface, build_epsilon_r,
     burn_matrix_to_faer, read_sphere_fixture, sphere_n_interior_nodes, upload_mesh,
-    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, PHYS_OUTER_BOUNDARY,
 };
 
 type B = DefaultBackend;

--- a/crates/geode-core/tests/spiral_inductor_benchmark.rs
+++ b/crates/geode-core/tests/spiral_inductor_benchmark.rs
@@ -55,10 +55,10 @@ use std::path::PathBuf;
 
 use geode_core::mesh::spiral::CONDUCTOR_SIGMA_NATURAL;
 use geode_core::{
-    driven_frequency_sweep, mohan_current_sheet_l, pec_interior_mask_from_triangles,
-    read_spiral_fixture, read_spiral_smoke_fixture, CurrentSource, DefaultBackend, DrivenBcs,
-    DrivenMaterials, SpiralFixture, SquareSpiral, SurfaceImpedanceBc, SurfaceImpedanceModel,
-    SweepPoint,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, SpiralFixture, SquareSpiral,
+    SurfaceImpedanceBc, SurfaceImpedanceModel, SweepPoint, driven_frequency_sweep,
+    mohan_current_sheet_l, pec_interior_mask_from_triangles, read_spiral_fixture,
+    read_spiral_smoke_fixture,
 };
 
 /// Free-space impedance η₀ (Ω).

--- a/crates/geode-core/tests/spiral_mesh.rs
+++ b/crates/geode-core/tests/spiral_mesh.rs
@@ -46,10 +46,10 @@ use geode_core::mesh::spiral::{
     PHYS_OUTER_BOUNDARY, PHYS_PORT, PHYS_SUBSTRATE, PORT_E_HAT,
 };
 use geode_core::{
-    driven_solve_with_ports, pec_interior_mask_from_triangles, port_current, port_input_impedance,
-    port_voltage, read_spiral_fixture, read_spiral_smoke_fixture, CurrentSource, DefaultBackend,
-    DrivenBcs, DrivenMaterials, DrivenOperator, SpiralFixture, SurfaceImpedanceBc,
-    SurfaceImpedanceModel,
+    CurrentSource, DefaultBackend, DrivenBcs, DrivenMaterials, DrivenOperator, SpiralFixture,
+    SurfaceImpedanceBc, SurfaceImpedanceModel, driven_solve_with_ports,
+    pec_interior_mask_from_triangles, port_current, port_input_impedance, port_voltage,
+    read_spiral_fixture, read_spiral_smoke_fixture,
 };
 use std::collections::BTreeSet;
 
@@ -387,10 +387,11 @@ fn driven_operator_assembles_and_solves_benchmark_fixture() {
         "direct-solve residual {} not at round-off floor",
         sol.residual_rel
     );
-    assert!(sol
-        .e_edges
-        .iter()
-        .all(|e| e.re.is_finite() && e.im.is_finite()));
+    assert!(
+        sol.e_edges
+            .iter()
+            .all(|e| e.re.is_finite() && e.im.is_finite())
+    );
 
     let v = op.port_voltage(0, &sol.e_edges);
     let i = op.port_current(0, v);

--- a/crates/geode-core/tests/step_index_fiber_benchmark.rs
+++ b/crates/geode-core/tests/step_index_fiber_benchmark.rs
@@ -69,9 +69,9 @@
 //!   ```
 
 use geode_core::{
-    dielectric_mode_field_shape_pml, disk_pec_interior_dofs2, disk_tri_mesh_pml,
-    epsilon_r_from_region_tags, fiber_lp_neff, normalized_b, solve_dielectric_modes2_pml, v_number,
-    TriMesh, REGION_CORE,
+    REGION_CORE, TriMesh, dielectric_mode_field_shape_pml, disk_pec_interior_dofs2,
+    disk_tri_mesh_pml, epsilon_r_from_region_tags, fiber_lp_neff, normalized_b,
+    solve_dielectric_modes2_pml, v_number,
 };
 
 const N_CORE: f64 = 1.4504;

--- a/crates/geode-core/tests/wave_port.rs
+++ b/crates/geode-core/tests/wave_port.rs
@@ -35,9 +35,9 @@
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
+    DefaultBackend, DrivenBcs, DrivenMaterials, PortMode, TetMesh, WavePort,
     extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
     map_mode_profile_to_full_mesh, solve_rect_waveguide_modes, solve_wave_port_sweep,
-    DefaultBackend, DrivenBcs, DrivenMaterials, PortMode, TetMesh, WavePort,
 };
 
 type B = DefaultBackend;
@@ -100,11 +100,7 @@ fn build_te10_port(
         .iter()
         .map(|e| {
             let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
-            if a3 < b3 {
-                [a3, b3]
-            } else {
-                [b3, a3]
-            }
+            if a3 < b3 { [a3, b3] } else { [b3, a3] }
         })
         .collect();
 
@@ -475,11 +471,7 @@ fn build_te10_port_step(
         .iter()
         .map(|e| {
             let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
-            if a3 < b3 {
-                [a3, b3]
-            } else {
-                [b3, a3]
-            }
+            if a3 < b3 { [a3, b3] } else { [b3, a3] }
         })
         .collect();
 
@@ -689,11 +681,7 @@ fn build_multimode_port(
         .iter()
         .map(|e| {
             let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
-            if a3 < b3 {
-                [a3, b3]
-            } else {
-                [b3, a3]
-            }
+            if a3 < b3 { [a3, b3] } else { [b3, a3] }
         })
         .collect();
 

--- a/crates/geode-core/tests/wave_port_step_mode_matching.rs
+++ b/crates/geode-core/tests/wave_port_step_mode_matching.rs
@@ -56,9 +56,9 @@
 use burn::tensor::backend::BackendTypes;
 use faer::c64;
 use geode_core::{
+    DefaultBackend, DrivenBcs, DrivenMaterials, PortMode, TetMesh, WavePort,
     extruded_height_step_waveguide_mesh, map_mode_profile_to_full_mesh, rect_tri_mesh,
-    solve_rect_waveguide_modes, solve_wave_port_sweep, DefaultBackend, DrivenBcs, DrivenMaterials,
-    PortMode, TetMesh, WavePort,
+    solve_rect_waveguide_modes, solve_wave_port_sweep,
 };
 
 type B = DefaultBackend;
@@ -382,11 +382,7 @@ fn build_multimode_step_port(
         .iter()
         .map(|e| {
             let (a3, b3) = (n2d_to_n3d[e[0] as usize], n2d_to_n3d[e[1] as usize]);
-            if a3 < b3 {
-                [a3, b3]
-            } else {
-                [b3, a3]
-            }
+            if a3 < b3 { [a3, b3] } else { [b3, a3] }
         })
         .collect();
 

--- a/crates/geode-core/tests/waveguide_gauge_higher_order.rs
+++ b/crates/geode-core/tests/waveguide_gauge_higher_order.rs
@@ -20,7 +20,7 @@
 //! rectangular guide never hits that path (every physical mode overlaps a
 //! reference), as this test confirms by solving 6 modes without error.
 
-use geode_core::{rect_tri_mesh, solve_rect_waveguide_modes, TriMesh};
+use geode_core::{TriMesh, rect_tri_mesh, solve_rect_waveguide_modes};
 use std::f64::consts::PI;
 
 /// Signed projection of a transverse-E eigenvector onto the analytic

--- a/crates/geode-validation/src/diff.rs
+++ b/crates/geode-validation/src/diff.rs
@@ -33,10 +33,10 @@ impl ComparisonReport {
     /// Write this report to disk as JSON. Always pretty-printed —
     /// these are friction artifacts intended for human review.
     pub fn write_diff_artifact(&self, path: &Path) -> Result<(), std::io::Error> {
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent)?;
-            }
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
         }
         let json = serde_json::to_string_pretty(self).expect("ComparisonReport serializes");
         std::fs::write(path, json)

--- a/crates/geode-validation/tests/cube_cavity_jax_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_jax_reference.rs
@@ -26,8 +26,8 @@ use std::path::{Path, PathBuf};
 
 use burn::tensor::backend::BackendTypes;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/cube_cavity_julia_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_julia_reference.rs
@@ -36,8 +36,8 @@ use std::path::{Path, PathBuf};
 
 use burn::tensor::backend::BackendTypes;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, upload_mesh,
-    DefaultBackend, EigenSolver, FaerDenseEigensolver, GmshReader, MeshReader,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, GmshReader, MeshReader, apply_dirichlet_bc,
+    assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
@@ -55,12 +55,12 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, upload_mesh,
-    DefaultBackend, GmshReader, MeshReader,
+    DefaultBackend, GmshReader, MeshReader, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
@@ -24,8 +24,8 @@ use std::path::{Path, PathBuf};
 
 use burn::tensor::backend::BackendTypes;
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_p1, burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh,
-    upload_mesh, DefaultBackend, EigenSolver, FaerDenseEigensolver,
+    DefaultBackend, EigenSolver, FaerDenseEigensolver, apply_dirichlet_bc, assemble_global_p1,
+    burn_matrix_to_faer, cube_interior_mask, cube_tet_mesh, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
+++ b/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
@@ -28,7 +28,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use geode_core::{mie_efficiencies, R_SPHERE};
+use geode_core::{R_SPHERE, mie_efficiencies};
 use geode_validation::{Fixture, FixtureFormat};
 
 const N_INSIDE: f64 = 1.5;

--- a/crates/geode-validation/tests/mie_roots_julia_reference.rs
+++ b/crates/geode-validation/tests/mie_roots_julia_reference.rs
@@ -35,7 +35,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use geode_core::{
-    mie_roots_catalog, resonance_roots, MiePolarisation, MieRoot, R_BUFFER, R_SPHERE,
+    MiePolarisation, MieRoot, R_BUFFER, R_SPHERE, mie_roots_catalog, resonance_roots,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/mie_roots_numpy_reference.rs
+++ b/crates/geode-validation/tests/mie_roots_numpy_reference.rs
@@ -36,7 +36,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use geode_core::{
-    merged_roots, mie_roots_catalog, resonance_roots, MiePolarisation, MieRoot, R_BUFFER, R_SPHERE,
+    MiePolarisation, MieRoot, R_BUFFER, R_SPHERE, merged_roots, mie_roots_catalog, resonance_roots,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
@@ -50,7 +50,7 @@ use std::path::{Path, PathBuf};
 use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Tensor, TensorData};
 
-use geode_core::{batched_nedelec_local_matrices, DefaultBackend};
+use geode_core::{DefaultBackend, batched_nedelec_local_matrices};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = DefaultBackend;

--- a/crates/geode-validation/tests/p1_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/p1_local_numpy_reference.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Tensor, TensorData};
 
-use geode_core::{batched_p1_local_matrices, DefaultBackend};
+use geode_core::{DefaultBackend, batched_p1_local_matrices};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = DefaultBackend;

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -41,11 +41,11 @@ use burn::tensor::backend::BackendTypes;
 use num_complex::Complex64;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, SphereFixture, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     build_anisotropic_pml_tensor_diag, burn_complex_mass_to_faer, burn_matrix_to_faer,
     merged_roots, read_sphere_fixture_from_bytes, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, SphereFixture, R_BUFFER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroids, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -46,11 +46,11 @@ use burn::tensor::backend::BackendTypes;
 use num_complex::Complex64;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, SphereFixture, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     build_anisotropic_pml_tensor_diag, burn_complex_mass_to_faer, burn_matrix_to_faer,
     merged_roots, read_sphere_fixture_from_bytes, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, SphereFixture, R_BUFFER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroids, upload_mesh,
 };
 use geode_validation::diff::FieldStatus;
 use geode_validation::{Fixture, FixtureFormat};

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -78,11 +78,11 @@ use burn::tensor::backend::BackendTypes;
 use num_complex::Complex64;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, SphereFixture, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     build_anisotropic_pml_tensor_diag, burn_complex_mass_to_faer, burn_matrix_to_faer,
     merged_roots, read_sphere_fixture, read_sphere_fixture_from_bytes, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, SphereFixture, R_BUFFER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroids, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -48,11 +48,11 @@ use burn::tensor::backend::BackendTypes;
 use num_complex::Complex64;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, MiePolarisation, R_BUFFER,
+    R_SPHERE, SphereFixture, apply_dirichlet_bc, assemble_global_nedelec_with_anisotropic_epsilon,
     build_anisotropic_pml_tensor_diag, burn_complex_mass_to_faer, burn_matrix_to_faer,
     merged_roots, read_sphere_fixture_from_bytes, sphere_n_interior_nodes,
-    sphere_pec_interior_edges, tet_centroids, upload_mesh, ComplexEigenSolver, DefaultBackend,
-    FaerComplexEigensolver, MiePolarisation, SphereFixture, R_BUFFER, R_SPHERE,
+    sphere_pec_interior_edges, tet_centroids, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_pec_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_jax_reference.rs
@@ -37,13 +37,13 @@
 use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+    DefaultBackend, R_BUFFER, apply_dirichlet_bc, assemble_global_nedelec_with_epsilon,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, sphere_pec_interior_edges,
+    sphere_pec_node_interior_mask, spurious_dim_from_derham, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_pec_julia_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_julia_reference.rs
@@ -41,13 +41,13 @@
 use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+    DefaultBackend, R_BUFFER, apply_dirichlet_bc, assemble_global_nedelec_with_epsilon,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, sphere_pec_interior_edges,
+    sphere_pec_node_interior_mask, spurious_dim_from_derham, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_pec_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_numpy_reference.rs
@@ -62,13 +62,13 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+    DefaultBackend, R_BUFFER, apply_dirichlet_bc, assemble_global_nedelec_with_epsilon,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, sphere_pec_interior_edges,
+    sphere_pec_node_interior_mask, spurious_dim_from_derham, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 
@@ -336,11 +336,7 @@ fn filter_spurious(lambdas: &[f64], n_spurious: usize) -> (usize, f64) {
     } else {
         let a = lambdas[n_spurious - 1].abs();
         let b = lambdas[n_spurious].abs();
-        if a > 0.0 {
-            b / a
-        } else {
-            f64::INFINITY
-        }
+        if a > 0.0 { b / a } else { f64::INFINITY }
     };
     (n_spurious, ratio)
 }

--- a/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
@@ -54,13 +54,13 @@
 use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+    DefaultBackend, R_BUFFER, apply_dirichlet_bc, assemble_global_nedelec_with_epsilon,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, sphere_pec_interior_edges,
+    sphere_pec_node_interior_mask, spurious_dim_from_derham, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
@@ -51,13 +51,13 @@
 use std::path::PathBuf;
 
 use burn::tensor::backend::BackendTypes;
-use faer::mat::MatRef;
 use faer::Mat;
+use faer::mat::MatRef;
 
 use geode_core::{
-    apply_dirichlet_bc, assemble_global_nedelec_with_epsilon, build_epsilon_r, burn_matrix_to_faer,
-    read_sphere_fixture, sphere_pec_interior_edges, sphere_pec_node_interior_mask,
-    spurious_dim_from_derham, upload_mesh, DefaultBackend, R_BUFFER,
+    DefaultBackend, R_BUFFER, apply_dirichlet_bc, assemble_global_nedelec_with_epsilon,
+    build_epsilon_r, burn_matrix_to_faer, read_sphere_fixture, sphere_pec_interior_edges,
+    sphere_pec_node_interior_mask, spurious_dim_from_derham, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 

--- a/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
@@ -79,11 +79,11 @@ use burn::tensor::backend::BackendTypes;
 use num_complex::Complex64;
 
 use geode_core::{
+    ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver, R_BUFFER, SphereFixture,
     apply_dirichlet_bc, assemble_global_nedelec_with_complex_epsilon, build_complex_epsilon_r_pml,
     burn_complex_mass_to_faer, burn_matrix_to_faer, read_sphere_fixture,
     read_sphere_fixture_from_bytes, sphere_n_interior_nodes, sphere_pec_interior_edges,
-    tet_centroid_radii, upload_mesh, ComplexEigenSolver, DefaultBackend, FaerComplexEigensolver,
-    SphereFixture, R_BUFFER,
+    tet_centroid_radii, upload_mesh,
 };
 use geode_validation::{Fixture, FixtureFormat};
 


### PR DESCRIPTION
## Summary

Migrates the workspace to **Rust Edition 2024** and pins **`rust-version = "1.94.1"`**. The root `[workspace.package]` now declares `edition = "2024"`; all three crates (`geode-core`, `geode-cli`, `geode-validation`) inherit it via `edition.workspace = true` / `rust-version.workspace = true`. Local toolchain is rustc 1.96.0, so the new ceiling is satisfiable.

The migration was driven by `cargo fix --edition` (run from edition 2021) for the automatic rewrites, then completed by hand for the lints `cargo fix` does not auto-apply, followed by `cargo fmt --all` for the edition-2024 style pass.

## Changes

- `Cargo.toml`: `edition` `2021 → 2024`, `rust-version` `1.92 → 1.94.1`.
- **Match-ergonomics / binding modes (RFC 3627)** — rewrote `.filter()` closures that mixed implicit outer-`&` elision with explicit inner `&` sub-patterns:
  - `silvermuller.rs` — `.filter(|(_, &tag)| …)` → `.filter(|&(_, &tag)| …)`
  - `nedelec_sparse.rs` — `.filter(|(&r, _)| …)` → `.filter(|&(&r, _)| …)`
  - `sphere_pml_eigenmode.rs` — three `.filter(|(c, &t)| …)` sites rewritten to `.filter(|&(c, &t)| …)` (binding the `Copy` `c64` by value rather than `cargo fix`'s `ref c`, which `clippy` flagged as a needless reference-to-reference).
- **let-chain `collapsible_if`** — edition 2024 stabilises let-chains, so `clippy` now collapses nested `if cond { if let … }` into `if cond && let …`. Applied in `driven.rs`, `extraction.rs`, `silvermuller_self_consistent.rs` (2 sites), `iterate.rs`, `geode-validation/src/diff.rs`, and the `mie_sphere`, `spiral_inductor`, `patch_antenna`, `extract_baseline` examples.
- **Edition-2024 rustfmt style** — `cargo fmt --all` re-ordered `use` imports workspace-wide (types before lowercase free functions, case-sensitive sort). This is the bulk of the 114-file diff and is mechanical/no-op semantically; the existing `rustfmt.yml` CI gate reads the edition from `Cargo.toml` and will expect it.

No `#[allow(...)]` annotations were added to suppress edition lints — every pattern was rewritten. No numeric results or test assertions changed.

### Edition-2024 changes that did NOT require work
`gen` keyword (no such identifiers), `unsafe fn` body semantics (no `unsafe fn` in the workspace), `Box<[T]>::into_iter` (unused), and RPIT lifetime capture (the one `'a`-bounded site was already correct) — consistent with the curator's impact assessment.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `[workspace.package]` has `edition = "2024"` and `rust-version = "1.94.1"` | ✅ | `Cargo.toml` diff |
| `cargo check`/`clippy` clean — no match-ergonomics/binding-mode warnings | ✅ | `cargo clippy --workspace --all-targets --no-default-features --features geode-core/ndarray -- -D warnings` exits 0 |
| Existing tests pass | ✅ | Scoped run below (lib + edited tests) green; full suite delegated to CI |
| `cargo fmt --all -- --check` exits 0 | ✅ | Ran locally, exit 0 |
| No new `#[allow(...)]` for edition lints | ✅ | Patterns rewritten, not suppressed |
| No numeric results / assertions changed | ✅ | Only control-flow shape and pattern syntax changed |

## Test Plan

**Passed locally:**
- `cargo clippy --workspace --all-targets --no-default-features --features geode-core/ndarray -- -D warnings` → exit 0
- `cargo build --workspace --all-targets` (default **wgpu** backend) → exit 0
- `cargo fmt --all -- --check` → exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps --no-default-features --features ndarray` (mirrors `doc-lint.yml`) → exit 0
- Scoped tests (`--no-default-features --features geode-core/ndarray`): `geode-core` lib (262 passed / 2 ignored), `extraction` (11), `silvermuller_self_consistent` (6), `nedelec_sparse`, `sphere_pml_eigenmode` — all green. These cover every file where control flow was rewritten.

**Delegated to CI:** the full `cargo test --no-default-features --features geode-core/ndarray` suite (many physics/cross-check integration tests; full-workspace compile is ~1h locally). The migration edits are semantically inert (let-chains and match-ergonomics rewrites are behaviour-preserving), and `clippy --all-targets` already confirms every test/bench/example target compiles under edition 2024.

Closes #360