### PR TITLE
feat(geode-core): add metal (Apple GPU) Burn backend feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "cfg_aliases",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-cpp",
  "cubecl-ir",
  "cubecl-runtime",
  "derive-new",

--- a/README.md
+++ b/README.md
@@ -166,10 +166,23 @@ cargo build
 
 # CUDA (requires a CUDA toolkit and an NVIDIA GPU)
 cargo build -p geode-core --no-default-features --features cuda
+
+# Metal (Apple platforms only; local-only — no Apple CI runner)
+cargo build -p geode-core --no-default-features --features metal
 ```
 
-Enabling both `wgpu` and `cuda`, or neither, is a hard compile error — see
-`compile_error!` guards in `crates/geode-core/src/lib.rs`.
+Enabling more than one of `wgpu` / `cuda` / `metal`, or none of the four
+backends, is a hard compile error — see the `compile_error!` guards in
+`crates/geode-core/src/lib.rs`.
+
+Note the macOS nuance: the default `wgpu` backend **already runs on Metal at
+runtime** on macOS (wgpu selects the Metal graphics API there). The opt-in
+`metal` feature is different — it pins the Metal graphics API and the MSL
+(`cubecl-msl`) shader-compilation pipeline at compile time (`burn::backend::Metal`
+= `Wgpu<f32, i32, u8>`), rather than going through wgpu's runtime adapter
+selection. It is Apple-only and not exercised on CI (all runners are headless
+Linux, which use the `ndarray` CPU backend); verify it locally on Apple hardware
+with `cargo run --bin geode --no-default-features --features metal`.
 
 ## System dependencies
 

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -34,6 +34,12 @@ pkg-config = { workspace = true, optional = true }
 default = ["wgpu"]
 wgpu = ["burn/wgpu"]
 cuda = ["burn/cuda"]
+# Apple-GPU backend — opt-in, local-only (Apple platforms). `burn::backend::Metal`
+# is `Wgpu<f32, i32, u8>` pinned to the Metal graphics API / MSL (`cubecl-msl`)
+# shader pipeline; it shares the f32 GPU posture of `wgpu`/`cuda`. Mutually
+# exclusive with `wgpu` and `cuda`. Not exercised on CI (no Apple runner); verify
+# locally with `cargo run --bin geode --no-default-features --features metal`.
+metal = ["burn/metal"]
 # CPU (ndarray) backend — opt-in, headless. Used by CI (no Vulkan/CUDA
 # adapter on the runner) to exercise the `arpack` acceptance test against
 # a real backend. Locally the `wgpu` default still wins. `DefaultBackend`

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -163,30 +163,42 @@ use burn::tensor::Tensor;
 use burn::tensor::backend::{Backend, BackendTypes};
 
 // Backend selection is feature-driven, with a precedence policy:
-// `ndarray` > `cuda` > `wgpu`. The native GPU backends `wgpu` and
-// `cuda` remain mutually exclusive (both pull native GPU stacks that
-// cannot coexist), but `ndarray` is allowed to coexist with either
-// because Cargo feature unification across workspace targets can
-// re-activate the default `wgpu` feature even when the user passes
-// `--no-default-features --features ndarray`. The headless CPU
-// backend takes precedence in that case so that CI / local clippy
-// runs against `--features ndarray` compile cleanly.
-#[cfg(all(feature = "wgpu", feature = "cuda"))]
+// `ndarray` > `cuda` > `metal` > `wgpu`. The native GPU backends `wgpu`,
+// `cuda`, and `metal` remain mutually exclusive (each pins a native GPU
+// stack / shader pipeline that cannot coexist — `metal` is `wgpu` pinned
+// to the Metal/MSL path with a different `B` element width, so an
+// ambiguous `DefaultBackend` must be ruled out). `ndarray` is allowed to
+// coexist with any GPU backend because Cargo feature unification across
+// workspace targets can re-activate the default `wgpu` feature even when
+// the user passes `--no-default-features --features ndarray`. The
+// headless CPU backend takes precedence in that case so that CI / local
+// clippy runs against `--features ndarray` compile cleanly.
+#[cfg(any(
+    all(feature = "wgpu", feature = "cuda"),
+    all(feature = "wgpu", feature = "metal"),
+    all(feature = "cuda", feature = "metal"),
+))]
 compile_error!(
-    "geode-core: backends `wgpu` and `cuda` are mutually exclusive — \
-     both pull native GPU stacks. To switch backends, build with \
-     `--no-default-features --features cuda` (NVIDIA) or \
+    "geode-core: backends `wgpu`, `cuda`, and `metal` are mutually \
+     exclusive — each pins a native GPU stack. To switch backends, build \
+     with `--no-default-features --features cuda` (NVIDIA), \
+     `--no-default-features --features metal` (Apple), or \
      `--no-default-features --features ndarray` (CPU)."
 );
 
-#[cfg(not(any(feature = "wgpu", feature = "cuda", feature = "ndarray")))]
+#[cfg(not(any(
+    feature = "wgpu",
+    feature = "cuda",
+    feature = "metal",
+    feature = "ndarray"
+)))]
 compile_error!(
     "geode-core: enable exactly one backend feature: `wgpu` (default), \
-     `cuda`, or `ndarray` (CPU)."
+     `cuda`, `metal` (Apple), or `ndarray` (CPU)."
 );
 
-// Precedence: ndarray > cuda > wgpu. `ndarray` wins so CI / headless
-// `--features ndarray` builds compile even when Cargo feature
+// Precedence: ndarray > cuda > metal > wgpu. `ndarray` wins so CI /
+// headless `--features ndarray` builds compile even when Cargo feature
 // unification across workspace dev-targets silently re-activates the
 // default `wgpu` feature. The CPU backend with f64 floats keeps the
 // double-precision ARPACK driver (`dsaupd_c`/`dseupd_c`) in full
@@ -195,16 +207,23 @@ compile_error!(
 // `assembly::tets_to_cpu` reads connectivity back as `i32`, and Burn's
 // typed readback rejects a width mismatch.
 //
+// `burn::backend::Metal` is `Wgpu<f32, i32, u8>` pinned to the Metal/MSL
+// shader pipeline (Apple-only); it carries the same f32/i32 element
+// posture as the other GPU arms.
+//
 // `cfg_select!` is first-match-wins, so arm order encodes the
-// `ndarray > cuda > wgpu` precedence and the previous `not(...)` guards
-// are no longer needed. The two `compile_error!` guards above still own
-// the "exactly one / no conflicting GPU backend" assertions.
+// `ndarray > cuda > metal > wgpu` precedence and the previous `not(...)`
+// guards are no longer needed. The two `compile_error!` guards above
+// still own the "exactly one / no conflicting GPU backend" assertions.
 std::cfg_select! {
     feature = "ndarray" => {
         pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
     }
     feature = "cuda" => {
         pub type DefaultBackend = burn::backend::Cuda;
+    }
+    feature = "metal" => {
+        pub type DefaultBackend = burn::backend::Metal;
     }
     feature = "wgpu" => {
         pub type DefaultBackend = burn::backend::Wgpu;
@@ -254,14 +273,17 @@ pub fn device_info() -> DeviceInfo {
     }
 }
 
-// Same precedence as `DefaultBackend`: ndarray > cuda > wgpu. Arm order
-// in `cfg_select!` (first-match-wins) encodes that precedence.
+// Same precedence as `DefaultBackend`: ndarray > cuda > metal > wgpu.
+// Arm order in `cfg_select!` (first-match-wins) encodes that precedence.
 std::cfg_select! {
     feature = "ndarray" => {
         const BACKEND_NAME: &str = "ndarray";
     }
     feature = "cuda" => {
         const BACKEND_NAME: &str = "cuda";
+    }
+    feature = "metal" => {
+        const BACKEND_NAME: &str = "metal";
     }
     feature = "wgpu" => {
         const BACKEND_NAME: &str = "wgpu";
@@ -349,7 +371,16 @@ mod tests {
         #[cfg(feature = "ndarray")]
         assert_eq!(
             info.backend, "ndarray",
-            "ndarray must take precedence over wgpu/cuda when enabled"
+            "ndarray must take precedence over wgpu/cuda/metal when enabled"
+        );
+
+        // When `metal` is the selected backend (Apple-only, no `ndarray`),
+        // it must win over the default `wgpu` arm, mirroring the precedence
+        // `ndarray > cuda > metal > wgpu`.
+        #[cfg(all(feature = "metal", not(feature = "ndarray")))]
+        assert_eq!(
+            info.backend, "metal",
+            "metal must take precedence over wgpu when enabled"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds a fourth compile-time Burn backend, `metal`, to `geode-core`, wired symmetrically with the existing `wgpu` and `cuda` backends. `burn::backend::Metal` is `Wgpu<f32, i32, u8>` pinned to the Metal graphics API / MSL (`cubecl-msl`) shader pipeline — the Apple-GPU counterpart to the existing native GPU stacks. Enabling `--no-default-features --features metal` now resolves cleanly to the `metal` arm on Apple hardware.

## Changes

- **`crates/geode-core/Cargo.toml`**: new `metal = ["burn/metal"]` feature with a doc comment (Apple-only, f32, local-only).
- **`crates/geode-core/src/lib.rs`**:
  - `metal` arm added to both `cfg_select!` cascades (`DefaultBackend` -> `burn::backend::Metal`, `BACKEND_NAME` -> `"metal"`), placed **before** the `wgpu` arm so precedence is `ndarray > cuda > metal > wgpu`.
  - Both `compile_error!` guards extended: mutual-exclusivity now rejects any pair of `wgpu`/`cuda`/`metal`; the no-backend guard includes `metal`.
  - Precedence doc-comments updated; added a `#[cfg(all(feature = "metal", not(feature = "ndarray")))]` precedence assertion in the existing test, mirroring the `ndarray` one.
- **`README.md`**: documented the `metal` build line and the macOS nuance (the default `wgpu` backend already runs on Metal *at runtime*; the `metal` feature pins the Metal API + MSL pipeline at *compile time*). Noted Apple-only / local-only.
- **`Cargo.lock`**: `cubecl-cpp` now appears as a reachable `burn-wgpu` dependency (transitively pulled in once the `metal` feature exists in the graph). No version changes.

## Design decision: mutual exclusivity

`burn/metal` transitively enables burn's *internal* `wgpu` sub-feature, but `geode-core`'s own `wgpu` Cargo feature is independent, so `--no-default-features --features metal` leaves `cfg(feature = "wgpu")` false and resolves unambiguously to the `metal` arm. `metal` is treated as mutually exclusive with `cuda` and `wgpu` (avoids an ambiguous `DefaultBackend` and the `B` width mismatch — `Wgpu` defaults `B = u32` vs `Metal`'s `B = u8`). The existing `ndarray`-coexists escape hatch is unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `metal = ["burn/metal"]` Cargo feature added | ✅ | Confirmed `burn/metal` exists at pinned burn 0.21.0 (`metal = ["wgpu", "burn-wgpu/metal", ...]`) and `pub use burn_wgpu::Metal;` in `burn/src/backend.rs` |
| `metal` arm in both `cfg_select!` cascades, before `wgpu` | ✅ | See diff; precedence is `ndarray > cuda > metal > wgpu` |
| Both `compile_error!` guards extended for `metal` | ✅ | Mutual-exclusivity covers all three pairs; no-backend guard includes `metal` |
| Default `ndarray` build/test not broken | ✅ | `cargo test -p geode-core --no-default-features --features ndarray --lib` → 262 passed, 0 failed |
| README documents `metal` (Apple-only) | ✅ | New build line + macOS runtime-vs-compile nuance |
| No CI job / Linux compile-check for metal added | ✅ | No workflow changes |

## Test Plan — what was run on this Linux host

| Command | Result |
|---------|--------|
| `cargo fmt -p geode-core -- --check` | clean |
| `cargo build -p geode-core` (default = wgpu) | Finished OK |
| `cargo test -p geode-core --no-default-features --features ndarray --lib` | **262 passed, 0 failed, 2 ignored** (includes `smoke_add_runs_on_default_backend`, `device_info_is_populated`) |
| `cargo clippy -p geode-core --all-targets` | clean, no warnings |

### Verification boundary (could NOT be run locally)

This was implemented on a **Linux host**, so the `metal` feature itself **cannot be compiled here** — the `cubecl/wgpu-msl` -> Metal path pulls Apple-gated deps (objc / metal-rs). This is expected and matches the existing precedent: `wgpu`/`cuda` are likewise not exercised on the headless ubuntu CI runners (which use `ndarray`). Per the curated spec, **no CI job and no speculative Linux compile-check were added** for `metal`.

The `metal` arm's correctness was verified statically instead: (a) `burn/metal` and the `burn::backend::Metal` re-export both confirmed present in the pinned burn 0.21.0 registry source; (b) the shared `cfg_select!` cascade and guards compile cleanly for the default `wgpu` and `ndarray` selections. **Manual smoke verification on Apple hardware** (`cargo run --bin geode --no-default-features --features metal` → `backend=metal`) remains the final check, as noted in the issue's Test Plan.

Closes #375