### PR TITLE
chore: gitignore .claude/worktrees/ agent-isolation worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ build/
 dist/
 .loom/spawn-loop-state.json
 .loom/worktrees/
+# Claude Code agent-isolation worktrees (local session state, never committed)
+.claude/worktrees/
 .loom/state.json
 .loom/*.log
 .loom/*.sock


### PR DESCRIPTION
## Summary

Add a `.gitignore` rule for `.claude/worktrees/` so Claude Code's agent-isolation worktrees (local session state) can never be committed. During the Loom 0.10.6 upgrade (commit `2031a4e`), a bare `git add -A` in the installer staged an untracked `.claude/worktrees/agent-<id>` embedded worktree — caught manually, but any future `git add -A`/`git add .` had the same exposure. This closes that gap.

## Changes

- Add `.claude/worktrees/` ignore rule to `.gitignore`, placed directly beside the existing `.loom/worktrees/` entry (its sibling pattern for the same class of local-only worktree state), with an explanatory comment.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `.gitignore` contains `.claude/worktrees/` | ✅ | `grep -n '^.claude/worktrees/$' .gitignore` → line 77 |
| `git check-ignore .claude/worktrees/anything` exits 0 | ✅ | `git check-ignore -v .claude/worktrees/anything` → matches `.gitignore:77`, exit 0 |
| `git status` no longer lists `.claude/worktrees/` as untracked | ✅ | Rule now matches the path repo-wide; edge case `.claude/worktrees/agent-test123/some-file` also matched with exit 0 |

## Test Plan

- `git check-ignore -v .claude/worktrees/anything` → `.gitignore:77:.claude/worktrees/`, exit 0
- Edge case: `git check-ignore -v .claude/worktrees/agent-test123/some-file` → matched, exit 0
- No source code affected (repo-config-only change); no build/tests required.

Closes #444