### PR TITLE
test(geode-util): backfill repo + crate-root tests, deepen viz coverage

### DIFF
--- a/crates/geode-util/src/lib.rs
+++ b/crates/geode-util/src/lib.rs
@@ -28,3 +28,41 @@ pub mod fixture;
 pub mod interop;
 pub mod repo;
 pub mod viz;
+
+#[cfg(test)]
+mod tests {
+    //! Crate-root public-surface smoke test.
+    //!
+    //! `lib.rs` is purely `pub mod` declarations, so the crate root's
+    //! observable "behavior" is the re-export surface itself. This test
+    //! reaches one public item per declared module *through its
+    //! crate-root path* and exercises the pure ones. An accidental
+    //! `pub mod` → `mod` downgrade — or removal/rename of one of these
+    //! re-exported helpers — fails to compile here rather than silently
+    //! shrinking the crate's public API.
+    //!
+    //! Deep per-module behavior is covered in each module's own `tests`
+    //! submodule; this guard only asserts reachability + a trivial sanity
+    //! result so the crate root is no longer at zero coverage.
+
+    #[test]
+    fn declared_modules_are_publicly_reachable() {
+        // repo: an absolute workspace root resolved from the crate root path.
+        assert!(crate::repo::repo_root().is_absolute());
+
+        // convert: empty input round-trips to an empty Vec.
+        assert!(crate::convert::complex_slice_to_vec(&[]).is_empty());
+
+        // interop: empty interleaved payload decodes to no complex values.
+        assert!(crate::interop::decode_real_imag_interleave(&[]).is_empty());
+
+        // fixture (deep tests owned by Phase 4.2): the type and a free
+        // helper must remain reachable from the crate root.
+        let _fixture_ty: Option<crate::fixture::Fixture> = None;
+        assert_eq!(crate::fixture::sweep_freqs(1.0, 2.0, 3).len(), 3);
+
+        // viz: bind the public entry point as a fn item to prove the path
+        // resolves (its numerics are exercised in viz::tests).
+        let _ = crate::viz::edge_field_to_nodes;
+    }
+}

--- a/crates/geode-util/src/repo.rs
+++ b/crates/geode-util/src/repo.rs
@@ -64,3 +64,99 @@ pub fn current_commit() -> String {
         })
         .unwrap_or_else(|| "unknown".to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_root_is_absolute_and_contains_reference() {
+        let root = repo_root();
+        assert!(
+            root.is_absolute(),
+            "repo_root must be an absolute path, got {}",
+            root.display()
+        );
+        assert!(
+            root.join("reference").is_dir(),
+            "repo_root {} must contain a reference/ directory",
+            root.display()
+        );
+    }
+
+    #[test]
+    fn repo_root_is_stable_across_calls() {
+        // Resolved from a compile-time constant, so repeated calls must
+        // return byte-identical paths.
+        assert_eq!(repo_root(), repo_root());
+    }
+
+    #[test]
+    fn fixture_path_is_rooted_under_reference_fixtures() {
+        let p = fixture_path("sphere_pec/julia_baseline.json");
+        assert!(
+            p.starts_with(repo_root()),
+            "fixture path must live under the repo root"
+        );
+        assert!(
+            p.ends_with("reference/fixtures/sphere_pec/julia_baseline.json"),
+            "unexpected fixture path tail: {}",
+            p.display()
+        );
+    }
+
+    #[test]
+    fn fixture_path_joins_relative_input_onto_fixtures_dir() {
+        // A bare relative file name lands directly in reference/fixtures/.
+        let p = fixture_path("baseline.json");
+        assert_eq!(
+            p,
+            repo_root().join("reference/fixtures").join("baseline.json")
+        );
+        assert!(p.is_absolute());
+    }
+
+    #[test]
+    fn fixture_path_accepts_path_and_pathbuf_inputs() {
+        // `impl AsRef<Path>` must accept the common owned/borrowed forms,
+        // all yielding the same join.
+        let from_str = fixture_path("a/b.json");
+        let from_path = fixture_path(Path::new("a/b.json"));
+        let from_pathbuf = fixture_path(PathBuf::from("a/b.json"));
+        assert_eq!(from_str, from_path);
+        assert_eq!(from_str, from_pathbuf);
+    }
+
+    #[test]
+    fn fixture_path_with_empty_relative_is_the_fixtures_dir() {
+        // Joining an empty relative component is a no-op, so the result is
+        // exactly the fixtures directory itself.
+        assert_eq!(fixture_path(""), repo_root().join("reference/fixtures"));
+    }
+
+    #[test]
+    fn current_commit_is_nonempty_and_trimmed() {
+        let commit = current_commit();
+        assert!(!commit.is_empty(), "current_commit must never be empty");
+        assert_eq!(
+            commit,
+            commit.trim(),
+            "current_commit must be trimmed of surrounding whitespace"
+        );
+    }
+
+    #[test]
+    fn current_commit_is_either_a_sha_or_the_unknown_fallback() {
+        // Deterministic shape check that holds whether or not the test
+        // host has git / is inside a work tree: the result is either the
+        // literal "unknown" fallback or a 40-char lowercase-or-upper hex
+        // SHA-1. We never assert a specific commit.
+        let commit = current_commit();
+        let is_unknown = commit == "unknown";
+        let is_sha = commit.len() == 40 && commit.chars().all(|c| c.is_ascii_hexdigit());
+        assert!(
+            is_unknown || is_sha,
+            "current_commit must be \"unknown\" or a 40-char hex SHA, got {commit:?}"
+        );
+    }
+}

--- a/crates/geode-util/src/viz.rs
+++ b/crates/geode-util/src/viz.rs
@@ -222,4 +222,163 @@ mod tests {
             .any(|v| v.iter().any(|&c| c != 0.0));
         assert!(any_nonzero, "nonzero edge DOFs must reconstruct nonzero E");
     }
+
+    /// Two non-degenerate tets sharing the face `{1, 2, 3}`. Nodes 1, 2, 3
+    /// are incident to both tets (per-node count 2 → exercises the
+    /// averaging divide), while nodes 0 and 4 belong to a single tet.
+    fn two_tets() -> TetMesh {
+        TetMesh {
+            nodes: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            tets: vec![[0, 1, 2, 3], [1, 2, 3, 4]],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cross_dot_sub_match_hand_computed_values() {
+        // Right-handed basis: x × y = z.
+        assert_eq!(cross([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]), [0.0, 0.0, 1.0]);
+        // Parallel vectors have a zero cross product.
+        assert_eq!(cross([2.0, 0.0, 0.0], [3.0, 0.0, 0.0]), [0.0, 0.0, 0.0]);
+        assert_eq!(dot([1.0, 2.0, 3.0], [4.0, -5.0, 6.0]), 4.0 - 10.0 + 18.0);
+        // Orthogonal vectors dot to zero.
+        assert_eq!(dot([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]), 0.0);
+        assert_eq!(sub([1.0, 2.0, 3.0], [0.5, 1.0, 5.0]), [0.5, 1.0, -2.0]);
+    }
+
+    #[test]
+    fn tet_grads_on_reference_tet_are_the_canonical_basis_gradients() {
+        // For the corner tet at {origin, e_x, e_y, e_z} the barycentric
+        // gradients are exactly ∇λ_0 = (-1,-1,-1) and ∇λ_i = e_i.
+        let mesh = unit_tet();
+        let grads = tet_grads(&mesh, &mesh.tets[0]);
+        assert_eq!(grads[0], [-1.0, -1.0, -1.0]);
+        assert_eq!(grads[1], [1.0, 0.0, 0.0]);
+        assert_eq!(grads[2], [0.0, 1.0, 0.0]);
+        assert_eq!(grads[3], [0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn tet_grads_of_degenerate_tet_fall_back_to_zero() {
+        // Four coplanar (z = 0) points give a zero Jacobian determinant;
+        // the `det != 0.0` guard must zero `inv` so every gradient is the
+        // zero vector rather than an inf/NaN from dividing by zero.
+        let mesh = TetMesh {
+            nodes: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            tets: vec![[0, 1, 2, 3]],
+            ..Default::default()
+        };
+        let grads = tet_grads(&mesh, &mesh.tets[0]);
+        for g in grads {
+            assert_eq!(g, [0.0, 0.0, 0.0]);
+            for c in g {
+                assert!(c.is_finite());
+            }
+        }
+    }
+
+    #[test]
+    fn degenerate_tet_reconstructs_to_finite_zero_field() {
+        // With zero gradients the whole interpolant collapses to zero, so
+        // even a nonzero edge excitation reconstructs to an all-zero (and
+        // finite, never NaN) nodal field.
+        let mesh = TetMesh {
+            nodes: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            tets: vec![[0, 1, 2, 3]],
+            ..Default::default()
+        };
+        let e_edges = vec![c64::new(2.0, -3.0); mesh.edges().len()];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        for v in re.iter().chain(im.iter()) {
+            for &c in v {
+                assert_eq!(c, 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn isolated_node_with_no_incident_tet_stays_zero() {
+        // A node referenced by no tet keeps count 0, so the averaging
+        // divide is skipped and its slot stays the zero initializer.
+        let mesh = TetMesh {
+            nodes: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                // Unreferenced extra node.
+                [5.0, 5.0, 5.0],
+            ],
+            tets: vec![[0, 1, 2, 3]],
+            ..Default::default()
+        };
+        let e_edges = vec![c64::new(1.0, 1.0); mesh.edges().len()];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        assert_eq!(re.len(), 5);
+        assert_eq!(re[4], [0.0, 0.0, 0.0]);
+        assert_eq!(im[4], [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn real_and_imaginary_channels_are_independent() {
+        // A purely real excitation must leave the imaginary nodal field
+        // exactly zero (and vice-versa): the accumulation treats re/im as
+        // independent linear channels.
+        let mesh = unit_tet();
+        let n_edges = mesh.edges().len();
+
+        let (re_only_re, re_only_im) =
+            edge_field_to_nodes(&mesh, &vec![c64::new(1.5, 0.0); n_edges]);
+        for v in &re_only_im {
+            assert_eq!(*v, [0.0, 0.0, 0.0]);
+        }
+        assert!(re_only_re.iter().any(|v| v.iter().any(|&c| c != 0.0)));
+
+        let (im_only_re, im_only_im) =
+            edge_field_to_nodes(&mesh, &vec![c64::new(0.0, -2.0); n_edges]);
+        for v in &im_only_re {
+            assert_eq!(*v, [0.0, 0.0, 0.0]);
+        }
+        assert!(im_only_im.iter().any(|v| v.iter().any(|&c| c != 0.0)));
+    }
+
+    #[test]
+    fn multi_tet_mesh_averages_shared_nodes_into_finite_values() {
+        // The two-tet mesh drives the count > 1 averaging path on the
+        // three shared-face nodes. Output stays correctly sized and finite.
+        let mesh = two_tets();
+        assert_eq!(mesh.n_tets(), 2);
+        let e_edges = vec![c64::new(0.7, 0.3); mesh.edges().len()];
+        let (re, im) = edge_field_to_nodes(&mesh, &e_edges);
+        assert_eq!(re.len(), mesh.n_nodes());
+        assert_eq!(im.len(), mesh.n_nodes());
+        for v in re.iter().chain(im.iter()) {
+            for &c in v {
+                assert!(c.is_finite());
+            }
+        }
+        // The excitation is nonzero on non-degenerate tets, so the
+        // reconstruction cannot be identically zero.
+        let any_nonzero = re
+            .iter()
+            .chain(im.iter())
+            .any(|v| v.iter().any(|&c| c != 0.0));
+        assert!(any_nonzero);
+    }
 }


### PR DESCRIPTION
## Summary

Phase 4.1 of Epic #429: brings the under-tested **non-fixture** modules of `geode-util` off zero coverage and deepens `viz` beyond its three existing cases. Test-only — no public behavior changes.

Per-module `#[test]` counts: `repo.rs` 0 → 8, `lib.rs` 0 → 1, `viz.rs` 3 → 10.

## Changes

- **`repo.rs`** — cover all three public functions:
  - `repo_root()`: absolute, contains a `reference/` dir, stable across calls.
  - `fixture_path()`: rooted under `reference/fixtures/`, relative-input join, `&str`/`Path`/`PathBuf` input equivalence, empty-component no-op.
  - `current_commit()`: non-empty and trimmed; deterministic `"unknown"`-or-40-char-hex shape check that holds in or out of a git tree (no specific SHA asserted).
- **`lib.rs`** — crate-root public-surface smoke test reaching one public item per declared module through its crate-root path; guards against an accidental `pub mod` → `mod` downgrade or removal of a re-exported helper.
- **`viz.rs`** — added tests for the private `cross`/`dot`/`sub`/`tet_grads` helpers (incl. the canonical reference-tet gradients), the degenerate-tet `det == 0.0` zero fallback, the isolated-node (`count == 0`) and shared-node (`count > 1`) averaging branches, and real/imaginary channel independence.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `repo.rs` has meaningful tests for all three public fns (no longer 0) | ✅ | 8 tests covering `repo_root`, `fixture_path`, `current_commit` |
| Crate/`lib` level has a public-surface/smoke test (no longer 0) | ✅ | `tests::declared_modules_are_publicly_reachable` |
| `viz.rs` deepened beyond 3 tests, exercising untested paths | ✅ | 10 tests; adds degenerate-det, count==0, count>1, channel-independence branches |
| `cargo test -p geode-util` passes | ✅ | 52 passed; 0 failed |
| `cargo clippy -p geode-util -- -D warnings` clean | ✅ | exit 0 |
| `cargo fmt --check` clean | ✅ | exit 0 |

## Scope fence

Touched only `crates/geode-util/src/{repo.rs, lib.rs, viz.rs}`. `fixture.rs` (Phase 4.2, building in parallel), `convert.rs`, and `interop.rs` are untouched.

## Test Plan

- `cargo test -p geode-util` → 52 passed, 0 failed.
- `cargo clippy -p geode-util --all-targets -- -D warnings` → clean.
- `cargo fmt -p geode-util -- --check` → clean.

Closes #438