### PR TITLE
refactor(geode-util): dedup &Fixture-taking scalar/vector input accessors

### DIFF
--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -507,6 +507,89 @@ impl Fixture {
             }
         })
     }
+
+    // -----------------------------------------------------------------------
+    // Scalar / vector convenience accessors for reference-test drivers
+    //
+    // These panic on missing or malformed fields — they are deliberately
+    // ergonomic helpers for the reference-test suite (call sites read like
+    // `fixture.input_f64("side")`), not fallible library entry points. Use
+    // the field maps (`inputs`/`outputs`) or the `*_f64`/`*_c128` accessors
+    // directly when a non-panicking path is needed.
+    // -----------------------------------------------------------------------
+
+    /// Pull a scalar `f64` from an **input** field.
+    ///
+    /// The field's `data` is flattened through [`flatten_numeric`] (so a
+    /// bare number, a `[x]` array, or a nested singleton all work) and
+    /// asserted to hold exactly one value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input field is missing or does not flatten to exactly
+    /// one numeric element.
+    pub fn input_f64(&self, name: &str) -> f64 {
+        let field = self
+            .inputs
+            .get(name)
+            .unwrap_or_else(|| panic!("fixture missing input `{name}`"));
+        let v = flatten_numeric(&field.data);
+        assert_eq!(
+            v.len(),
+            1,
+            "expected scalar input `{name}`, got len {}",
+            v.len()
+        );
+        v[0]
+    }
+
+    /// Pull a scalar `i64` from an **input** field.
+    ///
+    /// Identical to [`input_f64`](Self::input_f64) but truncates the
+    /// (integer-valued) scalar to `i64`. The v1 schema has no typed integer
+    /// accessor, so this round-trips through `f64`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input field is missing or is not a single value.
+    pub fn input_i64(&self, name: &str) -> i64 {
+        self.input_f64(name) as i64
+    }
+
+    /// Pull a full **input** field as a flat row-major `Vec<f64>`,
+    /// flattening nested arrays through [`flatten_numeric`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input field is missing.
+    pub fn input_vec(&self, name: &str) -> Vec<f64> {
+        let field = self
+            .inputs
+            .get(name)
+            .unwrap_or_else(|| panic!("fixture missing input `{name}`"));
+        flatten_numeric(&field.data)
+    }
+
+    /// Pull a scalar `f64` from an **output** (golden) field.
+    ///
+    /// Mirrors [`input_f64`](Self::input_f64) but reads from `outputs` via
+    /// [`output_f64`](Self::output_f64), preserving the input-vs-output
+    /// distinction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the output field is missing or is not a single value.
+    pub fn output_scalar(&self, name: &str) -> f64 {
+        let golden = self
+            .output_f64(name)
+            .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
+        assert_eq!(
+            golden.data.len(),
+            1,
+            "scalar output `{name}` should be length 1"
+        );
+        golden.data[0]
+    }
 }
 
 /// A golden output field flattened into f64 row-major.
@@ -758,5 +841,98 @@ q = 2.000e1
         assert_eq!(value_i64(&json!(u64::MAX)), None);
         assert_eq!(value_i64(&json!("7")), None);
         assert_eq!(value_i64(&json!(null)), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scalar / vector convenience accessors
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal in-memory [`Fixture`] from the given input and output
+    /// `data` JSON nodes (each declared `f64`), bypassing disk I/O.
+    fn scalar_fixture(
+        inputs: &[(&str, serde_json::Value)],
+        outputs: &[(&str, serde_json::Value)],
+    ) -> Fixture {
+        let to_input = |(name, data): &(&str, serde_json::Value)| {
+            (
+                name.to_string(),
+                json!({"shape": [1], "dtype": "f64", "data": data}),
+            )
+        };
+        let to_output = |(name, data): &(&str, serde_json::Value)| {
+            (
+                name.to_string(),
+                json!({"shape": [1], "dtype": "f64", "tolerance_abs": 0.0, "data": data}),
+            )
+        };
+        let value = json!({
+            "schema_version": "1",
+            "fixture_id": "unit/scalar_accessors",
+            "description": "",
+            "units": "",
+            "inputs": inputs.iter().map(to_input).collect::<serde_json::Map<_, _>>(),
+            "outputs": outputs.iter().map(to_output).collect::<serde_json::Map<_, _>>(),
+            "provenance": {"source": "unit test"},
+        });
+        serde_json::from_value(value).expect("scalar_fixture should deserialize")
+    }
+
+    #[test]
+    fn input_f64_reads_scalar_from_inputs() {
+        let fx = scalar_fixture(&[("side", json!([0.25])), ("bare", json!(1.5))], &[]);
+        // Both array-wrapped and bare scalars flatten to a single value.
+        assert_eq!(fx.input_f64("side"), 0.25);
+        assert_eq!(fx.input_f64("bare"), 1.5);
+    }
+
+    #[test]
+    fn input_i64_truncates_scalar_from_inputs() {
+        let fx = scalar_fixture(&[("n", json!([4]))], &[]);
+        assert_eq!(fx.input_i64("n"), 4_i64);
+    }
+
+    #[test]
+    fn input_vec_reads_full_input_field() {
+        let fx = scalar_fixture(&[("ka_curve", json!([1.0, 2.0, 3.5]))], &[]);
+        assert_eq!(fx.input_vec("ka_curve"), vec![1.0, 2.0, 3.5]);
+        // Nested arrays flatten row-major.
+        let fx = scalar_fixture(&[("grid", json!([[1.0, 2.0], [3.0, 4.0]]))], &[]);
+        assert_eq!(fx.input_vec("grid"), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn output_scalar_reads_scalar_from_outputs() {
+        let fx = scalar_fixture(&[], &[("analytic_tm11_k", json!([2.74]))]);
+        assert_eq!(fx.output_scalar("analytic_tm11_k"), 2.74);
+    }
+
+    #[test]
+    fn input_and_output_accessors_respect_the_inputs_vs_outputs_split() {
+        // A name present only as an input is not visible to `output_scalar`,
+        // and vice-versa — the two accessors read disjoint maps.
+        let fx = scalar_fixture(&[("k", json!([1.0]))], &[("k", json!([9.0]))]);
+        assert_eq!(fx.input_f64("k"), 1.0);
+        assert_eq!(fx.output_scalar("k"), 9.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "fixture missing input `nope`")]
+    fn input_f64_panics_on_missing_input() {
+        let fx = scalar_fixture(&[("side", json!([0.25]))], &[]);
+        fx.input_f64("nope");
+    }
+
+    #[test]
+    #[should_panic(expected = "fixture missing scalar output `nope`")]
+    fn output_scalar_panics_on_missing_output() {
+        let fx = scalar_fixture(&[], &[("k", json!([1.0]))]);
+        fx.output_scalar("nope");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected scalar input `vec`")]
+    fn input_f64_panics_on_non_scalar_input() {
+        let fx = scalar_fixture(&[("vec", json!([1.0, 2.0]))], &[]);
+        fx.input_f64("vec");
     }
 }

--- a/crates/geode-validation/tests/cube_cavity_jax_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_jax_reference.rs
@@ -109,45 +109,8 @@ fn burn_cube_cavity(n: usize, side: f64, k: usize) -> (Vec<f64>, f64, f64) {
     (eigvals, trk, trm)
 }
 
-// ---------------------------------------------------------------------------
-// Fixture input helpers
-// ---------------------------------------------------------------------------
-
-/// Pull an `i64` scalar input from the fixture (declared `dtype = i64`,
-/// shape `[1]`). Goes through the f64 flattener — the loader doesn't
-/// have a typed integer accessor at v1, so we round-trip via f64.
-fn input_i64(fixture: &Fixture, key: &str) -> i64 {
-    let field = fixture
-        .inputs
-        .get(key)
-        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
-    let v = flatten_numeric(&field.data);
-    assert_eq!(
-        v.len(),
-        1,
-        "expected scalar input `{key}`, got len {}",
-        v.len()
-    );
-    v[0] as i64
-}
-
-/// Pull an `f64` scalar input from the fixture.
-fn input_f64(fixture: &Fixture, key: &str) -> f64 {
-    let field = fixture
-        .inputs
-        .get(key)
-        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
-    let v = flatten_numeric(&field.data);
-    assert_eq!(
-        v.len(),
-        1,
-        "expected scalar input `{key}`, got len {}",
-        v.len()
-    );
-    v[0]
-}
-
-// Recursive JSON numeric flatten lives in the shared staging crate.
+// Scalar input accessors (`fixture.input_i64` / `fixture.input_f64`) and the
+// recursive JSON numeric flatten live in the shared staging crate.
 use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
@@ -188,8 +151,8 @@ fn burn_cube_cavity_agrees_with_jax_baseline() {
     let fixture =
         Fixture::load_from(&fixture_path(), FixtureFormat::Json).expect("load jax_baseline.json");
 
-    let n = input_i64(&fixture, "n") as usize;
-    let side = input_f64(&fixture, "side");
+    let n = fixture.input_i64("n") as usize;
+    let side = fixture.input_f64("side");
     eprintln!(
         "JAX baseline fixture id = {}, n = {n}, side = {side}",
         fixture.fixture_id

--- a/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_onnx_reference.rs
@@ -114,45 +114,8 @@ fn burn_cube_cavity(n: usize, side: f64, k: usize) -> (Vec<f64>, f64, f64) {
     (eigvals, trk, trm)
 }
 
-// ---------------------------------------------------------------------------
-// Fixture input helpers
-// ---------------------------------------------------------------------------
-
-/// Pull an `i64` scalar input from the fixture (declared `dtype = i64`,
-/// shape `[1]`). Goes through the f64 flattener — the loader doesn't
-/// have a typed integer accessor at v1, so we round-trip via f64.
-fn input_i64(fixture: &Fixture, key: &str) -> i64 {
-    let field = fixture
-        .inputs
-        .get(key)
-        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
-    let v = flatten_numeric(&field.data);
-    assert_eq!(
-        v.len(),
-        1,
-        "expected scalar input `{key}`, got len {}",
-        v.len()
-    );
-    v[0] as i64
-}
-
-/// Pull an `f64` scalar input from the fixture.
-fn input_f64(fixture: &Fixture, key: &str) -> f64 {
-    let field = fixture
-        .inputs
-        .get(key)
-        .unwrap_or_else(|| panic!("fixture missing input `{key}`"));
-    let v = flatten_numeric(&field.data);
-    assert_eq!(
-        v.len(),
-        1,
-        "expected scalar input `{key}`, got len {}",
-        v.len()
-    );
-    v[0]
-}
-
-// Recursive JSON numeric flatten lives in the shared staging crate.
+// Scalar input accessors (`fixture.input_i64` / `fixture.input_f64`) and the
+// recursive JSON numeric flatten live in the shared staging crate.
 use geode_util::fixture::flatten_numeric;
 
 // ---------------------------------------------------------------------------
@@ -193,8 +156,8 @@ fn burn_cube_cavity_agrees_with_onnx_baseline() {
     let fixture =
         Fixture::load_from(&fixture_path(), FixtureFormat::Json).expect("load onnx_baseline.json");
 
-    let n = input_i64(&fixture, "n") as usize;
-    let side = input_f64(&fixture, "side");
+    let n = fixture.input_i64("n") as usize;
+    let side = fixture.input_f64("side");
     eprintln!(
         "ONNX baseline fixture id = {}, n = {n}, side = {side}",
         fixture.fixture_id

--- a/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
+++ b/crates/geode-validation/tests/mie_efficiencies_numpy_reference.rs
@@ -51,16 +51,6 @@ fn fixture_path() -> PathBuf {
     );
 }
 
-fn input_vec(fixture: &Fixture, name: &str) -> Vec<f64> {
-    fixture.inputs[name]
-        .data
-        .as_array()
-        .unwrap_or_else(|| panic!("input `{name}` should be an array"))
-        .iter()
-        .map(|v| v.as_f64().unwrap())
-        .collect()
-}
-
 #[test]
 fn fixture_loads_with_expected_schema() {
     let fixture = Fixture::load_from(&fixture_path(), FixtureFormat::Json)
@@ -87,9 +77,9 @@ fn fixture_loads_with_expected_schema() {
     }
 
     // Geometry / material constants must match the Burn side exactly.
-    let n = input_vec(&fixture, "n_inside");
+    let n = fixture.input_vec("n_inside");
     assert_eq!(n, vec![N_INSIDE]);
-    let r = input_vec(&fixture, "r_sphere");
+    let r = fixture.input_vec("r_sphere");
     assert_eq!(r, vec![R_SPHERE]);
 }
 
@@ -103,7 +93,7 @@ fn efficiencies_agree_with_numpy_on_both_grids() {
         ("ka_benchmark", "q_ext_benchmark", "q_sca_benchmark"),
         ("ka_curve", "q_ext_curve", "q_sca_curve"),
     ] {
-        let ka = input_vec(&fixture, ka_field);
+        let ka = fixture.input_vec(ka_field);
         let effs: Vec<_> = ka.iter().map(|&x| mie_efficiencies(N_INSIDE, x)).collect();
         actual.insert(
             ext_field.to_string(),
@@ -147,7 +137,7 @@ fn efficiencies_agree_with_numpy_on_both_grids() {
 fn benchmark_grid_matches_driven_benchmark_sweep() {
     let fixture = Fixture::load_from(&fixture_path(), FixtureFormat::Json)
         .expect("mie_efficiencies baseline.json should load");
-    let ka = input_vec(&fixture, "ka_benchmark");
+    let ka = fixture.input_vec("ka_benchmark");
     // Mirror of examples/mie_driven_scattering.rs KA_VALUES and
     // tests/mie_driven_scattering.rs KA_BANDS.
     assert_eq!(ka, vec![1.0, 1.5, 1.9, 2.4, 3.0]);

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -194,20 +194,6 @@ fn q_factor_from_lambda(lambda: Complex64) -> f64 {
     }
 }
 
-fn input_scalar(fixture: &Fixture, name: &str) -> f64 {
-    fixture.inputs[name].data.as_array().unwrap()[0]
-        .as_f64()
-        .unwrap()
-}
-
-fn output_scalar(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(f.data.len(), 1, "scalar `{name}` should be length 1");
-    f.data[0]
-}
-
 fn load_jax_fixture() -> Fixture {
     Fixture::load_from(&jax_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small/jax_baseline.json should load")
@@ -293,23 +279,23 @@ fn jax_mie_autodiff_probe_verdict_is_clean() {
     // Phase H.3 scalar-isotropic finding and must be filed on #88 + #5.
     let fixture = load_jax_fixture();
     assert_eq!(
-        output_scalar(&fixture, "autodiff_jit_ok"),
+        fixture.output_scalar("autodiff_jit_ok"),
         1.0,
         "jax.jit failed to lower the tensor-ε complex assembly loss"
     );
     assert_eq!(
-        output_scalar(&fixture, "autodiff_grad_ok"),
+        fixture.output_scalar("autodiff_grad_ok"),
         1.0,
         "jax.grad failed through the tensor-ε kernel — partially reverses \
          the Phase H.3 finding; file on #88 + #5"
     );
     assert_eq!(
-        output_scalar(&fixture, "autodiff_grad_finite"),
+        fixture.output_scalar("autodiff_grad_finite"),
         1.0,
         "autodiff gradient through the tensor-ε path contains NaN/inf"
     );
-    let g_re = output_scalar(&fixture, "autodiff_grad_max_abs_re");
-    let g_im = output_scalar(&fixture, "autodiff_grad_max_abs_im");
+    let g_re = fixture.output_scalar("autodiff_grad_max_abs_re");
+    let g_im = fixture.output_scalar("autodiff_grad_max_abs_im");
     assert!(
         g_re.is_finite() && g_re > 0.0,
         "||grad_re||_∞ = {g_re} should be finite and non-trivial"
@@ -326,9 +312,9 @@ fn jax_mie_analytic_anchor_matches_mie_roots() {
     // The fixture re-exports the J.1 catalogue's TM_1,1 root; pin it
     // against the live `merged_roots` computation.
     let fixture = load_jax_fixture();
-    let anchor = output_scalar(&fixture, "analytic_tm11_k");
+    let anchor = fixture.output_scalar("analytic_tm11_k");
 
-    let n_index = input_scalar(&fixture, "n_index");
+    let n_index = fixture.input_f64("n_index");
     let analytic = merged_roots(n_index, &[1, 2, 3], R_SPHERE, R_BUFFER, 3);
     let ground = analytic
         .iter()
@@ -363,8 +349,8 @@ fn jax_mie_consistent_with_numpy_small_baseline() {
         ("q_median_tm11_triplet", 1e-6),
         ("strict_mode_window_len", 0.0),
     ] {
-        let a = output_scalar(&jax, field);
-        let b = output_scalar(&numpy, field);
+        let a = jax.output_scalar(field);
+        let b = numpy.output_scalar(field);
         assert!(
             (a - b).abs() <= tol,
             "JAX vs NumPy snapshot drift on `{field}`: {a} vs {b} (tol {tol:.0e})"
@@ -381,9 +367,9 @@ fn jax_mie_epsilon_tensor_decodes() {
         .input_c128("epsilon_tensor_diag")
         .expect("c128 input decodes");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
@@ -421,24 +407,24 @@ fn jax_mie_epsilon_tensor_decodes() {
 fn jax_mie_small_spectrum_agrees_with_burn() {
     let fixture = load_jax_fixture();
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
 
     // Mesh-shape integer cross-checks.
-    assert_eq!(burn.n_nodes, output_scalar(&fixture, "n_nodes") as usize);
-    assert_eq!(burn.n_tets, output_scalar(&fixture, "n_tets") as usize);
-    assert_eq!(burn.n_edges, output_scalar(&fixture, "n_edges") as usize);
+    assert_eq!(burn.n_nodes, fixture.output_scalar("n_nodes") as usize);
+    assert_eq!(burn.n_tets, fixture.output_scalar("n_tets") as usize);
+    assert_eq!(burn.n_edges, fixture.output_scalar("n_edges") as usize);
     assert_eq!(
         burn.n_interior_edges,
-        output_scalar(&fixture, "n_interior_edges") as usize
+        fixture.output_scalar("n_interior_edges") as usize
     );
     assert_eq!(
         burn.spurious_dim,
-        output_scalar(&fixture, "spurious_dim") as usize
+        fixture.output_scalar("spurious_dim") as usize
     );
 
     // Solve the complex generalized tensor-ε pencil on the Burn side.
@@ -465,7 +451,7 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
         golden_full.data.len()
     );
 
-    let n_spurious_ref = output_scalar(&fixture, "n_spurious_observed") as usize;
+    let n_spurious_ref = fixture.output_scalar("n_spurious_observed") as usize;
     assert_eq!(
         n_spurious_ref, burn.spurious_dim,
         "n_spurious_observed in fixture should match Burn's spurious_dim"
@@ -507,7 +493,7 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
     }
 
     // Strict cross-IR window (#160): the TM_1,1 triplet.
-    let window_len = output_scalar(&fixture, "strict_mode_window_len") as usize;
+    let window_len = fixture.output_scalar("strict_mode_window_len") as usize;
     assert!(window_len <= physical_take);
     let mut window_max = 0.0_f64;
     for (got, want) in burn_physical
@@ -539,9 +525,9 @@ fn jax_mie_small_spectrum_agrees_with_burn() {
     }
 
     // J.1 analytic anchor: lowest mode within the 8 % band on both sides.
-    let analytic_tm11_k = output_scalar(&fixture, "analytic_tm11_k");
+    let analytic_tm11_k = fixture.output_scalar("analytic_tm11_k");
     let burn_re_k = re_k_from_lambda(burn_physical[0]);
-    let jax_re_k = output_scalar(&fixture, "lowest_physical_re_k");
+    let jax_re_k = fixture.output_scalar("lowest_physical_re_k");
     let burn_rel_err = (burn_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     let jax_rel_err = (jax_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     assert!(

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -211,20 +211,6 @@ fn q_factor_from_lambda(lambda: Complex64) -> f64 {
     }
 }
 
-fn input_scalar(fixture: &Fixture, name: &str) -> f64 {
-    fixture.inputs[name].data.as_array().unwrap()[0]
-        .as_f64()
-        .unwrap()
-}
-
-fn output_scalar(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(f.data.len(), 1, "scalar `{name}` should be length 1");
-    f.data[0]
-}
-
 // ---------------------------------------------------------------------------
 // Schema-level tests (no eigensolve)
 // ---------------------------------------------------------------------------
@@ -294,12 +280,12 @@ fn julia_mie_small_fixture_loads_with_expected_schema() {
 #[test]
 fn julia_mie_small_mesh_counts_match_small_mesh() {
     let fixture = load_julia_fixture();
-    assert_eq!(output_scalar(&fixture, "n_nodes") as usize, 48);
-    assert_eq!(output_scalar(&fixture, "n_tets") as usize, 197);
-    assert_eq!(output_scalar(&fixture, "n_edges") as usize, 259);
-    assert_eq!(output_scalar(&fixture, "n_interior_edges") as usize, 214);
-    assert_eq!(output_scalar(&fixture, "spurious_dim") as usize, 31);
-    assert_eq!(output_scalar(&fixture, "n_spurious_observed") as usize, 31);
+    assert_eq!(fixture.output_scalar("n_nodes") as usize, 48);
+    assert_eq!(fixture.output_scalar("n_tets") as usize, 197);
+    assert_eq!(fixture.output_scalar("n_edges") as usize, 259);
+    assert_eq!(fixture.output_scalar("n_interior_edges") as usize, 214);
+    assert_eq!(fixture.output_scalar("spurious_dim") as usize, 31);
+    assert_eq!(fixture.output_scalar("n_spurious_observed") as usize, 31);
 }
 
 #[test]
@@ -307,9 +293,9 @@ fn julia_mie_small_analytic_anchor_matches_burn_and_j1() {
     // The fixture re-exports the J.1 catalogue's TM_1,1 root; pin it
     // against the live Burn computation and the J.1 fixture.
     let fixture = load_julia_fixture();
-    let anchor = output_scalar(&fixture, "analytic_tm11_k");
+    let anchor = fixture.output_scalar("analytic_tm11_k");
 
-    let n_index = input_scalar(&fixture, "n_index");
+    let n_index = fixture.input_f64("n_index");
     let analytic = merged_roots(n_index, &[1, 2, 3], R_SPHERE, R_BUFFER, 3);
     let ground = analytic
         .iter()
@@ -356,9 +342,9 @@ fn julia_mie_small_epsilon_tensor_matches_burn() {
         .input_c128("epsilon_tensor_diag")
         .expect("c128 input decodes");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
@@ -434,8 +420,8 @@ fn julia_mie_small_agrees_with_numpy_at_full_scope() {
 
     // σ₀ = 0 PEC anchors agree (same floor as the NumPy fixture's own
     // tolerance on this field).
-    let julia_pec = output_scalar(&julia_fixture, "sigma_zero_lowest_physical_re");
-    let numpy_pec = output_scalar(&numpy_fixture, "sigma_zero_lowest_physical_re");
+    let julia_pec = julia_fixture.output_scalar("sigma_zero_lowest_physical_re");
+    let numpy_pec = numpy_fixture.output_scalar("sigma_zero_lowest_physical_re");
     let pec_delta = (julia_pec - numpy_pec).abs();
     assert!(
         pec_delta < 5e-5,
@@ -445,8 +431,8 @@ fn julia_mie_small_agrees_with_numpy_at_full_scope() {
 
     // Strict-window bookkeeping must agree too.
     assert_eq!(
-        output_scalar(&julia_fixture, "strict_mode_window_len") as usize,
-        output_scalar(&numpy_fixture, "strict_mode_window_len") as usize,
+        julia_fixture.output_scalar("strict_mode_window_len") as usize,
+        numpy_fixture.output_scalar("strict_mode_window_len") as usize,
         "strict_mode_window_len drifted between the Julia and NumPy fixtures"
     );
 
@@ -465,24 +451,24 @@ fn julia_mie_small_agrees_with_numpy_at_full_scope() {
 fn julia_mie_small_spectrum_agrees_with_burn() {
     let fixture = load_julia_fixture();
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
 
     // Mesh-shape integer cross-checks.
-    assert_eq!(burn.n_nodes, output_scalar(&fixture, "n_nodes") as usize);
-    assert_eq!(burn.n_tets, output_scalar(&fixture, "n_tets") as usize);
-    assert_eq!(burn.n_edges, output_scalar(&fixture, "n_edges") as usize);
+    assert_eq!(burn.n_nodes, fixture.output_scalar("n_nodes") as usize);
+    assert_eq!(burn.n_tets, fixture.output_scalar("n_tets") as usize);
+    assert_eq!(burn.n_edges, fixture.output_scalar("n_edges") as usize);
     assert_eq!(
         burn.n_interior_edges,
-        output_scalar(&fixture, "n_interior_edges") as usize
+        fixture.output_scalar("n_interior_edges") as usize
     );
     assert_eq!(
         burn.spurious_dim,
-        output_scalar(&fixture, "spurious_dim") as usize
+        fixture.output_scalar("spurious_dim") as usize
     );
 
     // Solve the complex generalized tensor-ε pencil on the Burn side.
@@ -509,7 +495,7 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
         golden_full.data.len()
     );
 
-    let n_spurious_ref = output_scalar(&fixture, "n_spurious_observed") as usize;
+    let n_spurious_ref = fixture.output_scalar("n_spurious_observed") as usize;
     assert_eq!(n_spurious_ref, burn.spurious_dim);
     let golden_physical = fixture
         .output_c128("physical_eigenvalues_complex")
@@ -537,7 +523,7 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
 
     // Strict cross-IR window (#160 cluster closure): the TM_1,1
     // triplet, closed at a spectral gap on the Burn side too.
-    let window_len = output_scalar(&fixture, "strict_mode_window_len") as usize;
+    let window_len = fixture.output_scalar("strict_mode_window_len") as usize;
     assert!(window_len <= physical_take);
     let mut window_max = 0.0_f64;
     for (got, want) in burn_physical
@@ -578,9 +564,9 @@ fn julia_mie_small_spectrum_agrees_with_burn() {
 
     // J.1 analytic anchor: lowest mode within the documented 8 % band
     // on both sides, and Burn-vs-Julia Re(k) within the fixture floor.
-    let analytic_tm11_k = output_scalar(&fixture, "analytic_tm11_k");
+    let analytic_tm11_k = fixture.output_scalar("analytic_tm11_k");
     let burn_re_k = re_k_from_lambda(burn_physical[0]);
-    let julia_re_k = output_scalar(&fixture, "lowest_physical_re_k");
+    let julia_re_k = fixture.output_scalar("lowest_physical_re_k");
     let burn_rel_err = (burn_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     let julia_rel_err = (julia_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     assert!(

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -237,20 +237,6 @@ fn q_factor_from_lambda(lambda: Complex64) -> f64 {
     }
 }
 
-fn input_scalar(fixture: &Fixture, name: &str) -> f64 {
-    fixture.inputs[name].data.as_array().unwrap()[0]
-        .as_f64()
-        .unwrap()
-}
-
-fn output_scalar(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(f.data.len(), 1, "scalar `{name}` should be length 1");
-    f.data[0]
-}
-
 // ---------------------------------------------------------------------------
 // Schema-level tests (no eigensolve; default `cargo test`)
 // ---------------------------------------------------------------------------
@@ -333,9 +319,9 @@ fn sphere_mie_small_analytic_anchor_matches_mie_roots() {
     // fixture so the two Phase J fixtures cannot silently drift apart.
     let fixture = Fixture::load_from(&small_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small baseline.json should load");
-    let anchor = output_scalar(&fixture, "analytic_tm11_k");
+    let anchor = fixture.output_scalar("analytic_tm11_k");
 
-    let n_index = input_scalar(&fixture, "n_index");
+    let n_index = fixture.input_f64("n_index");
     let analytic = merged_roots(n_index, &[1, 2, 3], R_SPHERE, R_BUFFER, 3);
     let ground = analytic
         .iter()
@@ -384,9 +370,9 @@ fn sphere_mie_small_epsilon_tensor_decodes() {
         .input_c128("epsilon_tensor_diag")
         .expect("c128 input decodes");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
@@ -429,24 +415,24 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
     let fixture = Fixture::load_from(&small_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small baseline.json should load");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
 
     // Mesh-shape integer cross-checks.
-    assert_eq!(burn.n_nodes, output_scalar(&fixture, "n_nodes") as usize);
-    assert_eq!(burn.n_tets, output_scalar(&fixture, "n_tets") as usize);
-    assert_eq!(burn.n_edges, output_scalar(&fixture, "n_edges") as usize);
+    assert_eq!(burn.n_nodes, fixture.output_scalar("n_nodes") as usize);
+    assert_eq!(burn.n_tets, fixture.output_scalar("n_tets") as usize);
+    assert_eq!(burn.n_edges, fixture.output_scalar("n_edges") as usize);
     assert_eq!(
         burn.n_interior_edges,
-        output_scalar(&fixture, "n_interior_edges") as usize
+        fixture.output_scalar("n_interior_edges") as usize
     );
     assert_eq!(
         burn.spurious_dim,
-        output_scalar(&fixture, "spurious_dim") as usize
+        fixture.output_scalar("spurious_dim") as usize
     );
 
     // Solve the complex generalized tensor-ε pencil on the Burn side.
@@ -487,7 +473,7 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
         golden_full.data.len()
     );
 
-    let n_spurious_ref = output_scalar(&fixture, "n_spurious_observed") as usize;
+    let n_spurious_ref = fixture.output_scalar("n_spurious_observed") as usize;
     assert_eq!(
         n_spurious_ref, burn.spurious_dim,
         "n_spurious_observed in fixture should match Burn's spurious_dim"
@@ -529,7 +515,7 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
     // triplet, closed at a spectral gap. Report the measured residual
     // on the window separately — dense-vs-dense on the identical
     // pencil should be far inside the per-field tolerance.
-    let window_len = output_scalar(&fixture, "strict_mode_window_len") as usize;
+    let window_len = fixture.output_scalar("strict_mode_window_len") as usize;
     assert!(window_len <= physical_take);
     let mut window_max = 0.0_f64;
     for (got, want) in burn_physical
@@ -567,9 +553,9 @@ fn sphere_mie_small_spectrum_agrees_with_numpy() {
 
     // J.1 analytic anchor: lowest mode within the documented 8 % band
     // on both sides.
-    let analytic_tm11_k = output_scalar(&fixture, "analytic_tm11_k");
+    let analytic_tm11_k = fixture.output_scalar("analytic_tm11_k");
     let burn_re_k = re_k_from_lambda(burn_physical[0]);
-    let numpy_re_k = output_scalar(&fixture, "lowest_physical_re_k");
+    let numpy_re_k = fixture.output_scalar("lowest_physical_re_k");
     let burn_rel_err = (burn_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     let numpy_rel_err = (numpy_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     assert!(
@@ -658,8 +644,8 @@ fn sphere_mie_small_sigma_zero_collapses_to_real_isotropic() {
     // lowest physical Re(λ) must hit the in-fixture PEC anchor.
     let fixture = Fixture::load_from(&small_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small baseline.json should load");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, 0.0, n_index, k0_ref);
@@ -763,23 +749,23 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
     let fixture = Fixture::load_from(&full_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie baseline.json should load");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = read_sphere_fixture().expect("bundled sphere fixture load");
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
 
-    assert_eq!(burn.n_nodes, output_scalar(&fixture, "n_nodes") as usize);
-    assert_eq!(burn.n_tets, output_scalar(&fixture, "n_tets") as usize);
-    assert_eq!(burn.n_edges, output_scalar(&fixture, "n_edges") as usize);
+    assert_eq!(burn.n_nodes, fixture.output_scalar("n_nodes") as usize);
+    assert_eq!(burn.n_tets, fixture.output_scalar("n_tets") as usize);
+    assert_eq!(burn.n_edges, fixture.output_scalar("n_edges") as usize);
     assert_eq!(
         burn.n_interior_edges,
-        output_scalar(&fixture, "n_interior_edges") as usize
+        fixture.output_scalar("n_interior_edges") as usize
     );
     assert_eq!(
         burn.spurious_dim,
-        output_scalar(&fixture, "spurious_dim") as usize
+        fixture.output_scalar("spurious_dim") as usize
     );
 
     // Tensor cross-check at the f64 floor (the full-mesh sibling of
@@ -818,7 +804,7 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
         .expect("c128 output decodes");
     assert_eq!(burn_eigvals.len(), golden_full.data.len());
 
-    let n_spurious_ref = output_scalar(&fixture, "n_spurious_observed") as usize;
+    let n_spurious_ref = fixture.output_scalar("n_spurious_observed") as usize;
     assert_eq!(n_spurious_ref, burn.spurious_dim);
     let golden_physical = fixture
         .output_c128("physical_eigenvalues_complex")
@@ -843,16 +829,16 @@ fn sphere_mie_spectrum_agrees_with_numpy() {
     }
 
     // 8 % TM_1,1 band + Q tripwire, both sides.
-    let analytic_tm11_k = output_scalar(&fixture, "analytic_tm11_k");
+    let analytic_tm11_k = fixture.output_scalar("analytic_tm11_k");
     let burn_re_k = re_k_from_lambda(burn_physical[0]);
-    let numpy_re_k = output_scalar(&fixture, "lowest_physical_re_k");
+    let numpy_re_k = fixture.output_scalar("lowest_physical_re_k");
     let burn_rel_err = (burn_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     let numpy_rel_err = (numpy_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     assert!(burn_rel_err < TM11_REL_TOL);
     assert!(numpy_rel_err < TM11_REL_TOL);
 
     let burn_q = q_factor_from_lambda(burn_physical[0]);
-    let numpy_q = output_scalar(&fixture, "q_factor_lowest_physical");
+    let numpy_q = fixture.output_scalar("q_factor_lowest_physical");
     assert!(burn_q > Q_LOWER_BAND_TM11);
     assert!(numpy_q > Q_LOWER_BAND_TM11);
 

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -211,20 +211,6 @@ fn q_factor_from_lambda(lambda: Complex64) -> f64 {
     }
 }
 
-fn input_scalar(fixture: &Fixture, name: &str) -> f64 {
-    fixture.inputs[name].data.as_array().unwrap()[0]
-        .as_f64()
-        .unwrap()
-}
-
-fn output_scalar(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(f.data.len(), 1, "scalar `{name}` should be length 1");
-    f.data[0]
-}
-
 // ---------------------------------------------------------------------------
 // Schema-level tests (no eigensolve)
 // ---------------------------------------------------------------------------
@@ -299,9 +285,9 @@ fn tfjava_mie_analytic_anchor_matches_mie_roots() {
     // The fixture re-exports the J.1 catalogue's TM_1,1 root; pin it
     // against the live `merged_roots` computation.
     let fixture = load_tfjava_fixture();
-    let anchor = output_scalar(&fixture, "analytic_tm11_k");
+    let anchor = fixture.output_scalar("analytic_tm11_k");
 
-    let n_index = input_scalar(&fixture, "n_index");
+    let n_index = fixture.input_f64("n_index");
     let analytic = merged_roots(n_index, &[1, 2, 3], R_SPHERE, R_BUFFER, 3);
     let ground = analytic
         .iter()
@@ -336,8 +322,8 @@ fn tfjava_mie_consistent_with_numpy_small_baseline() {
         ("q_median_tm11_triplet", 1e-6),
         ("strict_mode_window_len", 0.0),
     ] {
-        let a = output_scalar(&tfjava, field);
-        let b = output_scalar(&numpy, field);
+        let a = tfjava.output_scalar(field);
+        let b = numpy.output_scalar(field);
         assert!(
             (a - b).abs() <= tol,
             "TF-Java vs NumPy snapshot drift on `{field}`: {a} vs {b} (tol {tol:.0e})"
@@ -413,7 +399,7 @@ fn tfjava_mie_physical_eigenvalues_have_tensor_pencil_signature() {
     // eigensolve cross-checks.
     let fixture = load_tfjava_fixture();
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
+    let sigma_0 = fixture.input_f64("sigma_0");
     assert!(
         sigma_0 > 0.0,
         "canonical TF-Java Mie fixture should carry σ₀ > 0 (got {sigma_0})"
@@ -454,9 +440,9 @@ fn tfjava_mie_epsilon_tensor_decodes() {
         .input_c128("epsilon_tensor_diag")
         .expect("c128 input decodes");
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
@@ -496,24 +482,24 @@ fn tfjava_mie_epsilon_tensor_decodes() {
 fn tfjava_mie_small_spectrum_agrees_with_burn() {
     let fixture = load_tfjava_fixture();
 
-    let sigma_0 = input_scalar(&fixture, "sigma_0");
-    let n_index = input_scalar(&fixture, "n_index");
-    let k0_ref = input_scalar(&fixture, "k0_ref");
+    let sigma_0 = fixture.input_f64("sigma_0");
+    let n_index = fixture.input_f64("n_index");
+    let k0_ref = fixture.input_f64("k0_ref");
 
     let sphere = load_small_sphere_fixture();
     let burn = run_burn_mie_pipeline(&sphere, sigma_0, n_index, k0_ref);
 
     // Mesh-shape integer cross-checks.
-    assert_eq!(burn.n_nodes, output_scalar(&fixture, "n_nodes") as usize);
-    assert_eq!(burn.n_tets, output_scalar(&fixture, "n_tets") as usize);
-    assert_eq!(burn.n_edges, output_scalar(&fixture, "n_edges") as usize);
+    assert_eq!(burn.n_nodes, fixture.output_scalar("n_nodes") as usize);
+    assert_eq!(burn.n_tets, fixture.output_scalar("n_tets") as usize);
+    assert_eq!(burn.n_edges, fixture.output_scalar("n_edges") as usize);
     assert_eq!(
         burn.n_interior_edges,
-        output_scalar(&fixture, "n_interior_edges") as usize
+        fixture.output_scalar("n_interior_edges") as usize
     );
     assert_eq!(
         burn.spurious_dim,
-        output_scalar(&fixture, "spurious_dim") as usize
+        fixture.output_scalar("spurious_dim") as usize
     );
 
     // Solve the complex generalized tensor-ε pencil on the Burn side.
@@ -540,7 +526,7 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
         golden_full.data.len()
     );
 
-    let n_spurious_ref = output_scalar(&fixture, "n_spurious_observed") as usize;
+    let n_spurious_ref = fixture.output_scalar("n_spurious_observed") as usize;
     assert_eq!(
         n_spurious_ref, burn.spurious_dim,
         "n_spurious_observed in fixture should match Burn's spurious_dim"
@@ -582,7 +568,7 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
     }
 
     // Strict cross-IR window (#160): the TM_1,1 triplet.
-    let window_len = output_scalar(&fixture, "strict_mode_window_len") as usize;
+    let window_len = fixture.output_scalar("strict_mode_window_len") as usize;
     assert!(window_len <= physical_take);
     let mut window_max = 0.0_f64;
     for (got, want) in burn_physical
@@ -614,9 +600,9 @@ fn tfjava_mie_small_spectrum_agrees_with_burn() {
     }
 
     // J.1 analytic anchor: lowest mode within the 8 % band on both sides.
-    let analytic_tm11_k = output_scalar(&fixture, "analytic_tm11_k");
+    let analytic_tm11_k = fixture.output_scalar("analytic_tm11_k");
     let burn_re_k = re_k_from_lambda(burn_physical[0]);
-    let tfjava_re_k = output_scalar(&fixture, "lowest_physical_re_k");
+    let tfjava_re_k = fixture.output_scalar("lowest_physical_re_k");
     let burn_rel_err = (burn_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     let tfjava_rel_err = (tfjava_re_k - analytic_tm11_k).abs() / analytic_tm11_k;
     assert!(


### PR DESCRIPTION
## Summary

Phase 2.2 of Epic #429. Consolidates the `&Fixture`-taking value helpers that
the reference-test suite had copy-pasted into shared convenience methods on the
migrated `Fixture` type (`geode_util::fixture`), then removes the per-test
copies and repoints all call sites.

**Scope note:** The comparison-seam portion of the original issue
(`compare_against` / `compare_complex_against` as `geode-validation` free
functions) was **already delivered by #434 (issue #432)** and is on `main`.
This PR is therefore scoped to the `input_*`/`*_scalar` dedup only.

## Changes

- Add four panicking convenience accessors on `Fixture` (documented as
  reference-test/driver ergonomics, built on the Phase-1 `flatten_numeric`
  primitive and the existing `output_f64`):
  - `input_f64(name) -> f64` / `input_i64(name) -> i64` — scalar **inputs**
  - `input_vec(name) -> Vec<f64>` — full **input** field, row-major flat
  - `output_scalar(name) -> f64` — scalar golden **output**
- Fold the redundant per-test `input_scalar` into `input_f64` (the sphere_mie
  scalar inputs are `[x]`/shape `[1]` — identical semantics).
- Delete the duplicated `input_f64`/`input_i64`/`input_scalar`/`output_scalar`/
  `input_vec` copies from the reference tests and repoint every call site to the
  shared `fixture.method(...)` form (cube_cavity jax/onnx, mie_efficiencies_numpy,
  sphere_mie jax/numpy/tfjava/julia_small).
- Add `geode-util` unit tests covering the inputs-vs-outputs split, scalar/vector
  extraction, and missing-key / non-scalar panic behavior.

API choice: **methods on `Fixture`** (over free fns) for `fixture.input_f64("k")`
ergonomics, matching the existing `output_f64`/`input_c128` accessor style.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Helpers consolidated into geode-util; per-test copies removed | ✅ | `grep -rn "fn input_f64\|fn input_i64\|fn input_scalar\|fn output_scalar\|fn input_vec" crates/geode-validation/tests` → empty |
| New helpers have unit tests | ✅ | 8 new tests in `crates/geode-util/src/fixture.rs` (`input_f64_*`, `input_i64_*`, `input_vec_*`, `output_scalar_*`, inputs-vs-outputs split, panic cases) |
| `cargo test -p geode-util` passes | ✅ | 34 passed; 0 failed |
| `cargo test -p geode-validation` passes (default backend) | ✅ | all suites passed; only backend-specific tests `ignored` |
| `cargo build` workspace + `clippy -p geode-util -p geode-validation -- -D warnings` clean | ✅ | build finished; clippy clean |
| geode-core does NOT depend on geode-util | ✅ | no `geode-util` entry in `crates/geode-core/Cargo.toml` |

## Test Plan

- `cargo fmt --all --check` — clean
- `cargo clippy -p geode-util -p geode-validation -- -D warnings` — clean
- `cargo test -p geode-util` — 34 passed
- `cargo test -p geode-validation` — all pass (backend-gated tests ignored)
- `cargo build` (workspace) — green

Closes #433