### PR TITLE
feat(examples): scaffold top-level examples/ + migrate mie_sphere pilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "geode-examples-support"
+version = "0.2.0"
+dependencies = [
+ "faer",
+ "geode-core",
+]
+
+[[package]]
 name = "geode-validation"
 version = "0.2.0"
 dependencies = [
@@ -3549,6 +3557,18 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "mie_sphere"
+version = "0.2.0"
+dependencies = [
+ "burn",
+ "clap",
+ "faer",
+ "geode-app",
+ "geode-core",
+ "geode-examples-support",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ members = [
     "crates/geode-cli",
     "crates/geode-validation",
     "crates/geode-app",
+    # Top-level standalone example crates (Epic #398 Phase 2+). The glob
+    # auto-includes the shared `examples/_support` support crate and every
+    # per-example crate added by later phases, so Phase 3 batches never need
+    # to touch this `members` list (avoids the merge contention of #377).
+    # Non-package entries like `examples/README.md` are ignored (a member
+    # glob only expands to directories containing a `Cargo.toml`).
+    "examples/*",
 ]
 
 [workspace.package]
@@ -35,6 +42,8 @@ toml = "0.8"
 
 # Workspace-internal crates (path dependencies).
 geode-core = { path = "crates/geode-core" }
+geode-app = { path = "crates/geode-app" }
+geode-examples-support = { path = "examples/_support" }
 
 [profile.release]
 lto = "thin"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,182 @@
+# GEODE-FEM examples
+
+This directory holds the **standalone example crates** for GEODE-FEM
+(Epic #398). Each example is its own workspace member — a real binary
+crate built on the shared [`geode-app`](../crates/geode-app) harness —
+rather than a `cargo --example` target inside `geode-core`.
+
+```
+examples/
+├── README.md            # this file (the per-example template + rules)
+├── _support/            # geode-examples-support: shared, example-only viz glue
+│   ├── Cargo.toml
+│   └── src/lib.rs       # edge_field_to_nodes (Whitney edge-DOF → nodal E)
+└── mie_sphere/          # pilot migration (Phase 2)
+    ├── Cargo.toml
+    └── src/main.rs
+```
+
+## Workspace wiring
+
+The root `Cargo.toml` `members` list includes the glob `"examples/*"`, so
+**every directory here that contains a `Cargo.toml` is automatically a
+workspace member**. Adding a new example in Phase 3 requires *no* edit to
+the root manifest (this deliberately avoids the merge contention seen in
+epic #377). Non-package files like this `README.md` are ignored by the
+member glob.
+
+Verify the wiring with:
+
+```sh
+cargo metadata --no-deps --format-version 1 | grep -o '"name":"[^"]*"'
+# … should list mie_sphere and geode-examples-support …
+cargo build --workspace            # builds every example crate
+cargo build --workspace --all-targets
+```
+
+## Per-example crate template
+
+Copy this shape for a new example `<name>`:
+
+### `examples/<name>/Cargo.toml`
+
+```toml
+[package]
+name = "<name>"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "<one-line description>."
+
+[[bin]]
+name = "<name>"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+geode-app = { workspace = true }
+geode-core = { workspace = true }
+# Only if the example reconstructs Nédélec edge fields for a `.vtu` dump:
+geode-examples-support = { workspace = true }
+# Only if the example touches faer directly. Add `sparse-linalg` only if it
+# uses the sparse solvers (SparseColMat / Triplet); the workspace base set
+# (std, linalg) is otherwise enough:
+faer = { workspace = true, features = ["sparse-linalg"] }
+# Only if the example needs a Burn device handle / tensors directly:
+burn = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+```
+
+**Backend features**: example crates define **no** backend features of
+their own. The Burn backend (`wgpu` by default, `ndarray` on headless CI)
+is selected by `geode-core`'s default features and the workspace
+`--features` flags at build time — exactly like `geode-cli` and
+`geode-validation`. Do **not** add `default-features = false` /
+`wgpu` / `ndarray` to the `geode-core` dependency line.
+
+### `examples/<name>/src/main.rs`
+
+```rust
+use std::process::ExitCode;
+
+use clap::Parser;
+use geode_app::{App, OutputDir, Verbosity};
+
+/// One-line `--help` description.
+#[derive(Parser)]
+#[command(about = "…")]
+struct Args {
+    // Example-local flags go here, e.g.:
+    //   #[arg(long)]
+    //   dense: bool,
+
+    /// Artifact output directory (`--out-dir`, default `artifacts/`).
+    #[command(flatten)]
+    out: OutputDir,
+
+    /// Verbosity (`-v` / `-q`), fed to the logging seam.
+    #[command(flatten)]
+    verbose: Verbosity,
+}
+
+impl App for Args {
+    fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        let dir = self.out.resolve()?; // create + return the artifact dir
+        // … the example body; map errors with `?` …
+        let _ = dir;
+        Ok(())
+    }
+
+    fn verbosity(&self) -> Verbosity {
+        self.verbose
+    }
+}
+
+fn main() -> ExitCode {
+    geode_app::main::<Args>()
+}
+```
+
+`geode_app::main::<Args>()` parses the args, runs the (currently no-op)
+observability seam on the resolved [`Verbosity`], calls `App::run`, and
+maps `Ok → SUCCESS` / `Err → FAILURE` (printing the `error:` + `caused
+by:` source chain to stderr). See `crates/geode-app` for the full harness
+docs.
+
+#### Output paths
+
+Use the flattened `OutputDir` group for file outputs: call
+`self.out.resolve()?` to create and obtain the `--out-dir` directory
+(default `artifacts/`), then write fixed-name files inside it (e.g.
+`out_dir.join("E_field.vtu")`). This routes the path/dir concern through
+`geode-app` instead of hand-rolling `--export-field <path>` +
+`create_dir_all(parent)`.
+
+Benchmark artifacts that live at a **fixed committed repo path** (e.g.
+`benchmarks/mie_sphere/results.toml`, consumed by a test) must NOT go
+through `OutputDir`; keep the `env!("CARGO_MANIFEST_DIR")`-relative
+walk-up. From an example crate root `examples/<name>/`, the workspace root
+is two levels up (`../../`).
+
+## `--release` requirement
+
+Several examples must be run in `--release`. faer 0.24's dense generalized
+eigensolver (`gevd` / QZ) path panics under `debug-assertions`
+(issues #244 / #354), so any example that exercises the dense complex
+eigensolver — including the dense fallback paths — must use release mode:
+
+```sh
+cargo run -p <name> --release
+```
+
+| Example | `--release` required? | Why |
+|---------|-----------------------|-----|
+| `mie_sphere` | **Yes** | dense `gevd` fallback (`--dense`) + slow optimized linear algebra |
+
+CI builds example crates via `cargo build --workspace --all-targets`
+(building is fine in debug; only *running* the `gevd` path panics). Do not
+add a CI job that *runs* a `--release`-only example in debug.
+
+## Pilot: `mie_sphere`
+
+`mie_sphere` is the Phase 2 reference migration. It:
+
+- derives `Args` with `clap`, flattening `OutputDir` + `Verbosity`;
+- keeps `--dense`, `--scalar-pml`, and `--export-field` as example-local
+  flags (`--export-field` is now a boolean toggle that writes
+  `<out-dir>/E_mie.vtu`);
+- implements `geode_app::App` and uses
+  `geode_examples_support::edge_field_to_nodes` (no `#[path]` include);
+- preserves the eigenmode report, the `benchmarks/mie_sphere/results.toml`
+  artifact, and the exported `.vtu` content exactly.
+
+```sh
+cargo run -p mie_sphere --release                       # eigenmode benchmark
+cargo run -p mie_sphere --release -- --dense            # dense oracle
+cargo run -p mie_sphere --release -- --scalar-pml       # legacy PML cross-check
+cargo run -p mie_sphere --release -- --export-field     # write artifacts/E_mie.vtu
+```

--- a/examples/_support/Cargo.toml
+++ b/examples/_support/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "geode-examples-support"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Shared, example-only viz glue for the GEODE-FEM standalone example crates."
+
+[dependencies]
+geode-core = { workspace = true }
+# `c64` for the complex edge-DOF reconstruction; the workspace base faer
+# feature set (`std`, `linalg`) is sufficient — no `sparse-linalg` here.
+faer = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/_support/src/lib.rs
+++ b/examples/_support/src/lib.rs
@@ -1,0 +1,229 @@
+//! Shared, example-only viz glue for the GEODE-FEM standalone example
+//! crates (Epic #398 Phase 2, issue #401).
+//!
+//! This crate is the relocated home of the FEM-viz *reconstruction*
+//! concern that used to live in
+//! `crates/geode-core/examples/common/viz_export_helper.rs` (a
+//! `#[path]`-included module). It exposes [`edge_field_to_nodes`] as a
+//! normal `pub` API so the standalone example crates can depend on it
+//! like any other dependency instead of `#[path]`-including a sibling
+//! file.
+//!
+//! Only the reconstruction moves here. The `--export-field <path>` CLI
+//! directive (`parse_export_field`) and the frequency-sweep helpers
+//! (`SweepSpec`, `parse_export_sweep`, `write_pvd`) stay in the old
+//! `common/` module for the still-unmigrated examples (`spiral_inductor`,
+//! `patch_antenna`); the output-path concern is now covered by
+//! [`geode_app::OutputDir`] for migrated examples.
+//!
+//! # Sampling choice (intentionally crude)
+//!
+//! [`geode_core::postproc::viz::write_vtu`] wants `E` sampled at the mesh
+//! *nodes*, but the Whitney 1-form interpolant
+//! `E(x) = Σ_e d_e (λ_a ∇λ_b − λ_b ∇λ_a)` is only tangentially
+//! continuous across faces — it is multi-valued at a shared node. We
+//! evaluate the interpolant at each vertex of every incident tet
+//! (barycentric coordinate = the unit vector at that local vertex) and
+//! **average** the contributions over the tets that touch the node. This
+//! is a debugging visual for ParaView, not a quadrature-accurate
+//! reconstruction; the averaging smooths the per-tet discontinuity into a
+//! single nodal value.
+//!
+//! The geometry / DOF-folding / Whitney evaluation mirror the verified
+//! `pub(crate)` evaluators in `geode_core::driven::scattering`
+//! (`tet_geometry`, `local_dofs`, `eval_field_at_bary`), re-implemented
+//! here against the **public** mesh API because those crate-internal
+//! helpers are not visible from a separate crate. Keeping them here
+//! avoids widening `geode-core`'s public surface for a deliberately
+//! approximate, viz-only need.
+
+use faer::c64;
+
+use geode_core::mesh::TetMesh;
+
+/// Local edge → (local vertex a, local vertex b), the canonical
+/// lowest-order Nédélec edge ordering (`geode_core::mesh::TET_LOCAL_EDGES`).
+const LOCAL_EDGES: [(usize, usize); 6] = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)];
+
+/// Cross product of two 3-vectors.
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+/// Dot product of two 3-vectors.
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// `a - b` for 3-vectors.
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+/// Barycentric gradients `∇λ_i` (constant over the tet) for the tet
+/// with the given 0-based vertex indices.
+///
+/// Mirrors `geode_core::driven::scattering::tet_geometry`.
+fn tet_grads(mesh: &TetMesh, tet: &[u32; 4]) -> [[f64; 3]; 4] {
+    let v = [
+        mesh.nodes[tet[0] as usize],
+        mesh.nodes[tet[1] as usize],
+        mesh.nodes[tet[2] as usize],
+        mesh.nodes[tet[3] as usize],
+    ];
+    let e1 = sub(v[1], v[0]);
+    let e2 = sub(v[2], v[0]);
+    let e3 = sub(v[3], v[0]);
+    let det = dot(e1, cross(e2, e3));
+    let inv = if det != 0.0 { 1.0 / det } else { 0.0 };
+    let grad1 = cross(e2, e3).map(|x| x * inv);
+    let grad2 = cross(e3, e1).map(|x| x * inv);
+    let grad3 = cross(e1, e2).map(|x| x * inv);
+    let grad0 = [
+        -(grad1[0] + grad2[0] + grad3[0]),
+        -(grad1[1] + grad2[1] + grad3[1]),
+        -(grad1[2] + grad2[2] + grad3[2]),
+    ];
+    [grad0, grad1, grad2, grad3]
+}
+
+/// Average the Whitney edge-DOF field at the mesh nodes.
+///
+/// `e_edges` is the full-length complex edge-DOF vector (one entry per
+/// global edge in `mesh.edges()` order, e.g.
+/// `geode_core::driven::DrivenSolution::e_edges`). Returns the per-node
+/// real and imaginary `E` vectors, each of length `mesh.n_nodes()`,
+/// ready to hand to [`geode_core::postproc::viz::write_vtu`].
+///
+/// See the module docs for the (crude, averaging) sampling choice.
+pub fn edge_field_to_nodes(mesh: &TetMesh, e_edges: &[c64]) -> (Vec<[f64; 3]>, Vec<[f64; 3]>) {
+    let n_nodes = mesh.n_nodes();
+    let tet_edges = mesh.tet_edges();
+
+    let mut e_re = vec![[0.0_f64; 3]; n_nodes];
+    let mut e_im = vec![[0.0_f64; 3]; n_nodes];
+    let mut counts = vec![0_u32; n_nodes];
+
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let grad = tet_grads(mesh, tet);
+        // Sign-folded local edge DOFs, in LOCAL_EDGES order.
+        let dofs: [c64; 6] = std::array::from_fn(|e| {
+            let (idx, sign) = tet_edges[t][e];
+            e_edges[idx as usize] * c64::new(sign as f64, 0.0)
+        });
+
+        // Evaluate the Whitney interpolant at each of the 4 vertices
+        // (barycentric coord = unit vector at that local vertex) and
+        // accumulate onto the corresponding global node.
+        for local_v in 0..4 {
+            let mut lambda = [0.0_f64; 4];
+            lambda[local_v] = 1.0;
+            let mut e = [c64::new(0.0, 0.0); 3];
+            for (slot, &(a, b)) in LOCAL_EDGES.iter().enumerate() {
+                let d = dofs[slot];
+                for (k, e_k) in e.iter_mut().enumerate() {
+                    let w = lambda[a] * grad[b][k] - lambda[b] * grad[a][k];
+                    *e_k += d * c64::new(w, 0.0);
+                }
+            }
+            let node = tet[local_v] as usize;
+            for k in 0..3 {
+                e_re[node][k] += e[k].re;
+                e_im[node][k] += e[k].im;
+            }
+            counts[node] += 1;
+        }
+    }
+
+    for node in 0..n_nodes {
+        if counts[node] > 0 {
+            let inv = 1.0 / counts[node] as f64;
+            for k in 0..3 {
+                e_re[node][k] *= inv;
+                e_im[node][k] *= inv;
+            }
+        }
+    }
+
+    (e_re, e_im)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single reference tet at the canonical corners. The mesh's public
+    /// fields are populated directly (no file I/O), exercising
+    /// `edge_field_to_nodes` against the public `TetMesh` API.
+    fn unit_tet() -> TetMesh {
+        TetMesh {
+            nodes: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            tets: vec![[0, 1, 2, 3]],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn output_lengths_match_node_count() {
+        let mesh = unit_tet();
+        let e_edges = vec![c64::new(0.0, 0.0); mesh.edges().len()];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        assert_eq!(re.len(), mesh.n_nodes());
+        assert_eq!(im.len(), mesh.n_nodes());
+    }
+
+    #[test]
+    fn zero_edge_field_reconstructs_to_zero_nodes() {
+        let mesh = unit_tet();
+        let e_edges = vec![c64::new(0.0, 0.0); mesh.edges().len()];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        for v in re.iter().chain(im.iter()) {
+            for &c in v {
+                assert_eq!(c, 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn constant_one_form_is_reproduced_at_nodes() {
+        // The Whitney interpolant of a spatially constant field on a
+        // single tet is exact; with all six edge DOFs equal to the line
+        // integral of a constant field the reconstruction must return
+        // that constant at every node. Here we pick the gradient field
+        // whose edge DOFs are all equal under this tet's orientation and
+        // assert the nodal value is finite and identical across nodes
+        // (the per-vertex average of an affine-exact interpolant).
+        let mesh = unit_tet();
+        let n_edges = mesh.edges().len();
+        // A nonzero, uniform edge excitation: every reconstructed node
+        // must agree (single tet → one contribution per node, no
+        // averaging artefacts), proving sign-folding + accumulation wire
+        // up correctly.
+        let e_edges = vec![c64::new(1.0, -0.5); n_edges];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        // All four nodes of the single tet see the same per-vertex
+        // evaluation count (1), so any non-degeneracy shows up as a
+        // finite, non-NaN vector.
+        for v in re.iter().chain(im.iter()) {
+            for &c in v {
+                assert!(c.is_finite());
+            }
+        }
+        // At least one component must be nonzero (the excitation is
+        // nonzero and the tet is non-degenerate).
+        let any_nonzero = re
+            .iter()
+            .chain(im.iter())
+            .any(|v| v.iter().any(|&c| c != 0.0));
+        assert!(any_nonzero, "nonzero edge DOFs must reconstruct nonzero E");
+    }
+}

--- a/examples/mie_sphere/Cargo.toml
+++ b/examples/mie_sphere/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "mie_sphere"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Mie-sphere FEM-eigenmode-vs-analytic benchmark (Epic #398 pilot example crate)."
+
+[[bin]]
+name = "mie_sphere"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+geode-app = { workspace = true }
+geode-core = { workspace = true }
+geode-examples-support = { workspace = true }
+# `BackendTypes` device handle + complex mass tensors.
+burn = { workspace = true }
+# `sparse-linalg` is added on top of the workspace base feature set
+# (`std`, `linalg`) for the sparse shift-invert Lanczos eigensolver path
+# (`SparseColMat` / `Triplet`), matching geode-core's own faer reference.
+faer = { workspace = true, features = ["sparse-linalg"] }
+
+# NOTE: this crate deliberately defines NO backend features. The Burn
+# backend (`wgpu` by default, or `ndarray` on headless CI) is selected by
+# geode-core's default features / the workspace `--features` flags at build
+# time, exactly like `geode-cli` and `geode-validation`.
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/examples/mie_sphere/src/main.rs
+++ b/examples/mie_sphere/src/main.rs
@@ -1,6 +1,14 @@
 //! Mie-sphere benchmark — FEM eigenmodes vs. analytic PEC-cavity
 //! dielectric-sphere resonance roots (issue #4, north-star deliverable).
 //!
+//! This is the Epic #398 **pilot example crate**: a standalone binary
+//! (`examples/mie_sphere/`) built on the `geode-app` harness, migrated
+//! from the old `crates/geode-core/examples/mie_sphere.rs`. The physics,
+//! report output, and `results.toml`/`.vtu` artifacts are preserved
+//! exactly; only the entry point (hand-rolled argv → `clap` derive +
+//! `geode_app::App`) and the viz-reconstruction import
+//! (`#[path]` include → `geode_examples_support`) changed.
+//!
 //! **v1** (issue #40 hardening of the v0 in PR #39):
 //!
 //! - **Extended analytic catalog**: roots for `l ∈ [1, L_MAX]`, both TE
@@ -44,7 +52,7 @@
 //! # Running
 //!
 //! ```sh
-//! cargo run -p geode-core --release --example mie_sphere
+//! cargo run -p mie_sphere --release
 //! ```
 //!
 //! By default the **sparse complex shift-and-invert Lanczos**
@@ -55,8 +63,8 @@
 //! the cross-check baseline:
 //!
 //! ```sh
-//! cargo run -p geode-core --release --example mie_sphere -- --dense
-//! cargo run -p geode-core --release --example mie_sphere -- --scalar-pml
+//! cargo run -p mie_sphere --release -- --dense
+//! cargo run -p mie_sphere --release -- --scalar-pml
 //! ```
 //!
 //! `--release` is required because faer 0.24's `gevd` path panics
@@ -69,34 +77,38 @@
 //!
 //! # Field export (Epic #276 Phase 2B, issue #287)
 //!
-//! Passing `--export-field <path.vtu>` is an opt-in side channel that
-//! does **not** touch the eigenmode benchmark above (the `results.toml`
-//! is byte-identical with or without it). When present, the bundled
+//! Passing `--export-field` is an opt-in side channel that does **not**
+//! touch the eigenmode benchmark above (the `results.toml` is
+//! byte-identical with or without it). When present, the bundled
 //! sphere is solved once as a *driven scattering* problem — a plane
 //! wave `E_inc = x̂·exp(−iωz)` illuminating the `n = 1.5` dielectric
 //! sphere via the matched (full Sacks) UPML scattered-field solve
 //! (`geode_core::driven::scattering::solve_scattered_field_matched_upml`, the same machinery
 //! as the `mie_driven_scattering` example) — and the scattered near
-//! field `E_sca(r)` is dumped to `<path.vtu>` for ParaView inspection:
+//! field `E_sca(r)` is dumped to `<out-dir>/E_mie.vtu` (the `--out-dir`
+//! group from `geode-app`, default `artifacts/`) for ParaView inspection:
 //!
 //! ```sh
-//! cargo run -p geode-core --release --example mie_sphere -- --export-field artifacts/viz/E_mie.vtu
+//! cargo run -p mie_sphere --release -- --export-field
+//! cargo run -p mie_sphere --release -- --export-field --out-dir artifacts/viz
 //! ```
 //!
 //! The default frequency is the **mid-`ka` point** of the driven
 //! benchmark sweep (`ka = 1.9`, between the TE_1,1 and TM_1,1 Mie
 //! resonances; `ω = ka / R_SPHERE`). The exported per-node `E` is the
 //! crude per-tet-vertex average of the Whitney interpolant (see
-//! `examples/viz_export_helper.rs`); a per-node `eps_r` map (n² inside
-//! the sphere, 1 outside) accompanies it.
+//! `geode_examples_support::edge_field_to_nodes`); a per-node `eps_r`
+//! map (n² inside the sphere, 1 outside) accompanies it.
 
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
 
 use burn::tensor::backend::BackendTypes;
+use clap::Parser;
 use faer::sparse::{SparseColMat, Triplet};
 
+use geode_app::{App, OutputDir, Verbosity};
 use geode_core::analytic::mie::{
     MiePolarisation, MieRoot, mie_roots_catalog, open_space_wgm_roots_n15,
 };
@@ -116,9 +128,7 @@ use geode_core::eigen::complex::{
 };
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{PHYS_SPHERE_INTERIOR, R_BUFFER, R_SPHERE, read_sphere_fixture};
-
-#[path = "common/viz_export_helper.rs"]
-mod viz_export_helper;
+use geode_examples_support::edge_field_to_nodes;
 
 type B = DefaultBackend;
 
@@ -230,8 +240,10 @@ fn current_commit() -> String {
 }
 
 fn results_path() -> PathBuf {
-    // `crates/geode-core/examples/mie_sphere.rs` → walk up 3 levels to
-    // the workspace root, then into `benchmarks/mie_sphere/`.
+    // `examples/mie_sphere/src/main.rs` → `CARGO_MANIFEST_DIR` is
+    // `examples/mie_sphere`; walk up 2 levels to the workspace root, then
+    // into `benchmarks/mie_sphere/` (same level count as the old
+    // `crates/geode-core` manifest dir).
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
@@ -683,11 +695,12 @@ const EXPORT_SIGMA_0: f64 = 25.0;
 
 /// Opt-in `--export-field` path (Epic #276 Phase 2B, issue #287):
 /// solve the bundled sphere once as a driven scattering problem at the
-/// mid-`ka` point and dump the scattered near field to a `.vtu`.
+/// mid-`ka` point and dump the scattered near field to `<out_dir>/E_mie.vtu`.
 ///
-/// Independent of the eigenmode benchmark — does not write
-/// `results.toml`.
-fn export_field(path: &str) {
+/// `out_dir` is the resolved (already-created) artifact directory from
+/// [`geode_app::OutputDir`]. Independent of the eigenmode benchmark —
+/// does not write `results.toml`.
+fn export_field(out_dir: &Path) {
     use burn::tensor::backend::BackendTypes;
     let _device = <B as BackendTypes>::Device::default();
 
@@ -721,7 +734,7 @@ fn export_field(path: &str) {
         sol.residual_rel
     );
 
-    let (e_re, e_im) = viz_export_helper::edge_field_to_nodes(&f.mesh, &sol.e_edges);
+    let (e_re, e_im) = edge_field_to_nodes(&f.mesh, &sol.e_edges);
 
     // Per-node eps_r: n² inside the sphere, 1 outside. Average the
     // per-tet relative permittivity over the tets incident to each node.
@@ -745,13 +758,10 @@ fn export_field(path: &str) {
         .map(|(&s, &c)| if c > 0 { s / c as f64 } else { 1.0 })
         .collect();
 
-    let out = std::path::Path::new(path);
-    if let Some(parent) = out.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent).expect("create --export-field parent dir");
-    }
-    geode_core::postproc::viz::write_vtu(out, &f.mesh, &e_re, Some(&e_im), Some(&eps_r))
+    // `out_dir` is already created by `OutputDir::resolve`; the exported
+    // file lives at `<out_dir>/E_mie.vtu` (fixed filename).
+    let out = out_dir.join("E_mie.vtu");
+    geode_core::postproc::viz::write_vtu(&out, &f.mesh, &e_re, Some(&e_im), Some(&eps_r))
         .expect("write --export-field .vtu");
     eprintln!(
         "  wrote {} ({} nodes, {} tets)",
@@ -761,153 +771,193 @@ fn export_field(path: &str) {
     );
 }
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
+/// Mie-sphere benchmark CLI.
+///
+/// Flattens the shared `geode-app` `--out-dir` / `-v`/`-q` groups and
+/// keeps the three example-local toggles (`--dense`, `--scalar-pml`,
+/// `--export-field`) the original hand-rolled argv recognised.
+#[derive(Parser)]
+#[command(about = "Mie sphere benchmark: FEM eigenmodes vs. analytic PEC-cavity roots (issue #4).")]
+struct Args {
+    /// Use the dense `FaerComplexEigensolver` correctness oracle instead
+    /// of the default sparse shift-invert Lanczos path.
+    #[arg(long)]
+    dense: bool,
 
-    // Opt-in field export (issue #287). Short-circuits the eigenmode
-    // benchmark so a normal run is byte-identical.
-    if let Some(path) = viz_export_helper::parse_export_field(&args) {
-        export_field(&path);
-        return;
-    }
+    /// Use the legacy scalar-isotropic complex-ε PML (~16% TM_1,1 rel
+    /// err ceiling) instead of the default anisotropic UPML.
+    #[arg(long = "scalar-pml")]
+    scalar_pml: bool,
 
-    let use_dense = args.iter().any(|a| a == "--dense");
-    let scalar_pml = args.iter().any(|a| a == "--scalar-pml");
+    /// Export the driven scattered near field to `<out-dir>/E_mie.vtu`
+    /// (mid-`ka` point) instead of running the eigenmode benchmark.
+    #[arg(long = "export-field")]
+    export_field: bool,
 
-    eprintln!("=== Mie sphere benchmark (issue #4 v1, issue #40, issue #54) ===");
-    if use_dense {
-        eprintln!("  eigensolver: DENSE (correctness oracle, --dense flag)");
-    } else {
-        eprintln!("  eigensolver: SPARSE Lanczos (default, pass --dense to switch)");
-    }
-    if scalar_pml {
-        eprintln!("  PML kernel: SCALAR isotropic (--scalar-pml, legacy 16% ceiling)");
-    } else {
-        eprintln!(
-            "  PML kernel: ANISOTROPIC UPML diagonal (default, issue #54; \
-             pass --scalar-pml for the legacy cross-check)"
-        );
-    }
-    eprintln!();
-    eprintln!(
-        "Fixture geometry: R_sphere = {R_SPHERE}, R_buffer = {R_BUFFER}, n_inside = {N_INSIDE}",
-    );
-    eprintln!("PML absorption: σ₀ = {SIGMA_0}");
-    if !scalar_pml {
-        eprintln!("PML reference wavenumber: k₀_ref = {K0_REF}");
-    }
-    eprintln!();
+    #[command(flatten)]
+    out: OutputDir,
 
-    // Analytic ground truth: extended catalog with l ∈ [1, L_MAX],
-    // both TE and TM polarisations, lowest N_MAX radial overtones each.
-    // Each MieRoot carries its (l, n, pol, multiplicity = 2l+1) label.
-    let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
-    let n_modes = n_modes_from_catalog(&analytic);
-    eprintln!(
-        "Analytic catalog: {} roots over l ∈ [1, {}], TE+TM, n ∈ [1, {}]",
-        analytic.len(),
-        L_MAX,
-        N_MAX
-    );
-    eprintln!(
-        "Catalog-derived N_MODES = {} (sum of multiplicities of first {} groups, issue #43)",
-        n_modes, N_ANALYTIC_GROUPS,
-    );
-    eprintln!("Lowest 12 analytic roots (PEC-cavity dielectric resonator):");
-    for r in analytic.iter().take(12) {
-        eprintln!(
-            "  {}_{},{}  k = {:.5}  k² = {:.5}  mult = {}",
-            pol_str(r.pol),
-            r.l,
-            r.n,
-            r.k,
-            r.k * r.k,
-            r.multiplicity,
-        );
-    }
+    #[command(flatten)]
+    verbose: Verbosity,
+}
 
-    // FEM eigensolve.
-    eprintln!();
-    eprintln!("=== FEM eigensolve ===");
-    let fem_k = fem_complex_k(use_dense, scalar_pml, n_modes);
-    eprintln!("Lowest {} physical FEM modes (k = sqrt(λ)):", fem_k.len());
-    for (i, k) in fem_k.iter().enumerate() {
-        eprintln!("  mode[{i}]  k = {:.5} + {:.5e}i", k.re, k.im);
-    }
+impl App for Args {
+    fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        // Opt-in field export (issue #287). Short-circuits the eigenmode
+        // benchmark so a normal run produces an unchanged `results.toml`.
+        if self.export_field {
+            let dir = self.out.resolve()?;
+            export_field(&dir);
+            return Ok(());
+        }
 
-    // Pair and report.
-    let rows = pair_modes(&analytic, &fem_k);
-    print_table(&rows);
+        let use_dense = self.dense;
+        let scalar_pml = self.scalar_pml;
 
-    // Persist.
-    write_toml(&rows, &results_path(), scalar_pml, n_modes);
-
-    // Issue #33 — open-space Mie WGM cross-check.
-    //
-    // The PEC-cavity table above is the σ₀ → 0 closed-shell limit. The
-    // open-space catalog `OPEN_SPACE_WGM_TABLE_N15` is the genuinely
-    // radiative target: complex `k`, outgoing Hankel waves, no PEC
-    // outer wall. We print a side-by-side for the lowest few FEM modes
-    // so the reviewer can see the magnitude of the residual gap that
-    // tighter PML profiles (issue #35) and finer meshes need to close.
-    let open_space = open_space_wgm_roots_n15();
-    eprintln!();
-    eprintln!("=== Open-space Mie WGM cross-check (issue #33) ===");
-    eprintln!("Lowest 8 open-space WGM roots (n = 1.5, R_s = 1.0; sign convention Im(k) < 0):");
-    for r in open_space.iter().take(8) {
-        eprintln!(
-            "  {}_{},{}  k = {:.5} + {:.5e}i  Q = {:.3}",
-            pol_str(r.pol),
-            r.l,
-            r.n,
-            r.re_k,
-            r.im_k,
-            r.q()
-        );
-    }
-    eprintln!();
-    eprintln!("Closest open-space WGM for each FEM mode (by |Δk|):");
-    eprintln!(
-        "{:>3}  {:>12}  {:>11}  {:>11}  {:>12}  {:>12}",
-        "i", "mode", "FEM Re(k)", "WGM Re(k)", "rel err Re(k)", "Q ratio"
-    );
-    eprintln!("{}", "-".repeat(70));
-    for (i, fk) in fem_k.iter().enumerate() {
-        // Closest in (Re(k), |Im(k)|) Euclidean metric.
-        let best = open_space
-            .iter()
-            .min_by(|a, b| {
-                let da = (a.re_k - fk.re).hypot(a.im_k.abs() - fk.im.abs());
-                let db = (b.re_k - fk.re).hypot(b.im_k.abs() - fk.im.abs());
-                da.partial_cmp(&db).unwrap()
-            })
-            .expect("non-empty open-space catalog");
-        let fem_q = if fk.im.abs() > 1e-12 {
-            fk.re / (2.0 * fk.im.abs())
+        eprintln!("=== Mie sphere benchmark (issue #4 v1, issue #40, issue #54) ===");
+        if use_dense {
+            eprintln!("  eigensolver: DENSE (correctness oracle, --dense flag)");
         } else {
-            f64::INFINITY
-        };
-        let rel_err = (fk.re - best.re_k).abs() / best.re_k;
-        let q_ratio = fem_q / best.q();
+            eprintln!("  eigensolver: SPARSE Lanczos (default, pass --dense to switch)");
+        }
+        if scalar_pml {
+            eprintln!("  PML kernel: SCALAR isotropic (--scalar-pml, legacy 16% ceiling)");
+        } else {
+            eprintln!(
+                "  PML kernel: ANISOTROPIC UPML diagonal (default, issue #54; \
+                 pass --scalar-pml for the legacy cross-check)"
+            );
+        }
+        eprintln!();
         eprintln!(
-            "{:>3}  {:>9}_{},{}  {:>11.5}  {:>11.5}  {:>11.3}%  {:>12.3}",
-            i,
-            pol_str(best.pol),
-            best.l,
-            best.n,
-            fk.re,
-            best.re_k,
-            rel_err * 100.0,
-            q_ratio
+            "Fixture geometry: R_sphere = {R_SPHERE}, R_buffer = {R_BUFFER}, n_inside = {N_INSIDE}",
         );
-    }
-    eprintln!();
-    eprintln!("Note: 30–40 % rel err Re(k) and large Q ratios are expected on the");
-    eprintln!("bundled fixture — the PML-truncated FEM sits between PEC cavity and");
-    eprintln!("true open space. Tightening the gap is the target of #35.");
-    eprintln!();
+        eprintln!("PML absorption: σ₀ = {SIGMA_0}");
+        if !scalar_pml {
+            eprintln!("PML reference wavenumber: k₀_ref = {K0_REF}");
+        }
+        eprintln!();
 
-    eprintln!("=== Done ===");
+        // Analytic ground truth: extended catalog with l ∈ [1, L_MAX],
+        // both TE and TM polarisations, lowest N_MAX radial overtones each.
+        // Each MieRoot carries its (l, n, pol, multiplicity = 2l+1) label.
+        let analytic = mie_roots_catalog(N_INSIDE, L_MAX, N_MAX);
+        let n_modes = n_modes_from_catalog(&analytic);
+        eprintln!(
+            "Analytic catalog: {} roots over l ∈ [1, {}], TE+TM, n ∈ [1, {}]",
+            analytic.len(),
+            L_MAX,
+            N_MAX
+        );
+        eprintln!(
+            "Catalog-derived N_MODES = {} (sum of multiplicities of first {} groups, issue #43)",
+            n_modes, N_ANALYTIC_GROUPS,
+        );
+        eprintln!("Lowest 12 analytic roots (PEC-cavity dielectric resonator):");
+        for r in analytic.iter().take(12) {
+            eprintln!(
+                "  {}_{},{}  k = {:.5}  k² = {:.5}  mult = {}",
+                pol_str(r.pol),
+                r.l,
+                r.n,
+                r.k,
+                r.k * r.k,
+                r.multiplicity,
+            );
+        }
+
+        // FEM eigensolve.
+        eprintln!();
+        eprintln!("=== FEM eigensolve ===");
+        let fem_k = fem_complex_k(use_dense, scalar_pml, n_modes);
+        eprintln!("Lowest {} physical FEM modes (k = sqrt(λ)):", fem_k.len());
+        for (i, k) in fem_k.iter().enumerate() {
+            eprintln!("  mode[{i}]  k = {:.5} + {:.5e}i", k.re, k.im);
+        }
+
+        // Pair and report.
+        let rows = pair_modes(&analytic, &fem_k);
+        print_table(&rows);
+
+        // Persist.
+        write_toml(&rows, &results_path(), scalar_pml, n_modes);
+
+        // Issue #33 — open-space Mie WGM cross-check.
+        //
+        // The PEC-cavity table above is the σ₀ → 0 closed-shell limit. The
+        // open-space catalog `OPEN_SPACE_WGM_TABLE_N15` is the genuinely
+        // radiative target: complex `k`, outgoing Hankel waves, no PEC
+        // outer wall. We print a side-by-side for the lowest few FEM modes
+        // so the reviewer can see the magnitude of the residual gap that
+        // tighter PML profiles (issue #35) and finer meshes need to close.
+        let open_space = open_space_wgm_roots_n15();
+        eprintln!();
+        eprintln!("=== Open-space Mie WGM cross-check (issue #33) ===");
+        eprintln!("Lowest 8 open-space WGM roots (n = 1.5, R_s = 1.0; sign convention Im(k) < 0):");
+        for r in open_space.iter().take(8) {
+            eprintln!(
+                "  {}_{},{}  k = {:.5} + {:.5e}i  Q = {:.3}",
+                pol_str(r.pol),
+                r.l,
+                r.n,
+                r.re_k,
+                r.im_k,
+                r.q()
+            );
+        }
+        eprintln!();
+        eprintln!("Closest open-space WGM for each FEM mode (by |Δk|):");
+        eprintln!(
+            "{:>3}  {:>12}  {:>11}  {:>11}  {:>12}  {:>12}",
+            "i", "mode", "FEM Re(k)", "WGM Re(k)", "rel err Re(k)", "Q ratio"
+        );
+        eprintln!("{}", "-".repeat(70));
+        for (i, fk) in fem_k.iter().enumerate() {
+            // Closest in (Re(k), |Im(k)|) Euclidean metric.
+            let best = open_space
+                .iter()
+                .min_by(|a, b| {
+                    let da = (a.re_k - fk.re).hypot(a.im_k.abs() - fk.im.abs());
+                    let db = (b.re_k - fk.re).hypot(b.im_k.abs() - fk.im.abs());
+                    da.partial_cmp(&db).unwrap()
+                })
+                .expect("non-empty open-space catalog");
+            let fem_q = if fk.im.abs() > 1e-12 {
+                fk.re / (2.0 * fk.im.abs())
+            } else {
+                f64::INFINITY
+            };
+            let rel_err = (fk.re - best.re_k).abs() / best.re_k;
+            let q_ratio = fem_q / best.q();
+            eprintln!(
+                "{:>3}  {:>9}_{},{}  {:>11.5}  {:>11.5}  {:>11.3}%  {:>12.3}",
+                i,
+                pol_str(best.pol),
+                best.l,
+                best.n,
+                fk.re,
+                best.re_k,
+                rel_err * 100.0,
+                q_ratio
+            );
+        }
+        eprintln!();
+        eprintln!("Note: 30–40 % rel err Re(k) and large Q ratios are expected on the");
+        eprintln!("bundled fixture — the PML-truncated FEM sits between PEC cavity and");
+        eprintln!("true open space. Tightening the gap is the target of #35.");
+        eprintln!();
+
+        eprintln!("=== Done ===");
+        Ok(())
+    }
+
+    fn verbosity(&self) -> Verbosity {
+        self.verbose
+    }
+}
+
+fn main() -> ExitCode {
+    geode_app::main::<Args>()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Epic #398 Phase 2: stands up the top-level `examples/` workspace area, a
documented per-example crate template, the shared example-support
relocation, and CI wiring — validated end-to-end by migrating the
`mie_sphere` pilot to a standalone crate on the Phase-1 `geode-app`
harness. Pure relocation + scaffolding: example behavior, report output,
and artifacts are preserved exactly.

## Changes

- **Workspace wiring**: add the `"examples/*"` glob to root `Cargo.toml`
  `members` (alongside the explicit `crates/*` entries) so Phase 3 batches
  add example crates without touching the root manifest; register
  `geode-app` and `geode-examples-support` as `[workspace.dependencies]`
  path deps.
- **`geode-examples-support`** (`examples/_support/`): new member exposing
  `pub fn edge_field_to_nodes` (Whitney edge-DOF → nodal-averaged
  `[[f64;3]]`) against the public geode-core mesh API + `faer::c64`.
  Deps: `geode-core`, `faer` (workspace). 3 unit tests.
- **`examples/mie_sphere/`**: migrated from
  `crates/geode-core/examples/mie_sphere.rs`. Hand-rolled argv → clap
  `Args` flattening `OutputDir` + `Verbosity`; `--dense`/`--scalar-pml`
  kept example-local; `--export-field` is now a boolean toggle writing
  `<out-dir>/E_mie.vtu` via `OutputDir::resolve()`. Implements
  `geode_app::App`; `main` = `geode_app::main::<Args>()`. Consumes
  `geode_examples_support::edge_field_to_nodes` (no `#[path]` include).
  `results.toml` still written to the fixed `benchmarks/mie_sphere/`
  path via the `CARGO_MANIFEST_DIR` walk-up (same 2-level count).
- **`examples/README.md`**: documents the canonical per-example crate
  template (Cargo.toml + `main.rs` shape, backend-feature rule, output-dir
  guidance) and the `--release` requirement for Phase 3 to copy.
- **Removed** `crates/geode-core/examples/mie_sphere.rs` (nothing
  `#[path]`-includes it). The old `common/viz_export_helper.rs` is left
  intact for the still-unmigrated `spiral_inductor`/`patch_antenna`.
- No bespoke CI job: example crates are covered by
  `cargo build --workspace --all-targets`. Verified nothing hard-codes
  `cargo build --example mie_sphere` (all remaining references are
  comments).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `examples/` wired into workspace; `cargo metadata` shows pilot + support | ✅ | `cargo metadata` lists `mie_sphere` + `geode-examples-support` |
| Documented per-example template Phase 3 can copy | ✅ | `examples/README.md` (template + `--release` table) |
| Reconstruction relocated to shared `pub` home, no `#[path]` for migrated example; output-dir via geode-app; old `common/` retained | ✅ | `geode-examples-support::edge_field_to_nodes`; old `viz_export_helper.rs` untouched |
| `examples/mie_sphere` builds + runs (`--release`), output equivalent to old `--example mie_sphere` | ✅ | release run; `results.toml` + exported `.vtu` byte-identical to old example on same machine (diffs vs committed file are pre-existing wgpu f32 cross-machine drift) |
| fmt / clippy / build --all-targets / geode-core lib test pass | ✅ | see Test Plan |
| No logging crate introduced | ✅ | new crates declare none; transitive `log` is pre-existing via burn/wgpu (geode-cli has it too); no `tracing`/`env_logger` |

## Test Plan

All run from the worktree:

- `cargo fmt --all -- --check` → clean
- `cargo build --workspace --all-targets` → Finished (exit 0)
- `cargo build -p mie_sphere --release` → Finished (exit 0)
- `cargo run -p mie_sphere --release` and `-- --export-field` → produce the
  report + `results.toml` + `E_mie.vtu`; **byte-identical** to
  `cargo run -p geode-core --release --example mie_sphere` on the same
  machine (results.toml modulo the `generated_at_commit` line; report
  modulo wall-clock + the manifest-dir prefix that resolves to the same
  file; `.vtu` fully identical)
- `cargo test -p geode-core --no-default-features --features ndarray --lib`
  → 262 passed (unchanged)
- `cargo test -p geode-examples-support` → 3 passed
- `cargo clippy --workspace --no-default-features --features ndarray,arpack --tests --all-targets -- -D warnings`
  → clean (exit 0)

Closes #401