### PR TITLE
docs: bump README MSRV reference to Rust 1.96+

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ radiating edges — while the lobe shows the broadside main beam peaking at
 
 ## Build
 
-Requires Rust stable (1.95+, set in `rust-toolchain.toml`).
+Requires Rust stable (1.96+, set in `rust-toolchain.toml`).
 
 ```sh
 cargo build              # builds workspace with default `wgpu` backend


### PR DESCRIPTION
## Summary

The workspace MSRV was raised to `1.96.0` in `Cargo.toml` (PR #371, required for `std::cfg_select!` which stabilized in Rust 1.96), but the human-facing MSRV statement in `README.md` still read `1.95+`. This corrects the README numeral so it matches `workspace.package.rust-version`.

## Changes

- `README.md` line 150: `Requires Rust stable (1.95+, ...)` → `(1.96+, ...)`. Single-token change; surrounding sentence and `rust-toolchain.toml` parenthetical left unchanged per the issue's scope guard.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| README line 150 reads `1.96+` only token changed | Done | `grep -n '1.96+' README.md` → line 150; sentence structure unchanged |
| README numeral matches `Cargo.toml` `rust-version` (`1.96.0`) | Done | `grep rust-version Cargo.toml` → `1.96.0` |
| No other README lines modified | Done | `git diff` shows only line 150 |
| No other files changed | Done | `git diff --stat origin/main` → `README.md \| 2 +-` only |

## Test Plan

- `grep -n '1.96+' README.md` shows the updated line; `grep -n '1.95+' README.md` returns no results.
- Consistency check against `Cargo.toml` `rust-version = "1.96.0"` confirmed.
- Documentation-only change; no code or tests affected.

Closes #372