### PR TITLE
refactor(geode-util): migrate JSON Fixture loader + schema + golden accessors (Phase 2.1, Epic #429)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "num-complex 0.4.6",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/geode-util/Cargo.toml
+++ b/crates/geode-util/Cargo.toml
@@ -30,6 +30,9 @@ num-complex = { workspace = true }
 # Both are existing workspace deps (also used by geode-validation).
 serde = { workspace = true }
 serde_json = { workspace = true }
+# Error-derive for the JSON fixture loader's `FixtureError` (Epic #429,
+# Phase 2; migrated from geode-validation along with the `Fixture` schema).
+thiserror = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -1,4 +1,4 @@
-//! Fixture adaptors.
+//! Fixture adaptors + JSON fixture loader/schema.
 //!
 //! Staging home (Epic #414, Phase 2) for the fixture-output glue that the
 //! standalone example crates would otherwise copy-paste: the TOML
@@ -10,10 +10,25 @@
 //! prose (those sections are unique per benchmark and not shared); the
 //! reusable pieces extracted here are the parts that were genuinely
 //! identical across crates.
+//!
+//! This module is also the canonical home (Epic #429, Phase 2) of the JSON
+//! `Fixture` loader, its schema types ([`Fixture`], [`Field`],
+//! [`OutputField`], [`Provenance`], [`FixtureError`], [`FixtureFormat`]),
+//! and the golden-value accessors ([`Fixture::output_f64`],
+//! [`Fixture::output_c128`], [`Fixture::input_c128`],
+//! [`Fixture::iter_outputs`]). `geode-validation` re-exports these so its
+//! reference-test suite keeps its existing call sites. The validation
+//! *diff artifact* (`ComparisonReport` + the comparison entry points)
+//! stays in `geode-validation`.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::Path;
+
+use num_complex::Complex64;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Write an assembled TOML document to `path`, creating parent directories
 /// and logging `wrote <path>` to stderr.
@@ -166,6 +181,406 @@ pub fn value_i64(v: &serde_json::Value) -> Option<i64> {
     match v {
         serde_json::Value::Number(n) => n.as_i64(),
         _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON fixture loader + schema + golden accessors
+//
+// Canonical home (Epic #429, Phase 2) of the JSON `Fixture` machinery
+// migrated from `geode-validation/src/fixture.rs`. `geode-validation`
+// re-exports these types so its reference-test suite is unchanged.
+//
+// A *fixture* is a single canonical (inputs, golden outputs) bundle for one
+// spine slice. The on-disk schema is documented in `reference/README.md` and
+// `reference/SCHEMA.md`; the corresponding Rust types here are loose
+// `Map<String, Field>` so the scaffolding stays useful as the schema evolves
+// (new fields can be added without requiring a Rust-side type-update churn).
+//
+// ## Format support
+//
+// Phase A wires only the JSON format. The [`FixtureFormat`] enum is a
+// deliberate extension point — when the cube-cavity fixture (#92) lands and
+// starts carrying complex eigenvectors, a `FixtureFormat::Hdf5` variant will
+// be added behind a feature gate so contributors aren't forced to install
+// `libhdf5` to run the smoke tests.
+// ---------------------------------------------------------------------------
+
+/// Errors raised by fixture I/O and validation.
+#[derive(Debug, Error)]
+pub enum FixtureError {
+    /// Filesystem read failure.
+    #[error("failed to read fixture file {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// JSON parse / structural validation failure.
+    #[error("failed to parse fixture as JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// On-disk schema version is not recognized by this build.
+    #[error("unsupported fixture schema_version: {0} (this build supports: {1:?})")]
+    UnsupportedSchemaVersion(String, &'static [&'static str]),
+
+    /// The requested field was not declared in the fixture.
+    #[error("fixture has no output field named '{0}'")]
+    MissingField(String),
+
+    /// HDF5 format requested but not compiled in.
+    #[error("HDF5 fixture format is not enabled in this build")]
+    HdfNotEnabled,
+
+    /// A `c128` field had an odd-length interleaved payload (real-imag
+    /// interleave requires `len == 2 * prod(shape)`).
+    #[error(
+        "fixture field '{name}' is dtype c128 but flattened payload has length {got}; \
+         expected {expected} (= 2 × prod(shape) for real-imag interleave)"
+    )]
+    InvalidComplexLength {
+        name: String,
+        got: usize,
+        expected: usize,
+    },
+
+    /// A field was requested under one dtype but declared as another.
+    #[error("fixture field '{name}' has dtype '{declared}', not '{requested}'")]
+    DtypeMismatch {
+        name: String,
+        declared: String,
+        requested: &'static str,
+    },
+}
+
+/// On-disk fixture format selector.
+///
+/// JSON is sufficient for small fixtures (Phase A smoke case);
+/// HDF5 becomes the format-of-record once eigenvector-class outputs
+/// land (#92 and later). The HDF5 variant is reserved here so callers
+/// can pin format choice without waiting for the implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixtureFormat {
+    /// Human-readable JSON. Small fixtures, easy review in PRs.
+    Json,
+    /// Binary HDF5 (not yet wired up — placeholder for the
+    /// eigenvector-class fixture work that will arrive with #92).
+    Hdf5,
+}
+
+/// Versions of the on-disk schema this build accepts.
+pub const SUPPORTED_SCHEMA_VERSIONS: &[&str] = &["1"];
+
+/// A single fixture: inputs, golden outputs, and provenance.
+///
+/// Field naming follows `reference/SCHEMA.md`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fixture {
+    /// Schema version (currently `"1"`).
+    pub schema_version: String,
+
+    /// Stable id of the fixture (e.g. `"p1_reference_tet/local_stiffness"`).
+    pub fixture_id: String,
+
+    /// Free-form one-liner describing what the fixture pins down.
+    pub description: String,
+
+    /// Units convention for the numeric values in this fixture.
+    pub units: String,
+
+    /// Input fields keyed by name (e.g. `"coords"`, `"mesh"`).
+    #[serde(default)]
+    pub inputs: BTreeMap<String, Field>,
+
+    /// Golden output fields keyed by name (e.g. `"k_local"`,
+    /// `"eigenvalues"`). Each carries its own tolerance.
+    pub outputs: BTreeMap<String, OutputField>,
+
+    /// Provenance metadata (where the golden values came from).
+    pub provenance: Provenance,
+}
+
+/// An input field — shape + dtype + data — no tolerance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Field {
+    /// Shape (row-major).
+    pub shape: Vec<usize>,
+    /// Element dtype (currently only `"f64"` and `"i64"` are exercised;
+    /// stored as a string so the schema can grow without a Rust-side
+    /// enum bump).
+    pub dtype: String,
+    /// Free-form per-field description.
+    #[serde(default)]
+    pub description: String,
+    /// Flattened or nested numeric values.
+    ///
+    /// We accept both a flat `[a, b, c, ...]` array and a nested array
+    /// matching `shape`, and normalize to row-major-flat at load time.
+    pub data: serde_json::Value,
+}
+
+/// An output field — same as [`Field`] but with a tolerance attached.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputField {
+    /// Shape (row-major).
+    pub shape: Vec<usize>,
+    /// Element dtype.
+    pub dtype: String,
+    /// Free-form per-field description.
+    #[serde(default)]
+    pub description: String,
+    /// Absolute tolerance used when comparing actual against golden.
+    /// Per-field is intentional — eigenvector residuals, eigenvalues,
+    /// and matrix entries do not share a sensible tolerance.
+    pub tolerance_abs: f64,
+    /// Nested or flat numeric values. Normalized at load time.
+    pub data: serde_json::Value,
+}
+
+/// Where the golden values came from.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Human description of the source (e.g. "hand-computed exact rationals",
+    /// "NumPy reference impl at reference/numpy/p1_local_matrices.py").
+    pub source: String,
+    /// Optional cross-reference to a Rust-side check.
+    #[serde(default)]
+    pub verified_against: String,
+    /// Issue/PR number tying this fixture to a tracker.
+    #[serde(default)]
+    pub issue: String,
+}
+
+impl Fixture {
+    /// Load a fixture from disk in the requested format.
+    pub fn load_from(path: &Path, format: FixtureFormat) -> Result<Self, FixtureError> {
+        match format {
+            FixtureFormat::Json => {
+                let bytes = std::fs::read(path).map_err(|e| FixtureError::Io {
+                    path: path.display().to_string(),
+                    source: e,
+                })?;
+                let fixture: Fixture = serde_json::from_slice(&bytes)?;
+                fixture.check_schema_version()?;
+                Ok(fixture)
+            }
+            FixtureFormat::Hdf5 => Err(FixtureError::HdfNotEnabled),
+        }
+    }
+
+    /// Load a JSON fixture by its path relative to `reference/fixtures/`
+    /// (e.g. `"cube_cavity/baseline.json"`).
+    ///
+    /// Convenience wrapper over [`Fixture::load_from`] +
+    /// [`crate::repo::fixture_path`] — the one-call form of the
+    /// `load_from(&fixture_path(...), FixtureFormat::Json)` pattern the
+    /// reference tests repeat.
+    pub fn load_json(relative: impl AsRef<Path>) -> Result<Self, FixtureError> {
+        Self::load_from(&crate::repo::fixture_path(relative), FixtureFormat::Json)
+    }
+
+    /// Auto-detect format from file extension.
+    pub fn load(path: &Path) -> Result<Self, FixtureError> {
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let format = match ext.as_str() {
+            "json" => FixtureFormat::Json,
+            "h5" | "hdf5" => FixtureFormat::Hdf5,
+            _ => FixtureFormat::Json, // default for now
+        };
+        Self::load_from(path, format)
+    }
+
+    /// Verify schema version is supported by this build.
+    fn check_schema_version(&self) -> Result<(), FixtureError> {
+        if SUPPORTED_SCHEMA_VERSIONS.contains(&self.schema_version.as_str()) {
+            Ok(())
+        } else {
+            Err(FixtureError::UnsupportedSchemaVersion(
+                self.schema_version.clone(),
+                SUPPORTED_SCHEMA_VERSIONS,
+            ))
+        }
+    }
+
+    /// Get a golden output field by name, returning the values as a
+    /// flat row-major `Vec<f64>` together with the declared shape and
+    /// tolerance.
+    ///
+    /// The returned [`GoldenF64`] borrows `name` and `shape` from
+    /// `self` (not from the caller-supplied `name` argument), so the
+    /// lifetime is tied to the fixture.
+    pub fn output_f64<'a>(&'a self, name: &str) -> Result<GoldenF64<'a>, FixtureError> {
+        let (key, f) = self
+            .outputs
+            .get_key_value(name)
+            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
+        let data = flatten_to_f64(&f.data);
+        Ok(GoldenF64 {
+            name: key.as_str(),
+            shape: &f.shape,
+            tolerance_abs: f.tolerance_abs,
+            data,
+        })
+    }
+
+    /// Iterate over all output fields in deterministic (sorted) order.
+    pub fn iter_outputs(&self) -> impl Iterator<Item = (&str, &OutputField)> {
+        self.outputs.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Get a golden output field by name, returning the values as a
+    /// flat row-major `Vec<Complex64>`.
+    ///
+    /// The on-disk encoding is the real-imag interleaved layout
+    /// documented in `reference/SCHEMA.md` ("Complex encoding
+    /// (`c128`)"). The declared `shape` is taken from the fixture
+    /// without modification — the interleave is invisible to callers
+    /// (length `prod(shape)`, not `2 * prod(shape)`).
+    ///
+    /// # Errors
+    ///
+    /// - [`FixtureError::MissingField`] if the field is not declared.
+    /// - [`FixtureError::DtypeMismatch`] if the field is declared with
+    ///   a non-`c128` dtype.
+    /// - [`FixtureError::InvalidComplexLength`] if the flattened
+    ///   payload length is not `2 * prod(shape)`.
+    pub fn output_c128<'a>(&'a self, name: &str) -> Result<GoldenC128<'a>, FixtureError> {
+        let (key, f) = self
+            .outputs
+            .get_key_value(name)
+            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
+        if f.dtype != "c128" {
+            return Err(FixtureError::DtypeMismatch {
+                name: name.to_string(),
+                declared: f.dtype.clone(),
+                requested: "c128",
+            });
+        }
+        let flat = flatten_to_f64(&f.data);
+        let expected = f.shape.iter().product::<usize>();
+        // Real-imag interleave reassembly lives in `crate::interop`
+        // (Epic #414, Phase 2); the schema-level length error stays here.
+        let data = crate::interop::decode_real_imag_interleave_exact(&flat, expected)
+            .ok_or_else(|| FixtureError::InvalidComplexLength {
+                name: name.to_string(),
+                got: flat.len(),
+                expected: 2 * expected,
+            })?;
+        Ok(GoldenC128 {
+            name: key.as_str(),
+            shape: &f.shape,
+            tolerance_abs: f.tolerance_abs,
+            data,
+        })
+    }
+
+    /// Like [`output_c128`](Self::output_c128) but reads from `inputs`
+    /// instead of `outputs`. Used by reference-impl drivers that need
+    /// to consume a complex input (e.g. per-tet `epsilon_r_complex`)
+    /// from the fixture.
+    pub fn input_c128(&self, name: &str) -> Result<Vec<Complex64>, FixtureError> {
+        let f = self
+            .inputs
+            .get(name)
+            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
+        if f.dtype != "c128" {
+            return Err(FixtureError::DtypeMismatch {
+                name: name.to_string(),
+                declared: f.dtype.clone(),
+                requested: "c128",
+            });
+        }
+        let flat = flatten_to_f64(&f.data);
+        let expected = f.shape.iter().product::<usize>();
+        // Same interleave decode as `output_c128`, reading from `inputs`.
+        crate::interop::decode_real_imag_interleave_exact(&flat, expected).ok_or_else(|| {
+            FixtureError::InvalidComplexLength {
+                name: name.to_string(),
+                got: flat.len(),
+                expected: 2 * expected,
+            }
+        })
+    }
+}
+
+/// A golden output field flattened into f64 row-major.
+///
+/// The `name` and `shape` borrow from the parent [`Fixture`] so callers
+/// can iterate cheaply without cloning per-field metadata.
+#[derive(Debug, Clone)]
+pub struct GoldenF64<'fix> {
+    pub name: &'fix str,
+    pub shape: &'fix [usize],
+    pub tolerance_abs: f64,
+    pub data: Vec<f64>,
+}
+
+impl GoldenF64<'_> {
+    /// Total element count implied by `shape`.
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+}
+
+/// A golden output field flattened into `Complex64` row-major.
+///
+/// On-disk this corresponds to a `c128`-dtype field with real-imag
+/// interleaved storage (length `2 * prod(shape)` on disk, length
+/// `prod(shape)` in memory). See `reference/SCHEMA.md` for the
+/// encoding convention.
+#[derive(Debug, Clone)]
+pub struct GoldenC128<'fix> {
+    pub name: &'fix str,
+    pub shape: &'fix [usize],
+    /// Absolute tolerance applied to the **complex modulus** of the
+    /// per-element residual (`|actual − golden|`). See
+    /// `reference/SCHEMA.md` → "Complex encoding (c128)".
+    pub tolerance_abs: f64,
+    pub data: Vec<Complex64>,
+}
+
+impl GoldenC128<'_> {
+    /// Total element count implied by `shape`.
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+}
+
+/// Recursively flatten a nested `serde_json::Value` of numbers into a
+/// row-major `Vec<f64>`. Accepts both nested arrays matching `shape`
+/// and an already-flat array.
+pub(crate) fn flatten_to_f64(v: &serde_json::Value) -> Vec<f64> {
+    let mut out = Vec::new();
+    push_numbers(v, &mut out);
+    out
+}
+
+fn push_numbers(v: &serde_json::Value, out: &mut Vec<f64>) {
+    match v {
+        serde_json::Value::Number(n) => {
+            if let Some(x) = n.as_f64() {
+                out.push(x);
+            } else if let Some(x) = n.as_i64() {
+                out.push(x as f64);
+            } else if let Some(x) = n.as_u64() {
+                out.push(x as f64);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                push_numbers(item, out);
+            }
+        }
+        _ => {
+            // Non-numeric values are silently skipped — the schema
+            // validator would have caught this at load time if we had
+            // one (deliberately deferred to keep Phase A small).
+        }
     }
 }
 

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -465,12 +465,13 @@ impl Fixture {
         let expected = f.shape.iter().product::<usize>();
         // Real-imag interleave reassembly lives in `crate::interop`
         // (Epic #414, Phase 2); the schema-level length error stays here.
-        let data = crate::interop::decode_real_imag_interleave_exact(&flat, expected)
-            .ok_or_else(|| FixtureError::InvalidComplexLength {
+        let data = crate::interop::decode_real_imag_interleave_exact(&flat, expected).ok_or_else(
+            || FixtureError::InvalidComplexLength {
                 name: name.to_string(),
                 got: flat.len(),
                 expected: 2 * expected,
-            })?;
+            },
+        )?;
         Ok(GoldenC128 {
             name: key.as_str(),
             shape: &f.shape,

--- a/crates/geode-validation/src/fixture.rs
+++ b/crates/geode-validation/src/fixture.rs
@@ -1,431 +1,63 @@
-//! Fixture loading + schema.
+//! Fixture loading + schema (re-export) + validation comparison seam.
 //!
-//! A *fixture* is a single canonical (inputs, golden outputs) bundle
-//! for one spine slice. The on-disk schema is documented in
-//! `reference/README.md` and `reference/SCHEMA.md`; the corresponding
-//! Rust types here are loose `Map<String, Field>` so the scaffolding
-//! stays useful as the schema evolves (new fields can be added without
-//! requiring a Rust-side type-update churn).
+//! The JSON `Fixture` loader, its schema types, and the golden-value
+//! accessors now live in [`geode_util::fixture`] (Epic #429, Phase 2). They
+//! are re-exported here so this crate's reference-test suite keeps its
+//! existing `geode_validation::Fixture` / `fixture.output_f64(...)` call
+//! sites unchanged.
 //!
-//! ## Format support
-//!
-//! Phase A wires only the JSON format. The [`FixtureFormat`] enum is a
-//! deliberate extension point — when the cube-cavity fixture (#92)
-//! lands and starts carrying complex eigenvectors, a `FixtureFormat::Hdf5`
-//! variant will be added behind a feature gate so contributors aren't
-//! forced to install `libhdf5` to run the smoke tests.
+//! What stays in `geode-validation` is the *diff artifact* — the
+//! [`ComparisonReport`](crate::ComparisonReport) producing comparison entry
+//! points. Because [`Fixture`] is now a foreign type, the orphan rule
+//! forbids keeping `compare_against` / `compare_complex_against` as inherent
+//! methods on it; they live here as free functions ([`compare_against`],
+//! [`compare_complex_against`]) wrapping [`crate::diff::compare`] /
+//! [`crate::diff::compare_complex`].
 
 use std::collections::BTreeMap;
-use std::path::Path;
 
 use num_complex::Complex64;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
-/// Errors raised by fixture I/O and validation.
-#[derive(Debug, Error)]
-pub enum FixtureError {
-    /// Filesystem read failure.
-    #[error("failed to read fixture file {path}: {source}")]
-    Io {
-        path: String,
-        #[source]
-        source: std::io::Error,
-    },
+// Re-export the JSON fixture schema + loader + golden accessors from their
+// canonical home in `geode-util`. The `flatten_to_f64` helper stays
+// `pub(crate)` in `geode-util`; nothing in `geode-validation` needs it.
+pub use geode_util::fixture::{
+    Field, Fixture, FixtureError, FixtureFormat, GoldenC128, GoldenF64, OutputField, Provenance,
+    SUPPORTED_SCHEMA_VERSIONS,
+};
 
-    /// JSON parse / structural validation failure.
-    #[error("failed to parse fixture as JSON: {0}")]
-    Json(#[from] serde_json::Error),
+use crate::ComparisonReport;
 
-    /// On-disk schema version is not recognized by this build.
-    #[error("unsupported fixture schema_version: {0} (this build supports: {1:?})")]
-    UnsupportedSchemaVersion(String, &'static [&'static str]),
-
-    /// The requested field was not declared in the fixture.
-    #[error("fixture has no output field named '{0}'")]
-    MissingField(String),
-
-    /// HDF5 format requested but not compiled in.
-    #[error("HDF5 fixture format is not enabled in this build")]
-    HdfNotEnabled,
-
-    /// A `c128` field had an odd-length interleaved payload (real-imag
-    /// interleave requires `len == 2 * prod(shape)`).
-    #[error(
-        "fixture field '{name}' is dtype c128 but flattened payload has length {got}; \
-         expected {expected} (= 2 × prod(shape) for real-imag interleave)"
-    )]
-    InvalidComplexLength {
-        name: String,
-        got: usize,
-        expected: usize,
-    },
-
-    /// A field was requested under one dtype but declared as another.
-    #[error("fixture field '{name}' has dtype '{declared}', not '{requested}'")]
-    DtypeMismatch {
-        name: String,
-        declared: String,
-        requested: &'static str,
-    },
-}
-
-/// On-disk fixture format selector.
+/// Compare a set of named actual outputs against the golden values in
+/// `fixture`. Returns a [`ComparisonReport`] describing each field's
+/// pass/fail status. Missing fields, shape mismatches, and tolerance
+/// violations all surface as distinct failure modes.
 ///
-/// JSON is sufficient for small fixtures (Phase A smoke case);
-/// HDF5 becomes the format-of-record once eigenvector-class outputs
-/// land (#92 and later). The HDF5 variant is reserved here so callers
-/// can pin format choice without waiting for the implementation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FixtureFormat {
-    /// Human-readable JSON. Small fixtures, easy review in PRs.
-    Json,
-    /// Binary HDF5 (not yet wired up — placeholder for the
-    /// eigenvector-class fixture work that will arrive with #92).
-    Hdf5,
-}
-
-/// Versions of the on-disk schema this build accepts.
-pub const SUPPORTED_SCHEMA_VERSIONS: &[&str] = &["1"];
-
-/// A single fixture: inputs, golden outputs, and provenance.
+/// Only `f64`-dtype output fields are checked by this entry point; `c128`
+/// fields go through [`compare_complex_against`].
 ///
-/// Field naming follows `reference/SCHEMA.md`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Fixture {
-    /// Schema version (currently `"1"`).
-    pub schema_version: String,
-
-    /// Stable id of the fixture (e.g. `"p1_reference_tet/local_stiffness"`).
-    pub fixture_id: String,
-
-    /// Free-form one-liner describing what the fixture pins down.
-    pub description: String,
-
-    /// Units convention for the numeric values in this fixture.
-    pub units: String,
-
-    /// Input fields keyed by name (e.g. `"coords"`, `"mesh"`).
-    #[serde(default)]
-    pub inputs: BTreeMap<String, Field>,
-
-    /// Golden output fields keyed by name (e.g. `"k_local"`,
-    /// `"eigenvalues"`). Each carries its own tolerance.
-    pub outputs: BTreeMap<String, OutputField>,
-
-    /// Provenance metadata (where the golden values came from).
-    pub provenance: Provenance,
+/// This is the free-function form of what was `Fixture::compare_against`
+/// before the loader moved to `geode-util` (Epic #429, Phase 2): the orphan
+/// rule forbids an inherent method on the now-foreign [`Fixture`] type.
+pub fn compare_against(fixture: &Fixture, actual: &BTreeMap<String, Vec<f64>>) -> ComparisonReport {
+    crate::diff::compare(fixture, actual)
 }
 
-/// An input field — shape + dtype + data — no tolerance.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Field {
-    /// Shape (row-major).
-    pub shape: Vec<usize>,
-    /// Element dtype (currently only `"f64"` and `"i64"` are exercised;
-    /// stored as a string so the schema can grow without a Rust-side
-    /// enum bump).
-    pub dtype: String,
-    /// Free-form per-field description.
-    #[serde(default)]
-    pub description: String,
-    /// Flattened or nested numeric values.
-    ///
-    /// We accept both a flat `[a, b, c, ...]` array and a nested array
-    /// matching `shape`, and normalize to row-major-flat at load time.
-    pub data: serde_json::Value,
-}
-
-/// An output field — same as [`Field`] but with a tolerance attached.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutputField {
-    /// Shape (row-major).
-    pub shape: Vec<usize>,
-    /// Element dtype.
-    pub dtype: String,
-    /// Free-form per-field description.
-    #[serde(default)]
-    pub description: String,
-    /// Absolute tolerance used when comparing actual against golden.
-    /// Per-field is intentional — eigenvector residuals, eigenvalues,
-    /// and matrix entries do not share a sensible tolerance.
-    pub tolerance_abs: f64,
-    /// Nested or flat numeric values. Normalized at load time.
-    pub data: serde_json::Value,
-}
-
-/// Where the golden values came from.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Provenance {
-    /// Human description of the source (e.g. "hand-computed exact rationals",
-    /// "NumPy reference impl at reference/numpy/p1_local_matrices.py").
-    pub source: String,
-    /// Optional cross-reference to a Rust-side check.
-    #[serde(default)]
-    pub verified_against: String,
-    /// Issue/PR number tying this fixture to a tracker.
-    #[serde(default)]
-    pub issue: String,
-}
-
-impl Fixture {
-    /// Load a fixture from disk in the requested format.
-    pub fn load_from(path: &Path, format: FixtureFormat) -> Result<Self, FixtureError> {
-        match format {
-            FixtureFormat::Json => {
-                let bytes = std::fs::read(path).map_err(|e| FixtureError::Io {
-                    path: path.display().to_string(),
-                    source: e,
-                })?;
-                let fixture: Fixture = serde_json::from_slice(&bytes)?;
-                fixture.check_schema_version()?;
-                Ok(fixture)
-            }
-            FixtureFormat::Hdf5 => Err(FixtureError::HdfNotEnabled),
-        }
-    }
-
-    /// Load a JSON fixture by its path relative to `reference/fixtures/`
-    /// (e.g. `"cube_cavity/baseline.json"`).
-    ///
-    /// Convenience wrapper over [`Fixture::load_from`] +
-    /// [`crate::fixture_path`] — the one-call form of the
-    /// `load_from(&fixture_path(...), FixtureFormat::Json)` pattern the
-    /// reference tests repeat.
-    pub fn load_json(relative: impl AsRef<Path>) -> Result<Self, FixtureError> {
-        Self::load_from(&crate::fixture_path(relative), FixtureFormat::Json)
-    }
-
-    /// Auto-detect format from file extension.
-    pub fn load(path: &Path) -> Result<Self, FixtureError> {
-        let ext = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_ascii_lowercase();
-        let format = match ext.as_str() {
-            "json" => FixtureFormat::Json,
-            "h5" | "hdf5" => FixtureFormat::Hdf5,
-            _ => FixtureFormat::Json, // default for now
-        };
-        Self::load_from(path, format)
-    }
-
-    /// Verify schema version is supported by this build.
-    fn check_schema_version(&self) -> Result<(), FixtureError> {
-        if SUPPORTED_SCHEMA_VERSIONS.contains(&self.schema_version.as_str()) {
-            Ok(())
-        } else {
-            Err(FixtureError::UnsupportedSchemaVersion(
-                self.schema_version.clone(),
-                SUPPORTED_SCHEMA_VERSIONS,
-            ))
-        }
-    }
-
-    /// Get a golden output field by name, returning the values as a
-    /// flat row-major `Vec<f64>` together with the declared shape and
-    /// tolerance.
-    ///
-    /// The returned [`GoldenF64`] borrows `name` and `shape` from
-    /// `self` (not from the caller-supplied `name` argument), so the
-    /// lifetime is tied to the fixture.
-    pub fn output_f64<'a>(&'a self, name: &str) -> Result<GoldenF64<'a>, FixtureError> {
-        let (key, f) = self
-            .outputs
-            .get_key_value(name)
-            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
-        let data = flatten_to_f64(&f.data);
-        Ok(GoldenF64 {
-            name: key.as_str(),
-            shape: &f.shape,
-            tolerance_abs: f.tolerance_abs,
-            data,
-        })
-    }
-
-    /// Iterate over all output fields in deterministic (sorted) order.
-    pub fn iter_outputs(&self) -> impl Iterator<Item = (&str, &OutputField)> {
-        self.outputs.iter().map(|(k, v)| (k.as_str(), v))
-    }
-
-    /// Get a golden output field by name, returning the values as a
-    /// flat row-major `Vec<Complex64>`.
-    ///
-    /// The on-disk encoding is the real-imag interleaved layout
-    /// documented in `reference/SCHEMA.md` ("Complex encoding
-    /// (`c128`)"). The declared `shape` is taken from the fixture
-    /// without modification — the interleave is invisible to callers
-    /// (length `prod(shape)`, not `2 * prod(shape)`).
-    ///
-    /// # Errors
-    ///
-    /// - [`FixtureError::MissingField`] if the field is not declared.
-    /// - [`FixtureError::DtypeMismatch`] if the field is declared with
-    ///   a non-`c128` dtype.
-    /// - [`FixtureError::InvalidComplexLength`] if the flattened
-    ///   payload length is not `2 * prod(shape)`.
-    pub fn output_c128<'a>(&'a self, name: &str) -> Result<GoldenC128<'a>, FixtureError> {
-        let (key, f) = self
-            .outputs
-            .get_key_value(name)
-            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
-        if f.dtype != "c128" {
-            return Err(FixtureError::DtypeMismatch {
-                name: name.to_string(),
-                declared: f.dtype.clone(),
-                requested: "c128",
-            });
-        }
-        let flat = flatten_to_f64(&f.data);
-        let expected = f.shape.iter().product::<usize>();
-        // Real-imag interleave reassembly lives in `geode_util::interop`
-        // (Epic #414, Phase 2); the schema-level length error stays here.
-        let data = geode_util::interop::decode_real_imag_interleave_exact(&flat, expected)
-            .ok_or_else(|| FixtureError::InvalidComplexLength {
-                name: name.to_string(),
-                got: flat.len(),
-                expected: 2 * expected,
-            })?;
-        Ok(GoldenC128 {
-            name: key.as_str(),
-            shape: &f.shape,
-            tolerance_abs: f.tolerance_abs,
-            data,
-        })
-    }
-
-    /// Like [`output_c128`](Self::output_c128) but reads from `inputs`
-    /// instead of `outputs`. Used by reference-impl drivers that need
-    /// to consume a complex input (e.g. per-tet `epsilon_r_complex`)
-    /// from the fixture.
-    pub fn input_c128(&self, name: &str) -> Result<Vec<Complex64>, FixtureError> {
-        let f = self
-            .inputs
-            .get(name)
-            .ok_or_else(|| FixtureError::MissingField(name.to_string()))?;
-        if f.dtype != "c128" {
-            return Err(FixtureError::DtypeMismatch {
-                name: name.to_string(),
-                declared: f.dtype.clone(),
-                requested: "c128",
-            });
-        }
-        let flat = flatten_to_f64(&f.data);
-        let expected = f.shape.iter().product::<usize>();
-        // Same interleave decode as `output_c128`, reading from `inputs`.
-        geode_util::interop::decode_real_imag_interleave_exact(&flat, expected).ok_or_else(|| {
-            FixtureError::InvalidComplexLength {
-                name: name.to_string(),
-                got: flat.len(),
-                expected: 2 * expected,
-            }
-        })
-    }
-}
-
-/// A golden output field flattened into f64 row-major.
+/// Compare a set of named complex actual outputs against the `c128`-dtype
+/// golden fields in `fixture`. Per-field tolerance is applied to the
+/// **complex modulus** of the residual `|actual − golden|`.
 ///
-/// The `name` and `shape` borrow from the parent [`Fixture`] so callers
-/// can iterate cheaply without cloning per-field metadata.
-#[derive(Debug, Clone)]
-pub struct GoldenF64<'fix> {
-    pub name: &'fix str,
-    pub shape: &'fix [usize],
-    pub tolerance_abs: f64,
-    pub data: Vec<f64>,
-}
-
-impl GoldenF64<'_> {
-    /// Total element count implied by `shape`.
-    pub fn numel(&self) -> usize {
-        self.shape.iter().product()
-    }
-}
-
-/// A golden output field flattened into `Complex64` row-major.
+/// Fields whose declared dtype is not `c128` are skipped (the caller is
+/// expected to compare them separately via [`compare_against`] — the two
+/// diff reports can be merged or kept independent depending on the
+/// downstream tool).
 ///
-/// On-disk this corresponds to a `c128`-dtype field with real-imag
-/// interleaved storage (length `2 * prod(shape)` on disk, length
-/// `prod(shape)` in memory). See `reference/SCHEMA.md` for the
-/// encoding convention.
-#[derive(Debug, Clone)]
-pub struct GoldenC128<'fix> {
-    pub name: &'fix str,
-    pub shape: &'fix [usize],
-    /// Absolute tolerance applied to the **complex modulus** of the
-    /// per-element residual (`|actual − golden|`). See
-    /// `reference/SCHEMA.md` → "Complex encoding (c128)".
-    pub tolerance_abs: f64,
-    pub data: Vec<Complex64>,
-}
-
-impl GoldenC128<'_> {
-    /// Total element count implied by `shape`.
-    pub fn numel(&self) -> usize {
-        self.shape.iter().product()
-    }
-}
-
-/// Recursively flatten a nested `serde_json::Value` of numbers into a
-/// row-major `Vec<f64>`. Accepts both nested arrays matching `shape`
-/// and an already-flat array.
-pub(crate) fn flatten_to_f64(v: &serde_json::Value) -> Vec<f64> {
-    let mut out = Vec::new();
-    push_numbers(v, &mut out);
-    out
-}
-
-fn push_numbers(v: &serde_json::Value, out: &mut Vec<f64>) {
-    match v {
-        serde_json::Value::Number(n) => {
-            if let Some(x) = n.as_f64() {
-                out.push(x);
-            } else if let Some(x) = n.as_i64() {
-                out.push(x as f64);
-            } else if let Some(x) = n.as_u64() {
-                out.push(x as f64);
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for item in arr {
-                push_numbers(item, out);
-            }
-        }
-        _ => {
-            // Non-numeric values are silently skipped — the schema
-            // validator would have caught this at load time if we had
-            // one (deliberately deferred to keep Phase A small).
-        }
-    }
-}
-
-impl Fixture {
-    /// Compare a set of named actual outputs against the golden values
-    /// in this fixture. Returns a [`ComparisonReport`] describing each
-    /// field's pass/fail status. Missing fields, shape mismatches, and
-    /// tolerance violations all surface as distinct failure modes.
-    ///
-    /// Only `f64`-dtype output fields are checked by this entry point;
-    /// `c128` fields go through [`compare_complex_against`](Self::compare_complex_against).
-    pub fn compare_against(&self, actual: &BTreeMap<String, Vec<f64>>) -> crate::ComparisonReport {
-        crate::diff::compare(self, actual)
-    }
-
-    /// Compare a set of named complex actual outputs against the
-    /// `c128`-dtype golden fields in this fixture. Per-field tolerance
-    /// is applied to the **complex modulus** of the residual
-    /// `|actual − golden|`.
-    ///
-    /// Fields whose declared dtype is not `c128` are skipped (the
-    /// caller is expected to compare them separately via
-    /// [`compare_against`](Self::compare_against) — the two diff
-    /// reports can be merged or kept independent depending on the
-    /// downstream tool).
-    pub fn compare_complex_against(
-        &self,
-        actual: &BTreeMap<String, Vec<Complex64>>,
-    ) -> crate::ComparisonReport {
-        crate::diff::compare_complex(self, actual)
-    }
+/// This is the free-function form of what was
+/// `Fixture::compare_complex_against` before the loader moved to
+/// `geode-util` (Epic #429, Phase 2).
+pub fn compare_complex_against(
+    fixture: &Fixture,
+    actual: &BTreeMap<String, Vec<Complex64>>,
+) -> ComparisonReport {
+    crate::diff::compare_complex(fixture, actual)
 }

--- a/crates/geode-validation/src/lib.rs
+++ b/crates/geode-validation/src/lib.rs
@@ -46,7 +46,7 @@
 //! let mut actual = std::collections::BTreeMap::new();
 //! actual.insert("k_local".to_string(), vec![0.5, -1.0 / 6.0 /* ... */]);
 //!
-//! let report = fixture.compare_against(&actual);
+//! let report = geode_validation::compare_against(&fixture, &actual);
 //! if !report.passed {
 //!     report.write_diff_artifact(std::path::Path::new("diff.json")).unwrap();
 //! }
@@ -58,8 +58,15 @@ pub mod diff;
 pub mod fixture;
 
 pub use diff::{ComparisonReport, FieldDiff};
+// The JSON `Fixture` loader + schema + golden accessors now live in
+// `geode_util::fixture` (Epic #429, Phase 2); `fixture` re-exports them so
+// these crate-root paths (`geode_validation::Fixture`, etc.) are unchanged.
+// `compare_against` / `compare_complex_against` are the validation-side
+// comparison free functions (orphan rule forbids them as inherent methods
+// on the now-foreign `Fixture`).
 pub use fixture::{
     Field, Fixture, FixtureError, FixtureFormat, GoldenC128, GoldenF64, OutputField, Provenance,
+    compare_against, compare_complex_against,
 };
 // The repo/provenance helpers now live in `geode-util` (Epic #414, Phase 2).
 // Re-export them at the crate root so the existing reference-test suite keeps

--- a/crates/geode-validation/tests/cube_cavity_jax_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_jax_reference.rs
@@ -233,7 +233,7 @@ fn burn_cube_cavity_agrees_with_jax_baseline() {
         field.tolerance_abs = tol.trace_abs;
     }
 
-    let report = relaxed.compare_against(&actual);
+    let report = geode_validation::compare_against(&relaxed, &actual);
 
     // Always write the diff artifact (pass or fail) so the
     // friction-mining loop has the artifact even on green runs.

--- a/crates/geode-validation/tests/cube_cavity_julia_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_julia_reference.rs
@@ -300,7 +300,7 @@ fn burn_substage_agrees_with_julia_baseline() {
         )
     });
 
-    let report = relaxed.compare_against(&actual);
+    let report = geode_validation::compare_against(&relaxed, &actual);
 
     let artifact_path =
         Path::new(env!("CARGO_TARGET_TMPDIR")).join("cube_cavity_julia_substage_diff.json");
@@ -368,7 +368,7 @@ fn burn_cube_cavity_agrees_with_julia_baseline() {
     }
     relaxed.outputs.retain(|k, _| k == "eigenvalues");
 
-    let report = relaxed.compare_against(&actual);
+    let report = geode_validation::compare_against(&relaxed, &actual);
 
     let artifact_path =
         Path::new(env!("CARGO_TARGET_TMPDIR")).join("cube_cavity_julia_eigvals_diff.json");

--- a/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
@@ -414,7 +414,7 @@ fn cube_cavity_burn_matches_numpy_reference_at_all_substages() {
     // on the eigenvalues to honor issue #92's acceptance criterion #2
     // (`1e-6` relative). The Fixture's absolute tolerances are the
     // sub-stage tripwires; the relative check below is the headline.
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
 
     // Always write the diff artifact (success or failure) so the
     // friction-mining loop has the artifact even on green runs.

--- a/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
@@ -239,7 +239,7 @@ fn burn_cube_cavity_agrees_with_onnx_baseline() {
         field.tolerance_abs = tol.trace_abs;
     }
 
-    let report = relaxed.compare_against(&actual);
+    let report = geode_validation::compare_against(&relaxed, &actual);
 
     // Always write the diff artifact (pass or fail) so the
     // friction-mining loop has the artifact even on green runs.

--- a/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
+++ b/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
@@ -115,7 +115,7 @@ fn efficiencies_agree_with_numpy_on_both_grids() {
         );
     }
 
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     if !report.passed {
         for f in &report.fields {
             eprintln!(

--- a/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
@@ -355,7 +355,7 @@ fn burn_agrees_with_numpy_baseline_on_all_nedelec_local_cases() {
         // the discrepancy is bigger than even the f32 GPU envelope
         // expects. Always write the diff artifact (pass or fail) so the
         // friction-mining loop has the artifact even on green runs.
-        let report = fixture.compare_against(&actual);
+        let report = geode_validation::compare_against(&fixture, &actual);
         let artifact_path = artifact_dir.join(format!("nedelec_local_{case}_diff.json"));
         let _ = report.write_diff_artifact(&artifact_path);
 

--- a/crates/geode-validation/tests/p1_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/p1_local_numpy_reference.rs
@@ -267,7 +267,7 @@ fn burn_agrees_with_numpy_baseline_on_all_p1_local_cases() {
         // the discrepancy is bigger than even the f32 GPU envelope
         // expects. Always write the diff artifact (pass or fail) so the
         // friction-mining loop has the artifact even on green runs.
-        let report = fixture.compare_against(&actual);
+        let report = geode_validation::compare_against(&fixture, &actual);
         let artifact_path = artifact_dir.join(format!("p1_local_{case}_diff.json"));
         let _ = report.write_diff_artifact(&artifact_path);
 

--- a/crates/geode-validation/tests/smoke.rs
+++ b/crates/geode-validation/tests/smoke.rs
@@ -76,7 +76,7 @@ fn smoke_fixture_loads_and_compares_within_1e_minus_12() {
     assert!(fixture.outputs.contains_key("signed_volume"));
 
     let actual = p1_reference_tet_actual();
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     assert!(
         report.passed,
         "Rust hand-coded baseline should match fixture within tolerance; report = {:#?}",
@@ -111,7 +111,7 @@ fn deliberate_corruption_produces_structured_diff_artifact() {
         k[0] += 1e-3; // way past the 1e-12 tolerance
     }
 
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     assert!(!report.passed, "corrupted baseline should fail comparison");
     assert_eq!(report.n_failures(), 1, "exactly one field should fail");
 
@@ -172,7 +172,7 @@ fn missing_field_in_actual_is_reported_as_distinct_failure_mode() {
     let mut actual = p1_reference_tet_actual();
     actual.remove("m_local");
 
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     assert!(!report.passed);
     let m_diff = report
         .fields
@@ -190,7 +190,7 @@ fn shape_mismatch_in_actual_is_reported_as_distinct_failure_mode() {
     // Truncate k_local so its length no longer matches the golden shape.
     actual.get_mut("k_local").unwrap().truncate(10);
 
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     assert!(!report.passed);
     let k_diff = report
         .fields

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -491,7 +491,7 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
         burn_physical.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!(
             "sphere_mie_small (JAX) complex-comparator report: {:#?}",

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -529,7 +529,7 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
         "physical_eigenvalues_complex".to_string(),
         burn_physical.clone(),
     );
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!("sphere_mie_small Julia comparator report: {:#?}", report);
         panic!("Burn complex spectrum disagreed with the Julia small-mesh baseline");
@@ -652,7 +652,7 @@ fn julia_mie_small_complex_comparator_self_round_trip() {
             complex_actual.insert(name.to_string(), g.data.clone());
         }
     }
-    let report = fixture.compare_complex_against(&complex_actual);
+    let report = geode_validation::compare_complex_against(&fixture, &complex_actual);
     assert!(
         report.passed,
         "self-round-trip on c128 outputs should pass; report = {report:#?}"

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -513,7 +513,7 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
         burn_physical.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!("sphere_mie_small complex-comparator report: {:#?}", report);
         for f in &report.fields {
@@ -836,7 +836,7 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
         "physical_eigenvalues_complex".to_string(),
         burn_physical.clone(),
     );
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!("sphere_mie complex-comparator report: {:#?}", report);
         panic!("sphere_mie full-mesh complex spectrum disagreed with NumPy baseline");

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -566,7 +566,7 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
         burn_physical.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!(
             "sphere_mie_small (TF-Java) complex-comparator report: {:#?}",

--- a/crates/geode-validation/tests/sphere_pml_julia_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_julia_reference.rs
@@ -444,7 +444,7 @@ fn julia_pml_complex_comparator_self_round_trip() {
             complex_actual.insert(name.to_string(), g.data.clone());
         }
     }
-    let report = fixture.compare_complex_against(&complex_actual);
+    let report = geode_validation::compare_complex_against(&fixture, &complex_actual);
     assert!(
         report.passed,
         "self-round-trip on c128 outputs should pass; report = {report:#?}"
@@ -482,7 +482,7 @@ fn julia_pml_real_comparator_skips_c128_outputs() {
             real_actual.insert(name.to_string(), g.data.clone());
         }
     }
-    let report = fixture.compare_against(&real_actual);
+    let report = geode_validation::compare_against(&fixture, &real_actual);
     assert!(
         report.passed,
         "real comparator self-round-trip on f64 outputs should pass; report = {report:#?}"

--- a/crates/geode-validation/tests/sphere_pml_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_julia_small_reference.rs
@@ -428,7 +428,7 @@ fn julia_pml_small_complex_comparator_self_round_trip() {
             complex_actual.insert(name.to_string(), g.data.clone());
         }
     }
-    let report = fixture.compare_complex_against(&complex_actual);
+    let report = geode_validation::compare_complex_against(&fixture, &complex_actual);
     assert!(
         report.passed,
         "self-round-trip on c128 outputs should pass; report = {report:#?}"

--- a/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
@@ -416,7 +416,7 @@ fn sphere_pml_spectrum_agrees_with_numpy() {
         burn_physical.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!("sphere_pml complex-comparator report (full): {:#?}", report);
         for f in &report.fields {
@@ -841,7 +841,7 @@ fn sphere_pml_small_spectrum_agrees_with_numpy() {
         burn_physical.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     if !report.passed {
         eprintln!(
             "sphere_pml_small complex-comparator report (full): {:#?}",

--- a/crates/geode-validation/tests/sphere_pml_schema_smoke.rs
+++ b/crates/geode-validation/tests/sphere_pml_schema_smoke.rs
@@ -187,7 +187,7 @@ fn complex_comparator_passes_on_exact_match() {
         golden_phys.data.clone(),
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     assert!(
         report.passed,
         "exact-match actual should pass complex comparator; report = {report:#?}"
@@ -239,7 +239,7 @@ fn complex_comparator_fails_on_imag_perturbation_with_correct_tolerance() {
     let mut actual: BTreeMap<String, Vec<Complex64>> = BTreeMap::new();
     actual.insert("eigenvalues_lowest_complex".to_string(), perturbed);
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     assert!(
         !report.passed,
         "imag-perturbed actual should fail complex comparator; report = {report:#?}"
@@ -281,7 +281,7 @@ fn complex_comparator_reports_missing_field_when_actual_omitted() {
         .expect("sphere_pml fixture should load");
 
     let actual: BTreeMap<String, Vec<Complex64>> = BTreeMap::new();
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     assert!(!report.passed);
 
     let lam_diff = report
@@ -309,7 +309,7 @@ fn complex_comparator_reports_shape_mismatch() {
         vec![Complex64::new(1.42, -0.1)],
     );
 
-    let report = fixture.compare_complex_against(&actual);
+    let report = geode_validation::compare_complex_against(&fixture, &actual);
     assert!(!report.passed);
     let lam_diff = report
         .fields
@@ -354,7 +354,7 @@ fn real_comparator_skips_c128_fields_in_mixed_dtype_fixture() {
     // Deliberately do NOT supply the c128 outputs — the real
     // comparator should skip them entirely.
 
-    let report = fixture.compare_against(&actual);
+    let report = geode_validation::compare_against(&fixture, &actual);
     assert!(
         report.passed,
         "real comparator should pass on f64 outputs while skipping c128; report = {report:#?}"


### PR DESCRIPTION
## Summary

Closes #432. Phase 2.1 of Epic #429 — move the JSON `Fixture` machinery from `geode-validation/src/fixture.rs` into `geode_util::fixture`; `geode-validation` re-exports so the reference-test suite keeps its existing call paths.

## What moved to `geode_util::fixture`
- **Schema**: `Fixture`, `Field`, `OutputField`, `Provenance`, `FixtureError`, `FixtureFormat`, `SUPPORTED_SCHEMA_VERSIONS`.
- **Loaders**: `load_from`, `load`, `load_json`. `load_json` now calls `geode_util::repo::fixture_path` directly (no cross-crate hop).
- **Golden accessors**: `output_f64`/`GoldenF64`, `output_c128`/`GoldenC128`, `input_c128`, `iter_outputs`, and `pub(crate) flatten_to_f64`. `output_c128`/`input_c128` keep the `geode_util::interop::decode_real_imag_interleave_exact` decode (now an in-crate `crate::interop` call).
- Added `thiserror` to `geode-util` for the `FixtureError` derive.

## What stayed in `geode-validation`
- `diff.rs` + `ComparisonReport`/`FieldDiff` (the validation diff artifact).
- **Orphan-rule handling**: since `Fixture` is now a foreign type, `compare_against`/`compare_complex_against` cannot remain inherent methods. They are converted to **free functions** in `fixture.rs` (`pub fn compare_against(&Fixture, &BTreeMap<..>) -> ComparisonReport` wrapping `diff::compare`, and the complex variant), re-exported at the crate root. The **28** reference-test call sites are repointed from `fixture.compare_against(&actual)` to `geode_validation::compare_against(&fixture, &actual)` (and the complex variant). `geode-validation/src/fixture.rs` is otherwise a thin re-export.

## Verification (run in the issue-432 worktree)
- `cargo build` (workspace): clean.
- `cargo clippy -p geode-util -p geode-validation --all-targets -- -D warnings`: clean.
- `cargo test -p geode-validation`: **130 passed, 0 failed** (pre-existing release-only complex-eigensolve tests remain `ignored`).
- `cargo test -p geode-util`: 26 passed.
- `geode-core` does **not** depend on `geode-util` (grep clean).

Part of Epic #429 (Deepen geode-util). Phase 2.2 (#433) builds on this (extension-trait/`input_*` dedup).

Note: the non-required macos-13 cube-cavity CI check may stall QUEUED — not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)