### PR TITLE
refactor(geode-core): group driven solver + ports/extraction/scattering under driven [6/10]

### DIFF
--- a/crates/geode-core/src/assembly/nedelec.rs
+++ b/crates/geode-core/src/assembly/nedelec.rs
@@ -1471,12 +1471,12 @@ fn upload_tensor33_component<B: Backend>(
 ///
 /// with `ν = Λ⁻¹` (the `μ = Λ` stretch lands on the curl term) and
 /// `ε = ε_r·Λ` for the matched UPML
-/// ([`crate::scattering::upml_matched_tensors`] /
-/// [`crate::scattering::build_matched_upml_materials`]). Off-diagonal
+/// ([`crate::driven::scattering::upml_matched_tensors`] /
+/// [`crate::driven::scattering::build_matched_upml_materials`]). Off-diagonal
 /// tensor entries are kept — unlike the diagonal-restriction
 /// approximation of [`build_anisotropic_pml_tensor_diag`] — so the
 /// result agrees with the host-assembled oracle
-/// ([`crate::scattering::solve_scattered_field_matched_upml`]) at
+/// ([`crate::driven::scattering::solve_scattered_field_matched_upml`]) at
 /// assembly precision.
 ///
 /// # Implementation / autodiff
@@ -1642,7 +1642,7 @@ pub fn assemble_global_nedelec_with_full_tensors_sparse<B: Backend>(
 ///
 /// Computes `b_i = ∫_Ω N_i · J dV` over the global edge basis (no `iωμ₀`
 /// prefactor — that is applied by the caller, see
-/// [`crate::driven::driven_solve`]). Follows the same batched-local-
+/// [`crate::driven::solve::driven_solve`]). Follows the same batched-local-
 /// kernel + autodiff-preserving 1-D `scatter(0, …, Add)` pattern as
 /// [`assemble_global_nedelec`]: the per-element `[n_elem, 6]` local RHS
 /// from [`crate::elements::nedelec::batched_nedelec_local_rhs`] is multiplied by
@@ -1723,7 +1723,7 @@ pub fn assemble_nedelec_current_rhs<B: Backend>(
 /// * `j_quad` — `[n_elem][4][3]` per-tet current density at the four
 ///   degree-2 quadrature points (see
 ///   [`crate::elements::nedelec::TET_QUAD4_A`] for the point convention; use
-///   [`crate::driven::QuadCurrentSource`] to sample a continuous
+///   [`crate::driven::solve::QuadCurrentSource`] to sample a continuous
 ///   `J(x)`).
 pub fn assemble_nedelec_current_rhs_quad4<B: Backend>(
     nodes: Tensor<B, 2>,

--- a/crates/geode-core/src/assembly/surface.rs
+++ b/crates/geode-core/src/assembly/surface.rs
@@ -62,7 +62,7 @@
 //!
 //! The per-face geometry and quadrature kernel live in the shared
 //! `whitney` module (issue #208), which this module and
-//! [`crate::lumped_port`] both delegate to.
+//! [`crate::driven::ports`] both delegate to.
 //!
 //! # Why the BAC-CAB rank reduction is valid here
 //!
@@ -164,7 +164,7 @@ pub fn assemble_silver_muller_surface(
 ///   units `η₀ = 1`, so `+j k₀ S`).
 /// - **Leontovich surface impedance** (Epic #193, issue #204):
 ///   coefficient `+j ω / Z_s(ω)` — see
-///   [`crate::driven::driven_solve_with_surface_impedance`].
+///   [`crate::driven::solve::driven_solve_with_surface_impedance`].
 ///
 /// Returns a real, symmetric `[n_edges, n_edges]` dense matrix whose
 /// only non-zero rows/columns are the edges of the listed triangles.
@@ -198,10 +198,10 @@ pub fn assemble_surface_mass(
 /// Duplicate `(row, col)` entries (edges shared by adjacent faces) are
 /// **not** summed — the caller accumulates them (e.g. faer's
 /// `try_new_from_triplets`, or a pattern-slot scatter as in
-/// [`crate::driven::DrivenOperator`]). Triplets appear in face order,
+/// [`crate::driven::solve::DrivenOperator`]). Triplets appear in face order,
 /// so summing them reproduces the dense accumulation order exactly.
 /// Same convention as
-/// [`crate::lumped_port::assemble_port_surface_mass`], which is the
+/// [`crate::driven::ports::assemble_port_surface_mass`], which is the
 /// **same kernel** — both delegate to the shared
 /// `whitney` module (issue #208), so the two entry points
 /// produce bit-identical triplet streams.

--- a/crates/geode-core/src/driven/extraction.rs
+++ b/crates/geode-core/src/driven/extraction.rs
@@ -2,7 +2,7 @@
 //! S-parameters` over port-driven solves (Epic #193, issue #203).
 //!
 //! Given a driven solve excited through a lumped port
-//! ([`crate::lumped_port::LumpedPort`], issue #202), this module
+//! ([`crate::driven::ports::LumpedPort`], issue #202), this module
 //! reduces the field solution to the circuit quantities that are the
 //! epic's actual deliverable:
 //!
@@ -19,7 +19,7 @@
 //! plus self-resonance detection from the `Im Z(ω)` zero crossing when
 //! a sweep brackets it.
 //!
-//! Everything here is **post-processing over [`crate::driven::DrivenSolution`]** — no
+//! Everything here is **post-processing over [`crate::driven::solve::DrivenSolution`]** — no
 //! new assembly physics. The field-to-circuit reduction reuses the
 //! lumped-port flux functional `f_i = ∮ N_i · ê dS` (the same discrete
 //! functional that drives the port, so the drive/measure pair is
@@ -42,7 +42,7 @@
 //! every other port passively terminated in its own reference `R`. At
 //! a fixed ω all N excitations share one LU factorization
 //! ([`DrivenOperator::factor_at`] +
-//! [`crate::driven::FactoredDrivenOperator::solve_excited`]), so an
+//! [`crate::driven::solve::FactoredDrivenOperator::solve_excited`]), so an
 //! N-port S-matrix costs one factorization + N back-substitutions per
 //! frequency. The per-excitation port V/I readbacks assemble the
 //! impedance matrix `Z = V·I⁻¹` and then
@@ -62,11 +62,11 @@ use burn::tensor::backend::Backend;
 use faer::c64;
 
 use crate::TetMesh;
-use crate::driven::{
+use crate::driven::ports::{LumpedPort, port_current, port_voltage};
+use crate::driven::solve::{
     CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
     SurfaceImpedanceBc,
 };
-use crate::lumped_port::{LumpedPort, port_current, port_voltage};
 
 /// Circuit quantities of one port at one frequency, read off a driven
 /// solution.
@@ -105,10 +105,10 @@ impl PortCircuit {
 
 /// Extract the port circuit quantities `V`, `I`, `Z` from a single
 /// driven solution (`e_edges` in `mesh.edges()` order, e.g.
-/// [`crate::driven::DrivenSolution::e_edges`]).
+/// [`crate::driven::solve::DrivenSolution::e_edges`]).
 ///
-/// Thin composition of [`crate::lumped_port::port_voltage`] and
-/// [`crate::lumped_port::port_current`]; sweeps should prefer
+/// Thin composition of [`crate::driven::ports::port_voltage`] and
+/// [`crate::driven::ports::port_current`]; sweeps should prefer
 /// [`driven_frequency_sweep`], which reuses the assembled operator and
 /// the cached port flux across frequencies.
 pub fn extract_port_circuit(
@@ -347,8 +347,8 @@ pub struct SweepPoint {
 /// source moments runs once for the whole sweep; per frequency only
 /// scalar recombination, the sparse LU, and the port readouts remain.
 /// One sweep point reproduces the corresponding single-ω
-/// [`crate::driven::driven_solve_with_ports`] /
-/// [`crate::driven::driven_solve_with_surface_impedance`] call exactly
+/// [`crate::driven::solve::driven_solve_with_ports`] /
+/// [`crate::driven::solve::driven_solve_with_surface_impedance`] call exactly
 /// (same arithmetic, same triplet stream).
 ///
 /// `surfaces` composes Leontovich impedance walls (issue #204) into the
@@ -520,7 +520,7 @@ pub fn s_parameter_frequency_sweep<B: Backend>(
 /// (issue #264).
 ///
 /// At each ω the sweep runs `n_ports` back-solves through one
-/// [`crate::driven::DrivenLinearSolver`] handle (one LU factorization
+/// [`crate::driven::solve::DrivenLinearSolver`] handle (one LU factorization
 /// on the direct path, one Jacobi preconditioner on the iterative path)
 /// — see [`SolverMode`] for the trade-off. Per-RHS iteration counts
 /// land in [`SParameterSweepPoint::iters_per_rhs`] for the regression

--- a/crates/geode-core/src/driven/mod.rs
+++ b/crates/geode-core/src/driven/mod.rs
@@ -1,0 +1,23 @@
+//! Frequency-domain **driven** (forced) solver and its port, extraction,
+//! and scattering satellites.
+//!
+//! This module groups the time-harmonic forced problem `A(ω) x = b` and
+//! everything built directly on top of it under one namespace:
+//!
+//! - [`solve`] — the driven solver core: operators, materials, boundary
+//!   conditions, and the `driven_solve*` entry points.
+//! - [`ports`] — lumped and waveguide port models (excitation, current /
+//!   voltage / impedance extraction, and waveguide mode reduction).
+//! - [`extraction`] — frequency sweeps, S-parameters, port-circuit and
+//!   self-resonance extraction built on the driven solver.
+//! - [`scattering`] — plane-wave scattering with a matched UPML, Mie
+//!   polarization sources, and radiated/extinction power integrals.
+//!
+//! The submodules keep their items canonical (`driven::solve::Foo`,
+//! `driven::ports::Bar`, …); the group root does **not** re-export them up
+//! a level, matching [`crate::eigen`].
+
+pub mod extraction;
+pub mod ports;
+pub mod scattering;
+pub mod solve;

--- a/crates/geode-core/src/driven/ports/lumped.rs
+++ b/crates/geode-core/src/driven/ports/lumped.rs
@@ -216,7 +216,7 @@ pub fn assemble_port_flux(
 /// every line, up to discretization).
 ///
 /// `e_edges` is the full-length edge-DOF vector in `mesh.edges()`
-/// order, e.g. [`crate::driven::DrivenSolution::e_edges`]; `edges` is
+/// order, e.g. [`crate::driven::solve::DrivenSolution::e_edges`]; `edges` is
 /// that same edge table.
 pub fn port_voltage(
     mesh: &TetMesh,
@@ -252,7 +252,7 @@ pub fn port_current(port: &LumpedPort<'_>, v_port: c64) -> c64 {
 /// resistance `R` (the source impedance) — the quantity the
 /// transmission-line oracle compares against `j Z₀ tan(ωd)`. The
 /// full `Z(ω) → L/R/Q/S` extraction API and the assembly-reusing
-/// frequency-sweep driver live in [`crate::extraction`] (issue #203).
+/// frequency-sweep driver live in [`crate::driven::extraction`] (issue #203).
 pub fn port_input_impedance(
     mesh: &TetMesh,
     port: &LumpedPort<'_>,

--- a/crates/geode-core/src/driven/ports/mod.rs
+++ b/crates/geode-core/src/driven/ports/mod.rs
@@ -1,0 +1,24 @@
+//! Port models for the driven solver: lumped ports and waveguide ports.
+//!
+//! The implementation lives in two private leaf modules — a lumped-port
+//! path and a waveguide-port path — re-exported here so callers see a
+//! single `driven::ports` namespace:
+//!
+//! - [`LumpedPort`] and the `assemble_port_*` / `port_*` helpers — lumped
+//!   (gap) port excitation plus current / voltage / impedance extraction.
+//! - [`WavePort`] / [`PortMode`] and the waveguide mesh + mode-reduction
+//!   helpers — modal waveguide ports and their parameter sweeps.
+
+mod lumped;
+mod wave;
+
+pub use lumped::{
+    LumpedPort, assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
+    port_voltage,
+};
+pub use wave::{
+    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort, WavePortSweepPoint,
+    extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
+    map_mode_profile_to_full_mesh, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
+    waveguide_mode_reduce,
+};

--- a/crates/geode-core/src/driven/ports/wave.rs
+++ b/crates/geode-core/src/driven/ports/wave.rs
@@ -2,7 +2,7 @@
 //! (Epic #234 wave-port, Phase 2, issue #236; multi-mode rank-N
 //! generalization, issue #255 / parent #250).
 //!
-//! Where a *lumped* port ([`crate::lumped_port`]) imposes a uniform
+//! Where a *lumped* port ([`crate::driven::ports`]) imposes a uniform
 //! voltage/current relation across a gap (the Palace Thévenin
 //! formulation), a **wave port** projects onto a true waveguide modal
 //! field on a port plane. Each port supports one **or more** transverse
@@ -111,13 +111,13 @@
 
 use faer::c64;
 
+use super::lumped::LumpedPort;
 use crate::TetMesh;
 use crate::assembly::surface::assemble_surface_mass_triplets;
-use crate::driven::{
+use crate::driven::solve::{
     CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SolverMode,
     SurfaceImpedanceBc,
 };
-use crate::lumped_port::LumpedPort;
 
 /// One mode of a [`WavePort`]: the modal eigenvector over the 3-D mesh
 /// edge table, the cutoff wavenumber `k_c`, and the incident modal
@@ -333,7 +333,7 @@ pub fn waveguide_mode_reduce(
 /// One frequency point of an N-port × K-mode **wave-port** S-parameter
 /// sweep ([`solve_wave_port_sweep`]).
 ///
-/// Mirrors [`crate::extraction::SParameterSweepPoint`] in shape but
+/// Mirrors [`crate::driven::extraction::SParameterSweepPoint`] in shape but
 /// without the impedance matrix (wave ports don't have a Thévenin
 /// V/I — the modal amplitude is the natural circuit quantity). The
 /// S-matrix is **block-structured** by (port, mode): rows and columns
@@ -465,11 +465,11 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
 }
 
 /// [`solve_wave_port_sweep`] with an explicit
-/// [`crate::driven::SolverMode`] knob (issue #264).
+/// [`crate::driven::solve::SolverMode`] knob (issue #264).
 ///
 /// The rank-N SMW machinery (issue #255) composes with both backends as
 /// a **post-step**: solve `A_base⁻¹ U` and `A_base⁻¹ b` through the
-/// uniform [`crate::driven::DrivenLinearSolver::back_solve`] API, then
+/// uniform [`crate::driven::solve::DrivenLinearSolver::back_solve`] API, then
 /// assemble the small `N × N` capacitance dense matrix and the SMW
 /// correction in host code. The matrix-vector pieces never change —
 /// only the back-solve does.
@@ -483,7 +483,7 @@ pub fn solve_wave_port_sweep<B: burn::tensor::backend::Backend>(
 /// entries per ω: the first `n_channels` from the U-column solves,
 /// the remaining `n_channels` from the per-excitation solves).
 ///
-/// See [`crate::driven::SolverMode`] for the documented trade-off.
+/// See [`crate::driven::solve::SolverMode`] for the documented trade-off.
 #[allow(clippy::too_many_arguments)]
 pub fn solve_wave_port_sweep_with_mode<B: burn::tensor::backend::Backend>(
     mesh: &TetMesh,
@@ -807,7 +807,7 @@ pub fn solve_wave_port_sweep_with_mode<B: burn::tensor::backend::Backend>(
 /// Returns `None` on an exactly singular pivot. For the channel-count
 /// matrices this serves (N = Σ_p K_p — single digits to low tens in
 /// practice) a dense elimination is the right tool — mirrors the
-/// `invert_complex` helper in [`crate::extraction`].
+/// `invert_complex` helper in [`crate::driven::extraction`].
 fn invert_complex_dense(m: &[c64], n: usize) -> Option<Vec<c64>> {
     debug_assert_eq!(m.len(), n * n);
     let mut a = m.to_vec();

--- a/crates/geode-core/src/driven/scattering.rs
+++ b/crates/geode-core/src/driven/scattering.rs
@@ -1,6 +1,6 @@
 //! Driven Mie scattering benchmark machinery (issue #195, Epic #193):
 //! scattered-field plane-wave source and `Q_ext` / `Q_sca` extraction
-//! from a [`crate::driven::driven_solve`] solution.
+//! from a [`crate::driven::solve::driven_solve`] solution.
 //!
 //! # Scattered-field formulation
 //!
@@ -58,8 +58,8 @@
 //! The matched UPML is also expressible through the Burn batched-
 //! kernel layer: [`build_matched_upml_materials`] evaluates the per-tet
 //! `(ε_r·Λ, Λ⁻¹)` pair at tet centroids and
-//! [`crate::driven::DrivenMaterials::MatchedUpml`] feeds it to
-//! [`crate::driven::driven_solve`], which assembles `K(Λ⁻¹)` and
+//! [`crate::driven::solve::DrivenMaterials::MatchedUpml`] feeds it to
+//! [`crate::driven::solve::driven_solve`], which assembles `K(Λ⁻¹)` and
 //! `M(ε_rΛ)` through the autodiff-preserving scatter path
 //! ([`crate::assembly::nedelec::assemble_global_nedelec_with_full_tensors`]).
 //! The Burn path and this host path agree at assembly precision for
@@ -116,7 +116,7 @@ use faer::c64;
 use faer::sparse::{SparseColMat, Triplet};
 
 use crate::TetMesh;
-use crate::driven::{CurrentSource, DrivenError, DrivenSolution};
+use crate::driven::solve::{CurrentSource, DrivenError, DrivenSolution};
 use crate::mesh::{TET_LOCAL_EDGES, TET_LOCAL_FACES};
 
 /// Incident plane wave `E_inc(x) = x̂ · exp(−i ω z)` (unit amplitude,
@@ -283,7 +283,7 @@ const QUAD_B: f64 = crate::elements::nedelec::TET_QUAD4_B;
 /// ```
 ///
 /// evaluated with the Whitney interpolant of `e_edges` (full-length
-/// edge-DOF vector from [`crate::driven::driven_solve`]) and a
+/// edge-DOF vector from [`crate::driven::solve::driven_solve`]) and a
 /// degree-2 four-point tet quadrature for the `E_inc` phase variation.
 pub fn extinction_power(
     mesh: &TetMesh,
@@ -754,8 +754,8 @@ pub fn upml_matched_tensors(
 /// centroid and returns `(ε, ν)` with `ε = ε_r·Λ` (mass weight) and
 /// `ν = Λ⁻¹` (curl-curl weight) — exactly the per-tet inputs the host
 /// path [`solve_scattered_field_matched_upml`] uses internally, so a
-/// [`crate::driven::driven_solve`] call with
-/// [`crate::driven::DrivenMaterials::MatchedUpml`] is a pure
+/// [`crate::driven::solve::driven_solve`] call with
+/// [`crate::driven::solve::DrivenMaterials::MatchedUpml`] is a pure
 /// assembly-equivalence counterpart of the host solve.
 ///
 /// - `ε_r = n_inside²` on tets tagged `interior_tag`, 1 elsewhere
@@ -823,7 +823,7 @@ fn sandwich(w: &[[c64; 3]; 3], a: [f64; 3], b: [f64; 3]) -> c64 {
 /// UPML: `A(ω) x = b` with `A(ω) = K(Λ⁻¹) − ω² M(ε_r Λ)` assembled
 /// exactly on the host. Kept as the **independent oracle** for the
 /// Burn-path matched UPML
-/// ([`crate::driven::DrivenMaterials::MatchedUpml`] +
+/// ([`crate::driven::solve::DrivenMaterials::MatchedUpml`] +
 /// [`build_matched_upml_materials`]) — see the module docs for the
 /// recorded retire-vs-keep decision.
 ///
@@ -839,7 +839,7 @@ fn sandwich(w: &[[c64; 3]; 3], a: [f64; 3], b: [f64; 3]) -> c64 {
 /// - `j_at(tet, x)` — current density at quadrature point `x` inside
 ///   tet `tet`. The RHS `b_i = iω ∫ N_i · J dV` is integrated with a
 ///   degree-2 four-point rule, which is exact for per-tet-constant `J`
-///   (matching [`crate::driven::driven_solve`]'s RHS bit-for-bit in
+///   (matching [`crate::driven::solve::driven_solve`]'s RHS bit-for-bit in
 ///   that case) and captures the plane-wave phase variation of the
 ///   scattered-field source.
 ///

--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -43,11 +43,11 @@
 //!   stiffness gains a complex full-3×3 weight `ν = Λ⁻¹` and the system
 //!   is `A(ω) = K(ν) + iωC(σ) − ω²M(ε)`. `Λ` is symmetric, so
 //!   `A(ω)ᵀ = A(ω)` still holds. Per-tet tensors come from
-//!   [`crate::scattering::build_matched_upml_materials`]; the
+//!   [`crate::driven::scattering::build_matched_upml_materials`]; the
 //!   host-assembled oracle is
-//!   [`crate::scattering::solve_scattered_field_matched_upml`].
+//!   [`crate::driven::scattering::solve_scattered_field_matched_upml`].
 //! - **Lumped port** (issue #202) — a Palace-style uniform port on a
-//!   boundary surface Γ_p ([`crate::lumped_port::LumpedPort`], passed
+//!   boundary surface Γ_p ([`crate::driven::ports::LumpedPort`], passed
 //!   to [`driven_solve_with_ports`]): a resistive termination adds the
 //!   iω-scaled tangential surface mass `(jω/Z_s) S_p` to `A(ω)`
 //!   (`Z_s = R·w/l`; real symmetric `S_p`, so `A(ω)ᵀ = A(ω)` is
@@ -114,8 +114,8 @@ use crate::assembly::nedelec::{
     assemble_global_nedelec_with_full_tensors_sparse, assemble_nedelec_current_rhs,
     assemble_nedelec_current_rhs_quad4, assemble_nedelec_sigma_damping_sparse, tet_centroids,
 };
+use crate::driven::ports::{LumpedPort, assemble_port_flux, assemble_port_surface_mass};
 use crate::eigen::complex::{solve_with_lu, spmv};
-use crate::lumped_port::{LumpedPort, assemble_port_flux, assemble_port_surface_mass};
 
 /// Errors produced by the driven-solve layer.
 #[derive(Debug, thiserror::Error)]
@@ -253,7 +253,7 @@ pub enum DrivenMaterials<'a> {
     DiagTensor(&'a [[c64; 3]]),
     /// Matched (full Sacks) UPML materials (issue #199): full 3×3
     /// complex per-tet tensors for **both** constitutive weights, as
-    /// produced by [`crate::scattering::build_matched_upml_materials`].
+    /// produced by [`crate::driven::scattering::build_matched_upml_materials`].
     /// The system becomes `A(ω) = K(ν) + iωC(σ) − ω²M(ε)` with
     /// `ε = ε_r·Λ` and `ν = Λ⁻¹` — the stiffness is complex too, but
     /// `Λ` is symmetric so the complex-symmetry invariant
@@ -397,7 +397,7 @@ impl CurrentSource {
 /// per-tet variation matters (e.g. the plane-wave phase of the Mie
 /// scattered-field polarization current). The RHS is integrated with
 /// the same rule the host-side matched-UPML oracle uses
-/// ([`crate::scattering::solve_scattered_field_matched_upml`]), so the
+/// ([`crate::driven::scattering::solve_scattered_field_matched_upml`]), so the
 /// two paths agree to round-off for the same `J`.
 ///
 /// For a per-tet-constant `J` this reduces exactly to
@@ -416,9 +416,9 @@ pub struct QuadCurrentSource {
 impl QuadCurrentSource {
     /// Sample `J(tet, x)` at every degree-2 quadrature point of every
     /// tet. The closure signature matches the `j_at` argument of
-    /// [`crate::scattering::solve_scattered_field_matched_upml`], so a
+    /// [`crate::driven::scattering::solve_scattered_field_matched_upml`], so a
     /// host-oracle source closure (e.g.
-    /// [`crate::scattering::plane_wave_polarization_current`]) can be
+    /// [`crate::driven::scattering::plane_wave_polarization_current`]) can be
     /// passed directly.
     pub fn from_fn(mesh: &TetMesh, f: impl Fn(usize, [f64; 3]) -> [c64; 3]) -> Self {
         use crate::elements::nedelec::{TET_QUAD4_A, TET_QUAD4_B};
@@ -565,9 +565,9 @@ pub fn driven_solve_with_sigma<B: Backend>(
 /// from both the port matrix rows/columns and the port RHS.
 ///
 /// Port voltage / current / input impedance are read off the solution
-/// with [`crate::lumped_port::port_voltage`],
-/// [`crate::lumped_port::port_current`] and
-/// [`crate::lumped_port::port_input_impedance`].
+/// with [`crate::driven::ports::port_voltage`],
+/// [`crate::driven::ports::port_current`] and
+/// [`crate::driven::ports::port_input_impedance`].
 ///
 /// An empty `ports` slice reproduces [`driven_solve_with_sigma`]
 /// exactly.
@@ -1296,7 +1296,7 @@ impl DrivenOperator {
 
     /// Port voltage `V = (1/w) ∮ E · ê dS` of port `port` read off a
     /// solution's full-length edge vector, using the cached flux
-    /// functional — identical to [`crate::lumped_port::port_voltage`].
+    /// functional — identical to [`crate::driven::ports::port_voltage`].
     ///
     /// # Panics
     ///
@@ -1314,7 +1314,7 @@ impl DrivenOperator {
 
     /// Port current from the Thevenin admittance relation
     /// `I = (2 V_inc − V) / R` of port `port` — identical to
-    /// [`crate::lumped_port::port_current`], using the port's **baked**
+    /// [`crate::driven::ports::port_current`], using the port's **baked**
     /// `V_inc`. For per-excitation bookkeeping (where a port may be
     /// driven in one solve and passively terminated in another), use
     /// [`DrivenOperator::port_current_with_v_inc`].
@@ -1632,7 +1632,7 @@ impl DrivenOperator {
 /// the cached factorization, so N excitations at a fixed ω cost one
 /// factorization + N triangular solves — the multi-RHS structure the
 /// N-port S-matrix extraction needs (one solve per excited port; see
-/// [`crate::extraction::s_parameter_frequency_sweep`]).
+/// [`crate::driven::extraction::s_parameter_frequency_sweep`]).
 pub struct FactoredDrivenOperator<'a> {
     op: &'a DrivenOperator,
     omega: f64,
@@ -1822,8 +1822,8 @@ pub struct BackSolveReport {
 ///   preconditioner + COCG knobs (iterative).
 ///
 /// Multi-RHS callers at the same ω
-/// ([`crate::extraction::s_parameter_frequency_sweep`],
-/// [`crate::wave_port::solve_wave_port_sweep`]) reuse one handle across
+/// ([`crate::driven::extraction::s_parameter_frequency_sweep`],
+/// [`crate::driven::ports::solve_wave_port_sweep`]) reuse one handle across
 /// every RHS; on the iterative path the Jacobi preconditioner is built
 /// once at construction and reused across every
 /// [`DrivenLinearSolver::back_solve`] call.
@@ -1901,7 +1901,7 @@ impl<'a> DrivenLinearSolver<'a> {
     /// must have length [`DrivenOperator::n_interior`].
     ///
     /// Bypasses the baked volume source / port drives — for callers
-    /// (wave-port SMW, see [`crate::wave_port::solve_wave_port_sweep`])
+    /// (wave-port SMW, see [`crate::driven::ports::solve_wave_port_sweep`])
     /// that build their own RHS on top of the same operator.
     pub fn back_solve(&self, b: &[c64], out: &mut [c64]) -> Result<BackSolveReport, DrivenError> {
         assert_eq!(b.len(), self.op.n_interior, "b length mismatch");

--- a/crates/geode-core/src/elements/nedelec.rs
+++ b/crates/geode-core/src/elements/nedelec.rs
@@ -541,7 +541,7 @@ pub fn batched_nedelec_local_mass_anisotropic_diag<B: Backend>(
 /// Barycentric weight of the "own" vertex in the symmetric degree-2
 /// 4-point tet quadrature rule: point `q` has `λ_q = TET_QUAD4_A` and
 /// `λ_p = TET_QUAD4_B` for `p ≠ q`, with equal weights `V/4`. Shared
-/// with the host-side reference assembly in [`crate::scattering`] so
+/// with the host-side reference assembly in [`crate::driven::scattering`] so
 /// the two paths integrate spatially varying sources identically.
 pub const TET_QUAD4_A: f64 = 0.585_410_196_624_968_5;
 /// Barycentric weight of the three "other" vertices in the degree-2
@@ -682,7 +682,7 @@ pub fn batched_nedelec_local_stiffness_weighted<B: Backend>(
 ///
 /// Note `G^W` is asymmetric for asymmetric `W`; the index order above
 /// (first basis index contracts the **left** slot of `W`) matches the
-/// host-path reference in [`crate::scattering`]. Complex weights run as
+/// host-path reference in [`crate::driven::scattering`]. Complex weights run as
 /// two passes (`Re(W)`, `Im(W)`).
 ///
 /// # Arguments
@@ -755,7 +755,7 @@ pub fn batched_nedelec_local_mass_anisotropic_full<B: Backend>(
 /// with the symmetric rule `λ_p(x_q) = TET_QUAD4_A` if `p = q` else
 /// `TET_QUAD4_B` ([`TET_QUAD4_A`]/[`TET_QUAD4_B`] — the same rule the
 /// host-side reference assembly in
-/// [`crate::scattering::solve_scattered_field_matched_upml`] uses, so
+/// [`crate::driven::scattering::solve_scattered_field_matched_upml`] uses, so
 /// the two RHS paths agree to round-off for the same samples).
 ///
 /// # Closed form used

--- a/crates/geode-core/src/elements/whitney.rs
+++ b/crates/geode-core/src/elements/whitney.rs
@@ -2,7 +2,7 @@
 //!
 //! Both the Silver-Müller / Leontovich impedance boundary conditions
 //! ([`crate::assembly::surface`]) and the uniform lumped port
-//! ([`crate::lumped_port`]) integrate first-order (Whitney) Nédélec
+//! ([`crate::driven::ports`]) integrate first-order (Whitney) Nédélec
 //! edge-element traces over flat boundary triangles. Before this module
 //! existed the per-face geometry (area, in-plane barycentric gradients,
 //! lower-tag-first edge orientation signs) and the tangential
@@ -185,7 +185,7 @@ pub(crate) fn face_mass_block(geo: &FaceGeometry) -> [[f64; 3]; 3] {
 ///
 /// This is the single kernel behind both
 /// [`crate::assembly::surface::assemble_surface_mass_triplets`] and
-/// [`crate::lumped_port::assemble_port_surface_mass`] (issue #208).
+/// [`crate::driven::ports::assemble_port_surface_mass`] (issue #208).
 ///
 /// # Panics
 ///

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -10,9 +10,7 @@ pub mod derham;
 pub mod driven;
 pub mod eigen;
 pub mod elements;
-pub mod extraction;
 pub mod fiber_lp;
-pub mod lumped_port;
 pub mod mesh;
 pub mod mie;
 pub mod mie_open;
@@ -21,11 +19,9 @@ pub mod mohan;
 pub mod ntff;
 pub mod palace;
 pub mod patch_cavity;
-pub mod scattering;
 pub mod silvermuller_self_consistent;
 pub mod solver;
 pub mod viz_vtu;
-pub mod wave_port;
 pub mod waveguide_modes;
 
 #[deprecated(note = "use geode_core::assembly::fe instead")]
@@ -69,7 +65,32 @@ pub use eigen::complex::{
 // these flat-root item re-exports become deprecated shims.
 #[deprecated(note = "use geode_core::derham instead")]
 pub use derham::{apply_divergence, apply_gradient, curl_map, divergence_map, gradient_map};
-pub use driven::{
+#[deprecated(note = "use geode_core::driven::extraction instead")]
+pub use driven::extraction::{
+    PortCircuit, SMatrix, SParameterSweepPoint, SweepPoint, detect_srf, driven_frequency_sweep,
+    driven_frequency_sweep_with_mode, extract_port_circuit, im_z_zero_crossings, inductance,
+    quality_factor, s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode, s11,
+};
+#[deprecated(note = "use geode_core::driven::ports instead")]
+pub use driven::ports::{
+    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort, WavePortSweepPoint,
+    extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
+    map_mode_profile_to_full_mesh, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
+    waveguide_mode_reduce,
+};
+#[deprecated(note = "use geode_core::driven::ports instead")]
+pub use driven::ports::{
+    LumpedPort, assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
+    port_voltage,
+};
+#[deprecated(note = "use geode_core::driven::scattering instead")]
+pub use driven::scattering::{
+    build_matched_upml_materials, extinction_power, flux_power_box, mie_polarization_source,
+    plane_wave_e_inc, plane_wave_polarization_current, q_from_power, scattered_flux_power,
+    solve_scattered_field_matched_upml, upml_matched_tensors,
+};
+#[deprecated(note = "use geode_core::driven::solve instead")]
+pub use driven::solve::{
     BackSolveReport, CurrentSource, DrivenBcs, DrivenError, DrivenLinearSolver, DrivenMaterials,
     DrivenOperator, DrivenSolution, FactoredDrivenOperator, IterativeSettings, QuadCurrentSource,
     SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel, driven_solve, driven_solve_iterative,
@@ -92,18 +113,9 @@ pub use elements::nedelec::{
 };
 #[deprecated(note = "use geode_core::elements::p1 instead")]
 pub use elements::p1::{P1LocalMatrices, batched_p1_local_matrices};
-pub use extraction::{
-    PortCircuit, SMatrix, SParameterSweepPoint, SweepPoint, detect_srf, driven_frequency_sweep,
-    driven_frequency_sweep_with_mode, extract_port_circuit, im_z_zero_crossings, inductance,
-    quality_factor, s_parameter_frequency_sweep, s_parameter_frequency_sweep_with_mode, s11,
-};
 pub use fiber_lp::{
     bessel_j, bessel_j0, bessel_j1, bessel_k, bessel_k0, bessel_k1, fiber_lp_neff, normalized_b,
     v_number,
-};
-pub use lumped_port::{
-    LumpedPort, assemble_port_flux, assemble_port_surface_mass, port_current, port_input_impedance,
-    port_voltage,
 };
 #[allow(deprecated)]
 pub use mesh::PHYS_VACUUM_BUFFER;
@@ -137,11 +149,6 @@ pub use ntff::{
     principal_plane_cuts, to_db,
 };
 pub use patch_cavity::PatchCavity;
-pub use scattering::{
-    build_matched_upml_materials, extinction_power, flux_power_box, mie_polarization_source,
-    plane_wave_e_inc, plane_wave_polarization_current, q_from_power, scattered_flux_power,
-    solve_scattered_field_matched_upml, upml_matched_tensors,
-};
 pub use silvermuller_self_consistent::{
     SelfConsistentResult, self_consistent_k, self_consistent_k_vector_tracked,
 };
@@ -151,12 +158,6 @@ pub use solver::iterate::{IterOutcome, IterReport, Step, iterate_while, iterate_
 pub use solver::ksp::{
     ChebyshevConfig, ChebyshevKind, ChebyshevPreconditioner, Cocg, IdentityPreconditioner,
     IluPreconditioner, JacobiPreconditioner, KspError, KspReport, KspSolve, Preconditioner,
-};
-pub use wave_port::{
-    ExtrudedHeightStepMesh, ExtrudedWaveguideMesh, PortMode, WavePort, WavePortSweepPoint,
-    extruded_height_step_waveguide_mesh, extruded_rect_waveguide_mesh,
-    map_mode_profile_to_full_mesh, solve_wave_port_sweep, solve_wave_port_sweep_with_mode,
-    waveguide_mode_reduce,
 };
 pub use waveguide_modes::*;
 

--- a/crates/geode-core/src/mesh/patch.rs
+++ b/crates/geode-core/src/mesh/patch.rs
@@ -69,7 +69,7 @@ use faer::c64;
 
 use super::sphere::{parse_elements_with_entity_tags, parse_entities_physical_tags};
 use super::{GmshReader, MeshError, MeshReader, TetMesh};
-use crate::lumped_port::LumpedPort;
+use crate::driven::ports::LumpedPort;
 
 /// Physical-group tag for the FR-4 substrate slab (3D).
 pub const PHYS_SUBSTRATE: i32 = 1;

--- a/crates/geode-core/src/mesh/spiral.rs
+++ b/crates/geode-core/src/mesh/spiral.rs
@@ -22,7 +22,7 @@
 //! subtracted cavity): per the issue-#210 design decision, skin-depth
 //! meshing is avoided entirely — the cavity walls carry either the
 //! Leontovich surface-impedance BC
-//! ([`crate::driven::SurfaceImpedanceBc`], issue #204) or a PEC edge
+//! ([`crate::driven::solve::SurfaceImpedanceBc`], issue #204) or a PEC edge
 //! mask.
 //!
 //! Generation is **offline** (gmsh is not a CI dependency): the fixture
@@ -79,7 +79,7 @@ use faer::c64;
 
 use super::sphere::{parse_elements_with_entity_tags, parse_entities_physical_tags};
 use super::{GmshReader, MeshError, MeshReader, TetMesh};
-use crate::lumped_port::LumpedPort;
+use crate::driven::ports::LumpedPort;
 
 /// Physical-group tag for the silicon substrate (3D).
 pub const PHYS_SUBSTRATE: i32 = 1;
@@ -137,7 +137,7 @@ impl SpiralMaterials {
     /// with the fixture's micron length unit:
     /// `σ_nat = σ_SI · Z₀ · L_unit` with `L_unit = 1e-6 m` (same
     /// normalization as
-    /// [`crate::driven::SurfaceImpedanceModel::GoodConductor`]).
+    /// [`crate::driven::solve::SurfaceImpedanceModel::GoodConductor`]).
     pub fn conductor_sigma_natural(&self) -> f64 {
         self.conductor_sigma_s_m * Z0_OHM * 1e-6
     }
@@ -186,7 +186,7 @@ pub const CONDUCTOR_SIGMA_S_M: f64 = 5.8e7;
 /// with the fixture's micron length unit:
 /// `σ_nat = σ_SI · Z₀ · L_unit = 5.8e7 · 376.730 · 1e-6 ≈ 2.185e4 /µm`
 /// (same normalization as
-/// [`crate::driven::SurfaceImpedanceModel::GoodConductor`]).
+/// [`crate::driven::solve::SurfaceImpedanceModel::GoodConductor`]).
 pub const CONDUCTOR_SIGMA_NATURAL: f64 = CONDUCTOR_SIGMA_S_M * 376.730_313_668 * 1e-6;
 
 /// Raw bytes of the bundled benchmark spiral fixture (MSH 4.1 ASCII).
@@ -414,7 +414,7 @@ pub fn read_spiral_fixture() -> Result<SpiralFixture, MeshError> {
 ///
 /// Same topology, layer stack, and physical-group convention as the
 /// benchmark fixture, but with a smaller footprint and coarser sizing
-/// so an end-to-end [`crate::driven::driven_solve_with_ports`] solve
+/// so an end-to-end [`crate::driven::solve::driven_solve_with_ports`] solve
 /// stays affordable for the current dense assembly path.
 pub fn read_spiral_smoke_fixture() -> Result<SpiralFixture, MeshError> {
     read_spiral_fixture_from_bytes(SPIRAL_SMOKE_MSH)
@@ -437,7 +437,7 @@ pub fn read_spiral_slcfet_3hp_fixture() -> Result<SpiralFixture, MeshError> {
 /// Same topology, layer stack, and physical-group convention as the
 /// 3HP benchmark fixture, but with a smaller footprint and coarser
 /// sizing so an end-to-end
-/// [`crate::driven::driven_solve_with_ports`] solve stays affordable in
+/// [`crate::driven::solve::driven_solve_with_ports`] solve stays affordable in
 /// default CI.
 pub fn read_spiral_slcfet_3hp_smoke_fixture() -> Result<SpiralFixture, MeshError> {
     read_spiral_fixture_from_bytes(SPIRAL_SLCFET_SMOKE_MSH)

--- a/crates/geode-core/src/ntff.rs
+++ b/crates/geode-core/src/ntff.rs
@@ -3,7 +3,7 @@
 //!
 //! The project's first **far-field** capability. Phases 1/2 deliver the
 //! driven near-field solution (`e_edges`) on the patch fixture plus a
-//! scalar radiated-power integrator ([`crate::scattering::flux_power_box`]);
+//! scalar radiated-power integrator ([`crate::driven::scattering::flux_power_box`]);
 //! this module turns the tangential `(E, H)` on the closed Huygens box
 //! into the angular far field `E(θ, φ)`, the directivity `D(θ, φ)`, and
 //! (with the Phase-2 efficiency) the gain `G = D · η`.
@@ -37,7 +37,7 @@
 //! # Convention
 //!
 //! The codebase uses `exp(+jωt)`: the incident plane wave
-//! ([`crate::scattering::plane_wave_e_inc`]) is `x̂·e^{−jωz}`, so an
+//! ([`crate::driven::scattering::plane_wave_e_inc`]) is `x̂·e^{−jωz}`, so an
 //! **outgoing** spherical wave carries `e^{−jkr}`. Consistency then
 //! forces the radiation-integral phase to be `e^{+j k r̂·r'}` (the
 //! retarded path-length difference `k(r − r̂·r')` enters the total
@@ -47,7 +47,7 @@
 //!
 //! `H = (i/ω) ∇×E` (`∇×E = −iωH`) is recovered per box face from the
 //! piecewise-constant Whitney curl
-//! ([`crate::scattering`] reuses the same evaluators), so no new field
+//! ([`crate::driven::scattering`] reuses the same evaluators), so no new field
 //! machinery is introduced — only the Love integral.
 
 use std::f64::consts::PI;
@@ -55,7 +55,7 @@ use std::f64::consts::PI;
 use faer::c64;
 
 use crate::TetMesh;
-use crate::scattering::{BoxFaceSample, box_surface_samples};
+use crate::driven::scattering::{BoxFaceSample, box_surface_samples};
 
 /// Free-space impedance in the codebase's natural units (`η₀ = 1`).
 const ETA_0_NATURAL: f64 = 1.0;
@@ -235,7 +235,7 @@ fn far_field_from_currents(
 ///
 /// Samples the tangential `(E, H)` on the closed Huygens box
 /// `[box_lo, box_hi]` (the same surface as
-/// [`crate::scattering::flux_power_box`]) from the per-edge complex
+/// [`crate::driven::scattering::flux_power_box`]) from the per-edge complex
 /// field `e_edges`, applies Love equivalence, and integrates the
 /// radiation vectors over a `(θ, φ)` grid.
 ///
@@ -244,7 +244,7 @@ fn far_field_from_currents(
 ///
 /// # Panics
 ///
-/// Same as [`crate::scattering::flux_power_box`] (empty / all-inside
+/// Same as [`crate::driven::scattering::flux_power_box`] (empty / all-inside
 /// box, `e_edges` length mismatch) and on degenerate grids
 /// (`n_theta < 2` or `n_phi < 1`).
 pub fn ntff_far_field(
@@ -398,8 +398,8 @@ fn ang_dist(a: f64, b: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::driven::scattering::{box_surface_samples, cross};
     use crate::mesh::cube_tet_mesh;
-    use crate::scattering::{box_surface_samples, cross};
 
     /// Analytic far-field components for a short z-directed dipole,
     /// built directly as box face samples (bypasses the FEM), so the

--- a/crates/geode-core/src/prelude.rs
+++ b/crates/geode-core/src/prelude.rs
@@ -1,9 +1,10 @@
 //! Common imports for geode-core: `use geode_core::prelude::*;`.
 //!
 //! Re-exports from the canonical module paths (`crate::assembly`,
-//! `crate::backend`, `crate::derham`, `crate::eigen`, `crate::elements`,
-//! `crate::solver`, `crate::traits`) — never the deprecated root shims — so
-//! glob-importing the prelude stays warning-free under `-D warnings`.
+//! `crate::backend`, `crate::derham`, `crate::driven`, `crate::eigen`,
+//! `crate::elements`, `crate::solver`, `crate::traits`) — never the
+//! deprecated root shims — so glob-importing the prelude stays warning-free
+//! under `-D warnings`.
 //! Later children of the namespace reorg add their own groups here.
 pub use crate::assembly::fe::{DirichletBc, ElementType, FeAssembleResult, fe_assemble};
 pub use crate::assembly::nedelec::assemble_global_nedelec;
@@ -11,6 +12,12 @@ pub use crate::assembly::p1::{GlobalSystem, assemble_global_p1};
 pub use crate::assembly::sparse::{SparseSystem, global_system_to_sparse};
 pub use crate::backend::{DefaultBackend, DeviceInfo, device_info, smoke_add};
 pub use crate::derham::{curl_map, divergence_map, gradient_map};
+pub use crate::driven::extraction::{SMatrix, s_parameter_frequency_sweep};
+pub use crate::driven::ports::{LumpedPort, PortMode, WavePort};
+pub use crate::driven::scattering::solve_scattered_field_matched_upml;
+pub use crate::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenMaterials, DrivenOperator, DrivenSolution, driven_solve,
+};
 pub use crate::eigen::complex::{
     ComplexEigenSolver, FaerComplexEigensolver, SparseComplexEigenSolver,
     SparseComplexShiftInvertLanczos,

--- a/crates/geode-core/src/solver/ksp.rs
+++ b/crates/geode-core/src/solver/ksp.rs
@@ -3,7 +3,7 @@
 //!
 //! All driven and eigen solves currently exit to a direct sparse LU
 //! ([`faer::sparse::linalg::solvers::Lu`]) at the solve boundary
-//! ([`crate::driven::FactoredDrivenOperator`],
+//! ([`crate::driven::solve::FactoredDrivenOperator`],
 //! [`crate::eigen::complex`]). Direct factorization caps the problem
 //! size at what fill-in can afford; for larger structures (the
 //! ~30k-edge patch fixture, future 3-D stacks) the next ceiling is the
@@ -142,7 +142,7 @@ pub enum KspError {
 /// Returned by every [`KspSolve::solve`] call. The relative residual
 /// is `‖A x − b‖₂ / ‖b‖₂`, computed with an explicit spmv on the
 /// final iterate — the **same** residual definition the direct path
-/// reports in [`crate::driven::DrivenSolution::residual_rel`], so the
+/// reports in [`crate::driven::solve::DrivenSolution::residual_rel`], so the
 /// two are directly comparable.
 #[derive(Debug, Clone, Copy)]
 pub struct KspReport {
@@ -1127,7 +1127,7 @@ impl Preconditioner for ChebyshevPreconditioner {
 /// Krylov-solver boundary — the iterative analog of the direct LU
 /// factor+solve path. Mirrors the role of
 /// [`faer::sparse::linalg::solvers::Lu`] in
-/// [`crate::driven::FactoredDrivenOperator`]: takes the assembled
+/// [`crate::driven::solve::FactoredDrivenOperator`]: takes the assembled
 /// sparse `A` and RHS `b` and produces the solution + a convergence
 /// report.
 ///

--- a/crates/geode-core/src/waveguide_modes.rs
+++ b/crates/geode-core/src/waveguide_modes.rs
@@ -139,7 +139,7 @@ impl WaveguideModeProfile {
 
 /// Outgoing-wave complex `β(ω, c, k_c)`: the canonical sign convention
 /// used by both [`WaveguideModeProfile::beta_complex`] and
-/// [`crate::wave_port::PortMode::beta`] under the `exp(+jωt)` time
+/// [`crate::driven::ports::PortMode::beta`] under the `exp(+jωt)` time
 /// convention.
 ///
 /// Returns `+√(ω²/c² − k_c²)` (real positive) for `ω/c ≥ k_c` and
@@ -1985,7 +1985,7 @@ pub(crate) fn assemble_2d_nedelec2_sparse_interior(
 }
 
 /// 2D radial coordinate-stretch (UPML) constitutive data at a Cartesian
-/// point, the 2D reduction of [`crate::scattering::upml_matched_tensors`]
+/// point, the 2D reduction of [`crate::driven::scattering::upml_matched_tensors`]
 /// (Epic #303 PML-A, issue #331).
 ///
 /// In the absorbing annulus `r_pml_inner ≤ r ≤ r_outer` the radial stretch
@@ -2089,7 +2089,7 @@ pub(crate) struct SparseModalOperatorsComplex {
 /// **identical**; the only addition is that on PML-tagged triangles the
 /// local 8×8 `K`/`M` blocks are built with the per-element constant stretch
 /// tensor from [`pml_stretch_tensor_2d`] (evaluated at the triangle
-/// centroid, exactly as the 3D [`crate::scattering::build_matched_upml_materials`]
+/// centroid, exactly as the 3D [`crate::driven::scattering::build_matched_upml_materials`]
 /// does per tet):
 ///
 /// - the curl-curl stiffness scalar curl product is weighted by


### PR DESCRIPTION
Closes #383

Child **[6/10]** of the geode-core namespace reorg (epic #377) — the largest child. Mirrors merged siblings #378–#382 and PR #392. **Pure refactor — no behavior change.** All relocations are `git mv` renames; every `#[cfg(...)]` gate and `pub(crate)` visibility is preserved.

## Layout — directory-backed `driven/`

```
crates/geode-core/src/driven/
├── mod.rs            // group //! rustdoc; pub mod solve/ports/extraction/scattering (no re-export up a level)
├── solve.rs          // git mv driven.rs       -> driven::solve  (the ~125 KB solver)
├── ports/
│   ├── mod.rs        // //! rustdoc; mod lumped; mod wave; pub use … (one driven::ports namespace)
│   ├── lumped.rs     // git mv lumped_port.rs   (private leaf)
│   └── wave.rs       // git mv wave_port.rs     (private leaf)
├── extraction.rs     // git mv extraction.rs   -> driven::extraction
└── scattering.rs     // git mv scattering.rs   -> driven::scattering
```

Canonical paths: `driven::solve::*`, `driven::ports::*`, `driven::extraction::*`, `driven::scattering::*`. The group root does **not** re-export items up to `driven::` (matches `eigen/mod.rs`); `ports/mod.rs` flattens the private `lumped`/`wave` leaves exactly as `eigen::complex` flattens `dense`+`lanczos`.

## lib.rs
- Dropped `pub mod extraction/lumped_port/scattering/wave_port`; kept `pub mod driven;` and `pub mod silvermuller_self_consistent;`.
- The five flat re-export blocks are now `#[deprecated(note = "use geode_core::driven::<sub> instead")]` shims repointed at canonical paths (public items only; lumped + wave both collapse to `geode_core::driven::ports`).
- The four `pub(crate)` cross-module scattering helpers (`BoxFaceSample`, `box_surface_samples`, `cross`, `tet_geometry`) relocate with **no** shim; `ntff.rs` imports repointed to `crate::driven::scattering::…`.

## prelude.rs
- Added the high-traffic driven set from **canonical** paths (`driven::solve`, `driven::ports`, `driven::extraction`, `driven::scattering`); listed `crate::driven` in the header.

## Same-PR caller migration (lib `src/` target only)
- **Class A** (10 compile-hard `use`/path sites): `driven/solve.rs`, `driven/extraction.rs`, `driven/scattering.rs`, `driven/ports/wave.rs` (internal), `mesh/patch.rs`, `mesh/spiral.rs`, `ntff.rs` (×2). `wave.rs` lumped import uses `super::lumped`.
- **Class B** (78 intra-doc links across 15 src files): all migrated — item refs `crate::driven::<item>` → `crate::driven::solve::<item>`, and `crate::{lumped_port,wave_port}` → `crate::driven::ports`, `crate::extraction` → `crate::driven::extraction`, `crate::scattering` → `crate::driven::scattering` (bare module links included).
- **Class C/D** flat-root item uses in `tests`/`benches`/`examples` deferred to **#387** (deprecated flat-root re-exports don't trip `-D warnings` downstream).

`silvermuller_self_consistent.rs` left top-level (epic open-question 3; eigen follow-up).

## Grep sweep (post-edit, #380 lesson)
```
grep -rnE 'crate::(driven|lumped_port|wave_port|extraction|scattering)::|geode_core::(…)::' crates/geode-core/src/
```
No stale MODULE-path refs remain. Residual matches are only valid new module links (`crate::driven::{ports,extraction,scattering}`) and the intentional `#[deprecated]` note strings in `lib.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Files moved via `git mv` per layout; new `mod.rs` carry `//!` rustdoc; `ports` flattens leaves | ✅ | `git diff --stat` shows R renames; `driven/mod.rs` + `driven/ports/mod.rs` added |
| `silvermuller_self_consistent.rs` not moved | ✅ | still top-level `pub mod silvermuller_self_consistent;` in lib.rs |
| Canonical paths compile and are reachable | ✅ | `cargo build` + `cargo doc` |
| Flat re-exports `#[deprecated]`; pub(crate) helpers relocate with no shim | ✅ | lib.rs shims; ntff.rs repointed to `crate::driven::scattering` |
| Prelude covers driven items from canonical paths | ✅ | prelude.rs additions |
| All Class A + Class B migrated; C/D deferred to #387 | ✅ | grep sweep clean; `cargo doc -D warnings` clean |
| Pure refactor — lib tests unchanged | ✅ | 262 passed (== main) |
| clippy `--features ndarray,arpack --tests --all-targets -D warnings` clean | ✅ | clean (arpack available locally) |
| `cargo doc -D warnings` renders driven with sub-modules, no broken links | ✅ | clean (default + `ndarray,arpack`) |

## Verification (all pass; arpack available locally)
- `cargo fmt -p geode-core -- --check` — clean
- `cargo build -p geode-core` — ok
- `cargo test -p geode-core --no-default-features --features ndarray --lib` — 262 passed, 0 failed, 2 ignored (unchanged vs main)
- `cargo clippy -p geode-core --no-default-features --features ndarray,arpack --tests --all-targets -- -D warnings` — clean (THE gate, run with arpack)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` (default and `--features ndarray,arpack`) — clean; `driven` renders with solve/ports/extraction/scattering
- `cargo build` (whole workspace) — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)