### PR TITLE
feat(geode-app): add clap app harness, arg groups, and lifecycle seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "geode-app"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "geode-cli"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/geode-core",
     "crates/geode-cli",
     "crates/geode-validation",
+    "crates/geode-app",
 ]
 
 [workspace.package]

--- a/crates/geode-app/Cargo.toml
+++ b/crates/geode-app/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "geode-app"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Shared application spine (clap harness + arg groups + lifecycle seam) for GEODE-FEM example binaries."
+
+[dependencies]
+clap = { workspace = true }
+thiserror = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/geode-app/src/args.rs
+++ b/crates/geode-app/src/args.rs
@@ -1,0 +1,196 @@
+//! Reusable [`clap::Args`] groups shared by GEODE-FEM example binaries.
+//!
+//! Each group is flattenable into a parent command via
+//! `#[command(flatten)]` so an example only declares the knobs it actually
+//! needs. Phase 1 ships exactly two groups:
+//!
+//! * [`OutputDir`] — an `--out-dir` artifact directory that
+//!   [`OutputDir::resolve`] creates on demand, generalizing the
+//!   `--export-field` / `create_dir_all(parent)` pattern the driven
+//!   benchmark examples hand-roll today.
+//! * [`Verbosity`] — counting `-v`/`-q` flags that resolve to a [`Level`].
+//!   This is a *placeholder only*: it produces a level value consumed by
+//!   the no-op logging seam ([`crate::lifecycle::init_observability`]) and
+//!   wires no logging backend.
+
+use std::path::PathBuf;
+
+/// Resolved verbosity level fed to the (currently no-op) logging seam.
+///
+/// The ordering of variants reflects increasing log detail; the enum
+/// carries no behavior of its own beyond being the value the future
+/// logging backend will switch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Level {
+    /// Suppress all but essential output (`-q`).
+    Quiet,
+    /// Default level when neither `-v` nor `-q` is given.
+    #[default]
+    Normal,
+    /// One `-v`: extra informational output.
+    Verbose,
+    /// Two or more `-v`: full debug detail.
+    Debug,
+}
+
+/// Errors produced while resolving an [`OutputDir`].
+#[derive(Debug, thiserror::Error)]
+pub enum OutputDirError {
+    /// `create_dir_all` failed for the requested output directory.
+    #[error("failed to create output directory `{}`: {source}", .path.display())]
+    Create {
+        /// The directory whose creation failed.
+        path: PathBuf,
+        /// The underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Output / artifact directory argument group.
+///
+/// Generalizes the recurring "take an output path, ensure its directory
+/// exists, write into it" pattern used by the `mie_sphere`,
+/// `spiral_inductor`, and `patch_antenna` examples (via
+/// `--export-field`). The directory defaults to `artifacts/` and is
+/// created on demand by [`resolve`](OutputDir::resolve).
+#[derive(Debug, Clone, clap::Args)]
+pub struct OutputDir {
+    /// Directory to write output artifacts into (created if missing).
+    #[arg(long = "out-dir", value_name = "DIR", default_value = "artifacts")]
+    pub out_dir: PathBuf,
+}
+
+impl OutputDir {
+    /// Ensure the output directory exists and return its path.
+    ///
+    /// Creates the directory (and any missing parents) with
+    /// [`std::fs::create_dir_all`], mirroring the `create_dir_all(parent)`
+    /// calls the examples make today, then returns the ready-to-write
+    /// directory path. Errors are surfaced as [`OutputDirError`].
+    pub fn resolve(&self) -> Result<PathBuf, OutputDirError> {
+        std::fs::create_dir_all(&self.out_dir).map_err(|source| OutputDirError::Create {
+            path: self.out_dir.clone(),
+            source,
+        })?;
+        Ok(self.out_dir.clone())
+    }
+}
+
+/// Verbosity argument group (logging-seam input only).
+///
+/// Counting flags `-v`/`--verbose` (repeatable) and `-q`/`--quiet`
+/// resolve to a [`Level`] via [`level`](Verbosity::level). `-q` takes
+/// precedence over any `-v`.
+///
+/// This group wires **no** logging backend: its resolved level is handed
+/// to the no-op [`crate::lifecycle::init_observability`] seam so a future
+/// epic can attach a subscriber without touching example call sites.
+/// `#[derive(Default)]` makes `Verbosity::default()` the no-verbosity
+/// case used by [`crate::App::verbosity`]'s default implementation.
+#[derive(Debug, Clone, Copy, Default, clap::Args)]
+pub struct Verbosity {
+    /// Increase verbosity (repeatable: `-v`, `-vv`).
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
+    verbose: u8,
+    /// Quiet mode: suppress non-essential output (overrides `-v`).
+    #[arg(short = 'q', long = "quiet", action = clap::ArgAction::Count)]
+    quiet: u8,
+}
+
+impl Verbosity {
+    /// Resolve the parsed flag counts to a [`Level`].
+    ///
+    /// `-q` (any count) maps to [`Level::Quiet`]; otherwise zero `-v`
+    /// flags is [`Level::Normal`], one is [`Level::Verbose`], and two or
+    /// more is [`Level::Debug`].
+    pub fn level(&self) -> Level {
+        if self.quiet > 0 {
+            Level::Quiet
+        } else {
+            match self.verbose {
+                0 => Level::Normal,
+                1 => Level::Verbose,
+                _ => Level::Debug,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct VerbProbe {
+        #[command(flatten)]
+        v: Verbosity,
+    }
+
+    #[derive(Parser)]
+    struct OutProbe {
+        #[command(flatten)]
+        o: OutputDir,
+    }
+
+    #[test]
+    fn verbosity_defaults_to_normal() {
+        let p = VerbProbe::try_parse_from(["prog"]).unwrap();
+        assert_eq!(p.v.level(), Level::Normal);
+        // The trait-default `Verbosity` must agree with parsing no flags.
+        assert_eq!(Verbosity::default().level(), Level::Normal);
+    }
+
+    #[test]
+    fn single_verbose_is_verbose() {
+        let p = VerbProbe::try_parse_from(["prog", "-v"]).unwrap();
+        assert_eq!(p.v.level(), Level::Verbose);
+    }
+
+    #[test]
+    fn double_verbose_is_debug() {
+        let p = VerbProbe::try_parse_from(["prog", "-vv"]).unwrap();
+        assert_eq!(p.v.level(), Level::Debug);
+        let long =
+            VerbProbe::try_parse_from(["prog", "--verbose", "--verbose", "--verbose"]).unwrap();
+        assert_eq!(long.v.level(), Level::Debug);
+    }
+
+    #[test]
+    fn quiet_overrides_verbose() {
+        let p = VerbProbe::try_parse_from(["prog", "-q"]).unwrap();
+        assert_eq!(p.v.level(), Level::Quiet);
+        let both = VerbProbe::try_parse_from(["prog", "-vv", "-q"]).unwrap();
+        assert_eq!(both.v.level(), Level::Quiet);
+    }
+
+    #[test]
+    fn out_dir_defaults_to_artifacts() {
+        let p = OutProbe::try_parse_from(["prog"]).unwrap();
+        assert_eq!(p.o.out_dir, PathBuf::from("artifacts"));
+    }
+
+    #[test]
+    fn resolve_creates_nested_directory() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("geode-app-test-{}-{}", std::process::id(), nanos));
+        let target = root.join("nested").join("out");
+        assert!(!target.exists());
+
+        let p = OutProbe::try_parse_from(["prog", "--out-dir", target.to_str().unwrap()]).unwrap();
+        let resolved = p.o.resolve().expect("resolve should create the directory");
+
+        assert!(resolved.is_dir());
+        assert_eq!(resolved, target);
+
+        // Idempotent: resolving again on an existing directory succeeds.
+        p.o.resolve().expect("resolve should be idempotent");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/geode-app/src/lib.rs
+++ b/crates/geode-app/src/lib.rs
@@ -1,0 +1,110 @@
+//! Shared application spine for GEODE-FEM example binaries.
+//!
+//! `geode-app` owns the common application-layer code that the
+//! `crates/geode-core/examples/*.rs` binaries hand-roll today: clap
+//! wiring, a uniform `Result → ExitCode` lifecycle, a couple of reusable
+//! argument groups, and a single documented attach point for a future
+//! logging backend. It deliberately keeps a tiny, stable public surface
+//! (`clap` + `thiserror` only) so the later phases of Epic #398 can build
+//! the example crates on top of it.
+//!
+//! # The harness
+//!
+//! Implement [`App`] on your top-level [`clap::Parser`] struct and make
+//! `main` a one-liner over [`main`]:
+//!
+//! ```no_run
+//! use std::process::ExitCode;
+//!
+//! use clap::Parser;
+//! use geode_app::{App, OutputDir, Verbosity};
+//!
+//! #[derive(Parser)]
+//! struct MyArgs {
+//!     #[command(flatten)]
+//!     out: OutputDir,
+//!     #[command(flatten)]
+//!     verbose: Verbosity,
+//! }
+//!
+//! impl App for MyArgs {
+//!     fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+//!         let dir = self.out.resolve()?; // create + return the artifact dir
+//!         println!("writing artifacts to {}", dir.display());
+//!         Ok(())
+//!     }
+//!
+//!     fn verbosity(&self) -> Verbosity {
+//!         self.verbose
+//!     }
+//! }
+//!
+//! fn main() -> ExitCode {
+//!     geode_app::main::<MyArgs>()
+//! }
+//! ```
+//!
+//! [`main`] parses the args, runs the observability seam, calls
+//! [`App::run`], and reports errors to stderr exactly like `geode-cli`
+//! before returning [`std::process::ExitCode::FAILURE`].
+//!
+//! # Argument groups
+//!
+//! Two flattenable [`clap::Args`] groups cover the patterns shared across
+//! the current examples:
+//!
+//! * [`OutputDir`] — an `--out-dir` artifact directory created on demand
+//!   by [`OutputDir::resolve`], generalizing the examples' `--export-field`
+//!   + `create_dir_all(parent)` behavior.
+//! * [`Verbosity`] — counting `-v`/`-q` flags resolving to a [`Level`].
+//!
+//! # Logging seam (intentionally a no-op)
+//!
+//! `geode-app` introduces **no logging crate** in Phase 1. Instead,
+//! [`lifecycle::init_observability`] is an explicit, documented no-op that
+//! receives the resolved [`Verbosity`]. A future epic can attach a
+//! `tracing`/`log` subscriber there without changing any example call
+//! site, because [`main`] funnels every binary through that one seam. The
+//! [`Verbosity`] group exists only to feed this seam — it wires no backend
+//! today.
+
+pub mod args;
+pub mod lifecycle;
+pub mod runner;
+
+pub use args::{Level, OutputDir, OutputDirError, Verbosity};
+pub use runner::{App, main};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Minimal `App` implementor exercising the harness shape end-to-end
+    /// (without going through `A::parse()`, which would consume the test
+    /// harness's own argv).
+    #[derive(Parser)]
+    struct DemoArgs {
+        #[command(flatten)]
+        verbose: Verbosity,
+    }
+
+    impl App for DemoArgs {
+        fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+
+        fn verbosity(&self) -> Verbosity {
+            self.verbose
+        }
+    }
+
+    #[test]
+    fn app_trait_wires_up_and_runs() {
+        let app = DemoArgs::try_parse_from(["prog", "-v"]).unwrap();
+        assert_eq!(app.verbosity().level(), Level::Verbose);
+        // The body runs the same way `main` invokes it.
+        crate::lifecycle::init_observability(app.verbosity());
+        assert!(app.run().is_ok());
+    }
+}

--- a/crates/geode-app/src/lifecycle.rs
+++ b/crates/geode-app/src/lifecycle.rs
@@ -1,0 +1,26 @@
+//! Runtime lifecycle for the [`crate::main`] harness.
+//!
+//! This module owns the setup/teardown that [`crate::main`] runs around an
+//! application body. In Phase 1 the only lifecycle step is the
+//! observability seam ([`init_observability`]), which is intentionally a
+//! **no-op** — GEODE-FEM has no logging backend dependency yet (Epic
+//! #398).
+
+use crate::args::Verbosity;
+
+/// Observability seam: the single, documented attach point for a future
+/// logging backend.
+///
+/// [`crate::main`] calls this once, immediately after argument parsing and
+/// before running the application body, passing the application's resolved
+/// [`Verbosity`]. Today it does nothing; a future epic can attach a
+/// `tracing`/`log` subscriber here (configured by
+/// [`Verbosity::level`](crate::Verbosity::level)) **without touching any
+/// example call site**, because every example funnels through this seam.
+///
+/// No logging crate is a dependency of `geode-app` in Phase 1, by design.
+pub fn init_observability(_verbosity: Verbosity) {
+    // TODO(logging): attach a tracing/log subscriber here, configured by
+    // `_verbosity.level()`. Intentionally a no-op in Phase 1 — no logging
+    // backend dependency exists yet (Epic #398).
+}

--- a/crates/geode-app/src/runner.rs
+++ b/crates/geode-app/src/runner.rs
@@ -1,0 +1,60 @@
+//! The [`App`] trait and the generic [`main`] entry point that together
+//! standardize an example binary's lifecycle.
+
+use std::error::Error;
+use std::process::ExitCode;
+
+use crate::args::Verbosity;
+
+/// Implemented by an example's top-level [`clap::Parser`] struct to plug
+/// into the [`main`] harness.
+///
+/// The body returns `Result<(), Box<dyn std::error::Error>>` so any error
+/// type that is `Into<Box<dyn Error>>` propagates with `?` — no `anyhow`
+/// or other error crate is required.
+pub trait App: clap::Parser {
+    /// The application body. Runs after argument parsing and the
+    /// observability seam; its `Result` is mapped to a process
+    /// [`ExitCode`] by [`main`].
+    fn run(self) -> Result<(), Box<dyn Error>>;
+
+    /// The resolved [`Verbosity`] fed to the (currently no-op) logging
+    /// seam. Defaults to no verbosity; override by returning your
+    /// flattened [`Verbosity`] group.
+    fn verbosity(&self) -> Verbosity {
+        Verbosity::default()
+    }
+}
+
+/// Standard entry point for an example binary.
+///
+/// An example's `main` becomes a one-liner:
+///
+/// ```ignore
+/// fn main() -> std::process::ExitCode {
+///     geode_app::main::<MyArgs>()
+/// }
+/// ```
+///
+/// The harness parses arguments ([`clap::Parser::parse`]), runs the no-op
+/// observability seam ([`crate::lifecycle::init_observability`]) with the
+/// app's [`App::verbosity`], executes [`App::run`], and maps the result to
+/// an [`ExitCode`]: `Ok(())` → [`ExitCode::SUCCESS`]; `Err(e)` → the error
+/// and its source chain are printed to stderr (matching `geode-cli`'s
+/// `eprintln!` style) and [`ExitCode::FAILURE`] is returned.
+pub fn main<A: App>() -> ExitCode {
+    let app = A::parse();
+    crate::lifecycle::init_observability(app.verbosity());
+    match app.run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            let mut source = e.source();
+            while let Some(s) = source {
+                eprintln!("  caused by: {s}");
+                source = s.source();
+            }
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 (foundation) of Epic #398. Adds a new workspace member crate `geode-app` that owns the shared application-layer spine the example binaries hand-roll today: clap wiring, a uniform `Result → ExitCode` lifecycle, two reusable arg groups, and a single documented no-op attach point for a future logging backend. No example is migrated (Phase 3) and no logging crate is introduced.

## Changes

- **Crate + workspace wiring**: new `crates/geode-app/` with `version/edition/license/repository/rust-version` inherited from the workspace; added `"crates/geode-app"` to root `Cargo.toml` `members`. Dependencies are exactly `clap` + `thiserror` (both workspace-inherited).
- **Runner harness** (`src/runner.rs`): `App: clap::Parser` trait with `run(self) -> Result<(), Box<dyn Error>>` and a defaulted `verbosity()`; generic `main::<A>()` that parses args → runs the no-op seam → executes the body → maps `Ok`→`SUCCESS`, `Err`→ stderr (`error: {e}` + `caused by:` source chain, matching `geode-cli`) → `FAILURE`.
- **Arg groups** (`src/args.rs`): `OutputDir` (`--out-dir`, default `artifacts/`) with `resolve() -> Result<PathBuf, OutputDirError>` (thiserror) that `create_dir_all`s and returns the directory; `Verbosity` (counting `-v`/`-q`, `#[derive(Default)]`) with `level() -> Level` (`Quiet | Normal | Verbose | Debug`, `-q` wins). Both are flattenable `#[derive(clap::Args)]`.
- **Lifecycle seam** (`src/lifecycle.rs`): `init_observability(Verbosity)` — empty body with a `TODO(logging)` marker, documented as the future subscriber attach point.
- **Docs/tests**: crate-level `//!` rustdoc covering the harness, the two arg groups, and the no-op seam; a `no_run` rustdoc doctest showing the `geode_app::main::<MyArgs>()` shape; unit tests for out-dir creation and verbosity resolution (driven via `try_parse_from`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `geode-app` is a new workspace member; `cargo build -p geode-app` succeeds | done | member added to root `Cargo.toml`; build green |
| No logging crate / no `anyhow`; deps are exactly `clap` + `thiserror`; seam present, documented, no-op | done | `cargo tree -p geode-app -e normal` shows only clap (+deps) and thiserror; `init_observability` is an empty body |
| `OutputDir` + `Verbosity` are flattenable `clap::Args` with tested behavior methods | done | both `#[derive(clap::Args)]`, flattened in tests; `resolve` creates dir, `level()` maps counts |
| `App` trait + `main::<A>()` maps `Result`→`ExitCode` with stderr matching geode-cli; doctest/test demonstrates the shape | done | `runner.rs` + `no_run` doctest + in-crate `app_trait_wires_up_and_runs` test |
| `cargo test -p geode-app` passes | done | 7 unit tests + doctest pass |
| `cargo clippy -p geode-app --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean | done | both exit 0 |
| Crate-level rustdoc explains harness, arg groups, no-op seam | done | `//!` in `lib.rs`; `cargo doc -p geode-app --no-deps` renders |

## Test Plan

Commands run (all green):
- `cargo fmt --all -- --check`
- `cargo build -p geode-app`
- `cargo test -p geode-app` (7 unit tests + 1 doctest pass, 1 ignored `no_run`)
- `cargo clippy -p geode-app --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo tree -p geode-app -e normal` (confirms clap + thiserror only)
- `cargo doc -p geode-app --no-deps`

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)