### PR TITLE
refactor(geode-util): retire empty math module stub

### DIFF
--- a/crates/geode-util/src/lib.rs
+++ b/crates/geode-util/src/lib.rs
@@ -26,6 +26,5 @@
 pub mod convert;
 pub mod fixture;
 pub mod interop;
-pub mod math;
 pub mod repo;
 pub mod viz;

--- a/crates/geode-util/src/math.rs
+++ b/crates/geode-util/src/math.rs
@@ -1,7 +1,0 @@
-//! Small vector / complex math helpers.
-//!
-//! Staging home (Epic #414, Phase 2) for low-level vector and complex-number
-//! helpers (dot/cross/norm, real-imag packing) shared by the conversion,
-//! interop, and viz layers above core.
-//!
-//! Empty in Phase 1 — populated by the `math` migration.


### PR DESCRIPTION
## Summary

Phase 3 of Epic #414. Resolves the never-populated `geode_util::math`
stub (created by #415). A survey of `examples/` and `crates/` found no
helper that clears the bar for promotion, so the empty module is retired
rather than left permanently empty.

**Decision: retire (not promote).**

## Survey (why nothing was promoted)

The bar for promotion was: a helper that is BOTH (a) genuinely-general
pure math/complex (not a physics conversion tied to one benchmark) AND
(b) duplicated across >=2 example crates / otherwise clearly reusable.

| Candidate | Where | Verdict |
|-----------|-------|---------|
| `cross` / `dot` / `sub` vector helpers | private fns in `geode_util::viz` (#419) | Single consumer (Whitney reconstruction); already homed in `viz`. Not general-reuse. |
| Principal-branch complex `sqrt` (`k_from_lambda`) | `mie_open_quasimode` + inline in `mie_sphere` | Pure math AND duplicated 2x — but already provided by `faer::c64` (== `num_complex::Complex<f64>`) via `.sqrt()`. A util wrapper would just re-expose std. |
| `ghz_to_omega` (`2*pi*f`) | spiral_inductor, slcfet_3hp_spiral, patch_antenna | Physics/unit conversion, explicitly excluded. |
| Inductance `Im Z/(2*pi*f)`, SRF detection | spiral_inductor, slcfet_3hp_spiral | Example-specific physics. |
| Fiber `Delta`, NA aperture | step_index_fiber | Example-specific physics. |
| `q_factor` = `Re(k)/(2|Im(k)|)` | mie_sphere only | Single benchmark, physics. |

No example-specific physics was hoisted into `geode-util`.

## Changes
- Remove `pub mod math;` from `crates/geode-util/src/lib.rs`.
- Delete the empty `crates/geode-util/src/math.rs` stub.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `math` contains tested helpers OR stub removed with rationale | ✅ | Stub removed; rationale above and in commit body. |
| No example-specific physics hoisted into geode-util | ✅ | No files under `examples/` touched; diff is 2 files in `geode-util`. |
| `cargo build` workspace clean | ✅ | `cargo build` finished, all crates compiled. |
| `cargo clippy -p geode-util -- -D warnings` clean | ✅ | Finished with no warnings. |
| If removed, `cargo doc -p geode-util --no-deps` clean (no dangling module) | ✅ | Doc generated, no dangling-module warning. |

## Test Plan
- `cargo build` (workspace): pass.
- `cargo clippy -p geode-util -- -D warnings`: pass.
- `cargo doc -p geode-util --no-deps`: pass, no dangling module reference.
- Confirmed no remaining references to `geode_util::math` via `git grep`.

Part of Epic #414 (Phase 3).

Closes #425