### PR TITLE
refactor(geode-core): extract backend, traits, prelude modules with deprecated root shims

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 354
-# Branch: feature/issue-354
+# Issue: 378
+# Branch: feature/issue-378
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-cli/src/main.rs
+++ b/crates/geode-cli/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> ExitCode {
 fn run_smoke() -> ExitCode {
     println!("geode-fem {}", env!("CARGO_PKG_VERSION"));
 
-    match geode_core::smoke_add() {
+    match geode_core::backend::smoke_add() {
         Ok(info) => {
             println!("  backend: {}", info.backend);
             println!("  device:  {}", info.device_label);

--- a/crates/geode-core/src/backend/mod.rs
+++ b/crates/geode-core/src/backend/mod.rs
@@ -1,0 +1,211 @@
+//! Backend selection and the device smoke surface for geode-core.
+//!
+//! This module owns the entire backend-selection story: the two
+//! `compile_error!` guards that enforce "exactly one / no conflicting GPU
+//! backend", both `std::cfg_select!` cascades (`DefaultBackend` and the
+//! private `BACKEND_NAME`), the device-description surface
+//! ([`DeviceInfo`] / [`device_info`]), and the [`smoke_add`] backend-wiring
+//! check.
+//!
+//! `pub mod backend;` is declared **unconditionally** in `lib.rs` (never
+//! `#[cfg]`-gated), so the compiler always evaluates the `compile_error!`
+//! guards below — the "no backend selected" assertion still fires when no
+//! backend feature is enabled.
+
+use burn::tensor::Tensor;
+use burn::tensor::backend::{Backend, BackendTypes};
+
+// Backend selection is feature-driven, with a precedence policy:
+// `ndarray` > `cuda` > `metal` > `wgpu`. The native GPU backends `wgpu`,
+// `cuda`, and `metal` remain mutually exclusive (each pins a native GPU
+// stack / shader pipeline that cannot coexist — `metal` is `wgpu` pinned
+// to the Metal/MSL path with a different `B` element width, so an
+// ambiguous `DefaultBackend` must be ruled out). `ndarray` is allowed to
+// coexist with any GPU backend because Cargo feature unification across
+// workspace targets can re-activate the default `wgpu` feature even when
+// the user passes `--no-default-features --features ndarray`. The
+// headless CPU backend takes precedence in that case so that CI / local
+// clippy runs against `--features ndarray` compile cleanly.
+#[cfg(any(
+    all(feature = "wgpu", feature = "cuda"),
+    all(feature = "wgpu", feature = "metal"),
+    all(feature = "cuda", feature = "metal"),
+))]
+compile_error!(
+    "geode-core: backends `wgpu`, `cuda`, and `metal` are mutually \
+     exclusive — each pins a native GPU stack. To switch backends, build \
+     with `--no-default-features --features cuda` (NVIDIA), \
+     `--no-default-features --features metal` (Apple), or \
+     `--no-default-features --features ndarray` (CPU)."
+);
+
+#[cfg(not(any(
+    feature = "wgpu",
+    feature = "cuda",
+    feature = "metal",
+    feature = "ndarray"
+)))]
+compile_error!(
+    "geode-core: enable exactly one backend feature: `wgpu` (default), \
+     `cuda`, `metal` (Apple), or `ndarray` (CPU)."
+);
+
+// Precedence: ndarray > cuda > metal > wgpu. `ndarray` wins so CI /
+// headless `--features ndarray` builds compile even when Cargo feature
+// unification across workspace dev-targets silently re-activates the
+// default `wgpu` feature. The CPU backend with f64 floats keeps the
+// double-precision ARPACK driver (`dsaupd_c`/`dseupd_c`) in full
+// precision parity with the dense oracle. The Int element is pinned
+// to `i32` (NdArray's default is `i64`) to match the GPU backends:
+// `assembly::tets_to_cpu` reads connectivity back as `i32`, and Burn's
+// typed readback rejects a width mismatch.
+//
+// `burn::backend::Metal` is `Wgpu<f32, i32, u8>` pinned to the Metal/MSL
+// shader pipeline (Apple-only); it carries the same f32/i32 element
+// posture as the other GPU arms.
+//
+// `cfg_select!` is first-match-wins, so arm order encodes the
+// `ndarray > cuda > metal > wgpu` precedence and the previous `not(...)`
+// guards are no longer needed. The two `compile_error!` guards above
+// still own the "exactly one / no conflicting GPU backend" assertions.
+std::cfg_select! {
+    feature = "ndarray" => {
+        pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
+    }
+    feature = "cuda" => {
+        pub type DefaultBackend = burn::backend::Cuda;
+    }
+    feature = "metal" => {
+        pub type DefaultBackend = burn::backend::Metal;
+    }
+    feature = "wgpu" => {
+        pub type DefaultBackend = burn::backend::Wgpu;
+    }
+}
+
+/// Backend / device description for the smoke test.
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+    pub backend: &'static str,
+    pub device_label: String,
+}
+
+/// Return a description of the active default backend and its default device.
+pub fn device_info() -> DeviceInfo {
+    DeviceInfo {
+        backend: BACKEND_NAME,
+        device_label: default_device_label(),
+    }
+}
+
+// Same precedence as `DefaultBackend`: ndarray > cuda > metal > wgpu.
+// Arm order in `cfg_select!` (first-match-wins) encodes that precedence.
+std::cfg_select! {
+    feature = "ndarray" => {
+        const BACKEND_NAME: &str = "ndarray";
+    }
+    feature = "cuda" => {
+        const BACKEND_NAME: &str = "cuda";
+    }
+    feature = "metal" => {
+        const BACKEND_NAME: &str = "metal";
+    }
+    feature = "wgpu" => {
+        const BACKEND_NAME: &str = "wgpu";
+    }
+}
+
+fn default_device_label() -> String {
+    let device = <DefaultBackend as BackendTypes>::Device::default();
+    <DefaultBackend as Backend>::name(&device)
+}
+
+/// Run a trivial GPU smoke op: tensor addition on the default device.
+///
+/// Returns `Ok(())` if the computed result matches the expected
+/// elementwise sum within tolerance; `Err` otherwise. Failure here
+/// indicates a backend wiring problem (driver, adapter, feature flag).
+pub fn smoke_add() -> Result<DeviceInfo, String> {
+    use burn::tensor::{ElementConversion, TensorData};
+
+    type B = DefaultBackend;
+    let device = <B as BackendTypes>::Device::default();
+
+    let a = Tensor::<B, 1>::from_data(TensorData::from([1.0f32, 2.0, 3.0, 4.0]), &device);
+    let b = Tensor::<B, 1>::from_data(TensorData::from([4.0f32, 3.0, 2.0, 1.0]), &device);
+    let c = a + b;
+
+    // Read back at `B::FloatElem` (which may be `f32` or `f64` depending
+    // on the backend selected via feature flags) and upcast to `f64` so
+    // the comparison logic is backend-agnostic. The previous
+    // `to_vec::<f32>()` panicked with `TypeMismatch` on the f64
+    // `ndarray` backend.
+    let data = c.into_data();
+    let values: Vec<f64> = data
+        .to_vec::<<B as BackendTypes>::FloatElem>()
+        .map_err(|e| format!("tensor readback failed: {e:?}"))?
+        .into_iter()
+        .map(|x| x.elem::<f64>())
+        .collect();
+
+    let expected = [5.0f64; 4];
+    if values.len() != expected.len()
+        || values
+            .iter()
+            .zip(expected.iter())
+            .any(|(g, e)| (g - e).abs() > 1e-6)
+    {
+        return Err(format!(
+            "smoke add mismatch: got {values:?}, expected {expected:?}"
+        ));
+    }
+
+    Ok(device_info())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_add_runs_on_default_backend() {
+        match smoke_add() {
+            Ok(info) => {
+                eprintln!(
+                    "geode-core smoke: backend={} device={}",
+                    info.backend, info.device_label
+                );
+            }
+            Err(e) => panic!("smoke_add failed: {e}"),
+        }
+    }
+
+    #[test]
+    fn device_info_is_populated() {
+        let info = device_info();
+        assert!(
+            !info.device_label.is_empty(),
+            "device label must be non-empty"
+        );
+        assert!(!info.backend.is_empty(), "backend name must be non-empty");
+
+        // Lock in the backend-selection precedence policy (issue #76):
+        // when `ndarray` is enabled it wins regardless of whether
+        // `wgpu` was re-activated via Cargo feature unification across
+        // workspace targets.
+        #[cfg(feature = "ndarray")]
+        assert_eq!(
+            info.backend, "ndarray",
+            "ndarray must take precedence over wgpu/cuda/metal when enabled"
+        );
+
+        // When `metal` is the selected backend (Apple-only, no `ndarray`),
+        // it must win over the default `wgpu` arm, mirroring the precedence
+        // `ndarray > cuda > metal > wgpu`.
+        #[cfg(all(feature = "metal", not(feature = "ndarray")))]
+        assert_eq!(
+            info.backend, "metal",
+            "metal must take precedence over wgpu when enabled"
+        );
+    }
+}

--- a/crates/geode-core/src/driven.rs
+++ b/crates/geode-core/src/driven.rs
@@ -2047,8 +2047,9 @@ impl DrivenOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::DefaultBackend;
+    use crate::cube_tet_mesh;
     use crate::nedelec_assembly::cube_pec_interior_edges;
-    use crate::{DefaultBackend, cube_tet_mesh};
     use burn::tensor::backend::BackendTypes;
 
     type B = DefaultBackend;

--- a/crates/geode-core/src/fe_assemble.rs
+++ b/crates/geode-core/src/fe_assemble.rs
@@ -120,7 +120,8 @@ pub struct FeAssembleResult {
 /// # Example (P1 on a 3×3×3 cube)
 ///
 /// ```rust,no_run
-/// use geode_core::{cube_tet_mesh, cube_interior_mask, DefaultBackend};
+/// use geode_core::{cube_tet_mesh, cube_interior_mask};
+/// use geode_core::backend::DefaultBackend;
 /// use geode_core::fe_assemble::{fe_assemble, DirichletBc, ElementType};
 /// use burn::tensor::backend::BackendTypes;
 ///

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -159,228 +159,29 @@ pub use waveguide_modes::*;
 #[cfg(feature = "arpack")]
 pub use arpack::ArpackEigensolver;
 
-use burn::tensor::Tensor;
-use burn::tensor::backend::{Backend, BackendTypes};
+// `backend` is declared UNCONDITIONALLY (never `#[cfg]`-gated): it owns the
+// two `compile_error!` guards and both `std::cfg_select!` cascades, so the
+// compiler must always evaluate it for the "no backend selected" guard to
+// fire. The `#[cfg(feature = ...)]` predicates inside resolve identically
+// from a submodule, so the guards fire exactly as before.
+pub mod backend;
+pub mod prelude;
+pub mod traits;
 
-// Backend selection is feature-driven, with a precedence policy:
-// `ndarray` > `cuda` > `metal` > `wgpu`. The native GPU backends `wgpu`,
-// `cuda`, and `metal` remain mutually exclusive (each pins a native GPU
-// stack / shader pipeline that cannot coexist — `metal` is `wgpu` pinned
-// to the Metal/MSL path with a different `B` element width, so an
-// ambiguous `DefaultBackend` must be ruled out). `ndarray` is allowed to
-// coexist with any GPU backend because Cargo feature unification across
-// workspace targets can re-activate the default `wgpu` feature even when
-// the user passes `--no-default-features --features ndarray`. The
-// headless CPU backend takes precedence in that case so that CI / local
-// clippy runs against `--features ndarray` compile cleanly.
-#[cfg(any(
-    all(feature = "wgpu", feature = "cuda"),
-    all(feature = "wgpu", feature = "metal"),
-    all(feature = "cuda", feature = "metal"),
-))]
-compile_error!(
-    "geode-core: backends `wgpu`, `cuda`, and `metal` are mutually \
-     exclusive — each pins a native GPU stack. To switch backends, build \
-     with `--no-default-features --features cuda` (NVIDIA), \
-     `--no-default-features --features metal` (Apple), or \
-     `--no-default-features --features ndarray` (CPU)."
-);
+// Deprecated root shims for the four genuinely-public moved backend items.
+// Deprecation warns at use sites only, so the lib target stays warning-free.
+// (`BACKEND_NAME` / `default_device_label` are private — they moved silently
+// with no shim.) Precedent: `#[allow(deprecated)] pub use mesh::PHYS_VACUUM_BUFFER;`.
+#[deprecated(note = "use geode_core::backend::DefaultBackend instead")]
+pub use backend::DefaultBackend;
+#[deprecated(note = "use geode_core::backend::DeviceInfo instead")]
+pub use backend::DeviceInfo;
+#[deprecated(note = "use geode_core::backend::device_info instead")]
+pub use backend::device_info;
+#[deprecated(note = "use geode_core::backend::smoke_add instead")]
+pub use backend::smoke_add;
 
-#[cfg(not(any(
-    feature = "wgpu",
-    feature = "cuda",
-    feature = "metal",
-    feature = "ndarray"
-)))]
-compile_error!(
-    "geode-core: enable exactly one backend feature: `wgpu` (default), \
-     `cuda`, `metal` (Apple), or `ndarray` (CPU)."
-);
-
-// Precedence: ndarray > cuda > metal > wgpu. `ndarray` wins so CI /
-// headless `--features ndarray` builds compile even when Cargo feature
-// unification across workspace dev-targets silently re-activates the
-// default `wgpu` feature. The CPU backend with f64 floats keeps the
-// double-precision ARPACK driver (`dsaupd_c`/`dseupd_c`) in full
-// precision parity with the dense oracle. The Int element is pinned
-// to `i32` (NdArray's default is `i64`) to match the GPU backends:
-// `assembly::tets_to_cpu` reads connectivity back as `i32`, and Burn's
-// typed readback rejects a width mismatch.
-//
-// `burn::backend::Metal` is `Wgpu<f32, i32, u8>` pinned to the Metal/MSL
-// shader pipeline (Apple-only); it carries the same f32/i32 element
-// posture as the other GPU arms.
-//
-// `cfg_select!` is first-match-wins, so arm order encodes the
-// `ndarray > cuda > metal > wgpu` precedence and the previous `not(...)`
-// guards are no longer needed. The two `compile_error!` guards above
-// still own the "exactly one / no conflicting GPU backend" assertions.
-std::cfg_select! {
-    feature = "ndarray" => {
-        pub type DefaultBackend = burn::backend::NdArray<f64, i32>;
-    }
-    feature = "cuda" => {
-        pub type DefaultBackend = burn::backend::Cuda;
-    }
-    feature = "metal" => {
-        pub type DefaultBackend = burn::backend::Metal;
-    }
-    feature = "wgpu" => {
-        pub type DefaultBackend = burn::backend::Wgpu;
-    }
-}
-
-/// A geometric mesh: element connectivity and node coordinates.
-///
-/// This trait describes an *in-pipeline* mesh — backend-parameterized so a
-/// concrete impl can hold device-side tensors. The raw CPU output of mesh
-/// I/O lives in [`mesh::TetMesh`], which is what `MeshReader` returns; a
-/// future `Mesh`-implementing struct will typically wrap one of those plus
-/// the Burn tensors it owns.
-pub trait Mesh {
-    type Backend: Backend;
-
-    fn n_nodes(&self) -> usize;
-    fn n_elements(&self) -> usize;
-}
-
-/// A finite element: local geometry, basis, and quadrature.
-pub trait Element {
-    type Backend: Backend;
-
-    fn n_basis(&self) -> usize;
-}
-
-/// An abstract linear operator on a discretized field.
-pub trait Operator {
-    type Backend: Backend;
-
-    fn apply(&self, input: Tensor<Self::Backend, 1>) -> Tensor<Self::Backend, 1>;
-}
-
-/// Backend / device description for the smoke test.
-#[derive(Debug, Clone)]
-pub struct DeviceInfo {
-    pub backend: &'static str,
-    pub device_label: String,
-}
-
-/// Return a description of the active default backend and its default device.
-pub fn device_info() -> DeviceInfo {
-    DeviceInfo {
-        backend: BACKEND_NAME,
-        device_label: default_device_label(),
-    }
-}
-
-// Same precedence as `DefaultBackend`: ndarray > cuda > metal > wgpu.
-// Arm order in `cfg_select!` (first-match-wins) encodes that precedence.
-std::cfg_select! {
-    feature = "ndarray" => {
-        const BACKEND_NAME: &str = "ndarray";
-    }
-    feature = "cuda" => {
-        const BACKEND_NAME: &str = "cuda";
-    }
-    feature = "metal" => {
-        const BACKEND_NAME: &str = "metal";
-    }
-    feature = "wgpu" => {
-        const BACKEND_NAME: &str = "wgpu";
-    }
-}
-
-fn default_device_label() -> String {
-    let device = <DefaultBackend as BackendTypes>::Device::default();
-    <DefaultBackend as Backend>::name(&device)
-}
-
-/// Run a trivial GPU smoke op: tensor addition on the default device.
-///
-/// Returns `Ok(())` if the computed result matches the expected
-/// elementwise sum within tolerance; `Err` otherwise. Failure here
-/// indicates a backend wiring problem (driver, adapter, feature flag).
-pub fn smoke_add() -> Result<DeviceInfo, String> {
-    use burn::tensor::{ElementConversion, TensorData};
-
-    type B = DefaultBackend;
-    let device = <B as BackendTypes>::Device::default();
-
-    let a = Tensor::<B, 1>::from_data(TensorData::from([1.0f32, 2.0, 3.0, 4.0]), &device);
-    let b = Tensor::<B, 1>::from_data(TensorData::from([4.0f32, 3.0, 2.0, 1.0]), &device);
-    let c = a + b;
-
-    // Read back at `B::FloatElem` (which may be `f32` or `f64` depending
-    // on the backend selected via feature flags) and upcast to `f64` so
-    // the comparison logic is backend-agnostic. The previous
-    // `to_vec::<f32>()` panicked with `TypeMismatch` on the f64
-    // `ndarray` backend.
-    let data = c.into_data();
-    let values: Vec<f64> = data
-        .to_vec::<<B as BackendTypes>::FloatElem>()
-        .map_err(|e| format!("tensor readback failed: {e:?}"))?
-        .into_iter()
-        .map(|x| x.elem::<f64>())
-        .collect();
-
-    let expected = [5.0f64; 4];
-    if values.len() != expected.len()
-        || values
-            .iter()
-            .zip(expected.iter())
-            .any(|(g, e)| (g - e).abs() > 1e-6)
-    {
-        return Err(format!(
-            "smoke add mismatch: got {values:?}, expected {expected:?}"
-        ));
-    }
-
-    Ok(device_info())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn smoke_add_runs_on_default_backend() {
-        match smoke_add() {
-            Ok(info) => {
-                eprintln!(
-                    "geode-core smoke: backend={} device={}",
-                    info.backend, info.device_label
-                );
-            }
-            Err(e) => panic!("smoke_add failed: {e}"),
-        }
-    }
-
-    #[test]
-    fn device_info_is_populated() {
-        let info = device_info();
-        assert!(
-            !info.device_label.is_empty(),
-            "device label must be non-empty"
-        );
-        assert!(!info.backend.is_empty(), "backend name must be non-empty");
-
-        // Lock in the backend-selection precedence policy (issue #76):
-        // when `ndarray` is enabled it wins regardless of whether
-        // `wgpu` was re-activated via Cargo feature unification across
-        // workspace targets.
-        #[cfg(feature = "ndarray")]
-        assert_eq!(
-            info.backend, "ndarray",
-            "ndarray must take precedence over wgpu/cuda/metal when enabled"
-        );
-
-        // When `metal` is the selected backend (Apple-only, no `ndarray`),
-        // it must win over the default `wgpu` arm, mirroring the precedence
-        // `ndarray > cuda > metal > wgpu`.
-        #[cfg(all(feature = "metal", not(feature = "ndarray")))]
-        assert_eq!(
-            info.backend, "metal",
-            "metal must take precedence over wgpu when enabled"
-        );
-    }
-}
+// Core traits stay reachable at the crate root WITHOUT deprecation (epic
+// #377 open-question 1): they are the crate's conceptual entry point and
+// this preserves the intra-doc link `[`Mesh`](crate::Mesh)` in `mesh/mod.rs`.
+pub use traits::{Element, Mesh, Operator};

--- a/crates/geode-core/src/prelude.rs
+++ b/crates/geode-core/src/prelude.rs
@@ -1,0 +1,8 @@
+//! Common imports for geode-core: `use geode_core::prelude::*;`.
+//!
+//! Re-exports from the canonical module paths (`crate::backend`,
+//! `crate::traits`) — never the deprecated root shims — so glob-importing
+//! the prelude stays warning-free under `-D warnings`. Later children of
+//! the namespace reorg add their own groups here.
+pub use crate::backend::{DefaultBackend, DeviceInfo, device_info, smoke_add};
+pub use crate::traits::{Element, Mesh, Operator};

--- a/crates/geode-core/src/sparse.rs
+++ b/crates/geode-core/src/sparse.rs
@@ -127,9 +127,8 @@ pub fn global_system_to_sparse<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        DefaultBackend, assemble_global_p1, cube_interior_mask, cube_tet_mesh, upload_mesh,
-    };
+    use crate::backend::DefaultBackend;
+    use crate::{assemble_global_p1, cube_interior_mask, cube_tet_mesh, upload_mesh};
     use burn::tensor::backend::BackendTypes;
 
     type B = DefaultBackend;

--- a/crates/geode-core/src/traits/mod.rs
+++ b/crates/geode-core/src/traits/mod.rs
@@ -1,0 +1,37 @@
+//! Core abstractions for the geode-core finite-element pipeline.
+//!
+//! These thin, backend-parameterized traits ([`Mesh`], [`Element`],
+//! [`Operator`]) establish the directional shape of the API. They remain
+//! reachable at the crate root (`geode_core::{Mesh, Element, Operator}`)
+//! and via [`crate::prelude`] as the conceptual entry point.
+
+use burn::tensor::Tensor;
+use burn::tensor::backend::Backend;
+
+/// A geometric mesh: element connectivity and node coordinates.
+///
+/// This trait describes an *in-pipeline* mesh — backend-parameterized so a
+/// concrete impl can hold device-side tensors. The raw CPU output of mesh
+/// I/O lives in [`mesh::TetMesh`](crate::mesh::TetMesh), which is what
+/// `MeshReader` returns; a future `Mesh`-implementing struct will typically
+/// wrap one of those plus the Burn tensors it owns.
+pub trait Mesh {
+    type Backend: Backend;
+
+    fn n_nodes(&self) -> usize;
+    fn n_elements(&self) -> usize;
+}
+
+/// A finite element: local geometry, basis, and quadrature.
+pub trait Element {
+    type Backend: Backend;
+
+    fn n_basis(&self) -> usize;
+}
+
+/// An abstract linear operator on a discretized field.
+pub trait Operator {
+    type Backend: Backend;
+
+    fn apply(&self, input: Tensor<Self::Backend, 1>) -> Tensor<Self::Backend, 1>;
+}


### PR DESCRIPTION
## Summary

Foundation child [1/10] of the geode-core namespace reorg (epic #377). Moves the backend-selection machinery and device smoke surface out of `lib.rs` into a directory-backed `backend` module, extracts the `Mesh`/`Element`/`Operator` traits into a `traits` module, adds an initial `prelude`, and installs `#[deprecated]` root shims for the moved public items. **Pure refactor — no behavior change.** Establishes the pattern (new home + re-export + deprecated root shim + prelude entry) that children #379–#386 copy.

## Changes

- **`backend/mod.rs` (new)** — owns **both** `compile_error!` guards and **both** `std::cfg_select!` cascades (`DefaultBackend`, private `BACKEND_NAME`), plus `DeviceInfo`, `device_info()`, private `default_device_label()`, `smoke_add()`, and the relocated `#[cfg(test)] mod tests`. Module-level `//!` rustdoc added.
- **`traits/mod.rs` (new)** — `Mesh` / `Element` / `Operator` + `use burn::tensor::{Tensor, backend::Backend};`. Module-level `//!` rustdoc.
- **`prelude.rs` (new)** — re-exports the four backend items + three traits from their **canonical** module paths (not the deprecated shims), so `use geode_core::prelude::*;` is warning-free under `-D warnings`.
- **`lib.rs`** — declares `pub mod backend;` **unconditionally** (never cfg-gated) plus `pub mod traits; pub mod prelude;`; adds four `#[deprecated]` root `pub use` shims for `DefaultBackend`/`DeviceInfo`/`device_info`/`smoke_add`; keeps a **non-deprecated** `pub use traits::{Element, Mesh, Operator};` at the root. `BACKEND_NAME`/`default_device_label` are private and moved with no shim.
- **In-crate caller migration** — `driven.rs` + `sparse.rs` test modules and the `fe_assemble.rs` doctest now use `crate::backend::DefaultBackend` / `geode_core::backend::DefaultBackend`; `geode-cli/src/main.rs` now calls `geode_core::backend::smoke_add()`. (The ~17 `geode-validation/tests/*` `device_info()` callers are deferred to cleanup child #386; they emit deprecation warnings but still compile.)

### How the `compile_error!` / `cfg_select!` move was handled

Both `compile_error!` guards and both `std::cfg_select!` cascades moved verbatim into `backend/mod.rs`. `#[cfg(feature = ...)]` predicates are crate-level, so they resolve identically from the submodule. Because `pub mod backend;` is declared **unconditionally** (no `#[cfg]` on the `mod` line), the compiler always evaluates the guards. Verified: a `--no-default-features` build still trips `geode-core: enable exactly one backend feature: ...` — now reported from `crates/geode-core/src/backend/mod.rs:48`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `backend`/`traits` directory-backed modules + `prelude`, each with `//!` rustdoc | ✅ | `cargo doc` renders `backend`, `traits`, `prelude` pages |
| Both cfg_select! cascades + both compile_error! guards in `backend/mod.rs`; `pub mod backend;` unconditional | ✅ | `--no-default-features` build trips the guard from `backend/mod.rs:48` |
| Root backend paths resolve but emit `#[deprecated]` warnings | ✅ | Four `#[deprecated]` shims in lib.rs; clippy `-D warnings` clean (no lib-target use sites) |
| `Mesh`/`Element`/`Operator` resolve at root without deprecation + in prelude | ✅ | Non-deprecated `pub use traits::{...}`; doctest using `crate::Mesh` link builds |
| Prelude re-exports from canonical paths; glob is warning-free | ✅ | clippy `--all-targets -D warnings` clean |
| `cargo build -p geode-core` (default ndarray... wgpu) | ✅ | exit 0 |
| `cargo test -p geode-core --features ndarray` passes unchanged | ✅ | 262 passed; 0 failed (incl. relocated `backend::tests`) |
| `cargo clippy ... -D warnings` clean | ✅ | exit 0 |
| `cargo doc -p geode-core --no-deps` renders new tree | ✅ | exit 0; module pages present |
| In-crate callers + geode-cli migrated | ✅ | driven/sparse/fe_assemble/cli updated; workspace `cargo build` exit 0 |

## Test Plan

- `cargo fmt -p geode-core -- --check` → clean
- `cargo build -p geode-core` (default backend) → exit 0
- `cargo test -p geode-core --no-default-features --features ndarray --lib` → 262 passed, 0 failed, 2 ignored
- `cargo clippy -p geode-core --no-default-features --features ndarray --all-targets -- -D warnings` → exit 0
- `cargo test -p geode-core --no-default-features --features ndarray --doc fe_assemble` → 1 passed (migrated doctest compiles)
- `cargo doc -p geode-core --no-deps` → exit 0, `backend`/`traits`/`prelude` rendered
- `cargo build -p geode-core --no-default-features` → fails with the "enable exactly one backend" guard from `backend/mod.rs` (confirms the guard survived the move)
- `cargo build` (whole workspace) → exit 0 (verifies the geode-cli migration)

Closes #378