### PR TITLE
refactor(geode-core): express backend-selection cascades with std::cfg_select!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/rjwalters/geode-fem"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 [workspace.dependencies]
 # Third-party dependencies — all versions are defined here and referenced

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -194,14 +194,22 @@ compile_error!(
 // to `i32` (NdArray's default is `i64`) to match the GPU backends:
 // `assembly::tets_to_cpu` reads connectivity back as `i32`, and Burn's
 // typed readback rejects a width mismatch.
-#[cfg(feature = "ndarray")]
-pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
-
-#[cfg(all(feature = "cuda", not(feature = "ndarray")))]
-pub type DefaultBackend = burn::backend::Cuda;
-
-#[cfg(all(feature = "wgpu", not(feature = "ndarray"), not(feature = "cuda")))]
-pub type DefaultBackend = burn::backend::Wgpu;
+//
+// `cfg_select!` is first-match-wins, so arm order encodes the
+// `ndarray > cuda > wgpu` precedence and the previous `not(...)` guards
+// are no longer needed. The two `compile_error!` guards above still own
+// the "exactly one / no conflicting GPU backend" assertions.
+std::cfg_select! {
+    feature = "ndarray" => {
+        pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
+    }
+    feature = "cuda" => {
+        pub type DefaultBackend = burn::backend::Cuda;
+    }
+    feature = "wgpu" => {
+        pub type DefaultBackend = burn::backend::Wgpu;
+    }
+}
 
 /// A geometric mesh: element connectivity and node coordinates.
 ///
@@ -246,15 +254,19 @@ pub fn device_info() -> DeviceInfo {
     }
 }
 
-// Same precedence as `DefaultBackend`: ndarray > cuda > wgpu.
-#[cfg(feature = "ndarray")]
-const BACKEND_NAME: &str = "ndarray";
-
-#[cfg(all(feature = "cuda", not(feature = "ndarray")))]
-const BACKEND_NAME: &str = "cuda";
-
-#[cfg(all(feature = "wgpu", not(feature = "ndarray"), not(feature = "cuda")))]
-const BACKEND_NAME: &str = "wgpu";
+// Same precedence as `DefaultBackend`: ndarray > cuda > wgpu. Arm order
+// in `cfg_select!` (first-match-wins) encodes that precedence.
+std::cfg_select! {
+    feature = "ndarray" => {
+        const BACKEND_NAME: &str = "ndarray";
+    }
+    feature = "cuda" => {
+        const BACKEND_NAME: &str = "cuda";
+    }
+    feature = "wgpu" => {
+        const BACKEND_NAME: &str = "wgpu";
+    }
+}
 
 fn default_device_label() -> String {
     let device = <DefaultBackend as BackendTypes>::Device::default();


### PR DESCRIPTION
## Summary

Migrate the two cfg-mode cascades in `crates/geode-core/src/lib.rs` (the `DefaultBackend` type alias and the `BACKEND_NAME` const) to `std::cfg_select!` blocks with `feature = "..."` arms. `cfg_select!` is first-match-wins, so arm order alone encodes the `ndarray > cuda > wgpu` precedence and every `not(...)` guard is dropped. Behavior is unchanged across all backend configs.

## Changes

- `crates/geode-core/src/lib.rs`:
  - `DefaultBackend` type alias: three `#[cfg(...)]` arms → one `std::cfg_select!` block (`ndarray` / `cuda` / `wgpu`), `not(...)` guards removed.
  - `BACKEND_NAME` const: same three-arm cascade → one `std::cfg_select!` block.
  - The two `compile_error!` backend guards (mutual-exclusion + at-least-one) are **left intact** — they own the assertion semantics and were deliberately not folded into `cfg_select!`.
- `Cargo.toml`: bump `workspace.package.rust-version` `1.95.0` → `1.96.0`. `cfg_select!` stabilized in 1.96; the repo's pinned `stable` toolchain is rustc 1.96.0 (verified locally with `rustc --version`).

No `#![feature(...)]` gate is added — `cfg_select!` is stable on the pinned toolchain (empirically verified: a standalone `std::cfg_select!` program compiles under `rustc --edition 2024` on stable 1.96.0).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Both cascades expressed via `std::cfg_select!` with `feature = "..."` arms | ✅ | Both blocks use explicit `feature = "..."` arms (no wildcard, matching the existing `compile_error!` guard semantics which already enforce at-least-one). |
| Arm order preserves `ndarray > cuda > wgpu`; redundant `not(...)` guards removed | ✅ | First-match-wins order is `ndarray`, then `cuda`, then `wgpu`; all `not(...)` guards dropped. |
| `compile_error!` guards (~L174–186) left intact | ✅ | Untouched — confirmed in diff. |
| Behavior unchanged: default (wgpu) | ✅ | `cargo check -p geode-core` + `cargo clippy` clean. |
| Behavior unchanged: `--features ndarray` | ✅ | `cargo check`/`clippy --no-default-features --features ndarray` clean; `cargo test --lib` 262 passed, 0 failed. |
| Behavior unchanged: `--features cuda` | ✅ | `cargo check -p geode-core --no-default-features --features cuda` compiles (CUDA SDK present locally). |
| Behavior unchanged: `ndarray` + other-feature precedence | ✅ | `cargo check -p geode-core --features ndarray` (ndarray + default wgpu both active) compiles; ndarray wins, as before. |
| MSRV bumped to where `cfg_select!` is stable | ✅ | `rust-version = "1.96.0"`; standalone `cfg_select!` program compiles on stable 1.96.0. |
| No `#![feature(...)]` gate added | ✅ | None added; stable feature. |

## Test Plan

Verified in the worktree against the local pinned `stable` toolchain (rustc 1.96.0):

- `cargo fmt`
- `cargo check -p geode-core` (default = unified wgpu) — clean
- `cargo clippy -p geode-core` — clean
- `cargo check -p geode-core --no-default-features --features ndarray` — clean
- `cargo clippy -p geode-core --no-default-features --features ndarray` — clean
- `cargo test -p geode-core --no-default-features --features ndarray --lib` — 262 passed, 0 failed
- `cargo check -p geode-core --no-default-features --features cuda` — compiles
- `cargo check -p geode-core --features ndarray` (ndarray + wgpu precedence case) — compiles, ndarray wins

All four backend configs (default wgpu, ndarray, cuda, ndarray+wgpu precedence) compile and behave identically to before.

Closes #370