### PR TITLE
refactor(geode-util): add serde JSON deps + shared Value numeric primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,8 @@ dependencies = [
  "faer",
  "geode-core",
  "num-complex 0.4.6",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/geode-util/Cargo.toml
+++ b/crates/geode-util/Cargo.toml
@@ -24,6 +24,12 @@ faer = { workspace = true }
 # so the `faer` → `num_complex` hand-off these helpers centralize is
 # zero-cost. Workspace base feature set (`std`) only.
 num-complex = { workspace = true }
+# JSON fixture support for the `fixture` staging module: backs the
+# `serde_json::Value`-based numeric primitives (`flatten_numeric`,
+# `value_f64`, `value_i64`) shared by the validation reference tests.
+# Both are existing workspace deps (also used by geode-validation).
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -95,6 +95,80 @@ pub fn sweep_freqs(f_start_ghz: f64, f_stop_ghz: f64, n: usize) -> Vec<f64> {
     (0..n).map(|i| f_start_ghz + step * i as f64).collect()
 }
 
+// ---------------------------------------------------------------------------
+// JSON (`serde_json::Value`) numeric primitives
+//
+// Shared home for the recursive numeric-flatten + scalar-extract helpers the
+// validation reference tests previously copy-pasted. These operate purely on
+// `serde_json::Value`; the `&Fixture`-typed loader helpers are a separate
+// (later) staging concern.
+// ---------------------------------------------------------------------------
+
+/// Recursively flatten a (possibly nested) JSON array of numbers into a
+/// flat, row-major [`Vec<f64>`].
+///
+/// - [`Number`](serde_json::Value::Number) nodes are appended as `f64`,
+///   preferring [`as_f64`](serde_json::Number::as_f64) and falling back to
+///   `as_i64` / `as_u64` for integers outside the lossless-float range.
+/// - [`Array`](serde_json::Value::Array) nodes recurse, depth-first, so a
+///   nested array matching some shape and an already-flat array both yield
+///   the same row-major sequence.
+/// - All other node kinds (null, bool, string, object) are silently
+///   skipped.
+///
+/// A scalar number flattens to a single-element vector; an empty array (or
+/// a non-numeric node) flattens to an empty vector.
+pub fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
+    let mut out = Vec::new();
+    push_numeric(v, &mut out);
+    out
+}
+
+fn push_numeric(v: &serde_json::Value, out: &mut Vec<f64>) {
+    match v {
+        serde_json::Value::Number(n) => {
+            if let Some(x) = n.as_f64() {
+                out.push(x);
+            } else if let Some(x) = n.as_i64() {
+                out.push(x as f64);
+            } else if let Some(x) = n.as_u64() {
+                out.push(x as f64);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                push_numeric(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract a scalar [`f64`] from a JSON [`Number`](serde_json::Value::Number)
+/// node, returning [`None`] for any other node kind.
+///
+/// Integer numbers convert via `as_i64` / `as_u64` when they fall outside
+/// the lossless-float range, mirroring [`flatten_numeric`].
+pub fn value_f64(v: &serde_json::Value) -> Option<f64> {
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .or_else(|| n.as_i64().map(|x| x as f64))
+            .or_else(|| n.as_u64().map(|x| x as f64)),
+        _ => None,
+    }
+}
+
+/// Extract a scalar [`i64`] from a JSON [`Number`](serde_json::Value::Number)
+/// node, returning [`None`] for any other node kind or for numbers that are
+/// not representable as an `i64` (e.g. fractional or out-of-range values).
+pub fn value_i64(v: &serde_json::Value) -> Option<i64> {
+    match v {
+        serde_json::Value::Number(n) => n.as_i64(),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +262,85 @@ q = 2.000e1
         );
         assert!(xml.trim_end().ends_with("</VTKFile>"));
         let _ = fs::remove_file(&path);
+    }
+
+    use serde_json::json;
+
+    #[test]
+    fn flatten_numeric_empty_array() {
+        assert_eq!(flatten_numeric(&json!([])), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn flatten_numeric_flat_array() {
+        assert_eq!(
+            flatten_numeric(&json!([1.0, 2.5, -3.0])),
+            vec![1.0, 2.5, -3.0]
+        );
+    }
+
+    #[test]
+    fn flatten_numeric_nested_arrays_row_major() {
+        // 2x3 nested array flattens row-major.
+        let v = json!([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        assert_eq!(flatten_numeric(&v), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        // Deeper / ragged nesting flattens depth-first as well.
+        let v = json!([[[1.0], [2.0, 3.0]], [4.0]]);
+        assert_eq!(flatten_numeric(&v), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn flatten_numeric_mixed_int_and_float() {
+        let v = json!([1, 2.5, 3, -4]);
+        assert_eq!(flatten_numeric(&v), vec![1.0, 2.5, 3.0, -4.0]);
+    }
+
+    #[test]
+    fn flatten_numeric_scalar() {
+        assert_eq!(flatten_numeric(&json!(42)), vec![42.0]);
+        assert_eq!(flatten_numeric(&json!(2.5)), vec![2.5]);
+    }
+
+    #[test]
+    fn flatten_numeric_skips_non_numeric_nodes() {
+        // null / bool / string / object nodes are silently skipped, while
+        // numeric siblings are still collected in order.
+        let v = json!([1.0, null, "x", true, [2.0, {"k": 9.0}], 3.0]);
+        assert_eq!(flatten_numeric(&v), vec![1.0, 2.0, 3.0]);
+        // A bare non-numeric node flattens to empty.
+        assert_eq!(flatten_numeric(&json!("nope")), Vec::<f64>::new());
+        assert_eq!(flatten_numeric(&json!(null)), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn flatten_numeric_large_u64() {
+        // Integer beyond the lossless-f64 range still flattens via the
+        // u64 fallback (lossy, but non-panicking).
+        let big = u64::MAX;
+        let v = json!([big]);
+        assert_eq!(flatten_numeric(&v), vec![big as f64]);
+    }
+
+    #[test]
+    fn value_f64_extracts_numbers_only() {
+        assert_eq!(value_f64(&json!(2.5)), Some(2.5));
+        assert_eq!(value_f64(&json!(7)), Some(7.0));
+        assert_eq!(value_f64(&json!(-3)), Some(-3.0));
+        assert_eq!(value_f64(&json!("2.5")), None);
+        assert_eq!(value_f64(&json!(true)), None);
+        assert_eq!(value_f64(&json!([1.0])), None);
+        assert_eq!(value_f64(&json!(null)), None);
+    }
+
+    #[test]
+    fn value_i64_extracts_integers_only() {
+        assert_eq!(value_i64(&json!(7)), Some(7));
+        assert_eq!(value_i64(&json!(-3)), Some(-3));
+        // Fractional values are not i64-representable.
+        assert_eq!(value_i64(&json!(2.5)), None);
+        // u64 beyond i64::MAX is not representable as i64.
+        assert_eq!(value_i64(&json!(u64::MAX)), None);
+        assert_eq!(value_i64(&json!("7")), None);
+        assert_eq!(value_i64(&json!(null)), None);
     }
 }

--- a/crates/geode-validation/tests/cube_cavity_jax_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_jax_reference.rs
@@ -147,33 +147,8 @@ fn input_f64(fixture: &Fixture, key: &str) -> f64 {
     v[0]
 }
 
-/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
-/// helper is `pub(crate)`); same semantics.
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                } else if let Some(x) = n.as_u64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/cube_cavity_julia_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_julia_reference.rs
@@ -197,31 +197,8 @@ fn burn_cube_cavity_from_mesh(k: usize, side: f64, want_eigs: bool) -> BurnCubeC
 // Fixture helpers
 // ---------------------------------------------------------------------------
 
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                } else if let Some(x) = n.as_u64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
@@ -690,33 +690,8 @@ fn print_substage_diff(fixture: &Fixture, actual: &BTreeMap<String, Vec<f64>>) {
     }
 }
 
-/// Recursively flatten a nested-or-flat `serde_json::Value` of numbers
-/// into a row-major `Vec<f64>`. Mirrors
-/// `geode_validation::fixture::flatten_to_f64` but is duplicated here
-/// because that helper is `pub(crate)`-scoped.
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 /// Dense matrix product `A · B` returning an owned `Mat<f64>`.
 fn mat_mul(a: MatRef<f64>, b: MatRef<f64>) -> Mat<f64> {

--- a/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
@@ -152,33 +152,8 @@ fn input_f64(fixture: &Fixture, key: &str) -> f64 {
     v[0]
 }
 
-/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
-/// helper is `pub(crate)`); same semantics.
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                } else if let Some(x) = n.as_u64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
@@ -269,34 +269,8 @@ fn burn_actual(fixture: &Fixture) -> BTreeMap<String, Vec<f64>> {
     out
 }
 
-/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
-/// helper is `pub(crate)`); same semantics — recursively flatten nested
-/// or pre-flat JSON arrays of numbers into row-major f64.
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                } else if let Some(x) = n.as_u64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/p1_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/p1_local_numpy_reference.rs
@@ -204,34 +204,8 @@ fn burn_actual(fixture: &Fixture) -> BTreeMap<String, Vec<f64>> {
     out
 }
 
-/// Tiny duplicate of `geode_validation::fixture::flatten_to_f64` (that
-/// helper is `pub(crate)`); same semantics — recursively flatten nested
-/// or pre-flat JSON arrays of numbers into row-major f64.
-fn flatten_numeric(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push(v, &mut out);
-    return out;
-
-    fn push(v: &serde_json::Value, out: &mut Vec<f64>) {
-        match v {
-            serde_json::Value::Number(n) => {
-                if let Some(x) = n.as_f64() {
-                    out.push(x);
-                } else if let Some(x) = n.as_i64() {
-                    out.push(x as f64);
-                } else if let Some(x) = n.as_u64() {
-                    out.push(x as f64);
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                for item in arr {
-                    push(item, out);
-                }
-            }
-            _ => {}
-        }
-    }
-}
+// Recursive JSON numeric flatten lives in the shared staging crate.
+use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## Summary

Phase 1 (seed) of Epic #429. Adds JSON support to `geode-util` and
consolidates the most-duplicated fixture helper family.

This introduces `serde_json::Value`-based numeric primitives in
`geode_util::fixture` and repoints the six geode-validation reference
tests that each carried a private copy of `flatten_numeric` to the
shared helper. The `&Fixture`-typed loader helpers and the `Fixture`
loader itself are explicitly out of scope (Phase 2).

## Changes

- **Deps**: add `serde = { workspace = true }` and `serde_json = { workspace = true }` to `crates/geode-util/Cargo.toml` (both pre-existing workspace deps).
- **New primitives** in `crates/geode-util/src/fixture.rs`:
  - `pub fn flatten_numeric(v: &serde_json::Value) -> Vec<f64>` — recursive depth-first flatten of a nested-or-flat JSON number array into a row-major `Vec<f64>`; non-numeric nodes (null/bool/string/object) silently skipped.
  - `pub fn value_f64(v: &serde_json::Value) -> Option<f64>` and `pub fn value_i64(v: &serde_json::Value) -> Option<i64>` scalar extractors.
  - All `pub`, `///`-documented.
- **Tests**: thorough `#[cfg(test)]` unit coverage — empty/flat/nested/ragged arrays, mixed int/float, scalar, non-numeric node skipping, large-u64 fallback, f64-vs-i64 extraction.
- **Dedup**: deleted the local `fn flatten_numeric` in all six validation reference tests; each now imports `geode_util::fixture::flatten_numeric`.

### Semantics reconciliation

Five of the six local copies included an `as_u64` fallback after
`as_f64`/`as_i64`; the `cube_cavity_numpy` copy lacked it. The shared
canonical keeps the `as_u64` fallback — a no-op superset for the
integer ranges these fixtures actually use, matching the existing
`pub(crate) flatten_to_f64` in `geode-validation/src/fixture.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| serde + serde_json added via `{ workspace = true }` | done | `crates/geode-util/Cargo.toml` |
| `flatten_numeric` + `value_f64`/`value_i64` documented pub + unit tests | done | `cargo test -p geode-util` → 26 passed |
| `grep -rn "fn flatten_numeric" crates/geode-validation/tests` returns nothing | done | grep exits 1 (no matches) |
| `cargo test -p geode-util` passes | done | 26 passed; 0 failed |
| geode-validation reference tests compile + pass | done | jax/numpy/julia/onnx/nedelec/p1 all pass (pre-existing faer debug-assert tests remain `ignored`) |
| `cargo build` workspace clean | done | `Finished dev profile` |
| `cargo clippy -p geode-util -p geode-validation -- -D warnings` clean | done | `Finished` with no warnings |
| geode-core still does NOT depend on geode-util | done | grep of `geode-core/Cargo.toml` for geode-util exits 1 |

## Test Plan

- `cargo test -p geode-util` — 26 passed, 0 failed.
- `cargo test -p geode-validation` reference tests (all six) — pass under the default wgpu backend; faer `qz_real` debug-assertion tests remain `ignored` (pre-existing, unrelated).
- `cargo clippy -p geode-util -p geode-validation --all-targets -- -D warnings` — clean.
- `cargo build` (workspace) — clean.

Part of Epic #429.

Closes #430