### PR TITLE
Refactor utility code into geode-util module

### DIFF
--- a/.github/workflows/arpack.yml
+++ b/.github/workflows/arpack.yml
@@ -51,25 +51,21 @@ jobs:
           key: ${{ runner.os }}-cargo-arpack-${{ hashFiles('**/Cargo.lock') }}
 
       # The runner is headless ubuntu-latest — no Vulkan/CUDA adapter — so
-      # we build against the CPU (`ndarray`) backend instead of the GPU-only
-      # `wgpu` default. `--no-default-features` keeps wgpu (and its native
-      # graphics deps) off the runner entirely. `ndarray` resolves
-      # `DefaultBackend` to `NdArray<f64>`, preserving the f64 precision the
+      # we build against the CPU (`ndarray`) backend.
+      # `ndarray` resolves `TestBackend` to `NdArray<f64>`, preserving the f64 precision the
       # ARPACK oracle test relies on.
       - name: Build geode-core with --features arpack (CPU backend)
         run: |
-          cargo build -p geode-core --no-default-features \
-              --features arpack --release
+          cargo build -p geode-core --features arpack --release
 
       - name: Clippy (arpack + ndarray, CPU backend)
         run: |
-          cargo clippy --tests -p geode-core --no-default-features \
-              --features arpack -- -D warnings
+          cargo clippy --tests -p geode-core --features arpack -- -D warnings
 
       - name: Run the gated sparse-eigensolver acceptance test
         # Issue #24 acceptance: matches dense oracle to 1e-6 at n=5 with
         # the same fixture as the Lanczos check. Runs on the CPU backend so
         # it works headless.
         run: |
-          cargo test --no-default-features --features arpack \
+          cargo test --features arpack \
               -p geode-core --release --test sparse_eigensolver -- --ignored

--- a/.github/workflows/cube-cavity-tolerance.yml
+++ b/.github/workflows/cube-cavity-tolerance.yml
@@ -145,7 +145,7 @@ jobs:
       # eigensolve test path is exercised.
       - name: Run cube_cavity substage test (--ignored --nocapture, ndarray, release)
         run: |
-          cargo test --no-default-features \
+          cargo test \
             --release -p geode-validation \
             --test cube_cavity_numpy_reference \
             -- --ignored --nocapture \

--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -14,10 +14,9 @@ name: doc-lint
 #
 # Backend note (mirrors arpack.yml): the runner is headless
 # `ubuntu-latest` with no Vulkan/CUDA adapter, so we build against the
-# CPU `ndarray` backend (`--no-default-features --features ndarray`)
-# rather than the GPU-only `wgpu` default. The intra-doc links being
+# CPU `ndarray` backend. The intra-doc links being
 # guarded are backend-independent doc comments, so the CPU backend
-# exercises the identical rustdoc surface. The `arpack,ndarray` combo
+# exercises the identical rustdoc surface. The `arpack` combo
 # additionally needs libarpack2-dev.
 
 on:
@@ -60,10 +59,8 @@ jobs:
 
       - name: Build docs (CPU backend)
         run: |
-          cargo doc -p geode-core --no-deps \
-              --no-default-features 
+          cargo doc -p geode-core --no-deps
 
       - name: Build docs (--features arpack, CPU backend)
         run: |
-          cargo doc -p geode-core --no-deps \
-              --no-default-features --features arpack
+          cargo doc -p geode-core --no-deps --features arpack

--- a/.github/workflows/rect-waveguide-modes-debug.yml
+++ b/.github/workflows/rect-waveguide-modes-debug.yml
@@ -96,6 +96,6 @@ jobs:
       # panic and surface the regression on the next push.
       - name: cargo test -p geode-core --test rect_waveguide_modes (debug)
         run: |
-          cargo test --no-default-features \
+          cargo test \
             -p geode-core --test rect_waveguide_modes \
             -- --nocapture

--- a/.run/rustfmt.run.xml
+++ b/.run/rustfmt.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="rustfmt" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="fmt" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,6 +2661,7 @@ dependencies = [
  "criterion",
  "faer",
  "geode-core",
+ "geode-util",
  "mshio",
  "pkg-config",
  "regex",

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -36,7 +36,7 @@ toml = { workspace = true }
 pkg-config = { workspace = true, optional = true }
 
 [features]
-default = ["wgpu"]
+default = []
 
 wgpu = ["burn/wgpu"]
 cuda = ["burn/cuda"]

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -68,6 +68,7 @@ testing = ["dep:regex"]
 # headless CI runner. The backend now comes solely from the top-level
 # feature selection (wgpu by default, or ndarray on CI).
 geode-core = { path = ".", default-features = false, features = ["testing", "autodiff"] }
+geode-util = { workspace = true }
 # Read regression-fixture TOML in `tests/cube_convergence_regression.rs`.
 toml = { workspace = true }
 # Performance benchmark harness (issue #50). Each `[[bench]]` below opts

--- a/crates/geode-core/src/analytic/mie/closed.rs
+++ b/crates/geode-core/src/analytic/mie/closed.rs
@@ -56,6 +56,26 @@ pub enum MiePolarisation {
     TM,
 }
 
+impl MiePolarisation {
+    /// Short label: `"TE"` or `"TM"`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MiePolarisation::TE => "TE",
+            MiePolarisation::TM => "TM",
+        }
+    }
+
+    /// Map a polarisation index (`0 = TE`, `1 = TM`) back to the enum;
+    /// `None` for any other index.
+    pub fn from_index(idx: u8) -> Option<Self> {
+        match idx {
+            0 => Some(MiePolarisation::TE),
+            1 => Some(MiePolarisation::TM),
+            _ => None,
+        }
+    }
+}
+
 /// A single analytic resonance root of the PEC-cavity dielectric
 /// sphere problem.
 #[derive(Debug, Clone, Copy)]

--- a/crates/geode-core/src/analytic/patch.rs
+++ b/crates/geode-core/src/analytic/patch.rs
@@ -53,11 +53,10 @@
 
 use std::f64::consts::PI;
 
-/// Speed of light in vacuum (m/s).
-pub const C_M_PER_S: f64 = 2.997_924_58e8;
-
-/// Free-space impedance η₀ (Ω).
-pub const ETA_0_OHM: f64 = 376.730_313_668;
+/// Speed of light in vacuum (m/s) and free-space impedance η₀ (Ω),
+/// re-exported from [`crate::constants`] so existing
+/// `patch::{C_M_PER_S, ETA_0_OHM}` paths keep resolving.
+pub use crate::constants::{C_M_PER_S, ETA_0_OHM};
 
 /// Rectangular microstrip patch geometry + substrate (lengths in
 /// meters).

--- a/crates/geode-core/src/constants.rs
+++ b/crates/geode-core/src/constants.rs
@@ -1,0 +1,21 @@
+//! Physical / electromagnetic constants shared across the crate and its
+//! consumers (reference tests, example binaries, `geode-util` conversions).
+//!
+//! Centralizes the speed-of-light and free-space-impedance literals that
+//! were otherwise copy-pasted as per-file `const`s. Length-unit variants
+//! of `c` are provided because the FEM meshes carry coordinates in
+//! millimeters or micrometers, and the natural-unit `ω = 2π f / c` then
+//! lands in the matching inverse-length unit (see
+//! `geode_util::units::ghz_to_omega`, which takes the appropriate `c`).
+
+/// Free-space (vacuum) wave impedance `η₀ = √(μ₀/ε₀)`, in ohms.
+pub const ETA_0_OHM: f64 = 376.730_313_668;
+
+/// Speed of light in vacuum, meters per second.
+pub const C_M_PER_S: f64 = 2.997_924_58e8;
+
+/// Speed of light in vacuum, millimeters per second.
+pub const C_MM_PER_S: f64 = 2.997_924_58e11;
+
+/// Speed of light in vacuum, micrometers per second.
+pub const C_UM_PER_S: f64 = 2.997_924_58e14;

--- a/crates/geode-core/src/lib.rs
+++ b/crates/geode-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod analytic;
 pub mod assembly;
+pub mod constants;
 pub mod derham;
 pub mod driven;
 pub mod eigen;

--- a/crates/geode-core/src/mesh/spiral.rs
+++ b/crates/geode-core/src/mesh/spiral.rs
@@ -107,7 +107,7 @@ pub const PORT_E_HAT: [f64; 3] = [0.0, 1.0, 0.0];
 
 /// Free-space impedance η₀ (Ω) used by the natural-unit conversion of
 /// [`SpiralMaterials::conductor_sigma_natural`].
-const Z0_OHM: f64 = 376.730_313_668;
+const Z0_OHM: f64 = crate::constants::ETA_0_OHM;
 
 /// Per-fixture material set applied at solve time (issue #212): the
 /// mesh carries only region tags, so each fixture YAML's recorded
@@ -187,7 +187,7 @@ pub const CONDUCTOR_SIGMA_S_M: f64 = 5.8e7;
 /// `σ_nat = σ_SI · Z₀ · L_unit = 5.8e7 · 376.730 · 1e-6 ≈ 2.185e4 /µm`
 /// (same normalization as
 /// [`crate::driven::solve::SurfaceImpedanceModel::GoodConductor`]).
-pub const CONDUCTOR_SIGMA_NATURAL: f64 = CONDUCTOR_SIGMA_S_M * 376.730_313_668 * 1e-6;
+pub const CONDUCTOR_SIGMA_NATURAL: f64 = CONDUCTOR_SIGMA_S_M * crate::constants::ETA_0_OHM * 1e-6;
 
 /// Raw bytes of the bundled benchmark spiral fixture (MSH 4.1 ASCII).
 const SPIRAL_MSH: &[u8] = include_bytes!("../../tests/fixtures/spiral_3p5.msh");
@@ -515,7 +515,7 @@ mod tests {
         let omega_si = 2.0 * std::f64::consts::PI * f_hz;
         let delta_si_um = (2.0 / (omega_si * mu0 * sigma_si)).sqrt() * 1e6;
 
-        let c_um_per_s = 2.997_924_58e14;
+        let c_um_per_s = crate::constants::C_UM_PER_S;
         let omega_nat = omega_si / c_um_per_s; // rad/µm
         let delta_nat_um = (2.0 / (omega_nat * sigma_nat)).sqrt();
 

--- a/crates/geode-core/tests/patch_antenna_benchmark.rs
+++ b/crates/geode-core/tests/patch_antenna_benchmark.rs
@@ -22,17 +22,13 @@
 
 use faer::c64;
 
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{SweepPoint, driven_frequency_sweep};
 use geode_core::driven::solve::{DrivenBcs, DrivenMaterials};
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::mesh::{PatchFixture, pec_interior_mask_from_triangles, read_patch_smoke_fixture};
 use geode_core::testing::TestBackend;
-
-/// Free-space impedance η₀ (Ω).
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in mm/s (fixture lengths are millimeters).
-const C_MM_PER_S: f64 = 2.997_924_58e11;
+use geode_util::units::ghz_to_omega_mm as ghz_to_omega;
 
 /// UPML strength (quadratic profile). Same family / magnitude as the
 /// Mie driven benchmark's σ₀ = 25.
@@ -41,10 +37,6 @@ const SIGMA_0: f64 = 25.0;
 /// Smoke-fixture UPML shell thickness (mm) — must match
 /// `reference/gmsh/patch_2g4_smoke.yaml` `pml_thick`.
 const SMOKE_PML_THICK: f64 = 8.0;
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_MM_PER_S
-}
 
 /// Run one matched-UPML, PEC-conductor, port-driven solve on the smoke
 /// fixture at the given frequency.

--- a/crates/geode-core/tests/patch_antenna_extraction.rs
+++ b/crates/geode-core/tests/patch_antenna_extraction.rs
@@ -58,6 +58,7 @@ use std::path::PathBuf;
 use faer::c64;
 
 use geode_core::analytic::patch::PatchCavity;
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::s11;
 use geode_core::driven::ports::{port_current, port_voltage};
 use geode_core::driven::scattering::flux_power_box;
@@ -67,12 +68,7 @@ use geode_core::driven::solve::{
 use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::mesh::{PatchFixture, pec_interior_mask_from_triangles, read_patch_smoke_fixture};
 use geode_core::testing::TestBackend;
-
-/// Free-space impedance η₀ (Ω).
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in mm/s (fixture lengths are millimeters).
-const C_MM_PER_S: f64 = 2.997_924_58e11;
+use geode_util::units::ghz_to_omega_mm as ghz_to_omega;
 
 /// Port reference resistance (Ω).
 const R_PORT_OHM: f64 = 50.0;
@@ -102,10 +98,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_MM_PER_S
 }
 
 /// One parsed committed sweep row.

--- a/crates/geode-core/tests/patch_antenna_matched.rs
+++ b/crates/geode-core/tests/patch_antenna_matched.rs
@@ -41,6 +41,7 @@ use std::path::PathBuf;
 use faer::c64;
 
 use geode_core::analytic::patch::PatchCavity;
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::s11;
 use geode_core::driven::ports::{port_current, port_voltage};
 use geode_core::driven::scattering::flux_power_box;
@@ -52,11 +53,8 @@ use geode_core::mesh::{
     PatchFixture, pec_interior_mask_from_triangles, read_patch_matched_fixture,
 };
 use geode_core::testing::TestBackend;
+use geode_util::units::ghz_to_omega_mm as ghz_to_omega;
 
-/// Free-space impedance η₀ (Ω).
-const ETA_0: f64 = 376.730_313_668;
-/// Speed of light in mm/s (fixture lengths are millimeters).
-const C_MM_PER_S: f64 = 2.997_924_58e11;
 /// Port reference resistance (Ω).
 const R_PORT_OHM: f64 = 50.0;
 /// Matched box-UPML strength (matches the example).
@@ -87,10 +85,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_MM_PER_S
 }
 
 struct Row {

--- a/crates/geode-core/tests/patch_antenna_radiation.rs
+++ b/crates/geode-core/tests/patch_antenna_radiation.rs
@@ -61,6 +61,7 @@ use std::path::PathBuf;
 use faer::c64;
 
 use geode_core::analytic::patch::PatchCavity;
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::ports::{port_current, port_voltage};
 use geode_core::driven::scattering::flux_power_box;
 use geode_core::driven::solve::{
@@ -70,9 +71,8 @@ use geode_core::mesh::patch::FR4_MATERIALS;
 use geode_core::mesh::{PatchFixture, pec_interior_mask_from_triangles, read_patch_smoke_fixture};
 use geode_core::postproc::ntff::{broadside_directivity, directivity, gain, ntff_far_field};
 use geode_core::testing::TestBackend;
+use geode_util::units::ghz_to_omega_mm as ghz_to_omega;
 
-const ETA_0: f64 = 376.730_313_668;
-const C_MM_PER_S: f64 = 2.997_924_58e11;
 const R_PORT_OHM: f64 = 50.0;
 const SIGMA_0: f64 = 25.0;
 const PML_THICK_BENCH_MM: f64 = 25.0;
@@ -100,10 +100,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_MM_PER_S
 }
 
 /// A parsed `[cut.*]` principal-plane block.

--- a/crates/geode-core/tests/slcfet_3hp_benchmark.rs
+++ b/crates/geode-core/tests/slcfet_3hp_benchmark.rs
@@ -51,6 +51,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use geode_core::analytic::spiral::{SquareSpiral, mohan_current_sheet_l};
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{SweepPoint, driven_frequency_sweep};
 use geode_core::driven::solve::{
     CurrentSource, DrivenBcs, DrivenMaterials, SurfaceImpedanceBc, SurfaceImpedanceModel,
@@ -60,12 +61,7 @@ use geode_core::mesh::{
     read_spiral_slcfet_3hp_fixture, read_spiral_slcfet_3hp_smoke_fixture,
 };
 use geode_core::testing::TestBackend;
-
-/// Free-space impedance η₀ (Ω).
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in µm/s (fixture lengths are microns).
-const C_UM_PER_S: f64 = 2.997_924_58e14;
+use geode_util::units::ghz_to_omega_um as ghz_to_omega;
 
 /// Reference frequency for the **Q** tracking ratio: 3 GHz — the mom
 /// 3HP LUT reference frequency; Au skin depth 1.28 µm < 2.25 µm OVERLAY
@@ -96,10 +92,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_UM_PER_S
 }
 
 /// Run the benchmark pipeline (Leontovich Au conductor surface, PEC

--- a/crates/geode-core/tests/sphere_matched_upml_eigenmode.rs
+++ b/crates/geode-core/tests/sphere_matched_upml_eigenmode.rs
@@ -64,6 +64,7 @@ use geode_core::eigen::complex::{SparseComplexEigenSolver, SparseComplexShiftInv
 use geode_core::eigen::dense::burn_matrix_to_faer;
 use geode_core::mesh::{PHYS_SPHERE_INTERIOR, R_BUFFER, TetMesh, read_sphere_fixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::k_from_lambda;
 
 type B = TestBackend;
 
@@ -91,15 +92,6 @@ fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
         .map(|row| std::array::from_fn(|i| row[i].1))
         .collect();
     (idx, sign)
-}
-
-/// Principal-branch `k = sqrt(λ)` with `Re(k) ≥ 0`.
-fn k_from_lambda(lam: c64) -> (f64, f64) {
-    let r = (lam.re * lam.re + lam.im * lam.im).sqrt();
-    let re_k = ((r + lam.re) / 2.0).sqrt();
-    let im_mag = ((r - lam.re) / 2.0).sqrt();
-    let im_k = if lam.im >= 0.0 { im_mag } else { -im_mag };
-    (re_k, im_k)
 }
 
 fn tm11_root() -> MieRootComplex {

--- a/crates/geode-core/tests/spiral_inductor_benchmark.rs
+++ b/crates/geode-core/tests/spiral_inductor_benchmark.rs
@@ -54,6 +54,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use geode_core::analytic::spiral::{SquareSpiral, mohan_current_sheet_l};
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{SweepPoint, driven_frequency_sweep};
 use geode_core::driven::solve::{
     CurrentSource, DrivenBcs, DrivenMaterials, SurfaceImpedanceBc, SurfaceImpedanceModel,
@@ -63,12 +64,7 @@ use geode_core::mesh::{
     SpiralFixture, pec_interior_mask_from_triangles, read_spiral_fixture, read_spiral_smoke_fixture,
 };
 use geode_core::testing::TestBackend;
-
-/// Free-space impedance η₀ (Ω).
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in µm/s (fixture lengths are microns).
-const C_UM_PER_S: f64 = 2.997_924_58e14;
+use geode_util::units::ghz_to_omega_um as ghz_to_omega;
 
 /// Low-frequency reference point for the L comparison (see the
 /// benchmark example for why 1 GHz: on the L plateau, inside the
@@ -87,10 +83,6 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_UM_PER_S
 }
 
 /// Run the benchmark pipeline (Leontovich conductor surface, PEC outer

--- a/crates/geode-util/src/compare.rs
+++ b/crates/geode-util/src/compare.rs
@@ -1,0 +1,221 @@
+//! Comparison / assertion helpers for the reference-test suite.
+//!
+//! Staging home (Epic #414) for the small tolerance-comparison and
+//! array-assertion utilities that were copy-pasted across the
+//! `geode-validation` reference tests: the mixed absolute/relative
+//! tolerance check ([`MixedTol`] / [`check_close`]) and the labeled
+//! integer-array equality assertion ([`assert_i64_eq`]).
+
+use crate::convert::CsrI64;
+use crate::fixture::{Fixture, fixture_array_i64, fixture_scalar_i64, fixture_shape};
+
+/// A mixed absolute/relative tolerance: a value `got` is accepted against
+/// `want` when `|got - want| <= abs + rel * |want|` (optionally floored;
+/// see [`check_close`]).
+#[derive(Debug, Clone, Copy)]
+pub struct MixedTol {
+    /// Relative tolerance, multiplied by `|want|`.
+    pub rel: f64,
+    /// Absolute tolerance floor.
+    pub abs: f64,
+}
+
+/// Mixed absolute/relative closeness check with an optional per-call
+/// absolute floor.
+///
+/// The effective allowed error is `max(abs + rel*|want|, fixture_floor)` —
+/// the looser of the mixed envelope and a fixture-declared absolute floor.
+/// Pass `fixture_floor = 0.0` when no floor applies (the P1-local case);
+/// the Nédélec-local case threads the fixture's own `tolerance_abs`.
+///
+/// Returns `Ok(())` on success or a descriptive `Err(String)` naming the
+/// field, the values, and the tolerance breakdown. Replaces the
+/// `check_close` helper duplicated across the `*_local_numpy` reference
+/// tests.
+pub fn check_close(
+    got: f64,
+    want: f64,
+    tol: MixedTol,
+    fixture_floor: f64,
+    label: &str,
+) -> Result<(), String> {
+    let abs_err = (got - want).abs();
+    let mixed = tol.abs + tol.rel * want.abs();
+    let allowed = mixed.max(fixture_floor);
+    if abs_err <= allowed {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label}: got {got:.17e}, want {want:.17e}, |err| = {abs_err:.3e} \
+             (allowed {allowed:.3e} = max(mixed {mixed:.3e}, fixture_floor {fixture_floor:.3e}); \
+             rel_tol={:.0e}, abs_tol={:.0e})",
+            tol.rel, tol.abs
+        ))
+    }
+}
+
+/// Assert two `i64` slices are equal, panicking with a labeled,
+/// context-windowed message at the first disagreement.
+///
+/// Replaces the `assert_i64_eq` helper duplicated across the `derham_*`
+/// reference tests.
+pub fn assert_i64_eq(name: &str, got: &[i64], want: &[i64]) {
+    assert_eq!(
+        got.len(),
+        want.len(),
+        "{name}: length mismatch (Burn {} vs NumPy {})",
+        got.len(),
+        want.len()
+    );
+    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+        if g != w {
+            // Print a small surrounding window for context.
+            let lo = i.saturating_sub(2);
+            let hi = (i + 3).min(got.len());
+            panic!(
+                "{name}: first disagreement at index {i}: Burn = {g}, NumPy = {w}\n\
+                 surrounding window (Burn): {:?}\n\
+                 surrounding window (NumPy): {:?}",
+                &got[lo..hi],
+                &want[lo..hi]
+            );
+        }
+    }
+}
+
+/// Cross-check an integer CSR operator against a fixture's `{prefix}_*`
+/// fields — `{prefix}_shape`, `{prefix}_nnz`, `{prefix}_indptr`,
+/// `{prefix}_indices`, `{prefix}_data` — with bit-exact integer equality.
+///
+/// Replaces the `cross_check_operator` helper duplicated across the
+/// `derham_*` reference tests.
+pub fn cross_check_operator(prefix: &str, csr: &CsrI64, fixture: &Fixture) {
+    // Shape.
+    let want_shape = fixture_shape(fixture, &format!("{prefix}_shape"));
+    assert_eq!(
+        (csr.n_rows, csr.n_cols),
+        want_shape,
+        "{prefix} shape: Burn = ({}, {}), NumPy = ({}, {})",
+        csr.n_rows,
+        csr.n_cols,
+        want_shape.0,
+        want_shape.1
+    );
+
+    // nnz.
+    let want_nnz = fixture_scalar_i64(fixture, &format!("{prefix}_nnz")) as usize;
+    assert_eq!(
+        csr.nnz(),
+        want_nnz,
+        "{prefix} nnz: Burn = {}, NumPy = {want_nnz}",
+        csr.nnz()
+    );
+
+    // indptr / indices / data — bit-exact integer equality.
+    assert_i64_eq(
+        &format!("{prefix}_indptr"),
+        &csr.indptr,
+        &fixture_array_i64(fixture, &format!("{prefix}_indptr")),
+    );
+    assert_i64_eq(
+        &format!("{prefix}_indices"),
+        &csr.indices,
+        &fixture_array_i64(fixture, &format!("{prefix}_indices")),
+    );
+    assert_i64_eq(
+        &format!("{prefix}_data"),
+        &csr.data,
+        &fixture_array_i64(fixture, &format!("{prefix}_data")),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn check_close_accepts_within_mixed_envelope() {
+        let tol = MixedTol {
+            rel: 1e-9,
+            abs: 1e-12,
+        };
+        assert!(check_close(1.0, 1.0 + 1e-12, tol, 0.0, "x").is_ok());
+    }
+
+    #[test]
+    fn check_close_rejects_outside_envelope() {
+        let tol = MixedTol { rel: 0.0, abs: 0.0 };
+        let err = check_close(1.0, 2.0, tol, 0.0, "field").unwrap_err();
+        assert!(err.contains("field"));
+    }
+
+    #[test]
+    fn check_close_fixture_floor_relaxes_tight_tolerance() {
+        // |err| = 5, mixed envelope = 0, fixture_floor = 10 -> allowed = 10 -> Ok.
+        let tol = MixedTol { rel: 0.0, abs: 0.0 };
+        assert!(check_close(0.0, 5.0, tol, 10.0, "x").is_ok());
+    }
+
+    #[test]
+    fn assert_i64_eq_passes_on_equal() {
+        assert_i64_eq("v", &[1, 2, 3], &[1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "first disagreement")]
+    fn assert_i64_eq_panics_on_value_mismatch() {
+        assert_i64_eq("v", &[1, 2, 3], &[1, 9, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "length mismatch")]
+    fn assert_i64_eq_panics_on_length_mismatch() {
+        assert_i64_eq("v", &[1, 2], &[1, 2, 3]);
+    }
+
+    /// Fixture mirroring the `[[1,0],[-1,1]]` operator under prefix `d`.
+    fn operator_fixture() -> Fixture {
+        let value = json!({
+            "schema_version": "1",
+            "fixture_id": "unit/cross_check_operator",
+            "description": "",
+            "units": "",
+            "inputs": {},
+            "outputs": {
+                "d_shape":   {"shape": [2], "dtype": "f64", "tolerance_abs": 0.0, "data": [2, 2]},
+                "d_nnz":     {"shape": [1], "dtype": "f64", "tolerance_abs": 0.0, "data": [3]},
+                "d_indptr":  {"shape": [3], "dtype": "f64", "tolerance_abs": 0.0, "data": [0, 1, 3]},
+                "d_indices": {"shape": [3], "dtype": "f64", "tolerance_abs": 0.0, "data": [0, 0, 1]},
+                "d_data":    {"shape": [3], "dtype": "f64", "tolerance_abs": 0.0, "data": [1, -1, 1]},
+            },
+            "provenance": {"source": "unit test"},
+        });
+        serde_json::from_value(value).expect("operator fixture should deserialize")
+    }
+
+    #[test]
+    fn cross_check_operator_matches_fixture() {
+        let csr = CsrI64 {
+            n_rows: 2,
+            n_cols: 2,
+            indptr: vec![0, 1, 3],
+            indices: vec![0, 0, 1],
+            data: vec![1, -1, 1],
+        };
+        cross_check_operator("d", &csr, &operator_fixture());
+    }
+
+    #[test]
+    #[should_panic]
+    fn cross_check_operator_detects_sign_drift() {
+        let csr = CsrI64 {
+            n_rows: 2,
+            n_cols: 2,
+            indptr: vec![0, 1, 3],
+            indices: vec![0, 0, 1],
+            data: vec![1, 1, 1], // the -1 entry flipped sign
+        };
+        cross_check_operator("d", &csr, &operator_fixture());
+    }
+}

--- a/crates/geode-util/src/convert.rs
+++ b/crates/geode-util/src/convert.rs
@@ -16,7 +16,80 @@
 //! duplicated across the `geode-validation` reference tests, and localizing
 //! the assumption so a future faer type split would surface in one place.
 
+use faer::sparse::SparseColMat;
 use num_complex::Complex64;
+
+/// A compressed-sparse-row integer matrix — the row-pointer / column-index
+/// / value triple for an operator whose entries are exact integers.
+///
+/// Mirrors the NumPy-side CSR layout of the de Rham ±1 incidence operators
+/// so the reference tests can cross-check them with bit-exact integer
+/// equality.
+#[derive(Debug, Clone)]
+pub struct CsrI64 {
+    pub n_rows: usize,
+    pub n_cols: usize,
+    pub indptr: Vec<i64>,
+    pub indices: Vec<i64>,
+    pub data: Vec<i64>,
+}
+
+impl CsrI64 {
+    /// Number of stored (structurally nonzero) entries.
+    #[must_use]
+    pub fn nnz(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// Convert a faer sparse `f64` matrix to [`CsrI64`], asserting every stored
+/// value is in the integer contract `{-1, 0, +1}`.
+///
+/// Panics if a nonzero entry is not exactly `±1`: the de Rham incidence
+/// operators are integer by construction, so a non-integer entry signals
+/// corruption of the Rust source of truth. Replaces the
+/// `faer_signed_csc_to_csr_i64` helper duplicated across the `derham_*`
+/// reference tests.
+pub fn faer_signed_csc_to_csr_i64(m: &SparseColMat<usize, f64>) -> CsrI64 {
+    let dense = m.to_dense();
+    let n_rows = dense.nrows();
+    let n_cols = dense.ncols();
+
+    let mut indptr: Vec<i64> = Vec::with_capacity(n_rows + 1);
+    let mut indices: Vec<i64> = Vec::new();
+    let mut data: Vec<i64> = Vec::new();
+    indptr.push(0);
+    for r in 0..n_rows {
+        for c in 0..n_cols {
+            let v = dense[(r, c)];
+            if v == 0.0 {
+                continue;
+            }
+            // The de Rham operators are integer ±1; assert no drift.
+            let iv: i64 = if v == 1.0 {
+                1
+            } else if v == -1.0 {
+                -1
+            } else {
+                panic!(
+                    "Burn-side de Rham operator entry ({r}, {c}) = {v} \
+                     is not in the integer contract {{-1, 0, +1}}; the \
+                     Rust source of truth has been corrupted somehow."
+                );
+            };
+            indices.push(c as i64);
+            data.push(iv);
+        }
+        indptr.push(data.len() as i64);
+    }
+    CsrI64 {
+        n_rows,
+        n_cols,
+        indptr,
+        indices,
+        data,
+    }
+}
 
 /// Copy a slice of complex scalars into an owned `Vec<Complex64>`.
 ///
@@ -96,5 +169,44 @@ mod tests {
             out,
             vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)]
         );
+    }
+
+    #[test]
+    fn csr_nnz_counts_stored_entries() {
+        let csr = CsrI64 {
+            n_rows: 2,
+            n_cols: 2,
+            indptr: vec![0, 1, 3],
+            indices: vec![0, 0, 1],
+            data: vec![1, -1, 1],
+        };
+        assert_eq!(csr.nnz(), 3);
+    }
+
+    #[test]
+    fn signed_csc_to_csr_is_row_major_pm1() {
+        use faer::sparse::{SparseColMat, Triplet};
+        // [[1, 0], [-1, 1]] — row-major CSR: indptr [0,1,3], cols [0,0,1], data [1,-1,1].
+        let trips = vec![
+            Triplet::new(0usize, 0usize, 1.0f64),
+            Triplet::new(1, 0, -1.0),
+            Triplet::new(1, 1, 1.0),
+        ];
+        let m = SparseColMat::<usize, f64>::try_new_from_triplets(2, 2, &trips).unwrap();
+        let csr = faer_signed_csc_to_csr_i64(&m);
+        assert_eq!((csr.n_rows, csr.n_cols), (2, 2));
+        assert_eq!(csr.indptr, vec![0, 1, 3]);
+        assert_eq!(csr.indices, vec![0, 0, 1]);
+        assert_eq!(csr.data, vec![1, -1, 1]);
+        assert_eq!(csr.nnz(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "integer contract")]
+    fn signed_csc_to_csr_rejects_non_pm1_entry() {
+        use faer::sparse::{SparseColMat, Triplet};
+        let trips = vec![Triplet::new(0usize, 0usize, 2.0f64)];
+        let m = SparseColMat::<usize, f64>::try_new_from_triplets(1, 1, &trips).unwrap();
+        let _ = faer_signed_csc_to_csr_i64(&m);
     }
 }

--- a/crates/geode-util/src/eigen.rs
+++ b/crates/geode-util/src/eigen.rs
@@ -1,0 +1,201 @@
+use faer::{Mat, MatRef};
+use num_complex::Complex64;
+
+/// Compute the lowest-`n` generalized eigenpairs of `K x = λ M x`
+/// using faer's dense `generalized_eigen`.
+///
+/// Returns `(eigvals, eigvecs)` with `eigvals` ascending and `eigvecs`
+/// as columns of an `(n_int, n)` matrix. Eigenvectors are
+/// M-orthonormalized post-hoc via modified Gram–Schmidt within each
+/// degenerate cluster, so the comparison against the NumPy reference
+/// (which is M-orthonormal by `eigsh` construction) is consistent.
+///
+/// The existing `FaerDenseEigensolver` trait only returns eigenvalues;
+/// extending it to return eigenpairs is tracked as a follow-up. For
+/// now, we inline the eigenvector path in this test.
+pub fn dense_lowest_eigenpairs(
+    k: MatRef<f64>,
+    m: MatRef<f64>,
+    n_take: usize,
+) -> (Vec<f64>, Mat<f64>) {
+    let dim = k.nrows();
+    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
+    let s_a = evd.S_a().column_vector();
+    let s_b = evd.S_b().column_vector();
+    let u = evd.U();
+
+    // Build (real eigenvalue, eigenvector) tuples, filtering complex pairs.
+    let mut pairs: Vec<(f64, Vec<f64>)> = Vec::with_capacity(dim);
+    for i in 0..dim {
+        let a = s_a[i];
+        let b = s_b[i];
+        let denom = b.norm_sqr();
+        if denom < 1e-30 {
+            continue;
+        }
+        let re = (a.re * b.re + a.im * b.im) / denom;
+        let im = (a.im * b.re - a.re * b.im) / denom;
+        // Skip eigenvalues with non-trivial imaginary part (shouldn't
+        // happen for our SPD pencil but the API doesn't promise it).
+        if im.abs() > 1e-9 * re.abs().max(1.0) {
+            continue;
+        }
+        // Real eigenvector — for an SPD pencil U columns are real to
+        // f64 precision modulo a global phase. Take the real part.
+        let mut v = Vec::with_capacity(dim);
+        for row in 0..dim {
+            v.push(u[(row, i)].re);
+        }
+        pairs.push((re, v));
+    }
+
+    pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    pairs.truncate(n_take);
+
+    let n = pairs.len();
+    let eigvals: Vec<f64> = pairs.iter().map(|(l, _)| *l).collect();
+    let mut q = Mat::<f64>::zeros(dim, n);
+    for (j, (_, v)) in pairs.iter().enumerate() {
+        for i in 0..dim {
+            q[(i, j)] = v[i];
+        }
+    }
+
+    // M-normalize each column so v^T M v = 1.
+    for j in 0..n {
+        let col = column_as_vec(q.as_ref(), j);
+        let norm_sq = quad_form(&col, m, &col);
+        let scale = 1.0 / norm_sq.max(1e-300).sqrt();
+        for i in 0..dim {
+            q[(i, j)] *= scale;
+        }
+    }
+
+    (eigvals, q)
+}
+
+/// The lowest-`n` generalized eigenvalues of `K x = λ M x`, ascending.
+///
+/// Eigenvalues-only convenience over [`dense_lowest_eigenpairs`] (drops
+/// the eigenvector matrix). Replaces the `dense_lowest_eigenvalues` helper
+/// duplicated across the `sphere_pec_*` reference tests.
+pub fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
+    dense_lowest_eigenpairs(k, m, n_take).0
+}
+
+/// Principal complex square root `k = √λ` of a complex eigenvalue
+/// `λ = k²`, returned as `(Re k, Im k)`.
+///
+/// `Re k = √(½(|λ| + Re λ))` (clamped at zero against roundoff); `Im k`
+/// takes the sign of `Im λ`. Replaces the `k_from_lambda` helper
+/// duplicated in the open-quasimode example and the matched-UPML test.
+pub fn k_from_lambda(lambda: Complex64) -> (f64, f64) {
+    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
+    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
+    let im_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
+    let im_k = if lambda.im >= 0.0 { im_mag } else { -im_mag };
+    (re_k, im_k)
+}
+
+/// Real part of the resonant wavenumber `k = √λ` for `λ = k²` — the
+/// `Re k` projection of [`k_from_lambda`].
+///
+/// Replaces the `re_k_from_lambda` helper duplicated across the
+/// `sphere_mie_*` reference tests.
+pub fn re_k_from_lambda(lambda: Complex64) -> f64 {
+    k_from_lambda(lambda).0
+}
+
+/// Quality factor of a complex wavenumber `k`: `Q = Re k / (2 |Im k|)`,
+/// or `+∞` when the mode is (numerically) lossless.
+pub fn q_factor(k: Complex64) -> f64 {
+    if k.im.abs() > 1e-12 {
+        k.re / (2.0 * k.im.abs())
+    } else {
+        f64::INFINITY
+    }
+}
+
+/// Quality factor from a complex eigenvalue `λ = k²` — composes
+/// [`k_from_lambda`] with [`q_factor`].
+///
+/// Replaces the `q_factor_from_lambda` helper duplicated across the
+/// `sphere_mie_*` reference tests.
+pub fn q_factor_from_lambda(lambda: Complex64) -> f64 {
+    let (re_k, im_k) = k_from_lambda(lambda);
+    q_factor(Complex64::new(re_k, im_k))
+}
+
+fn column_as_vec(m: MatRef<f64>, j: usize) -> Vec<f64> {
+    (0..m.nrows()).map(|i| m[(i, j)]).collect()
+}
+
+/// `x^T A y` for dense `A` and slices `x, y`.
+fn quad_form(x: &[f64], a: MatRef<f64>, y: &[f64]) -> f64 {
+    let n = x.len();
+    debug_assert_eq!(n, a.nrows());
+    debug_assert_eq!(n, a.ncols());
+    debug_assert_eq!(n, y.len());
+    let mut s = 0.0_f64;
+    for i in 0..n {
+        let xi = x[i];
+        let mut row_dot = 0.0_f64;
+        for j in 0..n {
+            row_dot += a[(i, j)] * y[j];
+        }
+        s += xi * row_dot;
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn re_k_from_real_lambda_is_principal_sqrt() {
+        // λ = 4 + 0i -> k = 2.
+        assert!((re_k_from_lambda(Complex64::new(4.0, 0.0)) - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn q_factor_is_infinite_for_lossless_mode() {
+        assert!(q_factor_from_lambda(Complex64::new(9.0, 0.0)).is_infinite());
+    }
+
+    #[test]
+    fn re_k_and_q_recover_known_complex_wavenumber() {
+        // k = 10 + 0.5i  =>  λ = k² = 99.75 + 10i; Q = Re k / (2 Im k) = 10.
+        let lambda = Complex64::new(99.75, 10.0);
+        assert!((re_k_from_lambda(lambda) - 10.0).abs() < 1e-9);
+        assert!((q_factor_from_lambda(lambda) - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn k_from_lambda_recovers_signed_imaginary_part() {
+        // k = 10 + 0.5i -> λ = 99.75 + 10i (Im λ > 0 -> Im k > 0).
+        let (re_k, im_k) = k_from_lambda(Complex64::new(99.75, 10.0));
+        assert!((re_k - 10.0).abs() < 1e-9);
+        assert!((im_k - 0.5).abs() < 1e-9);
+        // Conjugate eigenvalue flips the sign of Im k.
+        let (_, im_k_conj) = k_from_lambda(Complex64::new(99.75, -10.0));
+        assert!((im_k_conj + 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn q_factor_of_complex_wavenumber() {
+        assert!((q_factor(Complex64::new(10.0, 0.5)) - 10.0).abs() < 1e-12);
+        assert!(q_factor(Complex64::new(3.0, 0.0)).is_infinite());
+    }
+
+    #[test]
+    fn dense_lowest_eigenvalues_of_diagonal_pencil() {
+        // K = diag(3, 1, 2), M = I  =>  eigenvalues {1, 2, 3}; lowest two = [1, 2].
+        let k = Mat::<f64>::from_fn(3, 3, |i, j| if i == j { [3.0, 1.0, 2.0][i] } else { 0.0 });
+        let m = Mat::<f64>::from_fn(3, 3, |i, j| if i == j { 1.0 } else { 0.0 });
+        let eigs = dense_lowest_eigenvalues(k.as_ref(), m.as_ref(), 2);
+        assert_eq!(eigs.len(), 2);
+        assert!((eigs[0] - 1.0).abs() < 1e-9);
+        assert!((eigs[1] - 2.0).abs() < 1e-9);
+    }
+}

--- a/crates/geode-util/src/fixture.rs
+++ b/crates/geode-util/src/fixture.rs
@@ -1446,4 +1446,135 @@ median_ns = 6.0
         assert_eq!(flatten_to_f64(&json!({})), Vec::<f64>::new());
         assert_eq!(flatten_to_f64(&json!(null)), Vec::<f64>::new());
     }
+
+    #[test]
+    fn fixture_scalar_f64_reads_single_value() {
+        let fx = scalar_fixture(&[], &[("x", json!([2.5]))]);
+        assert_eq!(fixture_scalar_f64(&fx, "x"), 2.5);
+    }
+
+    #[test]
+    fn fixture_array_f64_returns_full_payload() {
+        let fx = scalar_fixture(&[], &[("v", json!([1.0, -2.0, 3.5]))]);
+        assert_eq!(fixture_array_f64(&fx, "v"), vec![1.0, -2.0, 3.5]);
+    }
+
+    #[test]
+    fn fixture_scalar_usize_rounds_to_index() {
+        let fx = scalar_fixture(&[], &[("n", json!([4.0]))]);
+        assert_eq!(fixture_scalar_usize(&fx, "n"), 4usize);
+    }
+
+    #[test]
+    fn fixture_array_usize_rounds_each_entry() {
+        let fx = scalar_fixture(&[], &[("ns", json!([0.0, 2.0, 5.0]))]);
+        assert_eq!(fixture_array_usize(&fx, "ns"), vec![0usize, 2, 5]);
+    }
+
+    #[test]
+    fn small_sphere_mesh_path_points_at_reference_asset() {
+        let p = small_sphere_mesh_path();
+        assert!(p.is_absolute());
+        assert!(p.ends_with("reference/fixtures/sphere_pml_small/sphere.msh"));
+    }
+
+    #[test]
+    fn load_small_sphere_fixture_parses_committed_mesh() {
+        let f = load_small_sphere_fixture();
+        assert!(f.mesh.n_nodes() > 0, "small sphere mesh should have nodes");
+        assert!(f.mesh.n_tets() > 0, "small sphere mesh should have tets");
+    }
+}
+
+pub fn fixture_scalar_i64(fixture: &Fixture, name: &str) -> i64 {
+    let f = fixture
+        .output_f64(name)
+        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
+    assert_eq!(
+        f.data.len(),
+        1,
+        "fixture scalar `{name}` should be length 1, got {}",
+        f.data.len()
+    );
+    f.data[0].round() as i64
+}
+
+pub fn fixture_shape(fixture: &Fixture, name: &str) -> (usize, usize) {
+    let f = fixture
+        .output_f64(name)
+        .unwrap_or_else(|e| panic!("fixture missing shape output `{name}`: {e}"));
+    assert_eq!(
+        f.data.len(),
+        2,
+        "fixture shape `{name}` should be length 2, got {}",
+        f.data.len()
+    );
+    (f.data[0].round() as usize, f.data[1].round() as usize)
+}
+
+pub fn fixture_array_i64(fixture: &Fixture, name: &str) -> Vec<i64> {
+    let f = fixture
+        .output_f64(name)
+        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"));
+    f.data.iter().map(|v| v.round() as i64).collect()
+}
+
+/// A required length-1 f64 scalar output. f64 sibling of
+/// [`fixture_scalar_i64`]; replaces the `fixture_scalar_f64` helper
+/// duplicated across the `mie_roots_*` reference tests.
+pub fn fixture_scalar_f64(fixture: &Fixture, name: &str) -> f64 {
+    let f = fixture
+        .output_f64(name)
+        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
+    assert_eq!(
+        f.data.len(),
+        1,
+        "fixture scalar `{name}` should be length 1, got {}",
+        f.data.len()
+    );
+    f.data[0]
+}
+
+/// A required f64 array output. f64 sibling of [`fixture_array_i64`];
+/// replaces the `fixture_array_f64` helper duplicated across the
+/// `mie_roots_*` reference tests.
+pub fn fixture_array_f64(fixture: &Fixture, name: &str) -> Vec<f64> {
+    fixture
+        .output_f64(name)
+        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"))
+        .data
+        .clone()
+}
+
+/// A required length-1 `usize` scalar output (rounded). `usize` sibling of
+/// [`fixture_scalar_i64`]; replaces the `fixture_scalar_usize` helper in
+/// the `mie_roots_*` reference tests.
+pub fn fixture_scalar_usize(fixture: &Fixture, name: &str) -> usize {
+    fixture_scalar_i64(fixture, name) as usize
+}
+
+/// A required `usize` array output (rounded). `usize` sibling of
+/// [`fixture_array_i64`]; replaces the `fixture_array_usize` helper in the
+/// `mie_roots_*` reference tests.
+pub fn fixture_array_usize(fixture: &Fixture, name: &str) -> Vec<usize> {
+    fixture_array_i64(fixture, name)
+        .into_iter()
+        .map(|v| v as usize)
+        .collect()
+}
+
+/// Path to the small-sphere reference mesh
+/// (`reference/fixtures/sphere_pml_small/sphere.msh`), shared by the
+/// `sphere_mie_*` / `sphere_pml_numpy` reference tests.
+pub fn small_sphere_mesh_path() -> std::path::PathBuf {
+    crate::repo::fixture_path("sphere_pml_small/sphere.msh")
+}
+
+/// Load the small-sphere reference fixture from its committed `.msh`.
+///
+/// Replaces the `load_small_sphere_fixture` helper duplicated across the
+/// `sphere_mie_*` / `sphere_pml_numpy` reference tests.
+pub fn load_small_sphere_fixture() -> geode_core::mesh::SphereFixture {
+    let bytes = std::fs::read(small_sphere_mesh_path()).expect("read small-mesh sphere.msh bytes");
+    geode_core::mesh::read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
 }

--- a/crates/geode-util/src/lib.rs
+++ b/crates/geode-util/src/lib.rs
@@ -23,10 +23,14 @@
 //! crates into the modules declared below as pure code-moves. Each module's
 //! doc header records what lands there.
 
+pub mod compare;
 pub mod convert;
+pub mod eigen;
 pub mod fixture;
 pub mod interop;
+pub mod math;
 pub mod repo;
+pub mod units;
 pub mod viz;
 
 #[cfg(test)]

--- a/crates/geode-util/src/math.rs
+++ b/crates/geode-util/src/math.rs
@@ -1,0 +1,95 @@
+use faer::MatRef;
+use faer::sparse::SparseColMat;
+
+pub fn frobenius_norm(m: MatRef<f64>) -> f64 {
+    let mut s = 0.0_f64;
+    for j in 0..m.ncols() {
+        for i in 0..m.nrows() {
+            let v = m[(i, j)];
+            s += v * v;
+        }
+    }
+    s.sqrt()
+}
+
+/// Worst-case asymmetry `max_{i,j} |M[i,j] - M[j,i]|` of a dense matrix.
+///
+/// Replaces the `symmetry_residual` helper duplicated across the
+/// `sphere_pec_*` reference tests (symmetry residual of the Nédélec
+/// curl-curl / mass pencil).
+pub fn symmetry_residual(m: MatRef<f64>) -> f64 {
+    let mut worst = 0.0_f64;
+    for j in 0..m.ncols() {
+        for i in 0..m.nrows() {
+            let d = (m[(i, j)] - m[(j, i)]).abs();
+            if d > worst {
+                worst = d;
+            }
+        }
+    }
+    worst
+}
+
+/// Count of structurally-and-numerically nonzero entries of a sparse
+/// matrix, measured on its densified form (matches the NumPy-side
+/// definition: an entry counts iff its value is exactly nonzero).
+///
+/// Replaces the `dense_nnz` helper duplicated across the `derham_*`
+/// reference tests.
+pub fn dense_nnz(m: &SparseColMat<usize, f64>) -> usize {
+    let dense = m.to_dense();
+    let mut nnz = 0usize;
+    for j in 0..dense.ncols() {
+        for i in 0..dense.nrows() {
+            if dense[(i, j)] != 0.0 {
+                nnz += 1;
+            }
+        }
+    }
+    nnz
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faer::Mat;
+    use faer::sparse::{SparseColMat, Triplet};
+
+    #[test]
+    fn frobenius_norm_is_root_sum_of_squares() {
+        // diag(3, 4) -> sqrt(9 + 16) = 5.
+        let m = Mat::<f64>::from_fn(2, 2, |i, j| if i == j { [3.0, 4.0][i] } else { 0.0 });
+        assert!((frobenius_norm(m.as_ref()) - 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn symmetry_residual_is_worst_transpose_gap() {
+        // [[1, 2], [5, 1]] -> max|M - Mᵀ| = |2 - 5| = 3.
+        let m = Mat::<f64>::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 1) => 2.0,
+            (1, 0) => 5.0,
+            (i, j) if i == j => 1.0,
+            _ => 0.0,
+        });
+        assert!((symmetry_residual(m.as_ref()) - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn symmetry_residual_zero_for_symmetric() {
+        // M[i,j] = i + j is symmetric.
+        let m = Mat::<f64>::from_fn(3, 3, |i, j| (i + j) as f64);
+        assert_eq!(symmetry_residual(m.as_ref()), 0.0);
+    }
+
+    #[test]
+    fn dense_nnz_counts_only_numeric_nonzeros() {
+        // Entries at (0,0)=1 and (2,1)=-1; an explicit 0.0 triplet must not count.
+        let trips = vec![
+            Triplet::new(0usize, 0usize, 1.0f64),
+            Triplet::new(2, 1, -1.0),
+            Triplet::new(1, 1, 0.0),
+        ];
+        let m = SparseColMat::<usize, f64>::try_new_from_triplets(3, 3, &trips).unwrap();
+        assert_eq!(dense_nnz(&m), 2);
+    }
+}

--- a/crates/geode-util/src/units.rs
+++ b/crates/geode-util/src/units.rs
@@ -1,0 +1,110 @@
+//! Unit conversions for the FEM / electromagnetics stack.
+
+/// Angular frequency `ω = 2π f` for `f` in GHz, expressed in the natural
+/// (inverse-length) unit of the mesh — i.e. divided by the speed of light
+/// in that length unit.
+///
+/// Pass `c_per_unit` as the matching `geode_core::constants::C_*_PER_S`
+/// (`C_MM_PER_S` for millimeter meshes, `C_UM_PER_S` for micrometer
+/// meshes). Centralizes the `ghz_to_omega` helper that was copy-pasted
+/// across the example binaries and the patch / spiral reference tests —
+/// where the divisor silently differed (mm vs µm) between call sites.
+pub fn ghz_to_omega(f_ghz: f64, c_per_unit: f64) -> f64 {
+    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / c_per_unit
+}
+
+/// [`ghz_to_omega`] for **millimeter** meshes (divisor
+/// [`geode_core::constants::C_MM_PER_S`]).
+pub fn ghz_to_omega_mm(f_ghz: f64) -> f64 {
+    ghz_to_omega(f_ghz, geode_core::constants::C_MM_PER_S)
+}
+
+/// [`ghz_to_omega`] for **micrometer** meshes (divisor
+/// [`geode_core::constants::C_UM_PER_S`]).
+pub fn ghz_to_omega_um(f_ghz: f64) -> f64 {
+    ghz_to_omega(f_ghz, geode_core::constants::C_UM_PER_S)
+}
+
+/// Inverse of [`ghz_to_omega`]: frequency in GHz from a natural-unit
+/// angular frequency `ω` and the speed of light `c_per_unit` in the mesh's
+/// length unit. Centralizes the `ω · c / (2π · 1e9)` SRF back-conversion
+/// duplicated in the spiral / slcfet example binaries.
+pub fn omega_to_ghz(omega: f64, c_per_unit: f64) -> f64 {
+    omega * c_per_unit / (2.0 * std::f64::consts::PI * 1.0e9)
+}
+
+/// [`omega_to_ghz`] for **millimeter** meshes.
+pub fn omega_to_ghz_mm(omega: f64) -> f64 {
+    omega_to_ghz(omega, geode_core::constants::C_MM_PER_S)
+}
+
+/// [`omega_to_ghz`] for **micrometer** meshes.
+pub fn omega_to_ghz_um(omega: f64) -> f64 {
+    omega_to_ghz(omega, geode_core::constants::C_UM_PER_S)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const C_MM_PER_S: f64 = 2.997_924_58e11;
+    const C_UM_PER_S: f64 = 2.997_924_58e14;
+
+    #[test]
+    fn ghz_to_omega_matches_closed_form() {
+        let w = ghz_to_omega(2.4, C_MM_PER_S);
+        let expected = 2.0 * std::f64::consts::PI * 2.4 * 1.0e9 / C_MM_PER_S;
+        assert!((w - expected).abs() < 1e-15);
+    }
+
+    #[test]
+    fn ghz_to_omega_scales_inversely_with_length_unit() {
+        // µm `c` is 1000× the mm `c`, so ω in µm-units is 1000× smaller.
+        let w_mm = ghz_to_omega(1.0, C_MM_PER_S);
+        let w_um = ghz_to_omega(1.0, C_UM_PER_S);
+        assert!((w_um * 1000.0 - w_mm).abs() < 1e-12);
+    }
+
+    #[test]
+    fn omega_to_ghz_is_inverse_of_ghz_to_omega() {
+        let f = 2.4;
+        let round_trip = omega_to_ghz(ghz_to_omega(f, C_MM_PER_S), C_MM_PER_S);
+        assert!((round_trip - f).abs() < 1e-12);
+    }
+
+    // The convenience wrappers bind `geode_core::constants` — assert they
+    // pick the *correct* length-unit `c` (the mm/µm mix-up this module
+    // exists to prevent), comparing against the canonical core constants.
+
+    #[test]
+    fn ghz_to_omega_mm_binds_millimeter_c() {
+        let f = 2.4;
+        assert_eq!(
+            ghz_to_omega_mm(f),
+            ghz_to_omega(f, geode_core::constants::C_MM_PER_S)
+        );
+    }
+
+    #[test]
+    fn ghz_to_omega_um_binds_micrometer_c() {
+        let f = 2.4;
+        assert_eq!(
+            ghz_to_omega_um(f),
+            ghz_to_omega(f, geode_core::constants::C_UM_PER_S)
+        );
+    }
+
+    #[test]
+    fn mm_and_um_wrappers_differ_by_the_unit_ratio() {
+        // ω_mm = 1000 · ω_µm — a wrapper that bound the wrong constant
+        // (the silent bug the unit split guards against) would fail here.
+        assert!((ghz_to_omega_mm(1.0) - 1000.0 * ghz_to_omega_um(1.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn omega_to_ghz_wrappers_invert_their_forward_partners() {
+        let f = 3.7;
+        assert!((omega_to_ghz_mm(ghz_to_omega_mm(f)) - f).abs() < 1e-12);
+        assert!((omega_to_ghz_um(ghz_to_omega_um(f)) - f).abs() < 1e-12);
+    }
+}

--- a/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
+++ b/crates/geode-validation/tests/cube_cavity_numpy_reference.rs
@@ -182,8 +182,14 @@ fn build_actual_outputs(
     actual.insert("eigenvalues".to_string(), eigvals.to_vec());
 
     // Frobenius norms.
-    actual.insert("k_int_frobenius".to_string(), vec![frobenius_norm(k_int)]);
-    actual.insert("m_int_frobenius".to_string(), vec![frobenius_norm(m_int)]);
+    actual.insert(
+        "k_int_frobenius".to_string(),
+        vec![math::frobenius_norm(k_int)],
+    );
+    actual.insert(
+        "m_int_frobenius".to_string(),
+        vec![math::frobenius_norm(m_int)],
+    );
 
     // Diagonals.
     let n = k_int.nrows();
@@ -210,111 +216,9 @@ fn build_actual_outputs(
     actual
 }
 
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
 // ---------------------------------------------------------------------------
 // Dense generalized eigensolve with eigenvectors
 // ---------------------------------------------------------------------------
-
-/// Compute the lowest-`n` generalized eigenpairs of `K x = λ M x`
-/// using faer's dense `generalized_eigen`.
-///
-/// Returns `(eigvals, eigvecs)` with `eigvals` ascending and `eigvecs`
-/// as columns of an `(n_int, n)` matrix. Eigenvectors are
-/// M-orthonormalized post-hoc via modified Gram–Schmidt within each
-/// degenerate cluster, so the comparison against the NumPy reference
-/// (which is M-orthonormal by `eigsh` construction) is consistent.
-///
-/// The existing `FaerDenseEigensolver` trait only returns eigenvalues;
-/// extending it to return eigenpairs is tracked as a follow-up. For
-/// now, we inline the eigenvector path in this test.
-fn dense_lowest_eigenpairs(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> (Vec<f64>, Mat<f64>) {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-    let u = evd.U();
-
-    // Build (real eigenvalue, eigenvector) tuples, filtering complex pairs.
-    let mut pairs: Vec<(f64, Vec<f64>)> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        // Skip eigenvalues with non-trivial imaginary part (shouldn't
-        // happen for our SPD pencil but the API doesn't promise it).
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        // Real eigenvector — for an SPD pencil U columns are real to
-        // f64 precision modulo a global phase. Take the real part.
-        let mut v = Vec::with_capacity(dim);
-        for row in 0..dim {
-            v.push(u[(row, i)].re);
-        }
-        pairs.push((re, v));
-    }
-
-    pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-    pairs.truncate(n_take);
-
-    let n = pairs.len();
-    let eigvals: Vec<f64> = pairs.iter().map(|(l, _)| *l).collect();
-    let mut q = Mat::<f64>::zeros(dim, n);
-    for (j, (_, v)) in pairs.iter().enumerate() {
-        for i in 0..dim {
-            q[(i, j)] = v[i];
-        }
-    }
-
-    // M-normalize each column so v^T M v = 1.
-    for j in 0..n {
-        let col = column_as_vec(q.as_ref(), j);
-        let norm_sq = quad_form(&col, m, &col);
-        let scale = 1.0 / norm_sq.max(1e-300).sqrt();
-        for i in 0..dim {
-            q[(i, j)] *= scale;
-        }
-    }
-
-    (eigvals, q)
-}
-
-fn column_as_vec(m: MatRef<f64>, j: usize) -> Vec<f64> {
-    (0..m.nrows()).map(|i| m[(i, j)]).collect()
-}
-
-/// `x^T A y` for dense `A` and slices `x, y`.
-fn quad_form(x: &[f64], a: MatRef<f64>, y: &[f64]) -> f64 {
-    let n = x.len();
-    debug_assert_eq!(n, a.nrows());
-    debug_assert_eq!(n, a.ncols());
-    debug_assert_eq!(n, y.len());
-    let mut s = 0.0_f64;
-    for i in 0..n {
-        let xi = x[i];
-        let mut row_dot = 0.0_f64;
-        for j in 0..n {
-            row_dot += a[(i, j)] * y[j];
-        }
-        s += xi * row_dot;
-    }
-    s
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -405,7 +309,8 @@ fn cube_cavity_burn_matches_numpy_reference_at_all_substages() {
         "Dirichlet-restricted K_int must be 9^3 = 729 (n=10)"
     );
 
-    let (eigvals_burn, _eigvecs_burn) = dense_lowest_eigenpairs(k_int.as_ref(), m_int.as_ref(), 5);
+    let (eigvals_burn, _eigvecs_burn) =
+        eigen::dense_lowest_eigenpairs(k_int.as_ref(), m_int.as_ref(), 5);
 
     let actual = build_actual_outputs(k_int.as_ref(), m_int.as_ref(), &eigvals_burn, k_int.nrows());
 
@@ -567,7 +472,7 @@ fn cube_cavity_eigenvector_subspaces_agree_per_cluster() {
     let (k_int, m_int, _interior) = burn_pipeline_to_interior();
     let k_modes = 6usize; // 5 for acceptance criterion + 1 to close cluster {4,5}
     let (_eigvals_burn, eigvecs_burn) =
-        dense_lowest_eigenpairs(k_int.as_ref(), m_int.as_ref(), k_modes);
+        eigen::dense_lowest_eigenpairs(k_int.as_ref(), m_int.as_ref(), k_modes);
 
     // Load Q_numpy from the fixture's INPUT field (eigenvectors are
     // stored as inputs because elementwise comparison is the wrong
@@ -692,6 +597,7 @@ fn print_substage_diff(fixture: &Fixture, actual: &BTreeMap<String, Vec<f64>>) {
 
 // Recursive JSON numeric flatten lives in the shared staging crate.
 use geode_util::fixture::flatten_numeric;
+use geode_util::{eigen, math};
 
 /// Dense matrix product `A · B` returning an owned `Mat<f64>`.
 fn mat_mul(a: MatRef<f64>, b: MatRef<f64>) -> Mat<f64> {

--- a/crates/geode-validation/tests/derham_julia_reference.rs
+++ b/crates/geode-validation/tests/derham_julia_reference.rs
@@ -41,6 +41,10 @@ use std::path::PathBuf;
 use faer::sparse::SparseColMat;
 use geode_core::derham::{curl_map, divergence_map, gradient_map};
 use geode_core::mesh::read_sphere_fixture;
+use geode_util::compare::cross_check_operator;
+use geode_util::convert::faer_signed_csc_to_csr_i64;
+use geode_util::fixture;
+use geode_util::math::dense_nnz;
 use geode_validation::{Fixture, FixtureFormat};
 
 // ---------------------------------------------------------------------------
@@ -49,194 +53,6 @@ use geode_validation::{Fixture, FixtureFormat};
 
 fn fixture_path() -> PathBuf {
     geode_validation::fixture_path("derham/julia_baseline.json")
-}
-
-// ---------------------------------------------------------------------------
-// Row-sorted CSR projection of a faer SparseColMat<usize, f64>.
-//
-// faer stores `d⁰`/`d¹`/`d²` as CSC; we project to row-major CSR by
-// materializing to dense and re-encoding (same approach as
-// `derham_numpy_reference.rs` — the largest matrix on the bundled
-// fixture is d¹ at 7074 × 4512 ≈ 256 MiB dense peak).
-// ---------------------------------------------------------------------------
-
-/// CSR row-sorted projection of a signed-integer sparse matrix, with
-/// `data` stored as `i64` to match the Julia reference's `Int` payload.
-#[derive(Debug, Clone)]
-struct CsrI64 {
-    n_rows: usize,
-    n_cols: usize,
-    indptr: Vec<i64>,
-    indices: Vec<i64>,
-    data: Vec<i64>,
-}
-
-impl CsrI64 {
-    fn nnz(&self) -> usize {
-        self.data.len()
-    }
-}
-
-/// Materialize a faer `SparseColMat<usize, f64>` whose entries are all
-/// in `{-1.0, 0.0, +1.0}` into a row-sorted integer CSR.
-///
-/// Asserts each non-zero entry is exactly `±1.0` (any other f64 value
-/// indicates the Burn operator drifted from its integer contract). The
-/// resulting CSR has columns sorted ascending within each row —
-/// matching the Julia generator's canonicalization.
-fn faer_signed_csc_to_csr_i64(m: &SparseColMat<usize, f64>) -> CsrI64 {
-    let dense = m.to_dense();
-    let n_rows = dense.nrows();
-    let n_cols = dense.ncols();
-
-    let mut indptr: Vec<i64> = Vec::with_capacity(n_rows + 1);
-    let mut indices: Vec<i64> = Vec::new();
-    let mut data: Vec<i64> = Vec::new();
-    indptr.push(0);
-    for r in 0..n_rows {
-        for c in 0..n_cols {
-            let v = dense[(r, c)];
-            if v == 0.0 {
-                continue;
-            }
-            // The de Rham operators are integer ±1; assert no drift.
-            let iv: i64 = if v == 1.0 {
-                1
-            } else if v == -1.0 {
-                -1
-            } else {
-                panic!(
-                    "Burn-side de Rham operator entry ({r}, {c}) = {v} \
-                     is not in the integer contract {{-1, 0, +1}}; the \
-                     Rust source of truth has been corrupted somehow."
-                );
-            };
-            indices.push(c as i64);
-            data.push(iv);
-        }
-        indptr.push(data.len() as i64);
-    }
-    CsrI64 {
-        n_rows,
-        n_cols,
-        indptr,
-        indices,
-        data,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Fixture field accessors — strip `f64` payload back to `i64` for the
-// integer cross-check. The fixture stores everything as `f64` per
-// schema v1's lack of an `i32` loader path, with `tolerance_abs = 0.5`
-// to make sub-integer differences trigger an assertion.
-// ---------------------------------------------------------------------------
-
-fn fixture_scalar_i64(fixture: &Fixture, name: &str) -> i64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        1,
-        "fixture scalar `{name}` should be length 1, got {}",
-        f.data.len()
-    );
-    f.data[0].round() as i64
-}
-
-fn fixture_shape(fixture: &Fixture, name: &str) -> (usize, usize) {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing shape output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        2,
-        "fixture shape `{name}` should be length 2, got {}",
-        f.data.len()
-    );
-    (f.data[0].round() as usize, f.data[1].round() as usize)
-}
-
-fn fixture_array_i64(fixture: &Fixture, name: &str) -> Vec<i64> {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"));
-    f.data.iter().map(|v| v.round() as i64).collect()
-}
-
-// ---------------------------------------------------------------------------
-// Assertion helpers.
-// ---------------------------------------------------------------------------
-
-/// Assert that two `i64` vectors are equal entrywise. Surfaces the
-/// first disagreement loudly — sign-convention drift between Burn and
-/// Julia is the load-bearing bug class this harness exists to catch.
-fn assert_i64_eq(name: &str, got: &[i64], want: &[i64]) {
-    assert_eq!(
-        got.len(),
-        want.len(),
-        "{name}: length mismatch (Burn {} vs Julia {})",
-        got.len(),
-        want.len()
-    );
-    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
-        if g != w {
-            // Print a small surrounding window for context.
-            let lo = i.saturating_sub(2);
-            let hi = (i + 3).min(got.len());
-            panic!(
-                "{name}: first disagreement at index {i}: Burn = {g}, Julia = {w}\n\
-                 surrounding window (Burn): {:?}\n\
-                 surrounding window (Julia): {:?}",
-                &got[lo..hi],
-                &want[lo..hi]
-            );
-        }
-    }
-}
-
-/// Cross-check one operator's full CSR payload (shape, nnz, indptr,
-/// indices, data) against the fixture under the `prefix` (e.g. `"d0"`,
-/// `"d1"`, `"d2"`).
-fn cross_check_operator(prefix: &str, csr: &CsrI64, fixture: &Fixture) {
-    // Shape.
-    let want_shape = fixture_shape(fixture, &format!("{prefix}_shape"));
-    assert_eq!(
-        (csr.n_rows, csr.n_cols),
-        want_shape,
-        "{prefix} shape: Burn = ({}, {}), Julia = ({}, {})",
-        csr.n_rows,
-        csr.n_cols,
-        want_shape.0,
-        want_shape.1
-    );
-
-    // nnz.
-    let want_nnz = fixture_scalar_i64(fixture, &format!("{prefix}_nnz")) as usize;
-    assert_eq!(
-        csr.nnz(),
-        want_nnz,
-        "{prefix} nnz: Burn = {}, Julia = {want_nnz}",
-        csr.nnz()
-    );
-
-    // indptr / indices / data — bit-exact integer equality.
-    assert_i64_eq(
-        &format!("{prefix}_indptr"),
-        &csr.indptr,
-        &fixture_array_i64(fixture, &format!("{prefix}_indptr")),
-    );
-    assert_i64_eq(
-        &format!("{prefix}_indices"),
-        &csr.indices,
-        &fixture_array_i64(fixture, &format!("{prefix}_indices")),
-    );
-    assert_i64_eq(
-        &format!("{prefix}_data"),
-        &csr.data,
-        &fixture_array_i64(fixture, &format!("{prefix}_data")),
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -297,11 +113,23 @@ fn cell_counts_agree_with_julia() {
     let n_faces = mesh.faces().len();
     let euler = n_nodes as i64 - n_edges as i64 + n_faces as i64 - n_tets as i64;
 
-    assert_eq!(n_nodes as i64, fixture_scalar_i64(&fixture, "n_nodes"));
-    assert_eq!(n_edges as i64, fixture_scalar_i64(&fixture, "n_edges"));
-    assert_eq!(n_faces as i64, fixture_scalar_i64(&fixture, "n_faces"));
-    assert_eq!(n_tets as i64, fixture_scalar_i64(&fixture, "n_tets"));
-    assert_eq!(euler, fixture_scalar_i64(&fixture, "euler_chi"));
+    assert_eq!(
+        n_nodes as i64,
+        fixture::fixture_scalar_i64(&fixture, "n_nodes")
+    );
+    assert_eq!(
+        n_edges as i64,
+        fixture::fixture_scalar_i64(&fixture, "n_edges")
+    );
+    assert_eq!(
+        n_faces as i64,
+        fixture::fixture_scalar_i64(&fixture, "n_faces")
+    );
+    assert_eq!(
+        n_tets as i64,
+        fixture::fixture_scalar_i64(&fixture, "n_tets")
+    );
+    assert_eq!(euler, fixture::fixture_scalar_i64(&fixture, "euler_chi"));
     assert_eq!(
         euler, 1,
         "Euler characteristic for the bundled sphere fixture should be 1 \
@@ -339,23 +167,6 @@ fn d2_csr_matches_julia_bit_exact() {
     cross_check_operator("d2", &csr, &fixture);
 }
 
-/// Count strict-nonzero entries in a faer `SparseColMat<usize, f64>`
-/// after dense expansion. Used to assert bit-exact zero on the de Rham
-/// compositional identities; the dense walk is invariant to whether
-/// `faer`'s sparse product strips structural zeros or not.
-fn dense_nnz(m: &SparseColMat<usize, f64>) -> usize {
-    let dense = m.to_dense();
-    let mut nnz = 0usize;
-    for j in 0..dense.ncols() {
-        for i in 0..dense.nrows() {
-            if dense[(i, j)] != 0.0 {
-                nnz += 1;
-            }
-        }
-    }
-    nnz
-}
-
 #[test]
 fn d1_d0_is_bit_exact_zero() {
     // Algebraic exactness identity d¹ ∘ d⁰ ≡ 0, anchored to the Julia
@@ -372,7 +183,7 @@ fn d1_d0_is_bit_exact_zero() {
     let prod: SparseColMat<usize, f64> = &d1 * &d0;
     let nnz = dense_nnz(&prod);
 
-    let want_nnz = fixture_scalar_i64(&fixture, "d1_d0_nnz") as usize;
+    let want_nnz = fixture::fixture_scalar_i64(&fixture, "d1_d0_nnz") as usize;
     assert_eq!(
         want_nnz, 0,
         "fixture's d1_d0_nnz should be 0 (algebraic exactness); got {want_nnz}"
@@ -397,7 +208,7 @@ fn d2_d1_is_bit_exact_zero() {
     let prod: SparseColMat<usize, f64> = &d2 * &d1;
     let nnz = dense_nnz(&prod);
 
-    let want_nnz = fixture_scalar_i64(&fixture, "d2_d1_nnz") as usize;
+    let want_nnz = fixture::fixture_scalar_i64(&fixture, "d2_d1_nnz") as usize;
     assert_eq!(
         want_nnz, 0,
         "fixture's d2_d1_nnz should be 0 (algebraic exactness); got {want_nnz}"
@@ -429,7 +240,7 @@ fn euler_rank_predictions_pinned() {
     let rank_d1 = n_edges - n_nodes + 1;
     let rank_d2 = n_faces - n_edges + n_nodes - 1;
 
-    assert_eq!(rank_d0, fixture_scalar_i64(&fixture, "rank_d0"));
-    assert_eq!(rank_d1, fixture_scalar_i64(&fixture, "rank_d1"));
-    assert_eq!(rank_d2, fixture_scalar_i64(&fixture, "rank_d2"));
+    assert_eq!(rank_d0, fixture::fixture_scalar_i64(&fixture, "rank_d0"));
+    assert_eq!(rank_d1, fixture::fixture_scalar_i64(&fixture, "rank_d1"));
+    assert_eq!(rank_d2, fixture::fixture_scalar_i64(&fixture, "rank_d2"));
 }

--- a/crates/geode-validation/tests/derham_numpy_reference.rs
+++ b/crates/geode-validation/tests/derham_numpy_reference.rs
@@ -41,6 +41,10 @@ use std::path::PathBuf;
 use faer::sparse::SparseColMat;
 use geode_core::derham::{curl_map, divergence_map, gradient_map};
 use geode_core::mesh::read_sphere_fixture;
+use geode_util::compare::cross_check_operator;
+use geode_util::convert::faer_signed_csc_to_csr_i64;
+use geode_util::fixture::fixture_scalar_i64;
+use geode_util::math::dense_nnz;
 use geode_validation::{Fixture, FixtureFormat};
 
 // ---------------------------------------------------------------------------
@@ -49,197 +53,6 @@ use geode_validation::{Fixture, FixtureFormat};
 
 fn fixture_path() -> PathBuf {
     geode_validation::fixture_path("derham/baseline.json")
-}
-
-// ---------------------------------------------------------------------------
-// Row-sorted CSR projection of a faer SparseColMat<usize, f64>.
-//
-// faer stores `d⁰`/`d¹`/`d²` as CSC; we project to row-major CSR by
-// materializing to dense and re-encoding. Dense is fine here — the
-// largest matrix on the bundled fixture is d¹ at 7074 × 4512 ≈ 32M
-// f64 cells = 256 MiB peak, which fits comfortably in any CI runner.
-// The bit-exactness depends on the values being exact integers, not on
-// the storage layout per se.
-// ---------------------------------------------------------------------------
-
-/// CSR row-sorted projection of a signed-integer sparse matrix, with
-/// `data` stored as `i64` to match the NumPy reference's `int64` dtype.
-#[derive(Debug, Clone)]
-struct CsrI64 {
-    n_rows: usize,
-    n_cols: usize,
-    indptr: Vec<i64>,
-    indices: Vec<i64>,
-    data: Vec<i64>,
-}
-
-impl CsrI64 {
-    fn nnz(&self) -> usize {
-        self.data.len()
-    }
-}
-
-/// Materialize a faer `SparseColMat<usize, f64>` whose entries are all
-/// in `{-1.0, 0.0, +1.0}` into a row-sorted integer CSR.
-///
-/// Asserts each non-zero entry is exactly `±1.0` (any other f64 value
-/// indicates the Burn operator drifted from its integer contract). The
-/// resulting CSR has columns sorted ascending within each row —
-/// matching `scipy.sparse.csr_matrix.sort_indices()` canonicalization
-/// on the NumPy side.
-fn faer_signed_csc_to_csr_i64(m: &SparseColMat<usize, f64>) -> CsrI64 {
-    let dense = m.to_dense();
-    let n_rows = dense.nrows();
-    let n_cols = dense.ncols();
-
-    let mut indptr: Vec<i64> = Vec::with_capacity(n_rows + 1);
-    let mut indices: Vec<i64> = Vec::new();
-    let mut data: Vec<i64> = Vec::new();
-    indptr.push(0);
-    for r in 0..n_rows {
-        for c in 0..n_cols {
-            let v = dense[(r, c)];
-            if v == 0.0 {
-                continue;
-            }
-            // The de Rham operators are integer ±1; assert no drift.
-            let iv: i64 = if v == 1.0 {
-                1
-            } else if v == -1.0 {
-                -1
-            } else {
-                panic!(
-                    "Burn-side de Rham operator entry ({r}, {c}) = {v} \
-                     is not in the integer contract {{-1, 0, +1}}; the \
-                     Rust source of truth has been corrupted somehow."
-                );
-            };
-            indices.push(c as i64);
-            data.push(iv);
-        }
-        indptr.push(data.len() as i64);
-    }
-    CsrI64 {
-        n_rows,
-        n_cols,
-        indptr,
-        indices,
-        data,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Fixture field accessors — strip `f64` payload back to `i64` for the
-// integer cross-check. The fixture stores everything as `f64` per
-// schema v1's lack of an `i32` loader path, with `tolerance_abs = 0.5`
-// to make sub-integer differences trigger an assertion.
-// ---------------------------------------------------------------------------
-
-fn fixture_scalar_i64(fixture: &Fixture, name: &str) -> i64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        1,
-        "fixture scalar `{name}` should be length 1, got {}",
-        f.data.len()
-    );
-    f.data[0].round() as i64
-}
-
-fn fixture_shape(fixture: &Fixture, name: &str) -> (usize, usize) {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing shape output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        2,
-        "fixture shape `{name}` should be length 2, got {}",
-        f.data.len()
-    );
-    (f.data[0].round() as usize, f.data[1].round() as usize)
-}
-
-fn fixture_array_i64(fixture: &Fixture, name: &str) -> Vec<i64> {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"));
-    f.data.iter().map(|v| v.round() as i64).collect()
-}
-
-// ---------------------------------------------------------------------------
-// Assertion helpers.
-// ---------------------------------------------------------------------------
-
-/// Assert that two `i64` vectors are equal entrywise. Surfaces the
-/// first disagreement loudly — sign-convention drift between Burn and
-/// NumPy is the load-bearing bug class this harness exists to catch.
-fn assert_i64_eq(name: &str, got: &[i64], want: &[i64]) {
-    assert_eq!(
-        got.len(),
-        want.len(),
-        "{name}: length mismatch (Burn {} vs NumPy {})",
-        got.len(),
-        want.len()
-    );
-    for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
-        if g != w {
-            // Print a small surrounding window for context.
-            let lo = i.saturating_sub(2);
-            let hi = (i + 3).min(got.len());
-            panic!(
-                "{name}: first disagreement at index {i}: Burn = {g}, NumPy = {w}\n\
-                 surrounding window (Burn): {:?}\n\
-                 surrounding window (NumPy): {:?}",
-                &got[lo..hi],
-                &want[lo..hi]
-            );
-        }
-    }
-}
-
-/// Cross-check one operator's full CSR payload (shape, nnz, indptr,
-/// indices, data) against the fixture under the `prefix` (e.g. `"d0"`,
-/// `"d1"`, `"d2"`).
-fn cross_check_operator(prefix: &str, csr: &CsrI64, fixture: &Fixture) {
-    // Shape.
-    let want_shape = fixture_shape(fixture, &format!("{prefix}_shape"));
-    assert_eq!(
-        (csr.n_rows, csr.n_cols),
-        want_shape,
-        "{prefix} shape: Burn = ({}, {}), NumPy = ({}, {})",
-        csr.n_rows,
-        csr.n_cols,
-        want_shape.0,
-        want_shape.1
-    );
-
-    // nnz.
-    let want_nnz = fixture_scalar_i64(fixture, &format!("{prefix}_nnz")) as usize;
-    assert_eq!(
-        csr.nnz(),
-        want_nnz,
-        "{prefix} nnz: Burn = {}, NumPy = {want_nnz}",
-        csr.nnz()
-    );
-
-    // indptr / indices / data — bit-exact integer equality.
-    assert_i64_eq(
-        &format!("{prefix}_indptr"),
-        &csr.indptr,
-        &fixture_array_i64(fixture, &format!("{prefix}_indptr")),
-    );
-    assert_i64_eq(
-        &format!("{prefix}_indices"),
-        &csr.indices,
-        &fixture_array_i64(fixture, &format!("{prefix}_indices")),
-    );
-    assert_i64_eq(
-        &format!("{prefix}_data"),
-        &csr.data,
-        &fixture_array_i64(fixture, &format!("{prefix}_data")),
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -340,23 +153,6 @@ fn d2_csr_matches_numpy_bit_exact() {
     let d2 = divergence_map(&f.mesh);
     let csr = faer_signed_csc_to_csr_i64(&d2);
     cross_check_operator("d2", &csr, &fixture);
-}
-
-/// Count strict-nonzero entries in a faer `SparseColMat<usize, f64>`
-/// after dense expansion. Used to assert bit-exact zero on the de Rham
-/// compositional identities; the dense walk is invariant to whether
-/// `faer`'s sparse product strips structural zeros or not.
-fn dense_nnz(m: &SparseColMat<usize, f64>) -> usize {
-    let dense = m.to_dense();
-    let mut nnz = 0usize;
-    for j in 0..dense.ncols() {
-        for i in 0..dense.nrows() {
-            if dense[(i, j)] != 0.0 {
-                nnz += 1;
-            }
-        }
-    }
-    nnz
 }
 
 #[test]

--- a/crates/geode-validation/tests/mie_roots_julia_reference.rs
+++ b/crates/geode-validation/tests/mie_roots_julia_reference.rs
@@ -36,6 +36,9 @@ use std::path::PathBuf;
 
 use geode_core::analytic::mie::{MiePolarisation, MieRoot, mie_roots_catalog, resonance_roots};
 use geode_core::mesh::{R_BUFFER, R_SPHERE};
+use geode_util::fixture::{
+    fixture_array_f64, fixture_array_usize, fixture_scalar_f64, fixture_scalar_usize,
+};
 use geode_validation::{Fixture, FixtureFormat};
 
 // ---------------------------------------------------------------------------
@@ -70,38 +73,6 @@ fn load_julia_fixture() -> Fixture {
 // Fixture field accessors (same helpers as mie_roots_numpy_reference.rs).
 // ---------------------------------------------------------------------------
 
-fn fixture_scalar_f64(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        1,
-        "fixture scalar `{name}` should be length 1, got {}",
-        f.data.len()
-    );
-    f.data[0]
-}
-
-fn fixture_scalar_usize(fixture: &Fixture, name: &str) -> usize {
-    fixture_scalar_f64(fixture, name).round() as usize
-}
-
-fn fixture_array_f64(fixture: &Fixture, name: &str) -> Vec<f64> {
-    fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"))
-        .data
-        .clone()
-}
-
-fn fixture_array_usize(fixture: &Fixture, name: &str) -> Vec<usize> {
-    fixture_array_f64(fixture, name)
-        .iter()
-        .map(|v| v.round() as usize)
-        .collect()
-}
-
 /// Canonical join key: `(pol_index, l, n)` with `pol_index` 0 = TE,
 /// 1 = TM — matching the fixtures' `root_pol` encoding.
 type RootKey = (u8, usize, usize);
@@ -114,11 +85,7 @@ fn pol_index(pol: MiePolarisation) -> u8 {
 }
 
 fn pol_name(idx: u8) -> &'static str {
-    match idx {
-        0 => "TE",
-        1 => "TM",
-        _ => "??",
-    }
+    MiePolarisation::from_index(idx).map_or("??", |p| p.as_str())
 }
 
 /// Load a roots fixture's catalogue as a `(pol, l, n) → k` map,

--- a/crates/geode-validation/tests/mie_roots_numpy_reference.rs
+++ b/crates/geode-validation/tests/mie_roots_numpy_reference.rs
@@ -39,6 +39,9 @@ use geode_core::analytic::mie::{
     MiePolarisation, MieRoot, merged_roots, mie_roots_catalog, resonance_roots,
 };
 use geode_core::mesh::{R_BUFFER, R_SPHERE};
+use geode_util::fixture::{
+    fixture_array_f64, fixture_array_usize, fixture_scalar_f64, fixture_scalar_usize,
+};
 use geode_validation::{Fixture, FixtureFormat};
 
 // ---------------------------------------------------------------------------
@@ -73,38 +76,6 @@ fn load_fixture() -> Fixture {
 // Fixture field accessors.
 // ---------------------------------------------------------------------------
 
-fn fixture_scalar_f64(fixture: &Fixture, name: &str) -> f64 {
-    let f = fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing scalar output `{name}`: {e}"));
-    assert_eq!(
-        f.data.len(),
-        1,
-        "fixture scalar `{name}` should be length 1, got {}",
-        f.data.len()
-    );
-    f.data[0]
-}
-
-fn fixture_scalar_usize(fixture: &Fixture, name: &str) -> usize {
-    fixture_scalar_f64(fixture, name).round() as usize
-}
-
-fn fixture_array_f64(fixture: &Fixture, name: &str) -> Vec<f64> {
-    fixture
-        .output_f64(name)
-        .unwrap_or_else(|e| panic!("fixture missing array output `{name}`: {e}"))
-        .data
-        .clone()
-}
-
-fn fixture_array_usize(fixture: &Fixture, name: &str) -> Vec<usize> {
-    fixture_array_f64(fixture, name)
-        .iter()
-        .map(|v| v.round() as usize)
-        .collect()
-}
-
 /// Canonical join key: `(pol_index, l, n)` with `pol_index` 0 = TE,
 /// 1 = TM — matching the fixture's `root_pol` encoding.
 type RootKey = (u8, usize, usize);
@@ -117,11 +88,7 @@ fn pol_index(pol: MiePolarisation) -> u8 {
 }
 
 fn pol_name(idx: u8) -> &'static str {
-    match idx {
-        0 => "TE",
-        1 => "TM",
-        _ => "??",
-    }
+    MiePolarisation::from_index(idx).map_or("??", |p| p.as_str())
 }
 
 /// Load the fixture's catalogue as a `(pol, l, n) → k` map, asserting

--- a/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/nedelec_local_numpy_reference.rs
@@ -53,6 +53,7 @@ use burn::tensor::{DType, Tensor, TensorData};
 
 use geode_core::elements::nedelec::batched_nedelec_local_matrices;
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::compare::{MixedTol, check_close};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -60,12 +61,6 @@ type B = TestBackend;
 // ---------------------------------------------------------------------------
 // Tolerances (backend-aware, mirrors p1_local_numpy_reference.rs)
 // ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy)]
-struct MixedTol {
-    rel: f64,
-    abs: f64,
-}
 
 /// Backend-aware tolerances, selected by the device's float dtype.
 fn active_tolerances() -> MixedTol {
@@ -93,41 +88,6 @@ fn active_tolerances() -> MixedTol {
         ],
     )
     .expect("a tolerance case must match the active backend dtype")
-}
-
-/// Mixed absolute/relative tolerance check with an optional per-field
-/// absolute floor from the fixture's own declared `tolerance_abs`. The
-/// effective tolerance is the looser of (a) the backend-aware mixed
-/// abs/rel envelope and (b) the fixture-declared absolute floor.
-///
-/// This per-field floor matters for the `near_degenerate_sliver` case:
-/// the Nédélec curl-curl closed form has a ``gg_ac gg_bd - gg_ad gg_bc``
-/// catastrophic-cancellation step inside a ``1/|det|^3`` amplification,
-/// so even in pure-f64 the sliver's K entries lose ~6 decimal digits to
-/// roundoff regardless of impl. The fixture declares ``tolerance_abs =
-/// 1e2`` on K there, encoding that *intrinsic* loss; the tight
-/// ``1e-10 rel / 1e-12 abs`` check is meaningful for the four
-/// well-conditioned cases but unrealistic for the sliver.
-fn check_close(
-    got: f64,
-    want: f64,
-    tol: MixedTol,
-    fixture_floor: f64,
-    label: &str,
-) -> Result<(), String> {
-    let abs_err = (got - want).abs();
-    let mixed = tol.abs + tol.rel * want.abs();
-    let allowed = mixed.max(fixture_floor);
-    if abs_err <= allowed {
-        Ok(())
-    } else {
-        Err(format!(
-            "{label}: got {got:.17e}, want {want:.17e}, |err| = {abs_err:.3e} \
-             (allowed {allowed:.3e} = max(mixed {mixed:.3e}, fixture_floor {fixture_floor:.3e}); \
-             rel_tol={:.0e}, abs_tol={:.0e})",
-            tol.rel, tol.abs
-        ))
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/geode-validation/tests/p1_local_numpy_reference.rs
+++ b/crates/geode-validation/tests/p1_local_numpy_reference.rs
@@ -45,6 +45,7 @@ use burn::tensor::{DType, Tensor, TensorData};
 
 use geode_core::elements::p1::batched_p1_local_matrices;
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::compare::{MixedTol, check_close};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -52,12 +53,6 @@ type B = TestBackend;
 // ---------------------------------------------------------------------------
 // Tolerances (backend-aware, mirrors the original p1_local test)
 // ---------------------------------------------------------------------------
-
-#[derive(Debug, Clone, Copy)]
-struct MixedTol {
-    rel: f64,
-    abs: f64,
-}
 
 /// Backend-aware tolerances, selected by the device's float dtype.
 fn active_tolerances() -> MixedTol {
@@ -85,22 +80,6 @@ fn active_tolerances() -> MixedTol {
         ],
     )
     .expect("a tolerance case must match the active backend dtype")
-}
-
-/// Mixed absolute/relative tolerance check. Returns `Ok(())` on success,
-/// `Err(msg)` describing the disagreement on failure.
-fn check_close(got: f64, want: f64, tol: MixedTol, label: &str) -> Result<(), String> {
-    let abs_err = (got - want).abs();
-    let allowed = tol.abs + tol.rel * want.abs();
-    if abs_err <= allowed {
-        Ok(())
-    } else {
-        Err(format!(
-            "{label}: got {got:.17e}, want {want:.17e}, |err| = {abs_err:.3e} \
-             (allowed {allowed:.3e}; rel_tol={:.0e}, abs_tol={:.0e})",
-            tol.rel, tol.abs
-        ))
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -296,7 +275,7 @@ fn burn_agrees_with_numpy_baseline_on_all_p1_local_cases() {
             .expect("signed_volume present")
             .data[0];
         let got_v = actual["signed_volume"][0];
-        if let Err(msg) = check_close(got_v, want_v, tol, "signed_volume") {
+        if let Err(msg) = check_close(got_v, want_v, tol, 0.0, "signed_volume") {
             case_failures.push(msg);
         }
 
@@ -310,6 +289,7 @@ fn burn_agrees_with_numpy_baseline_on_all_p1_local_cases() {
                     got_k[idx],
                     want_k.data[idx],
                     tol,
+                    0.0,
                     &format!("k_local[{i}][{j}]"),
                 ) {
                     case_failures.push(msg);
@@ -327,6 +307,7 @@ fn burn_agrees_with_numpy_baseline_on_all_p1_local_cases() {
                     got_m[idx],
                     want_m.data[idx],
                     tol,
+                    0.0,
                     &format!("m_local[{i}][{j}]"),
                 ) {
                     case_failures.push(msg);

--- a/crates/geode-validation/tests/sphere_mie_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_jax_reference.rs
@@ -48,8 +48,10 @@ use geode_core::assembly::nedelec::{
 use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::complex::{ComplexEigenSolver, FaerComplexEigensolver};
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
-use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture, read_sphere_fixture_from_bytes};
+use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::{q_factor_from_lambda, re_k_from_lambda};
+use geode_util::fixture::load_small_sphere_fixture;
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -72,16 +74,6 @@ fn jax_fixture_path() -> PathBuf {
 
 fn numpy_fixture_path() -> PathBuf {
     geode_validation::fixture_path("sphere_mie_small/baseline.json")
-}
-
-/// The small mesh is shared with the #158 sphere_pml_small fixture.
-fn small_mesh_path() -> PathBuf {
-    geode_validation::fixture_path("sphere_pml_small/sphere.msh")
-}
-
-fn load_small_sphere_fixture() -> SphereFixture {
-    let bytes = std::fs::read(small_mesh_path()).expect("read small-mesh sphere.msh bytes");
-    read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
 }
 
 // ---------------------------------------------------------------------------
@@ -177,22 +169,6 @@ fn run_burn_mie_pipeline(
 // ---------------------------------------------------------------------------
 // λ → k and Q helpers (principal branch, sign-agnostic Q)
 // ---------------------------------------------------------------------------
-
-fn re_k_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    (0.5 * (r + lambda.re)).max(0.0).sqrt()
-}
-
-fn q_factor_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
-    let im_k_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
-    if im_k_mag > 1e-12 {
-        re_k / (2.0 * im_k_mag)
-    } else {
-        f64::INFINITY
-    }
-}
 
 fn load_jax_fixture() -> Fixture {
     Fixture::load_from(&jax_fixture_path(), FixtureFormat::Json)

--- a/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_julia_small_reference.rs
@@ -53,8 +53,10 @@ use geode_core::assembly::nedelec::{
 use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::complex::{ComplexEigenSolver, FaerComplexEigensolver};
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
-use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture, read_sphere_fixture_from_bytes};
+use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::{q_factor_from_lambda, re_k_from_lambda};
+use geode_util::fixture::load_small_sphere_fixture;
 use geode_validation::diff::FieldStatus;
 use geode_validation::{Fixture, FixtureFormat};
 
@@ -86,19 +88,9 @@ fn numpy_fixture_path() -> PathBuf {
     geode_validation::fixture_path("sphere_mie_small/baseline.json")
 }
 
-/// The small mesh is shared with the #158 sphere_pml_small fixture.
-fn small_mesh_path() -> PathBuf {
-    geode_validation::fixture_path("sphere_pml_small/sphere.msh")
-}
-
 fn load_julia_fixture() -> Fixture {
     Fixture::load_from(&julia_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small/julia_baseline.json should load")
-}
-
-fn load_small_sphere_fixture() -> SphereFixture {
-    let bytes = std::fs::read(small_mesh_path()).expect("read small-mesh sphere.msh bytes");
-    read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
 }
 
 // ---------------------------------------------------------------------------
@@ -188,26 +180,6 @@ fn run_burn_mie_pipeline(
         epsilon_tensor_diag_flat,
         k_int_complex,
         m_int_complex,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// λ → k and Q helpers — mirror of mie_sphere.rs / sphere_mie.py.
-// ---------------------------------------------------------------------------
-
-fn re_k_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    (0.5 * (r + lambda.re)).max(0.0).sqrt()
-}
-
-fn q_factor_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
-    let im_k_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
-    if im_k_mag > 1e-12 {
-        re_k / (2.0 * im_k_mag)
-    } else {
-        f64::INFINITY
     }
 }
 

--- a/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_numpy_reference.rs
@@ -85,10 +85,10 @@ use geode_core::assembly::nedelec::{
 use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::complex::{ComplexEigenSolver, FaerComplexEigensolver};
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
-use geode_core::mesh::{
-    R_BUFFER, R_SPHERE, SphereFixture, read_sphere_fixture, read_sphere_fixture_from_bytes,
-};
+use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture, read_sphere_fixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::{q_factor_from_lambda, re_k_from_lambda};
+use geode_util::fixture::load_small_sphere_fixture;
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -112,17 +112,6 @@ fn full_fixture_path() -> PathBuf {
 
 fn small_fixture_path() -> PathBuf {
     geode_validation::fixture_path("sphere_mie_small/baseline.json")
-}
-
-/// The small mesh is shared with the #158 sphere_pml_small fixture —
-/// not duplicated under sphere_mie_small/.
-fn small_mesh_path() -> PathBuf {
-    geode_validation::fixture_path("sphere_pml_small/sphere.msh")
-}
-
-fn load_small_sphere_fixture() -> SphereFixture {
-    let bytes = std::fs::read(small_mesh_path()).expect("read small-mesh sphere.msh bytes");
-    read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
 }
 
 // ---------------------------------------------------------------------------
@@ -213,27 +202,6 @@ fn run_burn_mie_pipeline(
         epsilon_tensor_diag_flat,
         k_int_complex,
         m_int_complex,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// λ → k and Q helpers (principal branch, sign-agnostic Q) — mirror of
-// `mie_sphere.rs` and `reference/numpy/sphere_mie.py`.
-// ---------------------------------------------------------------------------
-
-fn re_k_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    (0.5 * (r + lambda.re)).max(0.0).sqrt()
-}
-
-fn q_factor_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
-    let im_k_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
-    if im_k_mag > 1e-12 {
-        re_k / (2.0 * im_k_mag)
-    } else {
-        f64::INFINITY
     }
 }
 

--- a/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_mie_tfjava_reference.rs
@@ -55,8 +55,10 @@ use geode_core::assembly::nedelec::{
 use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::complex::{ComplexEigenSolver, FaerComplexEigensolver};
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
-use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture, read_sphere_fixture_from_bytes};
+use geode_core::mesh::{R_BUFFER, R_SPHERE, SphereFixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::{q_factor_from_lambda, re_k_from_lambda};
+use geode_util::fixture::load_small_sphere_fixture;
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -86,19 +88,9 @@ fn numpy_fixture_path() -> PathBuf {
     geode_validation::fixture_path("sphere_mie_small/baseline.json")
 }
 
-/// The small mesh is shared with the #158 sphere_pml_small fixture.
-fn small_mesh_path() -> PathBuf {
-    geode_validation::fixture_path("sphere_pml_small/sphere.msh")
-}
-
 fn load_tfjava_fixture() -> Fixture {
     Fixture::load_from(&tfjava_fixture_path(), FixtureFormat::Json)
         .expect("sphere_mie_small/tfjava_baseline.json should load")
-}
-
-fn load_small_sphere_fixture() -> SphereFixture {
-    let bytes = std::fs::read(small_mesh_path()).expect("read small-mesh sphere.msh bytes");
-    read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
 }
 
 // ---------------------------------------------------------------------------
@@ -188,26 +180,6 @@ fn run_burn_mie_pipeline(
         epsilon_tensor_diag_flat,
         k_int_complex,
         m_int_complex,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// λ → k and Q helpers (principal branch, sign-agnostic Q)
-// ---------------------------------------------------------------------------
-
-fn re_k_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    (0.5 * (r + lambda.re)).max(0.0).sqrt()
-}
-
-fn q_factor_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
-    let im_k_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
-    if im_k_mag > 1e-12 {
-        re_k / (2.0 * im_k_mag)
-    } else {
-        f64::INFINITY
     }
 }
 

--- a/crates/geode-validation/tests/sphere_pec_jax_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_jax_reference.rs
@@ -38,7 +38,6 @@ use burn::prelude::Backend;
 use burn::tensor::DType;
 use burn::tensor::backend::BackendTypes;
 use faer::Mat;
-use faer::mat::MatRef;
 use std::path::PathBuf;
 
 use geode_core::assembly::nedelec::{
@@ -49,6 +48,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{R_BUFFER, read_sphere_fixture};
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::eigen::dense_lowest_eigenvalues;
+use geode_util::math::frobenius_norm;
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -182,44 +183,6 @@ fn run_burn_pipeline() -> BurnPipeline {
 // ---------------------------------------------------------------------------
 // Matrix helpers (same as sphere_pec_numpy_reference.rs)
 // ---------------------------------------------------------------------------
-
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
-/// Compute lowest-n real generalized eigenvalues of K x = λ M x.
-fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-
-    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        eigs.push(re);
-    }
-    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    eigs.truncate(n_take);
-    eigs
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/sphere_pec_julia_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_julia_reference.rs
@@ -42,7 +42,6 @@ use burn::prelude::Backend;
 use burn::tensor::DType;
 use burn::tensor::backend::BackendTypes;
 use faer::Mat;
-use faer::mat::MatRef;
 use std::path::PathBuf;
 
 use geode_core::assembly::nedelec::{
@@ -53,6 +52,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{R_BUFFER, read_sphere_fixture};
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::eigen::dense_lowest_eigenvalues;
+use geode_util::math::{frobenius_norm, symmetry_residual};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -189,56 +190,6 @@ fn run_burn_pipeline() -> BurnPipeline {
 // ---------------------------------------------------------------------------
 // Matrix helpers
 // ---------------------------------------------------------------------------
-
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
-fn symmetry_residual(m: MatRef<f64>) -> f64 {
-    let mut worst = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let d = (m[(i, j)] - m[(j, i)]).abs();
-            if d > worst {
-                worst = d;
-            }
-        }
-    }
-    worst
-}
-
-fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-
-    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        eigs.push(re);
-    }
-    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    eigs.truncate(n_take);
-    eigs
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/sphere_pec_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_numpy_reference.rs
@@ -74,6 +74,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{R_BUFFER, read_sphere_fixture};
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::eigen::dense_lowest_eigenvalues;
+use geode_util::math::{frobenius_norm, symmetry_residual};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -224,17 +226,6 @@ fn run_burn_pipeline() -> BurnPipeline {
 // Matrix helpers (Frobenius, per-row nnz histogram, symmetry residual)
 // ---------------------------------------------------------------------------
 
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
 /// Per-row nnz histogram on a dense matrix.
 ///
 /// Counts entries with exact-nonzero value (`!= 0.0`), matching scipy's
@@ -263,54 +254,9 @@ fn per_row_nnz_histogram(m: MatRef<f64>) -> Vec<i64> {
     hist
 }
 
-fn symmetry_residual(m: MatRef<f64>) -> f64 {
-    let mut worst = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let d = (m[(i, j)] - m[(j, i)]).abs();
-            if d > worst {
-                worst = d;
-            }
-        }
-    }
-    worst
-}
-
 // ---------------------------------------------------------------------------
 // Dense generalized eigensolve (mirror of cube_cavity_numpy_reference helper)
 // ---------------------------------------------------------------------------
-
-/// Compute the lowest-`n_take` real generalized eigenvalues of `K x = λ M x`
-/// using faer's dense `generalized_eigen`. The spurious null cluster
-/// (gradients of H¹₀) sit near zero; we keep them in the returned slice
-/// because the comparator wants to cross-check the full lowest-spectrum
-/// sequence against the NumPy reference, then run the spurious-mode
-/// filter on top.
-fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-
-    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        eigs.push(re);
-    }
-    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    eigs.truncate(n_take);
-    eigs
-}
 
 /// Spurious-cluster → physical-band diagnostic ratio
 /// `λ[n_spurious] / λ[n_spurious - 1]` on Burn's spectrum, computed

--- a/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_onnx_reference.rs
@@ -55,7 +55,6 @@ use burn::prelude::Backend;
 use burn::tensor::DType;
 use burn::tensor::backend::BackendTypes;
 use faer::Mat;
-use faer::mat::MatRef;
 use std::path::PathBuf;
 
 use geode_core::assembly::nedelec::{
@@ -66,6 +65,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{R_BUFFER, read_sphere_fixture};
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::eigen::dense_lowest_eigenvalues;
+use geode_util::math::{frobenius_norm, symmetry_residual};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -210,56 +211,6 @@ fn run_burn_pipeline() -> BurnPipeline {
 // ---------------------------------------------------------------------------
 // Matrix helpers
 // ---------------------------------------------------------------------------
-
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
-fn symmetry_residual(m: MatRef<f64>) -> f64 {
-    let mut worst = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let d = (m[(i, j)] - m[(j, i)]).abs();
-            if d > worst {
-                worst = d;
-            }
-        }
-    }
-    worst
-}
-
-fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-
-    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        eigs.push(re);
-    }
-    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    eigs.truncate(n_take);
-    eigs
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
+++ b/crates/geode-validation/tests/sphere_pec_tfjava_reference.rs
@@ -54,7 +54,6 @@ use burn::prelude::Backend;
 use burn::tensor::DType;
 use burn::tensor::backend::BackendTypes;
 use faer::Mat;
-use faer::mat::MatRef;
 
 use geode_core::assembly::nedelec::{
     assemble_global_nedelec_with_epsilon, build_epsilon_r, sphere_pec_interior_edges,
@@ -64,6 +63,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{R_BUFFER, read_sphere_fixture};
 use geode_core::testing::{TestBackend, device_tolerances};
+use geode_util::eigen::dense_lowest_eigenvalues;
+use geode_util::math::{frobenius_norm, symmetry_residual};
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -201,56 +202,6 @@ fn run_burn_pipeline() -> BurnPipeline {
 // ---------------------------------------------------------------------------
 // Matrix helpers
 // ---------------------------------------------------------------------------
-
-fn frobenius_norm(m: MatRef<f64>) -> f64 {
-    let mut s = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let v = m[(i, j)];
-            s += v * v;
-        }
-    }
-    s.sqrt()
-}
-
-fn symmetry_residual(m: MatRef<f64>) -> f64 {
-    let mut worst = 0.0_f64;
-    for j in 0..m.ncols() {
-        for i in 0..m.nrows() {
-            let d = (m[(i, j)] - m[(j, i)]).abs();
-            if d > worst {
-                worst = d;
-            }
-        }
-    }
-    worst
-}
-
-fn dense_lowest_eigenvalues(k: MatRef<f64>, m: MatRef<f64>, n_take: usize) -> Vec<f64> {
-    let dim = k.nrows();
-    let evd = k.generalized_eigen(&m).expect("faer generalized_eigen");
-    let s_a = evd.S_a().column_vector();
-    let s_b = evd.S_b().column_vector();
-
-    let mut eigs: Vec<f64> = Vec::with_capacity(dim);
-    for i in 0..dim {
-        let a = s_a[i];
-        let b = s_b[i];
-        let denom = b.norm_sqr();
-        if denom < 1e-30 {
-            continue;
-        }
-        let re = (a.re * b.re + a.im * b.im) / denom;
-        let im = (a.im * b.re - a.re * b.im) / denom;
-        if im.abs() > 1e-9 * re.abs().max(1.0) {
-            continue;
-        }
-        eigs.push(re);
-    }
-    eigs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    eigs.truncate(n_take);
-    eigs
-}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
+++ b/crates/geode-validation/tests/sphere_pml_numpy_reference.rs
@@ -86,10 +86,10 @@ use geode_core::assembly::nedelec::{
 use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::complex::{ComplexEigenSolver, FaerComplexEigensolver};
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
-use geode_core::mesh::{
-    R_BUFFER, SphereFixture, read_sphere_fixture, read_sphere_fixture_from_bytes,
-};
+use geode_core::mesh::{R_BUFFER, SphereFixture, read_sphere_fixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::q_factor_from_lambda;
+use geode_util::fixture::load_small_sphere_fixture;
 use geode_validation::{Fixture, FixtureFormat};
 
 type B = TestBackend;
@@ -104,10 +104,6 @@ fn fixture_path() -> PathBuf {
 
 fn small_fixture_path() -> PathBuf {
     geode_validation::fixture_path("sphere_pml_small/baseline.json")
-}
-
-fn small_mesh_path() -> PathBuf {
-    geode_validation::fixture_path("sphere_pml_small/sphere.msh")
 }
 
 // ---------------------------------------------------------------------------
@@ -210,23 +206,6 @@ fn run_burn_pml_pipeline_from_fixture(
         epsilon_r_complex,
         k_int_complex,
         m_int_complex,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Q-factor helper — k-space sign-agnostic form, mirror of the NumPy
-// reference (`sphere_pml.run_sphere_pml`) and the Burn integration test
-// print in `tests/sphere_pml_eigenmode.rs:362-372`.
-// ---------------------------------------------------------------------------
-
-fn q_factor_from_lambda(lambda: Complex64) -> f64 {
-    let r = (lambda.re * lambda.re + lambda.im * lambda.im).sqrt();
-    let re_k = (0.5 * (r + lambda.re)).max(0.0).sqrt();
-    let im_k_mag = (0.5 * (r - lambda.re)).max(0.0).sqrt();
-    if im_k_mag > 1e-12 {
-        re_k / (2.0 * im_k_mag)
-    } else {
-        f64::INFINITY
     }
 }
 
@@ -607,12 +586,6 @@ fn pml_sigma_zero_reduces_to_real_pec() {
 //     into Q-residual.
 //   - σ₀=0 PEC collapse: in-fixture anchor at 1e-5 absolute on the
 //     lowest physical Re(λ).
-
-fn load_small_sphere_fixture() -> SphereFixture {
-    let bytes = std::fs::read(small_mesh_path())
-        .expect("read small-mesh sphere.msh bytes (run reference/numpy/gen_sphere_pml_small_baseline.py if missing)");
-    read_sphere_fixture_from_bytes(&bytes).expect("parse small-mesh sphere.msh")
-}
 
 #[test]
 fn sphere_pml_small_fixture_loads_with_expected_schema() {

--- a/examples/mie_open_quasimode/src/main.rs
+++ b/examples/mie_open_quasimode/src/main.rs
@@ -93,6 +93,7 @@ use geode_core::eigen::complex::{
 };
 use geode_core::mesh::{PHYS_SPHERE_INTERIOR, R_BUFFER, SphereFixture, read_sphere_fixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen::k_from_lambda;
 
 /// Refractive index inside the sphere (matches the analytic catalog).
 const N_INSIDE: f64 = 1.5;
@@ -110,15 +111,6 @@ const N_NEAR_SHIFT: usize = 60;
 /// Extra eigenvalues requested above the gradient-nullspace count on
 /// the `--dense` oracle path (which sorts ascending by |Re(λ)| from 0).
 const N_EXTRA_DENSE: usize = 80;
-
-/// Principal-branch `k = sqrt(λ)` with `Re(k) ≥ 0`.
-fn k_from_lambda(lam: faer::c64) -> (f64, f64) {
-    let r = (lam.re * lam.re + lam.im * lam.im).sqrt();
-    let re_k = ((r + lam.re) / 2.0).sqrt();
-    let im_mag = ((r - lam.re) / 2.0).sqrt();
-    let im_k = if lam.im >= 0.0 { im_mag } else { -im_mag };
-    (re_k, im_k)
-}
 
 /// One frozen-ω matched-UPML eigensolve: assemble
 /// `K(Λ⁻¹(ω)) x = λ M(ε_rΛ(ω)) x` on the bundled fixture, PEC-reduce,
@@ -296,13 +288,6 @@ struct QuasiModeRow {
     picard: Option<(f64, f64, f64, f64)>,
 }
 
-fn pol_str(pol: MiePolarisation) -> &'static str {
-    match pol {
-        MiePolarisation::TE => "TE",
-        MiePolarisation::TM => "TM",
-    }
-}
-
 fn results_path() -> PathBuf {
     geode_util::repo::repo_root()
         .join("benchmarks")
@@ -358,7 +343,7 @@ fn write_results(rows: &[QuasiModeRow]) {
     for (i, r) in rows.iter().enumerate() {
         s.push_str(&format!("[quasimode_{i}]\n"));
         s.push_str(&format!("sigma_0 = {}\n", r.sigma_0));
-        s.push_str(&format!("polarisation = \"{}\"\n", pol_str(r.pol)));
+        s.push_str(&format!("polarisation = \"{}\"\n", r.pol.as_str()));
         s.push_str(&format!("l = {}\n", r.l));
         s.push_str(&format!("n = {}\n", r.n));
         s.push_str(&format!("omega_freeze = {:.15e}\n", r.omega_freeze));
@@ -438,7 +423,7 @@ impl App for Args {
                 let omega0 = root.re_k;
                 eprintln!(
                     "=== σ₀ = {sigma_0}, target {}_{},{} (analytic k = {:.4} {:+.4}j, Q = {:.3}) ===",
-                    pol_str(root.pol),
+                    root.pol.as_str(),
                     root.l,
                     root.n,
                     root.re_k,
@@ -519,7 +504,7 @@ impl App for Args {
                 "  σ₀ = {:>4}: {}_{},{}  Re(k) {:.4} vs {:.4} ({:.1}% err), \
              Q {:.3} vs {:.3} (ratio {:.3}){}",
                 r.sigma_0,
-                pol_str(r.pol),
+                r.pol.as_str(),
                 r.l,
                 r.n,
                 r.fem_re_k,

--- a/examples/mie_sphere/src/main.rs
+++ b/examples/mie_sphere/src/main.rs
@@ -109,9 +109,7 @@ use clap::Parser;
 use faer::sparse::{SparseColMat, Triplet};
 
 use geode_app::{App, OutputDir, Verbosity};
-use geode_core::analytic::mie::{
-    MiePolarisation, MieRoot, mie_roots_catalog, open_space_wgm_roots_n15,
-};
+use geode_core::analytic::mie::{MieRoot, mie_roots_catalog, open_space_wgm_roots_n15};
 use geode_core::assembly::nedelec::{
     assemble_global_nedelec_with_anisotropic_epsilon, assemble_global_nedelec_with_complex_epsilon,
     build_anisotropic_pml_tensor_diag, build_complex_epsilon_r_pml, burn_complex_mass_to_faer,
@@ -128,6 +126,7 @@ use geode_core::eigen::complex::{
 use geode_core::eigen::dense::{apply_dirichlet_bc, burn_matrix_to_faer};
 use geode_core::mesh::{PHYS_SPHERE_INTERIOR, R_BUFFER, R_SPHERE, read_sphere_fixture};
 use geode_core::testing::TestBackend;
+use geode_util::eigen;
 use geode_util::viz::edge_field_to_nodes;
 
 /// Refractive index inside the sphere. n=1.5 is the textbook
@@ -214,13 +213,6 @@ struct Row {
     fem_im_k: f64,
     rel_err_re_k: f64,
     q: f64,
-}
-
-fn pol_str(pol: MiePolarisation) -> &'static str {
-    match pol {
-        MiePolarisation::TE => "TE",
-        MiePolarisation::TM => "TM",
-    }
 }
 
 fn results_path() -> PathBuf {
@@ -424,15 +416,6 @@ fn fem_complex_k<B: Backend>(
         .collect()
 }
 
-/// Compute the Q factor of a complex `k`: `Q = Re(k) / (2 |Im(k)|)`.
-fn q_factor(k: faer::c64) -> f64 {
-    if k.im.abs() > 1e-12 {
-        k.re / (2.0 * k.im.abs())
-    } else {
-        f64::INFINITY
-    }
-}
-
 /// Multiplicity-aware mode-claim pairing with overlap gating
 /// (issues #40, #43).
 ///
@@ -490,7 +473,7 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
             if band > 0.10 {
                 eprintln!(
                     "  note: {}_{},{} multiplet Im(k) band = {:.1}% > 10% (mesh asymmetry)",
-                    pol_str(root.pol),
+                    root.pol.as_str(),
                     root.l,
                     root.n,
                     band * 100.0
@@ -521,11 +504,11 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
                         "  warn: close-pair gating — {}_{},{} (k = {:.5}) next root \
                          {}_{},{} (k = {:.5}, rel gap = {:.3}%) and within-multiplet \
                          FEM spread = {:.3e} > 0.5 * gap ({:.3e}); claim is ambiguous",
-                        pol_str(root.pol),
+                        root.pol.as_str(),
                         root.l,
                         root.n,
                         root.k,
-                        pol_str(next.pol),
+                        next.pol.as_str(),
                         next.l,
                         next.n,
                         next.k,
@@ -540,7 +523,7 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
         for (slot, fem_k) in group.iter().enumerate() {
             let rel_err = (fem_k.re - root.k).abs() / root.k;
             rows.push(Row {
-                pol: pol_str(root.pol),
+                pol: root.pol.as_str(),
                 l: root.l,
                 n: root.n,
                 m_idx: slot,
@@ -550,7 +533,7 @@ fn pair_modes(analytic: &[MieRoot], fem: &[faer::c64]) -> Vec<Row> {
                 fem_re_k: fem_k.re,
                 fem_im_k: fem_k.im,
                 rel_err_re_k: rel_err,
-                q: q_factor(*fem_k),
+                q: eigen::q_factor(*fem_k),
             });
         }
 
@@ -826,7 +809,7 @@ impl App for Args {
         for r in analytic.iter().take(12) {
             eprintln!(
                 "  {}_{},{}  k = {:.5}  k² = {:.5}  mult = {}",
-                pol_str(r.pol),
+                r.pol.as_str(),
                 r.l,
                 r.n,
                 r.k,
@@ -866,7 +849,7 @@ impl App for Args {
         for r in open_space.iter().take(8) {
             eprintln!(
                 "  {}_{},{}  k = {:.5} + {:.5e}i  Q = {:.3}",
-                pol_str(r.pol),
+                r.pol.as_str(),
                 r.l,
                 r.n,
                 r.re_k,
@@ -901,7 +884,7 @@ impl App for Args {
             eprintln!(
                 "{:>3}  {:>9}_{},{}  {:>11.5}  {:>11.5}  {:>11.3}%  {:>12.3}",
                 i,
-                pol_str(best.pol),
+                best.pol.as_str(),
                 best.l,
                 best.n,
                 fk.re,
@@ -932,6 +915,7 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use geode_core::analytic::mie::MiePolarisation;
 
     /// Build a synthetic FEM-mode vector that mimics a coarse-mesh
     /// split of an analytic root: three modes (multiplicity 2l+1 = 3)

--- a/examples/patch_antenna/src/main.rs
+++ b/examples/patch_antenna/src/main.rs
@@ -136,6 +136,7 @@ use faer::c64;
 
 use geode_app::{App, OutputDir, Verbosity};
 use geode_core::analytic::patch::PatchCavity;
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{im_z_zero_crossings, s11};
 use geode_core::driven::ports::{port_current, port_voltage};
 use geode_core::driven::scattering::flux_power_box;
@@ -152,14 +153,8 @@ use geode_core::postproc::ntff::{
 };
 use geode_core::postproc::viz::write_vtu_surface;
 use geode_core::testing::TestBackend;
+use geode_util::units::{ghz_to_omega_mm as ghz_to_omega, omega_to_ghz_mm};
 use geode_util::viz::edge_field_to_nodes;
-
-/// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in mm/s — the fixture length unit is the millimeter,
-/// so `ω_natural ≡ k₀ = 2π f / C_MM_PER_S` (rad/mm).
-const C_MM_PER_S: f64 = 2.997_924_58e11;
 
 /// Port reference resistance (Ω).
 const R_PORT_OHM: f64 = 50.0;
@@ -275,10 +270,6 @@ impl From<&Row> for PointRow {
             solve_residual_rel: r.residual_rel,
         }
     }
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_MM_PER_S
 }
 
 fn pml_thick_for(choice: FixtureChoice) -> f64 {
@@ -511,7 +502,7 @@ fn emit_results(rows: &[Row], path: &PathBuf, choice: FixtureChoice, pml_thick: 
     let zs: Vec<c64> = rows.iter().map(|r| r.z_ohm).collect();
     let f_res_fem_ghz = im_z_zero_crossings(&omegas, &zs)
         .first()
-        .map(|&w| w * C_MM_PER_S / (2.0 * std::f64::consts::PI * 1.0e9))
+        .map(|&w| omega_to_ghz_mm(w))
         .or_else(|| {
             rows.iter()
                 .min_by(|a, b| a.s11.norm().partial_cmp(&b.s11.norm()).unwrap())

--- a/examples/slcfet_3hp_spiral/src/main.rs
+++ b/examples/slcfet_3hp_spiral/src/main.rs
@@ -71,6 +71,7 @@ use geode_app::{App, Verbosity};
 use geode_core::analytic::spiral::{
     SquareSpiral, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l,
 };
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{detect_srf, driven_frequency_sweep};
 use geode_core::driven::solve::{
     CurrentSource, DrivenBcs, DrivenMaterials, SurfaceImpedanceBc, SurfaceImpedanceModel,
@@ -80,13 +81,7 @@ use geode_core::mesh::{
     read_spiral_slcfet_3hp_fixture, read_spiral_slcfet_3hp_smoke_fixture,
 };
 use geode_core::testing::TestBackend;
-
-/// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in µm/s — the fixture length unit is the micron, so
-/// `ω_natural = 2π f / C_UM_PER_S` (rad/µm).
-const C_UM_PER_S: f64 = 2.997_924_58e14;
+use geode_util::units::{ghz_to_omega_um as ghz_to_omega, omega_to_ghz_um};
 
 /// Port reference resistance (Ω).
 const R_PORT_OHM: f64 = 50.0;
@@ -184,10 +179,6 @@ impl From<&Row> for PointRow {
             solve_residual_rel: r.residual_rel,
         }
     }
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_UM_PER_S
 }
 
 /// Quasi-static inductance L0 by Richardson extrapolation of the two
@@ -490,8 +481,7 @@ fn run<B: Backend>(choice: FixtureChoice, device: &B::Device) {
 
     let omegas: Vec<f64> = rows.iter().map(|r| r.omega).collect();
     let zs: Vec<c64> = rows.iter().map(|r| r.z_ohm).collect();
-    let srf_ghz =
-        detect_srf(&omegas, &zs).map(|w| w * C_UM_PER_S / (2.0 * std::f64::consts::PI * 1.0e9));
+    let srf_ghz = detect_srf(&omegas, &zs).map(omega_to_ghz_um);
 
     let l_cs = mohan_current_sheet_l(&FIXTURE_SPIRAL) * 1.0e9;
     eprintln!(

--- a/examples/spiral_inductor/src/main.rs
+++ b/examples/spiral_inductor/src/main.rs
@@ -95,6 +95,7 @@ use geode_app::{App, OutputDir, Verbosity};
 use geode_core::analytic::spiral::{
     SquareSpiral, modified_wheeler_l, mohan_current_sheet_l, monomial_fit_l,
 };
+use geode_core::constants::ETA_0_OHM as ETA_0;
 use geode_core::driven::extraction::{detect_srf, driven_frequency_sweep};
 use geode_core::driven::solve::{
     CurrentSource, DrivenBcs, DrivenMaterials, SurfaceImpedanceBc, SurfaceImpedanceModel,
@@ -105,14 +106,8 @@ use geode_core::mesh::{
     SpiralFixture, pec_interior_mask_from_triangles, read_spiral_fixture, read_spiral_smoke_fixture,
 };
 use geode_core::testing::TestBackend;
+use geode_util::units::{ghz_to_omega_um as ghz_to_omega, omega_to_ghz_um};
 use geode_util::viz::edge_field_to_nodes;
-
-/// Free-space impedance η₀ (Ω) — the solver's natural impedance unit.
-const ETA_0: f64 = 376.730_313_668;
-
-/// Speed of light in µm/s — the fixture length unit is the micron, so
-/// `ω_natural = 2π f / C_UM_PER_S` (rad/µm).
-const C_UM_PER_S: f64 = 2.997_924_58e14;
 
 /// Port reference resistance (Ω).
 const R_PORT_OHM: f64 = 50.0;
@@ -204,10 +199,6 @@ impl From<&Row> for PointRow {
             solve_residual_rel: r.residual_rel,
         }
     }
-}
-
-fn ghz_to_omega(f_ghz: f64) -> f64 {
-    2.0 * std::f64::consts::PI * f_ghz * 1.0e9 / C_UM_PER_S
 }
 
 fn results_path(choice: FixtureChoice) -> PathBuf {
@@ -574,8 +565,7 @@ fn run<B: Backend>(device: &B::Device, choice: FixtureChoice) {
 
     let omegas: Vec<f64> = rows.iter().map(|r| r.omega).collect();
     let zs: Vec<c64> = rows.iter().map(|r| r.z_ohm).collect();
-    let srf_ghz =
-        detect_srf(&omegas, &zs).map(|w| w * C_UM_PER_S / (2.0 * std::f64::consts::PI * 1.0e9));
+    let srf_ghz = detect_srf(&omegas, &zs).map(omega_to_ghz_um);
 
     let l_cs = mohan_current_sheet_l(&FIXTURE_SPIRAL) * 1.0e9;
     eprintln!(


### PR DESCRIPTION
The utility code has been consolidated into the `geode-util` module for better organization and reuse. This change improves the structure and maintainability of the codebase. No functional changes were introduced.