### PR TITLE
refactor(geode-util): serde-derive TOML row writer + repoint 8 example emitters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3595,6 +3596,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -3619,6 +3621,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -4272,6 +4275,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -5242,6 +5246,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -5290,6 +5295,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -5312,6 +5318,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]
@@ -5361,6 +5368,7 @@ dependencies = [
  "geode-app",
  "geode-core",
  "geode-util",
+ "serde",
 ]
 
 [[package]]

--- a/crates/geode-util/Cargo.toml
+++ b/crates/geode-util/Cargo.toml
@@ -33,6 +33,11 @@ serde_json = { workspace = true }
 # Error-derive for the JSON fixture loader's `FixtureError` (Epic #429,
 # Phase 2; migrated from geode-validation along with the `Fixture` schema).
 thiserror = { workspace = true }
+# TOML serialization for the example results-row writer (`push_table` /
+# `push_rows`, Epic #429 Phase 3). The shared row seam serializes each
+# `#[derive(Serialize)]` row through the `toml` crate instead of hand-rolled
+# `{:.15e}` formatting. Existing workspace dep (also used by geode-core).
+toml = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -44,34 +44,49 @@ pub fn write_toml(path: &Path, contents: &str) -> io::Result<()> {
     Ok(())
 }
 
-/// A single fixture-results row that can serialise its own `key = value`
-/// body into an indexed TOML table.
+/// Append a single `[<header>]` TOML table to `out`, serializing `row`'s
+/// `key = value` body through the [`toml`] crate (followed by a blank
+/// line).
 ///
-/// The shared [`push_rows`] driver emits one `[<TABLE_PREFIX>_<i>]` table
-/// per row (followed by a blank line), matching the hand-rolled per-row
-/// loop the RF-sweep / eigenmode example crates previously copy-pasted.
-pub trait TomlRow {
-    /// Table-name prefix; the emitted header for row `i` is
-    /// `[<TABLE_PREFIX>_<i>]` (e.g. `point`, `mode`).
-    const TABLE_PREFIX: &'static str;
-
-    /// Append this row's `key = value` lines into `out`.
-    ///
-    /// Implementations write the body only — no table header and no
-    /// trailing blank line; [`push_rows`] frames each row.
-    fn write_fields(&self, out: &mut String);
+/// `row` is any `#[derive(Serialize)]` value whose fields are TOML
+/// scalars (or inline arrays / `Option`s) — the serializer emits the body
+/// in struct-field declaration order. This is the serde-derive
+/// replacement (Epic #429, Phase 3) for the hand-rolled `{:.15e}` /
+/// `{:.3e}` per-field `write_fields` impls the example crates previously
+/// copy-pasted: the numeric values are identical (the `toml` crate emits
+/// the exact, shortest-round-tripping decimal for each `f64`), only the
+/// float *spelling* changes (decimal / shortest instead of fixed-width
+/// exponential).
+///
+/// `header` is interpolated verbatim into `[<header>]`, so callers that
+/// need a quoted/dotted table name (e.g. `"\"group.input\""`) pass the
+/// already-quoted string.
+///
+/// # Panics
+///
+/// Panics if `row` fails to serialize as a TOML table (e.g. a non-string
+/// map key, or a non-finite float — neither of which the example rows
+/// produce).
+pub fn push_table<T: Serialize>(out: &mut String, header: &str, row: &T) {
+    out.push_str(&format!("[{header}]\n"));
+    let body =
+        toml::to_string(row).unwrap_or_else(|e| panic!("serialize TOML row under [{header}]: {e}"));
+    out.push_str(&body);
+    out.push('\n');
 }
 
 /// Append `rows` to `out` as a sequence of indexed `[<prefix>_<i>]` TOML
-/// tables, each followed by a blank line.
+/// tables, each serialized via [`push_table`] and followed by a blank
+/// line.
 ///
 /// Replaces the `for (i, r) in rows.iter().enumerate() { ... }` table
-/// loop duplicated across the example fixture writers.
-pub fn push_rows<T: TomlRow>(out: &mut String, rows: &[T]) {
-    for (i, r) in rows.iter().enumerate() {
-        out.push_str(&format!("[{}_{i}]\n", T::TABLE_PREFIX));
-        r.write_fields(out);
-        out.push('\n');
+/// loop (and the hand-rolled `TomlRow::write_fields` formatting) that the
+/// example fixture writers duplicated. Each `row` is a
+/// `#[derive(Serialize)]` value; the row's column order is its
+/// struct-field declaration order.
+pub fn push_rows<T: Serialize>(out: &mut String, prefix: &str, rows: &[T]) {
+    for (i, row) in rows.iter().enumerate() {
+        push_table(out, &format!("{prefix}_{i}"), row);
     }
 }
 
@@ -685,17 +700,10 @@ mod tests {
         ))
     }
 
+    #[derive(Serialize)]
     struct Pt {
         f_ghz: f64,
         q: f64,
-    }
-
-    impl TomlRow for Pt {
-        const TABLE_PREFIX: &'static str = "point";
-        fn write_fields(&self, out: &mut String) {
-            out.push_str(&format!("f_ghz = {:.3e}\n", self.f_ghz));
-            out.push_str(&format!("q = {:.3e}\n", self.q));
-        }
     }
 
     #[test]
@@ -711,15 +719,90 @@ mod tests {
             },
         ];
         let mut s = String::new();
-        push_rows(&mut s, &rows);
+        push_rows(&mut s, "point", &rows);
+        // Float spelling is the `toml` crate's shortest-round-trip decimal
+        // (`1.0`, not the old `1.000e0`); the indexed-table framing and the
+        // struct-field column order are unchanged.
         let expected = "\
 [point_0]
-f_ghz = 1.000e0
-q = 1.000e1
+f_ghz = 1.0
+q = 10.0
 
 [point_1]
-f_ghz = 2.000e0
-q = 2.000e1
+f_ghz = 2.0
+q = 20.0
+
+";
+        assert_eq!(s, expected);
+    }
+
+    #[test]
+    fn push_rows_values_round_trip_numerically() {
+        // The serde+toml seam must preserve every f64 exactly (shortest
+        // round-trip), so a re-parse of the emitted TOML recovers the
+        // original values bit-for-bit — the property the old `{:.15e}`
+        // formatting only approximated (16 significant figures).
+        let rows = vec![
+            Pt {
+                f_ghz: 2.4000000001,
+                q: 1.234_567_890_123_456_7e3,
+            },
+            Pt {
+                f_ghz: -3.0e-12,
+                q: std::f64::consts::PI,
+            },
+        ];
+        let mut s = String::new();
+        push_rows(&mut s, "point", &rows);
+        let doc: toml::Value = toml::from_str(&s).expect("emitted rows are valid TOML");
+        for (i, r) in rows.iter().enumerate() {
+            let t = &doc[format!("point_{i}")];
+            assert_eq!(t["f_ghz"].as_float().unwrap(), r.f_ghz);
+            assert_eq!(t["q"].as_float().unwrap(), r.q);
+        }
+    }
+
+    #[test]
+    fn push_table_uses_verbatim_header_and_serde_body() {
+        // `push_table` interpolates the header verbatim (so a quoted/dotted
+        // table name is the caller's responsibility) and serializes the row
+        // body via serde+toml.
+        #[derive(Serialize)]
+        struct Baseline<'a> {
+            group: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            input: Option<&'a str>,
+            median_ns: f64,
+        }
+        let mut s = String::new();
+        push_table(
+            &mut s,
+            "\"assemble.10\"",
+            &Baseline {
+                group: "assemble",
+                input: Some("10"),
+                median_ns: 1234.5,
+            },
+        );
+        // No `input` key when it is `None`.
+        push_table(
+            &mut s,
+            "\"eigensolve\"",
+            &Baseline {
+                group: "eigensolve",
+                input: None,
+                median_ns: 6.0,
+            },
+        );
+        let expected = "\
+[\"assemble.10\"]
+group = \"assemble\"
+input = \"10\"
+median_ns = 1234.5
+
+[\"eigensolve\"]
+group = \"eigensolve\"
+median_ns = 6.0
 
 ";
         assert_eq!(s, expected);

--- a/examples/extract_baseline/src/main.rs
+++ b/examples/extract_baseline/src/main.rs
@@ -33,7 +33,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use geode_app::{App, Verbosity};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Criterion's per-statistic shape inside `estimates.json`.
 #[derive(Debug, Deserialize)]
@@ -58,6 +58,21 @@ struct Row {
     median_ns: f64,
     median_abs_dev_ns: f64,
     mean_ns: f64,
+}
+
+/// Serde view of a [`Row`] matching the emitted per-bench TOML table
+/// body (the `["<group>.<input>"]` table). The `input` key is omitted
+/// for ungrouped benches and `human` is the pretty-printed median.
+/// Serialized through the shared `geode_util::fixture::push_table` seam.
+#[derive(Serialize)]
+struct BaselineRow<'a> {
+    group: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<&'a str>,
+    median_ns: f64,
+    median_abs_dev_ns: f64,
+    mean_ns: f64,
+    human: String,
 }
 
 /// Workspace root, two parents above `examples/extract_baseline/`.
@@ -195,17 +210,20 @@ fn emit_results(rows: &[Row], out_path: &Path) -> Result<(), Box<dyn std::error:
                 None => group.to_string(),
             };
             // Quote the table header so dotted/numeric inputs (e.g. "10")
-            // do not collide with the dotted-table syntax.
-            s.push_str(&format!("[\"{}\"]\n", key));
-            s.push_str(&format!("group = \"{}\"\n", r.group));
-            if let Some(input) = &r.input {
-                s.push_str(&format!("input = \"{}\"\n", input));
-            }
-            s.push_str(&format!("median_ns = {:.3}\n", r.median_ns));
-            s.push_str(&format!("median_abs_dev_ns = {:.3}\n", r.median_abs_dev_ns));
-            s.push_str(&format!("mean_ns = {:.3}\n", r.mean_ns));
-            s.push_str(&format!("human = \"{}\"\n", fmt_ns(r.median_ns)));
-            s.push('\n');
+            // do not collide with the dotted-table syntax. The body is
+            // serialized through the shared serde+toml row seam.
+            geode_util::fixture::push_table(
+                &mut s,
+                &format!("\"{key}\""),
+                &BaselineRow {
+                    group: &r.group,
+                    input: r.input.as_deref(),
+                    median_ns: r.median_ns,
+                    median_abs_dev_ns: r.median_abs_dev_ns,
+                    mean_ns: r.mean_ns,
+                    human: fmt_ns(r.median_ns),
+                },
+            );
         }
     }
 

--- a/examples/mie_driven_scattering/Cargo.toml
+++ b/examples/mie_driven_scattering/Cargo.toml
@@ -16,6 +16,9 @@ clap = { workspace = true }
 geode-app = { workspace = true }
 geode-core = { workspace = true }
 geode-util = { workspace = true }
+# `#[derive(Serialize)]` on the results `Row` for the serde+toml row seam
+# (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/mie_driven_scattering/src/main.rs
+++ b/examples/mie_driven_scattering/src/main.rs
@@ -106,6 +106,7 @@ const R_OBS: f64 = 0.5 * (R_SPHERE + R_PML_INNER);
 /// The benchmark `ka` sweep (see module docs).
 const KA_VALUES: [f64; 5] = [1.0, 1.5, 1.9, 2.4, 3.0];
 
+#[derive(serde::Serialize)]
 struct Row {
     ka: f64,
     q_ext_analytic: f64,
@@ -114,21 +115,8 @@ struct Row {
     q_sca_fem: f64,
     rel_err_q_ext: f64,
     rel_err_q_sca: f64,
+    #[serde(rename = "solve_residual_rel")]
     residual_rel: f64,
-}
-
-impl geode_util::fixture::TomlRow for Row {
-    const TABLE_PREFIX: &'static str = "point";
-    fn write_fields(&self, out: &mut String) {
-        out.push_str(&format!("ka = {:.15e}\n", self.ka));
-        out.push_str(&format!("q_ext_analytic = {:.15e}\n", self.q_ext_analytic));
-        out.push_str(&format!("q_sca_analytic = {:.15e}\n", self.q_sca_analytic));
-        out.push_str(&format!("q_ext_fem = {:.15e}\n", self.q_ext_fem));
-        out.push_str(&format!("q_sca_fem = {:.15e}\n", self.q_sca_fem));
-        out.push_str(&format!("rel_err_q_ext = {:.15e}\n", self.rel_err_q_ext));
-        out.push_str(&format!("rel_err_q_sca = {:.15e}\n", self.rel_err_q_sca));
-        out.push_str(&format!("solve_residual_rel = {:.3e}\n", self.residual_rel));
-    }
 }
 
 fn run_one(fixture: &SphereFixture, ka: f64) -> Row {
@@ -244,7 +232,7 @@ fn emit_results(rows: &[Row], path: &PathBuf, choice: FixtureChoice) {
     s.push_str("]\n");
     s.push('\n');
 
-    geode_util::fixture::push_rows(&mut s, rows);
+    geode_util::fixture::push_rows(&mut s, "point", rows);
 
     geode_util::fixture::write_toml(path, &s)
         .expect("write mie_driven_scattering driven_results.toml");

--- a/examples/mie_sphere/Cargo.toml
+++ b/examples/mie_sphere/Cargo.toml
@@ -23,6 +23,9 @@ burn = { workspace = true }
 # (`std`, `linalg`) for the sparse shift-invert Lanczos eigensolver path
 # (`SparseColMat` / `Triplet`), matching geode-core's own faer reference.
 faer = { workspace = true, features = ["sparse-linalg"] }
+# `#[derive(Serialize)]` on the results `Row` for the serde+toml row seam
+# (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/mie_sphere/src/main.rs
+++ b/examples/mie_sphere/src/main.rs
@@ -190,8 +190,9 @@ fn n_modes_from_catalog(analytic: &[MieRoot]) -> usize {
 /// Each row records one FEM eigenmode together with the analytic
 /// `(l, n, polarisation)` group it was claimed into and which slot
 /// within the `2 l + 1` magnetic-degeneracy multiplet it occupies.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 struct Row {
+    #[serde(rename = "polarisation")]
     pol: &'static str,
     l: usize,
     n: usize,
@@ -213,23 +214,6 @@ struct Row {
     fem_im_k: f64,
     rel_err_re_k: f64,
     q: f64,
-}
-
-impl geode_util::fixture::TomlRow for Row {
-    const TABLE_PREFIX: &'static str = "mode";
-    fn write_fields(&self, out: &mut String) {
-        out.push_str(&format!("polarisation = \"{}\"\n", self.pol));
-        out.push_str(&format!("l = {}\n", self.l));
-        out.push_str(&format!("n = {}\n", self.n));
-        out.push_str(&format!("m_idx = {}\n", self.m_idx));
-        out.push_str(&format!("incomplete = {}\n", self.incomplete));
-        out.push_str(&format!("ambiguous = {}\n", self.ambiguous));
-        out.push_str(&format!("analytic_k = {:.15e}\n", self.analytic_k));
-        out.push_str(&format!("fem_re_k = {:.15e}\n", self.fem_re_k));
-        out.push_str(&format!("fem_im_k = {:.15e}\n", self.fem_im_k));
-        out.push_str(&format!("rel_err_re_k = {:.15e}\n", self.rel_err_re_k));
-        out.push_str(&format!("q = {:.15e}\n", self.q));
-    }
 }
 
 fn pol_str(pol: MiePolarisation) -> &'static str {
@@ -663,7 +647,7 @@ fn emit_results(rows: &[Row], path: &PathBuf, scalar_pml: bool, n_modes: usize) 
     s.push_str("]\n");
     s.push('\n');
 
-    geode_util::fixture::push_rows(&mut s, rows);
+    geode_util::fixture::push_rows(&mut s, "mode", rows);
 
     geode_util::fixture::write_toml(path, &s).expect("write mie_sphere results.toml");
 }

--- a/examples/patch_antenna/Cargo.toml
+++ b/examples/patch_antenna/Cargo.toml
@@ -22,6 +22,9 @@ geode-util = { workspace = true }
 burn = { workspace = true }
 # `faer::c64` for the port impedance / S11 complex arithmetic.
 faer = { workspace = true }
+# `#[derive(Serialize)]` on the results row DTO for the serde+toml row seam
+# (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/patch_antenna/src/main.rs
+++ b/examples/patch_antenna/src/main.rs
@@ -236,24 +236,44 @@ struct Row {
     residual_rel: f64,
 }
 
-impl geode_util::fixture::TomlRow for Row {
-    const TABLE_PREFIX: &'static str = "point";
-    fn write_fields(&self, out: &mut String) {
-        out.push_str(&format!("f_ghz = {:.15e}\n", self.f_ghz));
-        out.push_str(&format!("omega_natural = {:.15e}\n", self.omega));
-        out.push_str(&format!("z_re_ohm = {:.15e}\n", self.z_ohm.re));
-        out.push_str(&format!("z_im_ohm = {:.15e}\n", self.z_ohm.im));
-        out.push_str(&format!("s11_re = {:.15e}\n", self.s11.re));
-        out.push_str(&format!("s11_im = {:.15e}\n", self.s11.im));
-        out.push_str(&format!("s11_mag = {:.15e}\n", self.s11.norm()));
-        out.push_str(&format!(
-            "s11_db = {:.15e}\n",
-            20.0 * self.s11.norm().log10()
-        ));
-        out.push_str(&format!("p_in = {:.15e}\n", self.p_in));
-        out.push_str(&format!("p_rad = {:.15e}\n", self.p_rad));
-        out.push_str(&format!("efficiency = {:.15e}\n", self.efficiency));
-        out.push_str(&format!("solve_residual_rel = {:.3e}\n", self.residual_rel));
+/// Serde view of a [`Row`] matching the emitted `[point_<i>]` TOML
+/// columns: the `c64` impedance and `c64` reflection coefficient are
+/// split into real/imaginary parts, with the `|S11|` magnitude and dB
+/// return loss derived here. Serialized through the shared
+/// `geode_util::fixture::push_rows` seam.
+#[derive(serde::Serialize)]
+struct PointRow {
+    f_ghz: f64,
+    omega_natural: f64,
+    z_re_ohm: f64,
+    z_im_ohm: f64,
+    s11_re: f64,
+    s11_im: f64,
+    s11_mag: f64,
+    s11_db: f64,
+    p_in: f64,
+    p_rad: f64,
+    efficiency: f64,
+    solve_residual_rel: f64,
+}
+
+impl From<&Row> for PointRow {
+    fn from(r: &Row) -> Self {
+        let s11_mag = r.s11.norm();
+        PointRow {
+            f_ghz: r.f_ghz,
+            omega_natural: r.omega,
+            z_re_ohm: r.z_ohm.re,
+            z_im_ohm: r.z_ohm.im,
+            s11_re: r.s11.re,
+            s11_im: r.s11.im,
+            s11_mag,
+            s11_db: 20.0 * s11_mag.log10(),
+            p_in: r.p_in,
+            p_rad: r.p_rad,
+            efficiency: r.efficiency,
+            solve_residual_rel: r.residual_rel,
+        }
     }
 }
 
@@ -630,7 +650,8 @@ fn emit_results(rows: &[Row], path: &PathBuf, choice: FixtureChoice, pml_thick: 
         s.push('\n');
     }
 
-    geode_util::fixture::push_rows(&mut s, rows);
+    let point_rows: Vec<PointRow> = rows.iter().map(PointRow::from).collect();
+    geode_util::fixture::push_rows(&mut s, "point", &point_rows);
 
     geode_util::fixture::write_toml(path, &s).expect("write patch_antenna results TOML");
 }

--- a/examples/slcfet_3hp_spiral/Cargo.toml
+++ b/examples/slcfet_3hp_spiral/Cargo.toml
@@ -20,6 +20,9 @@ geode-util = { workspace = true }
 burn = { workspace = true }
 # `faer::c64` for the per-port complex impedance arithmetic.
 faer = { workspace = true }
+# `#[derive(Serialize)]` on the results row DTO for the serde+toml row seam
+# (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/slcfet_3hp_spiral/src/main.rs
+++ b/examples/slcfet_3hp_spiral/src/main.rs
@@ -153,18 +153,36 @@ struct Row {
     residual_rel: f64,
 }
 
-impl geode_util::fixture::TomlRow for Row {
-    const TABLE_PREFIX: &'static str = "point";
-    fn write_fields(&self, out: &mut String) {
-        out.push_str(&format!("f_ghz = {:.15e}\n", self.f_ghz));
-        out.push_str(&format!("omega_natural = {:.15e}\n", self.omega));
-        out.push_str(&format!("z_re_ohm = {:.15e}\n", self.z_ohm.re));
-        out.push_str(&format!("z_im_ohm = {:.15e}\n", self.z_ohm.im));
-        out.push_str(&format!("l_nh = {:.15e}\n", self.l_nh));
-        out.push_str(&format!("r_ohm = {:.15e}\n", self.r_ohm));
-        out.push_str(&format!("q = {:.15e}\n", self.q));
-        out.push_str(&format!("s11_mag = {:.15e}\n", self.s11_mag));
-        out.push_str(&format!("solve_residual_rel = {:.3e}\n", self.residual_rel));
+/// Serde view of a [`Row`] matching the emitted `[point_<i>]` TOML
+/// columns: the `c64` impedance is split into its real/imaginary parts
+/// and the natural-frequency / residual columns are renamed. Serialized
+/// through the shared `geode_util::fixture::push_rows` seam.
+#[derive(serde::Serialize)]
+struct PointRow {
+    f_ghz: f64,
+    omega_natural: f64,
+    z_re_ohm: f64,
+    z_im_ohm: f64,
+    l_nh: f64,
+    r_ohm: f64,
+    q: f64,
+    s11_mag: f64,
+    solve_residual_rel: f64,
+}
+
+impl From<&Row> for PointRow {
+    fn from(r: &Row) -> Self {
+        PointRow {
+            f_ghz: r.f_ghz,
+            omega_natural: r.omega,
+            z_re_ohm: r.z_ohm.re,
+            z_im_ohm: r.z_ohm.im,
+            l_nh: r.l_nh,
+            r_ohm: r.r_ohm,
+            q: r.q,
+            s11_mag: r.s11_mag,
+            solve_residual_rel: r.residual_rel,
+        }
     }
 }
 
@@ -400,7 +418,8 @@ fn emit_results(rows: &[Row], path: &PathBuf, choice: FixtureChoice, srf_ghz: Op
         s.push('\n');
     }
 
-    geode_util::fixture::push_rows(&mut s, rows);
+    let point_rows: Vec<PointRow> = rows.iter().map(PointRow::from).collect();
+    geode_util::fixture::push_rows(&mut s, "point", &point_rows);
 
     geode_util::fixture::write_toml(path, &s).expect("write slcfet_3hp results TOML");
 }

--- a/examples/soi_waveguide/Cargo.toml
+++ b/examples/soi_waveguide/Cargo.toml
@@ -16,6 +16,9 @@ clap = { workspace = true }
 geode-app = { workspace = true }
 geode-core = { workspace = true }
 geode-util = { workspace = true }
+# `#[derive(Serialize)]` on the `[buffer_<i>]` row for the serde+toml row
+# seam (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/soi_waveguide/src/main.rs
+++ b/examples/soi_waveguide/src/main.rs
@@ -129,6 +129,49 @@ struct BufferResult {
     solve_s: f64,
 }
 
+/// Serde view of a [`BufferResult`] matching the emitted `[buffer_<i>]`
+/// TOML columns: the `(x, y)` tuple fields are flattened into the
+/// `*_x` / `*_y` scalar columns. Serialized through the shared
+/// `geode_util::fixture::push_rows` seam.
+#[derive(serde::Serialize)]
+struct BufferRow {
+    buffer_cells_x: usize,
+    buffer_cells_y: usize,
+    buffer_um_x: f64,
+    buffer_um_y: f64,
+    buffer_decay_lengths_x: f64,
+    buffer_decay_lengths_y: f64,
+    mesh_nx: usize,
+    mesh_ny: usize,
+    cell_um_x: f64,
+    cell_um_y: f64,
+    n_edges: usize,
+    n_eff: f64,
+    n_eff_all: Vec<f64>,
+    solve_s: f64,
+}
+
+impl From<&BufferResult> for BufferRow {
+    fn from(r: &BufferResult) -> Self {
+        BufferRow {
+            buffer_cells_x: r.nbuf.0,
+            buffer_cells_y: r.nbuf.1,
+            buffer_um_x: r.buf_um.0,
+            buffer_um_y: r.buf_um.1,
+            buffer_decay_lengths_x: r.buf_decay_lengths.0,
+            buffer_decay_lengths_y: r.buf_decay_lengths.1,
+            mesh_nx: r.mesh_nxny.0,
+            mesh_ny: r.mesh_nxny.1,
+            cell_um_x: r.cell_um.0,
+            cell_um_y: r.cell_um.1,
+            n_edges: r.n_edges,
+            n_eff: r.n_eff,
+            n_eff_all: r.n_eff_all.clone(),
+            solve_s: r.solve_s,
+        }
+    }
+}
+
 /// Build a grid-aligned SOI cross-section: the silicon core occupies
 /// exactly `NX_CORE × NY_CORE` cells, with `nbuf` cells of SiO₂ cladding
 /// on each side. The core boundaries land on grid lines (no centroid
@@ -337,31 +380,8 @@ fn emit_results(results: &[BufferResult]) {
     s.push_str(&format!("converged = {}\n", buf_delta < 1e-3));
     s.push('\n');
 
-    for (i, r) in results.iter().enumerate() {
-        s.push_str(&format!("[buffer_{i}]\n"));
-        s.push_str(&format!("buffer_cells_x = {}\n", r.nbuf.0));
-        s.push_str(&format!("buffer_cells_y = {}\n", r.nbuf.1));
-        s.push_str(&format!("buffer_um_x = {:.6e}\n", r.buf_um.0));
-        s.push_str(&format!("buffer_um_y = {:.6e}\n", r.buf_um.1));
-        s.push_str(&format!(
-            "buffer_decay_lengths_x = {:.6e}\n",
-            r.buf_decay_lengths.0
-        ));
-        s.push_str(&format!(
-            "buffer_decay_lengths_y = {:.6e}\n",
-            r.buf_decay_lengths.1
-        ));
-        s.push_str(&format!("mesh_nx = {}\n", r.mesh_nxny.0));
-        s.push_str(&format!("mesh_ny = {}\n", r.mesh_nxny.1));
-        s.push_str(&format!("cell_um_x = {:.6e}\n", r.cell_um.0));
-        s.push_str(&format!("cell_um_y = {:.6e}\n", r.cell_um.1));
-        s.push_str(&format!("n_edges = {}\n", r.n_edges));
-        s.push_str(&format!("n_eff = {:.15e}\n", r.n_eff));
-        let all: Vec<String> = r.n_eff_all.iter().map(|v| format!("{v:.6e}")).collect();
-        s.push_str(&format!("n_eff_all = [{}]\n", all.join(", ")));
-        s.push_str(&format!("solve_s = {:.3}\n", r.solve_s));
-        s.push('\n');
-    }
+    let buffer_rows: Vec<BufferRow> = results.iter().map(BufferRow::from).collect();
+    geode_util::fixture::push_rows(&mut s, "buffer", &buffer_rows);
 
     let path = results_path();
     geode_util::fixture::write_toml(&path, &s).expect("write soi_waveguide results TOML");

--- a/examples/spiral_inductor/Cargo.toml
+++ b/examples/spiral_inductor/Cargo.toml
@@ -21,6 +21,9 @@ geode-util = { workspace = true }
 burn = { workspace = true }
 # `faer::c64` for the per-port complex impedance arithmetic.
 faer = { workspace = true }
+# `#[derive(Serialize)]` on the results row DTO for the serde+toml row seam
+# (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/spiral_inductor/src/main.rs
+++ b/examples/spiral_inductor/src/main.rs
@@ -173,18 +173,36 @@ struct Row {
     residual_rel: f64,
 }
 
-impl geode_util::fixture::TomlRow for Row {
-    const TABLE_PREFIX: &'static str = "point";
-    fn write_fields(&self, out: &mut String) {
-        out.push_str(&format!("f_ghz = {:.15e}\n", self.f_ghz));
-        out.push_str(&format!("omega_natural = {:.15e}\n", self.omega));
-        out.push_str(&format!("z_re_ohm = {:.15e}\n", self.z_ohm.re));
-        out.push_str(&format!("z_im_ohm = {:.15e}\n", self.z_ohm.im));
-        out.push_str(&format!("l_nh = {:.15e}\n", self.l_nh));
-        out.push_str(&format!("r_ohm = {:.15e}\n", self.r_ohm));
-        out.push_str(&format!("q = {:.15e}\n", self.q));
-        out.push_str(&format!("s11_mag = {:.15e}\n", self.s11_mag));
-        out.push_str(&format!("solve_residual_rel = {:.3e}\n", self.residual_rel));
+/// Serde view of a [`Row`] matching the emitted `[point_<i>]` TOML
+/// columns: the `c64` impedance is split into its real/imaginary parts
+/// and the natural-frequency / residual columns are renamed. Serialized
+/// through the shared `geode_util::fixture::push_rows` seam.
+#[derive(serde::Serialize)]
+struct PointRow {
+    f_ghz: f64,
+    omega_natural: f64,
+    z_re_ohm: f64,
+    z_im_ohm: f64,
+    l_nh: f64,
+    r_ohm: f64,
+    q: f64,
+    s11_mag: f64,
+    solve_residual_rel: f64,
+}
+
+impl From<&Row> for PointRow {
+    fn from(r: &Row) -> Self {
+        PointRow {
+            f_ghz: r.f_ghz,
+            omega_natural: r.omega,
+            z_re_ohm: r.z_ohm.re,
+            z_im_ohm: r.z_ohm.im,
+            l_nh: r.l_nh,
+            r_ohm: r.r_ohm,
+            q: r.q,
+            s11_mag: r.s11_mag,
+            solve_residual_rel: r.residual_rel,
+        }
     }
 }
 
@@ -402,7 +420,8 @@ fn emit_results(rows: &[Row], path: &PathBuf, choice: FixtureChoice, srf_ghz: Op
         s.push('\n');
     }
 
-    geode_util::fixture::push_rows(&mut s, rows);
+    let point_rows: Vec<PointRow> = rows.iter().map(PointRow::from).collect();
+    geode_util::fixture::push_rows(&mut s, "point", &point_rows);
 
     geode_util::fixture::write_toml(path, &s).expect("write spiral_inductor results TOML");
 }

--- a/examples/step_index_fiber/Cargo.toml
+++ b/examples/step_index_fiber/Cargo.toml
@@ -16,6 +16,9 @@ clap = { workspace = true }
 geode-app = { workspace = true }
 geode-core = { workspace = true }
 geode-util = { workspace = true }
+# `#[derive(Serialize)]` on the `[series_<i>]` row for the serde+toml row
+# seam (geode_util::fixture::push_rows, Epic #429 Phase 3).
+serde = { workspace = true }
 
 # NOTE: this crate deliberately defines NO backend features. The Burn
 # backend (`wgpu` by default, or `ndarray` on headless CI) is selected by

--- a/examples/step_index_fiber/src/main.rs
+++ b/examples/step_index_fiber/src/main.rs
@@ -190,6 +190,89 @@ struct FiberResult {
     solve_s: f64,
 }
 
+/// A `[series_<i>]` column that is either a float (a mode was found) or a
+/// descriptive string fallback (e.g. `"none (...)"`) when the config
+/// returned no in-window guided mode.
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum SeriesScalar {
+    Float(f64),
+    Text(&'static str),
+}
+
+/// Serde view of a [`FiberResult`] matching the emitted `[series_<i>]`
+/// TOML columns. Optional diagnostic columns are omitted when absent
+/// (`Option` + `skip_serializing_if`); `re_n_eff` / `b_fem` fall back to a
+/// string when the config found no in-window guided mode. The field order
+/// reproduces the previous hand-rolled emission order. Serialized through
+/// the shared `geode_util::fixture::push_rows` seam.
+#[derive(serde::Serialize)]
+struct SeriesRow {
+    n_radial: usize,
+    n_angular: usize,
+    n_dof: usize,
+    re_n_eff: SeriesScalar,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    im_n_eff: Option<f64>,
+    b_fem: SeriesScalar,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    re_neff_rel_err_vs_oracle: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b_rel_err_vs_oracle: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    core_energy_fraction: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rel_im_beta_sq: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b_fem_closest_oracle: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b_rel_err_closest_oracle: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    core_energy_fraction_closest_oracle: Option<f64>,
+    re_n_eff_all: Vec<f64>,
+    solve_s: f64,
+}
+
+impl SeriesRow {
+    /// Build a row from a solved config, deriving the oracle-relative
+    /// errors. The no-mode branch leaves the string fallbacks and skips
+    /// every diagnostic column, matching the previous emission.
+    fn new(r: &FiberResult, oracle: f64, b_oracle: f64) -> Self {
+        let mut row = SeriesRow {
+            n_radial: r.res.0,
+            n_angular: r.res.1,
+            n_dof: r.n_dof,
+            re_n_eff: SeriesScalar::Text("none (no in-window guided mode at this config)"),
+            im_n_eff: None,
+            b_fem: SeriesScalar::Text("none"),
+            re_neff_rel_err_vs_oracle: None,
+            b_rel_err_vs_oracle: None,
+            core_energy_fraction: None,
+            rel_im_beta_sq: None,
+            b_fem_closest_oracle: None,
+            b_rel_err_closest_oracle: None,
+            core_energy_fraction_closest_oracle: None,
+            re_n_eff_all: r.re_n_eff_all.clone(),
+            solve_s: r.solve_s,
+        };
+        if let (Some(re_n_eff), Some(b)) = (r.re_n_eff, r.b) {
+            row.re_n_eff = SeriesScalar::Float(re_n_eff);
+            row.im_n_eff = r.im_n_eff;
+            row.b_fem = SeriesScalar::Float(b);
+            row.re_neff_rel_err_vs_oracle = Some((re_n_eff - oracle).abs() / oracle);
+            row.b_rel_err_vs_oracle = Some((b - b_oracle).abs() / b_oracle);
+            row.core_energy_fraction = r.core_frac;
+            row.rel_im_beta_sq = r.rel_im_beta_sq;
+            if let (Some(bc), Some(cfc)) = (r.b_closest_oracle, r.core_frac_closest_oracle) {
+                row.b_fem_closest_oracle = Some(bc);
+                row.b_rel_err_closest_oracle = Some((bc - b_oracle).abs() / b_oracle);
+                row.core_energy_fraction_closest_oracle = Some(cfc);
+            }
+        }
+        row
+    }
+}
+
 /// Build the PML-terminated step-index fiber cross-section.
 ///
 /// Returns `(mesh, region_tags, eps_r, p=2 interior-DOF mask, r_pml_inner,
@@ -514,47 +597,11 @@ fn emit_results(
     );
     s.push('\n');
 
-    for (i, r) in results.iter().enumerate() {
-        s.push_str(&format!("[series_{i}]\n"));
-        s.push_str(&format!("n_radial = {}\n", r.res.0));
-        s.push_str(&format!("n_angular = {}\n", r.res.1));
-        s.push_str(&format!("n_dof = {}\n", r.n_dof));
-        match (r.re_n_eff, r.b) {
-            (Some(re_n_eff), Some(b)) => {
-                let rel = (re_n_eff - oracle).abs() / oracle;
-                let b_rel = (b - b_oracle).abs() / b_oracle;
-                s.push_str(&format!("re_n_eff = {re_n_eff:.15e}\n"));
-                if let Some(im) = r.im_n_eff {
-                    s.push_str(&format!("im_n_eff = {im:.6e}\n"));
-                }
-                s.push_str(&format!("b_fem = {b:.6e}\n"));
-                s.push_str(&format!("re_neff_rel_err_vs_oracle = {rel:.6e}\n"));
-                s.push_str(&format!("b_rel_err_vs_oracle = {b_rel:.6e}\n"));
-                if let Some(cf) = r.core_frac {
-                    s.push_str(&format!("core_energy_fraction = {cf:.6e}\n"));
-                }
-                if let Some(ri) = r.rel_im_beta_sq {
-                    s.push_str(&format!("rel_im_beta_sq = {ri:.6e}\n"));
-                }
-                if let (Some(bc), Some(cfc)) = (r.b_closest_oracle, r.core_frac_closest_oracle) {
-                    let bc_rel = (bc - b_oracle).abs() / b_oracle;
-                    s.push_str(&format!("b_fem_closest_oracle = {bc:.6e}\n"));
-                    s.push_str(&format!("b_rel_err_closest_oracle = {bc_rel:.6e}\n"));
-                    s.push_str(&format!(
-                        "core_energy_fraction_closest_oracle = {cfc:.6e}\n"
-                    ));
-                }
-            }
-            _ => {
-                s.push_str("re_n_eff = \"none (no in-window guided mode at this config)\"\n");
-                s.push_str("b_fem = \"none\"\n");
-            }
-        }
-        let all: Vec<String> = r.re_n_eff_all.iter().map(|v| format!("{v:.6e}")).collect();
-        s.push_str(&format!("re_n_eff_all = [{}]\n", all.join(", ")));
-        s.push_str(&format!("solve_s = {:.3}\n", r.solve_s));
-        s.push('\n');
-    }
+    let series_rows: Vec<SeriesRow> = results
+        .iter()
+        .map(|r| SeriesRow::new(r, oracle, b_oracle))
+        .collect();
+    geode_util::fixture::push_rows(&mut s, "series", &series_rows);
 
     let path = results_path();
     geode_util::fixture::write_toml(&path, &s).expect("write step_index_fiber results.toml");


### PR DESCRIPTION
## Summary

Epic #429 Phase 3. Replaces the hand-rolled `TomlRow`/`write_fields` per-field string builder in `geode_util::fixture` with a serde-derive seam, and repoints all 8 example results-TOML writers onto it. The shared writer now serializes each `#[derive(Serialize)]` row through the `toml` crate, keeping the `[<prefix>_<i>]` indexed-table layout.

## Changes

- **`geode-util`**: add `toml = { workspace = true }`. New row seam:
  - `push_table<T: Serialize>(out, header, row)` — appends a `[<header>]` table whose body is `toml::to_string(row)`.
  - `push_rows<T: Serialize>(out, prefix, rows)` — emits the indexed `[<prefix>_<i>]` table sequence via `push_table`.
  - Removes the `TomlRow` trait + manual `write_fields` formatting.
  - Unit tests: indexed-table framing, exact f64 round-trip re-parse, verbatim/quoted headers + `Option` skip.
- **8 examples** (extract_baseline, mie_driven_scattering, mie_sphere, slcfet_3hp_spiral, spiral_inductor, patch_antenna, soi_waveguide, step_index_fiber): each results `Row` gains `#[derive(Serialize)]` and writes through the new seam; each example's bespoke `[meta]`/oracle/geometry prose assembly is preserved verbatim. `serde` added to the 7 example crates that didn't already depend on it (extract_baseline already did).

## Float-formatting normalization (documented)

The float *spelling* changes from the old fixed-width exponential (`{:.15e}` / `{:.3e}`, e.g. `4.500000e-1`) to the `toml` crate's shortest round-trip decimal (`0.45`, `8.723312862175161`). Values are **numerically equivalent and strictly more precise** — the toml crate emits the exact shortest-round-tripping decimal for each f64, where the old specifiers truncated the significand. Both spellings are valid TOML floats parsing to the identical f64, so no downstream parser (tearsheet/oracle tooling) breaks.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `toml = { workspace = true }` added; row seam uses serde-derive + toml (no hand-rolled per-field formatting in shared writer) | ✅ | `crates/geode-util/{Cargo.toml,src/fixture.rs}`; `TomlRow`/`write_fields` removed |
| 8 example emitters use new seam; bespoke `[meta]`/oracle prose preserved | ✅ | grep confirms 0 `TomlRow` left; all 8 use `push_rows`/`push_table` |
| Spot-checked `results.toml` numerically equivalent to committed baseline; normalization documented | ✅ | `cargo run -p soi_waveguide --release` diffed against committed baseline: every numeric value matches to prior significant digits; only diffs are float spelling (above), runtime `generated_at_commit`/`solve_s`, and pre-existing upstream `slab_te0_neff` path-rename prose drift |
| `cargo test -p geode-util` passes; `cargo build` workspace + examples; `cargo clippy -p geode-util -- -D warnings` clean | ✅ | 36 tests pass; `cargo build --workspace` green; clippy clean; `cargo fmt --check` clean |

## Test Plan

- `cargo test -p geode-util` → 36 passed.
- `cargo clippy -p geode-util -- -D warnings` → clean.
- `cargo build --workspace` → green (all examples).
- Output-equivalence: ran `cargo run -p soi_waveguide --release`, diffed emitted `results.toml` vs committed baseline — numerically equivalent (formatting normalized as documented). Baseline restored (not committed). step_index_fiber also runs and emits valid TOML; its solver-noise-floor values (~1e-17) show pre-existing run-to-run eigensolver nondeterminism in geode-core, independent of this formatting-only change.

Closes #436