### PR TITLE
feat(geode-util): scaffold pre-core staging crate skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "geode-util"
+version = "0.2.0"
+dependencies = [
+ "burn",
+ "faer",
+ "geode-core",
+]
+
+[[package]]
 name = "geode-validation"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ toml = "0.8"
 
 # Workspace-internal crates (path dependencies).
 geode-core = { path = "crates/geode-core" }
+geode-util = { path = "crates/geode-util" }
 geode-app = { path = "crates/geode-app" }
 geode-validation = { path = "crates/geode-validation" }
 geode-examples-support = { path = "examples/_support" }

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ crates/
   geode-core/        # FEM kernels, assembly, eigensolvers, driven solve,
                      # ports / BCs, S-parameter + NTFF extraction,
                      # benchmark examples and integration tests
+  geode-util/        # pre-core staging layer above geode-core: shared
+                     # math / convert / interop / fixture / viz helpers
+                     # (Epic #414)
   geode-cli/         # `geode` binary — prints device info and runs the smoke op
   geode-validation/  # cross-backend reference tests (NumPy / JAX / Julia /
                      # ONNX / TF-Java) and analytic-oracle gates

--- a/crates/geode-util/Cargo.toml
+++ b/crates/geode-util/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "geode-util"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "GEODE-FEM pre-core staging layer: shared math/convert/interop/fixture/viz utilities above geode-core."
+
+[dependencies]
+geode-core = { workspace = true }
+# Workspace base feature set only (`std`). Do NOT add a backend default or
+# extra features here — `geode-util` must not perturb backend selection
+# (wgpu/ndarray unification). The active backend is chosen by the consuming
+# crate via `geode-core`'s mutually-exclusive backend features. See the
+# feature/dtype notes in the root `Cargo.toml`.
+burn = { workspace = true }
+# Workspace base faer feature set (`std`, `linalg`); no `sparse-linalg`
+# (that lives on geode-core's own reference). Used by the `convert` /
+# `math` / `viz` staging modules in later epic phases.
+faer = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/geode-util/src/convert.rs
+++ b/crates/geode-util/src/convert.rs
@@ -1,0 +1,8 @@
+//! Format conversions.
+//!
+//! Staging home (Epic #414, Phase 2) for conversions between the numeric
+//! containers used across the stack — notably `burn` tensors ↔ `faer`
+//! matrices — plus the dtype glue (`f32`/`f64`/complex) that keeps those
+//! conversions backend-agnostic.
+//!
+//! Empty in Phase 1 — populated by the `convert` migration.

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -1,0 +1,7 @@
+//! Fixture adaptors.
+//!
+//! Staging home (Epic #414, Phase 2) for fixture-authoring helpers: TOML row
+//! writers, `.pvd` / `.vtu` collection assembly, and parameter-sweep specs
+//! used to generate and record regression fixtures.
+//!
+//! Empty in Phase 1 — populated by the `fixture` migration.

--- a/crates/geode-util/src/interop.rs
+++ b/crates/geode-util/src/interop.rs
@@ -1,0 +1,7 @@
+//! Language-interop reference decoders.
+//!
+//! Staging home (Epic #414, Phase 2) for decoders that read cross-language
+//! reference payloads (JAX / Julia / TF-Java real-imag splits) and reassemble
+//! them into complex / `faer` values for cross-backend validation.
+//!
+//! Empty in Phase 1 — populated by the `interop` migration.

--- a/crates/geode-util/src/lib.rs
+++ b/crates/geode-util/src/lib.rs
@@ -1,0 +1,31 @@
+//! GEODE-FEM pre-core staging layer.
+//!
+//! `geode-util` is a *staging layer that sits above [`geode_core`]*: a home
+//! for shared math / format-conversion / interop / fixture / visualization
+//! helpers that several consumers (`geode-validation`, the standalone example
+//! crates, future tools) would otherwise re-implement, but which are not (yet)
+//! core FEM kernels and so do not belong in `geode-core`.
+//!
+//! # Layering rule
+//!
+//! - `geode-util` depends on [`geode_core`] + [`burn`] + [`faer`].
+//! - [`geode_core`] stays **completely unaware** of `geode-util` — there is no
+//!   dependency edge back into core. Core remains the bottom of the stack; this
+//!   crate is glue layered on top. Keeping the arrow one-directional is what
+//!   lets `geode-core` stay a focused kernel crate while shared conveniences
+//!   accrete here.
+//!
+//! # Epic #414
+//!
+//! This crate is introduced by Epic #414 ("Introduce `geode-util` crate"). It
+//! starts life (Phase 1) as an empty grouped-module skeleton; the Phase 2/3
+//! migrations move existing helpers out of `geode-validation` / the example
+//! crates into the modules declared below as pure code-moves. Each module's
+//! doc header records what lands there.
+
+pub mod convert;
+pub mod fixture;
+pub mod interop;
+pub mod math;
+pub mod repo;
+pub mod viz;

--- a/crates/geode-util/src/math.rs
+++ b/crates/geode-util/src/math.rs
@@ -1,0 +1,7 @@
+//! Small vector / complex math helpers.
+//!
+//! Staging home (Epic #414, Phase 2) for low-level vector and complex-number
+//! helpers (dot/cross/norm, real-imag packing) shared by the conversion,
+//! interop, and viz layers above core.
+//!
+//! Empty in Phase 1 — populated by the `math` migration.

--- a/crates/geode-util/src/repo.rs
+++ b/crates/geode-util/src/repo.rs
@@ -1,0 +1,8 @@
+//! Repo-relative paths and git provenance.
+//!
+//! Staging home (Epic #414, Phase 2) for helpers that resolve paths relative
+//! to the workspace root and stamp generated artifacts with git
+//! provenance/commit information so fixtures and outputs are traceable to the
+//! source revision that produced them.
+//!
+//! Empty in Phase 1 — populated by the `repo` migration.

--- a/crates/geode-util/src/viz.rs
+++ b/crates/geode-util/src/viz.rs
@@ -1,0 +1,7 @@
+//! Visualization glue.
+//!
+//! Staging home (Epic #414, Phase 2) for edge-DOF → nodal field
+//! reconstruction so edge-element (Nédélec) solutions can be exported as
+//! nodal vector fields consumable by ParaView.
+//!
+//! Empty in Phase 1 — populated by the `viz` migration.


### PR DESCRIPTION
## Summary

Introduces the new `geode-util` crate as a **pre-core staging layer** above `geode-core`, holding shared math / convert / interop / fixture / viz helpers that several consumers (`geode-validation`, the example crates, future tools) would otherwise duplicate but which are not core FEM kernels.

This is the **Phase 1 seed** of Epic #414 ("Introduce `geode-util` crate"). It does **not** migrate any logic — it establishes the crate, wires it into the workspace, and creates the empty grouped-module skeleton that Phase 2 migrations land in as pure code-moves.

## Changes

- **`crates/geode-util/Cargo.toml`** — inherits workspace package fields (`version`/`edition`/`license`/`repository`/`rust-version`), depends on `geode-core` + `burn` + `faer` via `workspace = true` (base feature sets only — no new backend default, no `sparse-linalg`), and `[lints.rust] unsafe_code = "forbid"`.
- **Root `Cargo.toml`** — adds `geode-util = { path = "crates/geode-util" }` to `[workspace.dependencies]` (the `crates/*` members glob already covers the crate; not duplicated).
- **`crates/geode-util/src/lib.rs`** — crate-level `//!` docs explaining the staging-layer intent and the one-directional layering rule (`geode-core` stays unaware of `geode-util`), referencing Epic #414; declares the six `pub mod`s.
- **Six module files** (`repo`, `convert`, `interop`, `fixture`, `viz`, `math`) — each with a `//!` doc header describing what lands there in later phases; bodies empty, no blanket `#![allow(unused)]`.
- **README** — documents the new crate in the workspace-layout block.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `Cargo.toml` inherits workspace fields, declares geode-core+burn+faer via `workspace = true`, forbids unsafe_code | ✅ | File created mirroring sibling crates |
| `geode-util = { path = ... }` in root `[workspace.dependencies]` | ✅ | Added alongside sibling entries |
| `lib.rs` declares six `pub mod`s, each with doc header; crate-level `//!` docs | ✅ | `repo`/`convert`/`interop`/`fixture`/`viz`/`math` each in own file with `//!` |
| `geode-core` does NOT depend on `geode-util` | ✅ | `grep geode-util crates/geode-core/Cargo.toml` → no match |
| `cargo build -p geode-util` passes | ✅ | Finished clean (51s) |
| `cargo doc -p geode-util --no-deps` passes | ✅ | Generated `geode_util/index.html` clean |
| `cargo clippy -p geode-util -- -D warnings` passes | ✅ | Finished clean, no warnings |
| Workspace `cargo build` green, backend selection unchanged | ✅ | Full workspace build green; `cargo tree -p geode-util` shows backends only via geode-core (burn-ndarray + burn-wgpu unified), crate adds none |
| README documents the new crate | ✅ | Added to workspace-layout block |

## Test Plan

Commands run in the worktree (all clean):

- `cargo build -p geode-util` — Finished, no warnings
- `cargo clippy -p geode-util -- -D warnings` — Finished, no warnings
- `cargo doc -p geode-util --no-deps` — Generated docs clean
- `cargo build` (workspace) — Finished, all members green
- `cargo tree -p geode-util -e features` — confirms no new backend/feature is introduced; backends come transitively from `geode-core`

Part of Epic #414.

Closes #415