### PR TITLE
refactor(geode-util): migrate real/imag-interleave fixture decoders to interop/convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "burn",
  "faer",
  "geode-core",
+ "num-complex 0.4.6",
 ]
 
 [[package]]

--- a/crates/geode-util/Cargo.toml
+++ b/crates/geode-util/Cargo.toml
@@ -19,6 +19,11 @@ burn = { workspace = true }
 # (that lives on geode-core's own reference). Used by the `convert` /
 # `math` / `viz` staging modules in later epic phases.
 faer = { workspace = true }
+# Complex scalar type for the `interop` / `convert` decoders. In faer 0.24
+# `faer::c64` is a re-export of `num_complex::Complex<f64>` (== `Complex64`),
+# so the `faer` → `num_complex` hand-off these helpers centralize is
+# zero-cost. Workspace base feature set (`std`) only.
+num-complex = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/geode-util/src/convert.rs
+++ b/crates/geode-util/src/convert.rs
@@ -90,9 +90,11 @@ mod tests {
     /// and feed these helpers without any element-wise conversion.
     #[test]
     fn faer_c64_is_complex64() {
-        let faer_vals: Vec<faer::c64> =
-            vec![faer::c64::new(1.0, -1.0), faer::c64::new(2.0, -2.0)];
+        let faer_vals: Vec<faer::c64> = vec![faer::c64::new(1.0, -1.0), faer::c64::new(2.0, -2.0)];
         let out = complex_slice_to_vec(&faer_vals);
-        assert_eq!(out, vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)]);
+        assert_eq!(
+            out,
+            vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)]
+        );
     }
 }

--- a/crates/geode-util/src/convert.rs
+++ b/crates/geode-util/src/convert.rs
@@ -5,4 +5,94 @@
 //! matrices — plus the dtype glue (`f32`/`f64`/complex) that keeps those
 //! conversions backend-agnostic.
 //!
-//! Empty in Phase 1 — populated by the `convert` migration.
+//! # `faer` complex → `num_complex`
+//!
+//! The cross-backend reference suite produces complex data as `faer::c64`.
+//! In faer 0.24 `c64` is a re-export of `num_complex::Complex<f64>` — the
+//! same type as [`Complex64`] — so the "conversion" is a zero-cost copy.
+//! These helpers nonetheless give the `faer` → `num_complex` hand-off a
+//! single, intention-revealing home, replacing the
+//! `.map(|c| Complex64::new(c.re, c.im))` flattening idioms that were
+//! duplicated across the `geode-validation` reference tests, and localizing
+//! the assumption so a future faer type split would surface in one place.
+
+use num_complex::Complex64;
+
+/// Copy a slice of complex scalars into an owned `Vec<Complex64>`.
+///
+/// Intended for the `faer::c64` (== [`Complex64`]) eigenvalue / coefficient
+/// vectors the reference drivers obtain from `geode-core`, e.g.
+/// `complex_slice_to_vec(&burn_eigvals_faer)`.
+#[must_use]
+pub fn complex_slice_to_vec(src: &[Complex64]) -> Vec<Complex64> {
+    src.to_vec()
+}
+
+/// Flatten a row-major sequence of complex rows into one row-major
+/// `Vec<Complex64>`.
+///
+/// Each element of `rows` is any slice-like of complex scalars — e.g. the
+/// `[c64; 3]` per-tet diagonal tensors from `build_anisotropic_pml_tensor_diag`
+/// or `Vec<c64>` rows — mirroring the
+/// `rows.iter().flat_map(|row| row.iter().map(…))` idiom in the
+/// anisotropic-PML reference tests.
+#[must_use]
+pub fn flatten_complex_rows<R: AsRef<[Complex64]>>(rows: &[R]) -> Vec<Complex64> {
+    rows.iter()
+        .flat_map(|row| row.as_ref().iter().copied())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slice_to_vec_round_trips() {
+        let src = [Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)];
+        assert_eq!(complex_slice_to_vec(&src), src.to_vec());
+    }
+
+    #[test]
+    fn slice_to_vec_empty() {
+        assert!(complex_slice_to_vec(&[]).is_empty());
+    }
+
+    #[test]
+    fn flatten_rows_is_row_major() {
+        let rows = [
+            [Complex64::new(1.0, 1.0), Complex64::new(2.0, 2.0)],
+            [Complex64::new(3.0, 3.0), Complex64::new(4.0, 4.0)],
+        ];
+        let flat = flatten_complex_rows(&rows);
+        assert_eq!(
+            flat,
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, 2.0),
+                Complex64::new(3.0, 3.0),
+                Complex64::new(4.0, 4.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn flatten_rows_accepts_vec_rows() {
+        let rows = vec![
+            vec![Complex64::new(0.0, 1.0)],
+            vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 0.0)],
+        ];
+        assert_eq!(flatten_complex_rows(&rows).len(), 3);
+    }
+
+    /// Locks the load-bearing assumption that `faer::c64` is the same type
+    /// as [`Complex64`]: a `Vec<faer::c64>` must coerce to `&[Complex64]`
+    /// and feed these helpers without any element-wise conversion.
+    #[test]
+    fn faer_c64_is_complex64() {
+        let faer_vals: Vec<faer::c64> =
+            vec![faer::c64::new(1.0, -1.0), faer::c64::new(2.0, -2.0)];
+        let out = complex_slice_to_vec(&faer_vals);
+        assert_eq!(out, vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)]);
+    }
+}

--- a/crates/geode-util/src/interop.rs
+++ b/crates/geode-util/src/interop.rs
@@ -1,7 +1,97 @@
 //! Language-interop reference decoders.
 //!
 //! Staging home (Epic #414, Phase 2) for decoders that read cross-language
-//! reference payloads (JAX / Julia / TF-Java real-imag splits) and reassemble
-//! them into complex / `faer` values for cross-backend validation.
+//! reference payloads (JAX / Julia / TF-Java / NumPy real-imag splits) and
+//! reassemble them into complex values for cross-backend validation.
 //!
-//! Empty in Phase 1 — populated by the `interop` migration.
+//! The cross-language reference oracles serialize complex arrays as a flat
+//! `f64` buffer in **real-imag interleaved** order — `[re₀, im₀, re₁, im₁, …]`
+//! — because most of them lack a portable native complex on-disk dtype. This
+//! module owns the single, tested reassembly of that layout into
+//! [`Complex64`], replacing the per-test ad-hoc `chunks_exact(2)` /
+//! `Complex64::new(re, im)` idioms that used to live inside the
+//! `geode-validation` reference suite.
+
+use num_complex::Complex64;
+
+/// Decode a real-imag interleaved `f64` payload into a row-major
+/// `Vec<Complex64>`.
+///
+/// The on-disk encoding is `[re₀, im₀, re₁, im₁, …]`; each adjacent pair
+/// becomes one `Complex64`. This is the canonical reassembly used by the
+/// fixture `c128` decode path and the reference drivers.
+///
+/// `flat.len()` is expected to be even (`2 × <complex count>`). A trailing
+/// unpaired `f64` cannot form a complex value and is silently dropped — the
+/// fixture loader validates the declared length up front, and callers that
+/// must reject a malformed payload should use
+/// [`decode_real_imag_interleave_exact`].
+#[must_use]
+pub fn decode_real_imag_interleave(flat: &[f64]) -> Vec<Complex64> {
+    flat.chunks_exact(2)
+        .map(|pair| Complex64::new(pair[0], pair[1]))
+        .collect()
+}
+
+/// Length-checked variant of [`decode_real_imag_interleave`].
+///
+/// Returns `Some` only when `flat.len() == 2 * expected_len`, i.e. the
+/// payload holds exactly `expected_len` interleaved complex values; returns
+/// `None` otherwise (wrong length, including an odd-length / truncated
+/// payload). This lets schema-aware callers map the length mismatch onto
+/// their own domain error while keeping the interleave arithmetic here.
+#[must_use]
+pub fn decode_real_imag_interleave_exact(
+    flat: &[f64],
+    expected_len: usize,
+) -> Option<Vec<Complex64>> {
+    if flat.len() != 2 * expected_len {
+        return None;
+    }
+    Some(decode_real_imag_interleave(flat))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_interleaved_pairs() {
+        let flat = [1.0, 2.0, 3.0, -4.0];
+        let got = decode_real_imag_interleave(&flat);
+        assert_eq!(
+            got,
+            vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)]
+        );
+    }
+
+    #[test]
+    fn decodes_empty_to_empty() {
+        assert!(decode_real_imag_interleave(&[]).is_empty());
+    }
+
+    #[test]
+    fn drops_trailing_unpaired_value() {
+        // Odd length: the final lone `re` has no `im` partner and is dropped.
+        let got = decode_real_imag_interleave(&[1.0, 2.0, 3.0]);
+        assert_eq!(got, vec![Complex64::new(1.0, 2.0)]);
+    }
+
+    #[test]
+    fn exact_accepts_matching_length() {
+        let flat = [0.5, -0.5, 7.0, 0.0];
+        let got = decode_real_imag_interleave_exact(&flat, 2).expect("len matches 2 complex");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1], Complex64::new(7.0, 0.0));
+    }
+
+    #[test]
+    fn exact_rejects_wrong_length() {
+        // 4 f64 = 2 complex, but caller asked for 3.
+        assert!(decode_real_imag_interleave_exact(&[1.0, 2.0, 3.0, 4.0], 3).is_none());
+        // Odd-length payload can never satisfy any `expected_len`.
+        assert!(decode_real_imag_interleave_exact(&[1.0, 2.0, 3.0], 1).is_none());
+        // Zero-length round-trips at expected_len 0.
+        assert!(decode_real_imag_interleave_exact(&[], 0).is_some());
+    }
+}

--- a/crates/geode-validation/src/fixture.rs
+++ b/crates/geode-validation/src/fixture.rs
@@ -278,18 +278,15 @@ impl Fixture {
             });
         }
         let flat = flatten_to_f64(&f.data);
-        let expected_re_im = 2 * f.shape.iter().product::<usize>();
-        if flat.len() != expected_re_im {
-            return Err(FixtureError::InvalidComplexLength {
+        let expected = f.shape.iter().product::<usize>();
+        // Real-imag interleave reassembly lives in `geode_util::interop`
+        // (Epic #414, Phase 2); the schema-level length error stays here.
+        let data = geode_util::interop::decode_real_imag_interleave_exact(&flat, expected)
+            .ok_or_else(|| FixtureError::InvalidComplexLength {
                 name: name.to_string(),
                 got: flat.len(),
-                expected: expected_re_im,
-            });
-        }
-        let data = flat
-            .chunks_exact(2)
-            .map(|c| Complex64::new(c[0], c[1]))
-            .collect();
+                expected: 2 * expected,
+            })?;
         Ok(GoldenC128 {
             name: key.as_str(),
             shape: &f.shape,
@@ -315,18 +312,15 @@ impl Fixture {
             });
         }
         let flat = flatten_to_f64(&f.data);
-        let expected_re_im = 2 * f.shape.iter().product::<usize>();
-        if flat.len() != expected_re_im {
-            return Err(FixtureError::InvalidComplexLength {
+        let expected = f.shape.iter().product::<usize>();
+        // Same interleave decode as `output_c128`, reading from `inputs`.
+        geode_util::interop::decode_real_imag_interleave_exact(&flat, expected).ok_or_else(|| {
+            FixtureError::InvalidComplexLength {
                 name: name.to_string(),
                 got: flat.len(),
-                expected: expected_re_im,
-            });
-        }
-        Ok(flat
-            .chunks_exact(2)
-            .map(|c| Complex64::new(c[0], c[1]))
-            .collect())
+                expected: 2 * expected,
+            }
+        })
     }
 }
 

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -451,7 +451,8 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -117,10 +117,8 @@ fn run_burn_mie_pipeline(
         sigma_0,
         k0_ref,
     );
-    let epsilon_tensor_diag_flat: Vec<Complex64> = eps_aniso
-        .iter()
-        .flat_map(|row| row.iter().map(|c| Complex64::new(c.re, c.im)))
-        .collect();
+    let epsilon_tensor_diag_flat: Vec<Complex64> =
+        geode_util::convert::flatten_complex_rows(&eps_aniso);
 
     let edges = fixture.mesh.edges();
     let n_edges = edges.len();
@@ -453,10 +451,7 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -495,7 +495,8 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -134,10 +134,8 @@ fn run_burn_mie_pipeline(
         sigma_0,
         k0_ref,
     );
-    let epsilon_tensor_diag_flat: Vec<Complex64> = eps_aniso
-        .iter()
-        .flat_map(|row| row.iter().map(|c| Complex64::new(c.re, c.im)))
-        .collect();
+    let epsilon_tensor_diag_flat: Vec<Complex64> =
+        geode_util::convert::flatten_complex_rows(&eps_aniso);
 
     let edges = fixture.mesh.edges();
     let n_edges = edges.len();
@@ -497,10 +495,7 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -472,7 +472,8 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
         gevd_wall.as_secs_f64()
     );
 
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Full-slice + physical-band comparison via the c128 comparator.
     let golden_full = fixture
@@ -809,7 +810,8 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
             n_request,
         )
         .expect("Burn complex eigensolve on full Mie fixture");
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -159,10 +159,8 @@ fn run_burn_mie_pipeline(
         sigma_0,
         k0_ref,
     );
-    let epsilon_tensor_diag_flat: Vec<Complex64> = eps_aniso
-        .iter()
-        .flat_map(|row| row.iter().map(|c| Complex64::new(c.re, c.im)))
-        .collect();
+    let epsilon_tensor_diag_flat: Vec<Complex64> =
+        geode_util::convert::flatten_complex_rows(&eps_aniso);
 
     let edges = fixture.mesh.edges();
     let n_edges = edges.len();
@@ -474,10 +472,7 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
         gevd_wall.as_secs_f64()
     );
 
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Full-slice + physical-band comparison via the c128 comparator.
     let golden_full = fixture
@@ -814,10 +809,7 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
             n_request,
         )
         .expect("Burn complex eigensolve on full Mie fixture");
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -134,10 +134,8 @@ fn run_burn_mie_pipeline(
         sigma_0,
         k0_ref,
     );
-    let epsilon_tensor_diag_flat: Vec<Complex64> = eps_aniso
-        .iter()
-        .flat_map(|row| row.iter().map(|c| Complex64::new(c.re, c.im)))
-        .collect();
+    let epsilon_tensor_diag_flat: Vec<Complex64> =
+        geode_util::convert::flatten_complex_rows(&eps_aniso);
 
     let edges = fixture.mesh.edges();
     let n_edges = edges.len();
@@ -528,10 +526,7 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -526,7 +526,8 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
             n_request,
         )
         .expect("Burn complex eigensolve on small Mie fixture");
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     let golden_full = fixture
         .output_c128("eigenvalues_lowest_complex")

--- a/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
@@ -150,10 +150,8 @@ fn run_burn_pml_pipeline_from_fixture(
     // Convert faer::c64 → num_complex::Complex64 once for the
     // comparator (the on-disk encoding round-trips through
     // `Vec<Complex64>` via `Fixture::input_c128`).
-    let epsilon_r_complex: Vec<Complex64> = eps_complex_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let epsilon_r_complex: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&eps_complex_faer);
 
     let edges = fixture.mesh.edges();
     let n_edges = edges.len();
@@ -371,10 +369,7 @@ fn sphere_pml_spectrum_agrees_with_numpy() {
             n_request,
         )
         .expect("Burn complex eigensolve");
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Compare against the NumPy baseline via the c128 comparator.
     let golden_full = fixture
@@ -782,10 +777,7 @@ fn sphere_pml_small_spectrum_agrees_with_numpy() {
         gevd_wall.as_secs_f64()
     );
 
-    let burn_eigvals: Vec<Complex64> = burn_eigvals_faer
-        .iter()
-        .map(|c| Complex64::new(c.re, c.im))
-        .collect();
+    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Compare against the NumPy baseline via the c128 comparator.
     let golden_full = fixture

--- a/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
@@ -369,7 +369,8 @@ fn sphere_pml_spectrum_agrees_with_numpy() {
             n_request,
         )
         .expect("Burn complex eigensolve");
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Compare against the NumPy baseline via the c128 comparator.
     let golden_full = fixture
@@ -777,7 +778,8 @@ fn sphere_pml_small_spectrum_agrees_with_numpy() {
         gevd_wall.as_secs_f64()
     );
 
-    let burn_eigvals: Vec<Complex64> = geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
+    let burn_eigvals: Vec<Complex64> =
+        geode_util::convert::complex_slice_to_vec(&burn_eigvals_faer);
 
     // Compare against the NumPy baseline via the c128 comparator.
     let golden_full = fixture


### PR DESCRIPTION
Closes #418. Part of Epic #414 (Phase 2 — migrate utilities into `geode-util`).

## What

Lift the language-interop reference decoders out of the `geode-validation` tests into the `geode-util` staging layer, giving them a single tested home for reuse by future consumers.

### `geode_util::interop`
- `decode_real_imag_interleave(&[f64]) -> Vec<Complex64>` — reassembles the on-disk real-imag interleaved (`[re0, im0, re1, im1, ...]`) payloads emitted by the JAX / Julia / TF-Java / NumPy oracles.
- `decode_real_imag_interleave_exact(&[f64], expected_len)` — length-checked variant returning `Option`, so schema-aware callers map the length mismatch onto their own error.

### `geode_util::convert`
- `complex_slice_to_vec(&[Complex64]) -> Vec<Complex64>` and `flatten_complex_rows::<R: AsRef<[Complex64]>>(&[R]) -> Vec<Complex64>` centralize the `faer::c64 → num_complex::Complex64` hand-off. In faer 0.24 `c64` is a re-export of `num_complex::Complex<f64>` (== `Complex64`), so the copy is zero-cost; these replace the duplicated `.map(|c| Complex64::new(c.re, c.im))` / `.flat_map(...)` idioms.

Unit tests for both decoders live alongside the implementation (`cargo test -p geode-util`: 10 passed).

### `geode-validation`
- `Fixture::{output_c128, input_c128}` now call `geode_util::interop::decode_real_imag_interleave_exact`; the schema-level length error stays in validation. The c128 schema-smoke tests keep asserting the wiring and now exercise the new path.
- Repointed the `sphere_mie_{jax,julia_small,numpy,tfjava}` and `sphere_pml_numpy` reference tests onto the convert helpers.

### Scope fence
`burn_matrix_to_faer` / `burn_complex_mass_to_faer` remain in `geode-core` (unchanged) — grep confirms only geode-core hits. No changes to `examples/`, `viz.rs`, `geode-util/src/fixture.rs`, or `repo.rs` (concurrent siblings #419/#420).

## Verification
- `cargo build` (workspace): clean.
- `cargo clippy -p geode-util -p geode-validation --tests -- -D warnings`: clean.
- `cargo test -p geode-util`: 10 passed.
- `cargo test -p geode-validation` (default wgpu backend): full suite passed, 0 failed. Note: the `geode-core/ndarray` feature referenced in the older Cargo.toml comment was removed in #413; the default backend is now `wgpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)