### PR TITLE
feat(waveguide): add analytic-cladding DtN boundary-condition fiber solver

### DIFF
--- a/crates/geode-core/src/analytic/waveguide.rs
+++ b/crates/geode-core/src/analytic/waveguide.rs
@@ -6057,6 +6057,477 @@ fn physical_index_ceiling(mesh: &TriMesh, eps_r: &[f64], k0: f64) -> Option<f64>
     Some(ceiling.min(n_core))
 }
 
+// ===========================================================================
+// Epic #339 (#446): analytic-cladding boundary-condition solver (mode-matching)
+// ===========================================================================
+//
+// The PML path (`solve_dielectric_modes2_pml`) and its profile selector
+// (`solve_dielectric_modes2_pml_profile_selected`) both **discretize** the
+// infinite exterior (a cladding annulus + UPML) and let the eigensolver find
+// modes there. On a weakly-guiding fiber that discretized cladding continuum
+// spawns a dense ladder of genuinely-bound box/cladding-resonance eigenpairs
+// straddling the razor-thin `(n_clad², n_core²)` guided window — the root
+// cause of the ≤1 %-b miss proven by #336/#359/#365.
+//
+// This block adds, **additively / opt-in**, an alternative bounded-domain
+// solver that attacks that root cause by *removing* the discretized cladding
+// continuum. It meshes only the core + a thin cladding collar (no PML annulus)
+// and imposes the exact analytic exterior decay `K_l(κ·r)` as a β-dependent
+// **DtN / Robin boundary condition** on the truncation circle:
+//
+//   ∂_r E / E |_{r=r_bc} = κ · K_l'(κ·r_bc) / K_l(κ·r_bc),   κ = √(β² − n_clad²k₀²).
+//
+// The exterior then has no discretized free modes to pollute the spectrum, so
+// the ladder cannot form. Because the BC depends on the unknown `β²` through
+// `κ`, the eigensolve is wrapped in a small **self-consistent** (fixed-point)
+// outer loop over `β²` — the same containment discipline as `self_consistent.rs`
+// (solve at the current guess, update from the selected eigenvalue, repeat to
+// contraction). The proven p=2 curl-curl `K` / ε-mass `M_ε` assembly, the
+// `SparseComplexShiftInvertLanczos` eigensolve, PEC reduction, and the
+// `m=0`/zero-radial-node/core-peaked confirmation diagnostics are all reused
+// **bit-for-bit** — the only new physics is the boundary term added to `K`.
+
+/// Radial logarithmic derivative of the analytic exterior decay `K_l(κ·r)`
+/// evaluated at the truncation radius `r_bc` (Epic #339, #446):
+///
+/// ```text
+///   γ(β²) = κ · K_l'(κ·r_bc) / K_l(κ·r_bc),   κ = √(β² − n_clad²·k₀²) > 0,
+/// ```
+///
+/// with `K_l'(x) = −K_1(x)` for `l = 0` and `K_l'(x) = −½(K_{l−1}(x) +
+/// K_{l+1}(x))` for `l ≥ 1` (the standard modified-Bessel derivative
+/// identity). For a bound mode `β² > n_clad²·k₀²` so `κ` is real and positive,
+/// and `γ < 0` (the exterior field decays outward). This is the coefficient of
+/// the boundary term that replaces the discretized-exterior PML annulus: it
+/// enters the curl-curl operator as `K_eff = K − γ · S_bc`, where `S_bc` is the
+/// boundary tangential mass ([`assemble_boundary_tangential_mass`]).
+///
+/// Returns `None` if `beta_sq ≤ n_clad²·k₀²` (radiating / not bound — `κ`
+/// imaginary), so the caller can reject an out-of-window iterate.
+fn analytic_cladding_bc_gamma(
+    l: usize,
+    beta_sq: f64,
+    n_clad: f64,
+    k0: f64,
+    r_bc: f64,
+) -> Option<f64> {
+    let kappa_sq = beta_sq - n_clad * n_clad * k0 * k0;
+    if kappa_sq <= 0.0 {
+        return None;
+    }
+    let kappa = kappa_sq.sqrt();
+    let x = kappa * r_bc;
+    if x <= 0.0 {
+        return None;
+    }
+    let kl = crate::analytic::fiber::bessel_k(l, x);
+    if !kl.is_finite() || kl.abs() < 1e-300 {
+        return None;
+    }
+    // K_l'(x): -K_1 for l=0, else -(K_{l-1}+K_{l+1})/2.
+    let kl_prime = if l == 0 {
+        -crate::analytic::fiber::bessel_k1(x)
+    } else {
+        -0.5 * (crate::analytic::fiber::bessel_k(l - 1, x)
+            + crate::analytic::fiber::bessel_k(l + 1, x))
+    };
+    Some(kappa * kl_prime / kl)
+}
+
+/// Assemble the interior-restricted **boundary tangential mass** matrix `S_bc`
+/// on the truncation circle `r = r_bc` for the DtN / Robin analytic-cladding
+/// boundary condition (Epic #339, #446).
+///
+/// `S_bc[i][j] = ∮_{r=r_bc} (N_i·t̂)(N_j·t̂) ds` is the line integral of the
+/// tangential-field product of the p=2 Nédélec basis functions over every mesh
+/// edge that lies on the truncation circle (both endpoints at `r_bc`). It is
+/// the boundary analogue of the volume mass `M₁` and shares the *exact same*
+/// DOF numbering / orientation-sign scatter (`tri_nedelec2_dofs`,
+/// `TRI_NEDELEC2_DOF_FLIPS`) and the same interior (PEC) restriction, so the
+/// returned matrix is compatible entry-for-entry with the assembled `K`/`M`.
+///
+/// The tangential trace of each basis function is evaluated with a 3-point
+/// Gauss–Legendre rule along the physical edge (degree-5 exact — ample for the
+/// quadratic p=2 tangential trace). Only boundary edges contribute; every
+/// interior edge integrates to zero.
+///
+/// Returns a real `dim × dim` sparse matrix (`dim` = interior DOF count). It is
+/// symmetric by construction. With no boundary edges on `r_bc` it is the zero
+/// matrix.
+fn assemble_boundary_tangential_mass(
+    mesh: &TriMesh,
+    interior_dof_mask: &[bool],
+    r_bc: f64,
+) -> Result<SparseColMat<usize, f64>, EigenError> {
+    let n_edges = mesh.edges().len();
+    let (renumber, dim) = interior_renumber(interior_dof_mask);
+    let tri_edges = mesh.tri_edges();
+    let on_boundary = disk_boundary_nodes(mesh, r_bc);
+
+    // 3-point Gauss–Legendre on [0, 1] (mapped from the standard [-1, 1] rule).
+    // Nodes/weights on [-1,1]: ±√(3/5), 0 with weights 5/9, 8/9. Mapped to
+    // [0,1]: t = (ξ+1)/2, w = w_ξ/2.
+    const GL3: [(f64, f64); 3] = [
+        (0.112_701_665_379_258_3, 0.277_777_777_777_777_8),
+        (0.5, 0.444_444_444_444_444_4),
+        (0.887_298_334_620_741_7, 0.277_777_777_777_777_8),
+    ];
+
+    let mut trips: Vec<Triplet<usize, usize, f64>> = Vec::new();
+
+    for (tri_index, (tri, row)) in mesh.tris.iter().zip(tri_edges.iter()).enumerate() {
+        let coords = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let dofs = tri_nedelec2_dofs(row, tri_index, n_edges);
+
+        // Each of the triangle's three local edges: does it lie on r = r_bc?
+        for (le, &(la, lb)) in TRI_LOCAL_EDGES.iter().enumerate() {
+            let na = tri[la] as usize;
+            let nb = tri[lb] as usize;
+            if !(on_boundary[na] && on_boundary[nb]) {
+                continue;
+            }
+            let pa = coords[la];
+            let pb = coords[lb];
+            let edge_vec = [pb[0] - pa[0], pb[1] - pa[1]];
+            let edge_len = (edge_vec[0] * edge_vec[0] + edge_vec[1] * edge_vec[1]).sqrt();
+            if edge_len < 1e-300 {
+                continue;
+            }
+            // Unit tangent along the edge (parameterization direction la→lb).
+            let t_hat = [edge_vec[0] / edge_len, edge_vec[1] / edge_len];
+
+            // Barycentric coordinates along the edge: only λ_la, λ_lb vary
+            // (linearly), the third is 0. At parameter s ∈ [0,1]: λ_la = 1−s,
+            // λ_lb = s, λ_other = 0.
+            let other = 3 - la - lb; // remaining local vertex index (0+1+2=3)
+            for &(s, w) in GL3.iter() {
+                let mut lam = [0.0_f64; 3];
+                lam[la] = 1.0 - s;
+                lam[lb] = s;
+                lam[other] = 0.0;
+                let basis = tri_nedelec2_basis_values(&coords, lam);
+                // Tangential trace t̂·N_k of each of the 8 basis functions.
+                let mut t_trace = [0.0_f64; 8];
+                for (k, tk) in t_trace.iter_mut().enumerate() {
+                    *tk = basis[k][0] * t_hat[0] + basis[k][1] * t_hat[1];
+                }
+                let ds = w * edge_len; // physical arc-length weight
+                for i in 0..8 {
+                    let (gi, si) = dofs[i];
+                    let Some(ri) = renumber[gi] else {
+                        continue;
+                    };
+                    for j in 0..8 {
+                        let (gj, sj) = dofs[j];
+                        let Some(rj) = renumber[gj] else {
+                            continue;
+                        };
+                        let val = si * sj * t_trace[i] * t_trace[j] * ds;
+                        if val != 0.0 {
+                            trips.push(Triplet::new(ri, rj, val));
+                        }
+                    }
+                }
+            }
+            let _ = le;
+        }
+    }
+
+    triplets_to_sparse(dim, &trips)
+}
+
+/// Embed a real interior operator into a complex (`c64`) sparse matrix with
+/// zero imaginary part, preserving the sparsity pattern (Epic #339, #446). The
+/// analytic-cladding path assembles the proven **real** p=2 operators and adds
+/// only a real boundary term, so the whole pencil is real; embedding in `c64`
+/// lets it reuse the `SparseComplexShiftInvertLanczos` path unchanged (the
+/// recovered `β²` then carries `Im ≈ 0`, exactly as the σ₀ = 0 PML reduction).
+fn embed_real_sparse_c64(a: SparseColMatRef<'_, usize, f64>) -> SparseColMat<usize, c64> {
+    let n = a.nrows();
+    let cp = a.col_ptr();
+    let ri = a.row_idx();
+    let v = a.val();
+    let mut trips: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(cp[n]);
+    for j in 0..a.ncols() {
+        for kk in cp[j]..cp[j + 1] {
+            trips.push(Triplet::new(ri[kk], j, c64::new(v[kk], 0.0)));
+        }
+    }
+    SparseColMat::<usize, c64>::try_new_from_triplets(n, n, &trips)
+        .expect("real→c64 embed of an already-valid sparse operator cannot fail")
+}
+
+/// Outcome of the analytic-cladding self-consistent `β²` loop
+/// ([`solve_dielectric_modes2_analytic_cladding_bc`], Epic #339 #446). Records
+/// whether the fixed point over the β-dependent DtN boundary condition
+/// contracted, plus the diagnostics an honest-science benchmark needs.
+#[derive(Clone, Debug)]
+pub struct AnalyticCladdingBcMode {
+    /// Complex effective index `n_eff = √(β²)/k₀` of the selected core mode.
+    pub n_eff: c64,
+    /// Selected generalized-pencil eigenvalue `β²` at convergence.
+    pub beta_sq: c64,
+    /// `true` if the self-consistent `β²` fixed point **converged**
+    /// (`|Δβ²|/β² < tol` within the iteration budget). `false` if it hit the
+    /// iteration cap without contracting — the honest-negative signal that the
+    /// DtN loop did not settle.
+    pub converged: bool,
+    /// Number of eigensolves performed by the outer loop (≥ 1).
+    pub iterations: usize,
+    /// Full-length **complex** transverse field over the p=2 DOFs (length
+    /// [`n_dof_2d_nedelec2`]); PEC-eliminated DOFs carry exact zeros. Suitable
+    /// for the `dielectric_mode_*_pml` diagnostics via [`Self::as_pml_mode`].
+    pub e_edges: Vec<c64>,
+}
+
+impl AnalyticCladdingBcMode {
+    /// View this mode as a [`DielectricModePml`] so the existing
+    /// `dielectric_mode_field_shape_pml` / `dielectric_mode_radial_profile_pml`
+    /// diagnostics apply **unchanged** (Epic #339 #446). `guided` is set
+    /// `true`; `beta` is the principal square root of `beta_sq`.
+    pub fn as_pml_mode(&self) -> DielectricModePml {
+        DielectricModePml {
+            n_eff: self.n_eff,
+            beta: principal_sqrt_c64(self.beta_sq),
+            beta_sq: self.beta_sq,
+            guided: true,
+            e_edges: self.e_edges.clone(),
+        }
+    }
+}
+
+/// Solve the weakly-guiding dielectric fundamental with an **analytic-cladding
+/// DtN / Robin boundary condition** instead of a discretized+PML exterior
+/// (Epic #339, #446) — the mode-matching / continuum-removal approach.
+///
+/// The mesh (`mesh`, `eps_r`, `interior_dof_mask`) is a plain core + thin
+/// cladding-collar [`disk_tri_mesh`] truncated at `r_bc` (the outer radius,
+/// which must carry a PEC ring in `interior_dof_mask`); there is **no** PML
+/// annulus. The proven real p=2 operators `(K, M_ε, M₁)` come from
+/// `assemble_2d_nedelec2_sparse_interior` unchanged. The infinite exterior is
+/// represented exactly by the boundary term `−γ(β²)·S_bc` added to `K`, where
+/// `γ` is the analytic radial log-derivative of `K_l(κ·r)`
+/// (`analytic_cladding_bc_gamma`) and `S_bc` is the boundary tangential mass
+/// (`assemble_boundary_tangential_mass`).
+///
+/// Because `γ` depends on the unknown `β²` through `κ = √(β²−n_clad²k₀²)`, the
+/// eigensolve is wrapped in a **self-consistent fixed point**: solve at the
+/// current `β²` guess, pick the in-window, curl-bearing, most-core-confined
+/// eigenpair, update the guess from its eigenvalue, and repeat until
+/// `|Δβ²|/β² < tol` (converged) or the iteration cap is hit (honest negative:
+/// the DtN loop did not contract). The `SparseComplexShiftInvertLanczos` path,
+/// PEC reduction, and the curl / in-window gates are reused unchanged.
+///
+/// # Arguments
+///
+/// - `mesh` / `eps_r` / `interior_dof_mask` — plain core+collar disk mesh, its
+///   per-triangle `ε_r`, and the p=2 PEC interior mask (`disk_pec_interior_dofs2`
+///   at `r_bc`).
+/// - `r_bc` — truncation radius (the mesh outer radius); the DtN condition is
+///   imposed on this circle.
+/// - `k0` — free-space wavenumber (> 0).
+/// - `l` — analytic azimuthal order of the target mode (0 for LP₀₁).
+/// - `n_modes` — number of candidate eigenpairs to request per solve (the
+///   fundamental is selected among them).
+/// - `max_iter` / `tol` — self-consistent-loop budget and relative-`β²`
+///   convergence tolerance.
+///
+/// # Returns
+///
+/// The selected [`AnalyticCladdingBcMode`] (with the `converged` flag), or an
+/// empty `Vec` if no in-window curl-bearing mode is found at the seed. Errors
+/// propagate from the eigensolve.
+#[allow(clippy::too_many_arguments)]
+pub fn solve_dielectric_modes2_analytic_cladding_bc(
+    mesh: &TriMesh,
+    eps_r: &[f64],
+    interior_dof_mask: &[bool],
+    r_bc: f64,
+    k0: f64,
+    l: usize,
+    n_modes: usize,
+    max_iter: usize,
+    tol: f64,
+) -> Result<Vec<AnalyticCladdingBcMode>, EigenError> {
+    assert!(k0 > 0.0, "k0 must be positive; got {k0}");
+    assert!(r_bc > 0.0, "r_bc must be positive; got {r_bc}");
+    assert!(max_iter > 0, "max_iter must be positive");
+
+    let eps_max = eps_r.iter().cloned().fold(f64::MIN, f64::max);
+    let eps_min = eps_r.iter().cloned().fold(f64::MAX, f64::min);
+    let n_core = eps_max.sqrt();
+    let n_clad = eps_min.sqrt();
+    let k0_sq = k0 * k0;
+    let beta_sq_ceiling = n_core * n_core * k0_sq;
+    let beta_sq_floor = n_clad * n_clad * k0_sq;
+
+    // Proven real p=2 operators (K, M_ε, M₁) — assembled ONCE (β-independent),
+    // then embedded in c64 so the complex Lanczos path applies unchanged.
+    let ops = assemble_2d_nedelec2_sparse_interior(mesh, eps_r, interior_dof_mask)?;
+    let dim = ops.dim;
+    if dim == 0 {
+        return Ok(Vec::new());
+    }
+    let k_c = embed_real_sparse_c64(ops.k.as_ref());
+    let m_eps_c = embed_real_sparse_c64(ops.m_eps.as_ref());
+    let m1_c = embed_real_sparse_c64(ops.m1.as_ref());
+    // Boundary tangential mass S_bc — also β-independent, assembled ONCE.
+    let s_bc = assemble_boundary_tangential_mass(mesh, interior_dof_mask, r_bc)?;
+    let s_bc_c = embed_real_sparse_c64(s_bc.as_ref());
+
+    let n_dof = n_dof_2d_nedelec2(mesh);
+    let curl_floor = physical_curl_floor_pml();
+    let mut interior_to_full: Vec<usize> = Vec::with_capacity(n_dof);
+    for (full_idx, &keep) in interior_dof_mask.iter().enumerate() {
+        if keep {
+            interior_to_full.push(full_idx);
+        }
+    }
+
+    // curl-energy ratio r = |xᴴ K x| / (k₀² |xᴴ M_ε x|).
+    let curl_ratio = |x: &[c64]| -> f64 {
+        let xkx = sparse_quadratic_form_c64_herm(k_c.as_ref(), x).norm();
+        let xmx = sparse_quadratic_form_c64_herm(m_eps_c.as_ref(), x).norm();
+        let denom = (k0_sq * xmx).max(1e-300);
+        xkx / denom
+    };
+
+    let n_req = n_modes.max(1).min(dim);
+    let max_iters_lanczos = (n_req + 8).min(dim).max(1);
+
+    // Seed β² near the guided-band ceiling (bound modes sit just below n_core²).
+    let mut beta_sq = beta_sq_ceiling * (1.0 - 1e-3);
+    let mut selected: Option<(c64, Vec<c64>)> = None;
+    let mut converged = false;
+    let mut iterations = 0usize;
+
+    for it in 1..=max_iter {
+        iterations = it;
+        // Boundary coefficient at the current β² guess. If the guess falls out
+        // of the bound window (κ² ≤ 0), clamp it just inside so κ is real.
+        let gamma = match analytic_cladding_bc_gamma(l, beta_sq, n_clad, k0, r_bc) {
+            Some(g) => g,
+            None => {
+                let clamped =
+                    beta_sq_floor * (1.0 + 1e-6) + 0.5 * (beta_sq_ceiling - beta_sq_floor);
+                beta_sq = clamped;
+                analytic_cladding_bc_gamma(l, beta_sq, n_clad, k0, r_bc)
+                    .expect("mid-window β² always yields a real κ")
+            }
+        };
+
+        // K_eff = K − γ·S_bc  (the DtN boundary term).  A = k₀²M_ε − K_eff.
+        let k_eff = sparse_axpy_c64(k_c.as_ref(), s_bc_c.as_ref(), c64::new(-gamma, 0.0))?;
+        let a_sparse = sparse_pencil_a_c64(k_eff.as_ref(), m_eps_c.as_ref(), k0_sq)?;
+
+        // Shift just below the guided-band ceiling (guided β² sit near it).
+        let sigma = beta_sq_ceiling * (1.0 - 1e-3);
+        let solver = SparseComplexShiftInvertLanczos {
+            sigma,
+            max_iters: max_iters_lanczos,
+            tol: 1e-9,
+        };
+        let pairs = solver.smallest_eigenpairs(a_sparse.as_ref(), m1_c.as_ref(), n_req)?;
+
+        // Select the in-window, curl-bearing eigenpair with the LARGEST Re(β²)
+        // (most confined) — the fundamental. The single-mesh gates match the
+        // PML path; the analytic BC has removed the exterior continuum, so this
+        // is the genuine core mode rather than a top-of-ladder artifact.
+        let mut best: Option<(c64, &Vec<c64>)> = None;
+        for pair in &pairs {
+            let bsq = pair.lambda;
+            let in_window = bsq.re > beta_sq_floor && bsq.re < beta_sq_ceiling;
+            let has_curl = curl_ratio(&pair.vector) > curl_floor;
+            if !(in_window && has_curl) {
+                continue;
+            }
+            match &best {
+                Some((prev, _)) if prev.re >= bsq.re => {}
+                _ => best = Some((bsq, &pair.vector)),
+            }
+        }
+
+        let Some((new_beta_sq, vec)) = best else {
+            // No in-window mode at this guess — stop (nothing to return).
+            if selected.is_none() {
+                return Ok(Vec::new());
+            }
+            break;
+        };
+        let vec = vec.clone();
+
+        // Convergence on the relative β² step.
+        let rel = (new_beta_sq.re - beta_sq).abs() / beta_sq.abs().max(1.0);
+        selected = Some((new_beta_sq, vec));
+        beta_sq = new_beta_sq.re;
+        if rel < tol {
+            converged = true;
+            break;
+        }
+    }
+
+    let Some((final_beta_sq, vec_int)) = selected else {
+        return Ok(Vec::new());
+    };
+    let mut e_edges = vec![c64::new(0.0, 0.0); n_dof];
+    for (interior_idx, &full_idx) in interior_to_full.iter().enumerate() {
+        e_edges[full_idx] = vec_int[interior_idx];
+    }
+    let n_eff = principal_sqrt_c64(final_beta_sq) / c64::new(k0, 0.0);
+    eprintln!(
+        "solve_dielectric_modes2_analytic_cladding_bc (l={l}): k0={k0:.4}, n_core={n_core:.4}, \
+         n_clad={n_clad:.4}, r_bc={r_bc:.4}; β² window=({beta_sq_floor:.4e}, {beta_sq_ceiling:.4e}); \
+         self-consistent loop {} after {iterations} iter(s); β²={:.6e}, Re(n_eff)={:.6}",
+        if converged {
+            "CONVERGED"
+        } else {
+            "did NOT converge"
+        },
+        final_beta_sq.re,
+        n_eff.re,
+    );
+    Ok(vec![AnalyticCladdingBcMode {
+        n_eff,
+        beta_sq: final_beta_sq,
+        converged,
+        iterations,
+        e_edges,
+    }])
+}
+
+/// Compute `C = A + scale·B` for two complex sparse operators sharing
+/// compatible dimensions (Epic #339 #446). Used to add the DtN boundary term
+/// `−γ·S_bc` to the curl-curl stiffness. Duplicate `(row, col)` entries are
+/// summed by `try_new_from_triplets` exactly as the scatter-add does.
+fn sparse_axpy_c64(
+    a: SparseColMatRef<'_, usize, c64>,
+    b: SparseColMatRef<'_, usize, c64>,
+    scale: c64,
+) -> Result<SparseColMat<usize, c64>, EigenError> {
+    let n = a.nrows();
+    let mut trips: Vec<Triplet<usize, usize, c64>> =
+        Vec::with_capacity(a.col_ptr()[n] + b.col_ptr()[n]);
+    let push = |trips: &mut Vec<Triplet<usize, usize, c64>>,
+                m: SparseColMatRef<'_, usize, c64>,
+                s: c64| {
+        let cp = m.col_ptr();
+        let ri = m.row_idx();
+        let v = m.val();
+        for j in 0..m.ncols() {
+            for kk in cp[j]..cp[j + 1] {
+                trips.push(Triplet::new(ri[kk], j, s * v[kk]));
+            }
+        }
+    };
+    push(&mut trips, a, c64::new(1.0, 0.0));
+    push(&mut trips, b, scale);
+    triplets_to_sparse_c64(n, &trips)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/geode-core/tests/analytic_cladding_bc_fiber_benchmark.rs
+++ b/crates/geode-core/tests/analytic_cladding_bc_fiber_benchmark.rs
@@ -1,0 +1,366 @@
+//! SMF-28 fundamental-mode benchmark on the **analytic-cladding
+//! boundary-condition** dielectric solver
+//! ([`solve_dielectric_modes2_analytic_cladding_bc`], Epic #339 #446) — the
+//! mode-matching / continuum-removal approach.
+//!
+//! # What this experiment is for
+//!
+//! The PML siblings ([`step_index_fiber_benchmark.rs`],
+//! [`high_contrast_fiber_benchmark.rs`], [`lp01_profile_selector_benchmark.rs`])
+//! established — with data from PML-A/B/C (#334/#335/#336) and the profile
+//! selector (#363/#365) — that SMF-28's ≤1 %-b miss is a **formulation-level
+//! spectral-pollution limit**: the *discretized* cladding continuum (a
+//! meshed cladding annulus + UPML) spawns a dense ladder of genuinely-bound
+//! box/cladding-resonance modes straddling the razor-thin `(n_clad², n_core²)`
+//! guided window, and no single discrete mode is simultaneously LP₀₁-structured
+//! **and** ≤1 %-b. Approaches 2 (#365) and 4 (#359) are ruled out.
+//!
+//! This benchmark tests Epic #339's **approach 3**: *remove* the discretized
+//! cladding continuum. Mesh only the core + a thin cladding collar (no PML
+//! annulus) and impose the exact analytic exterior decay `K_l(κ·r)` as a
+//! β-dependent **DtN / Robin boundary condition** on the truncation circle,
+//! iterated to self-consistency over β². The exterior then has no discretized
+//! free modes to pollute the spectrum, so the ladder cannot form.
+//!
+//! # Honest-science gating
+//!
+//! This test is designed to be **decisive either way** and gated on the
+//! ACTUALLY-OBSERVED behavior (the same discipline #336/#359/#365 used):
+//!
+//! - **Win (intended GOOD flip):** if the self-consistent DtN loop isolates a
+//!   genuine core-confined LP₀₁ (m = 0, zero radial nodes, core-peaked) whose
+//!   normalized-b converges to **≤1 %** of the exact oracle, the
+//!   [`SELECTED_B_ERR_MIN`] inverse-tripwire below **fires** — forcing a human
+//!   to update the honest-finding records (this epic's negative becomes a
+//!   validated win).
+//! - **Next honest negative (still publishable):** if the DtN loop does not
+//!   contract, or isolates a clean mode whose b stays above the floor and does
+//!   not converge under refinement, that is recorded with data as-is (no
+//!   cherry-pick, no relaxed physics gates).
+//!
+//! Isolation gates are UNRELAXED: `core_energy_fraction ≥ 0.8`,
+//! `|Im(β²)|/Re(β²) < 1e-6`. The three existing PML tripwire tests stay green
+//! and untouched.
+//!
+//! # Observed result (this build) — the next honest negative
+//!
+//! The self-consistent β² (DtN) loop **contracts robustly** — 2 iterations at
+//! every mesh — and isolates a **clean fundamental**: core-confined
+//! (core-energy fraction ≈ 0.89), genuinely bound (`|Im(β²)|/Re(β²) = 0`, the
+//! pencil is real), m = 0 (az_var ≈ 0.04), core-peaked, and node-free once the
+//! collar resolves (radial-node count 6 → 3 → 0 as the mesh refines — the
+//! coarse-collar ringing cleans up, confirming a genuine LP₀₁-structured mode).
+//!
+//! **But its normalized b converges to ≈ 0.768 (≈ 68 % error), NOT ≤ 1 %**, and
+//! *monotonically increasing* toward the over-confined value — the SAME
+//! top-of-ladder b ≈ 0.77 the PML path lands ([`step_index_fiber_benchmark.rs`]
+//! / [`high_contrast_fiber_benchmark.rs`]). Removing the discretized cladding
+//! continuum is therefore **necessary but not sufficient**: the analytic-cladding
+//! BC produces a clean node-free LP₀₁-*structured* mode, yet at the wrong b — so
+//! the residual barrier is deeper than the discretized exterior (it points at
+//! the thin-collar / scalar-oracle fidelity floor, re-prioritizing approach 1).
+//! This test gates that **decisive negative** with data, unrelaxed, and arms
+//! the [`SELECTED_B_ERR_MIN`] inverse tripwire so a future fix that reaches
+//! ≤ 1 % (core-confined) forces the honest framing to be revisited.
+//!
+//! # Two tiers
+//!
+//! - **Tier 1** (default, debug-fast): structural single-mode facts + the
+//!   analytic-cladding solve at ≥3 refinement levels, asserting the loop
+//!   contracts, the isolated mode is core-confined + bound + m=0 + core-peaked,
+//!   that the finest mesh resolves it to node-free (LP₀₁ structure), and that
+//!   the selected b stays above the inverse-tripwire floor (the honest
+//!   non-result), reporting the b-trend as-is.
+//! - **Tier 2** (`#[ignore]`, release): a deeper refinement sweep confirming
+//!   the trend holds. Run:
+//!   ```sh
+//!   cargo test -p geode-core --release --test analytic_cladding_bc_fiber_benchmark -- --ignored
+//!   ```
+
+use geode_core::analytic::fiber::{fiber_lp_neff, normalized_b, v_number};
+use geode_core::analytic::waveguide::{
+    REGION_CORE, TriMesh, dielectric_mode_field_shape_pml, dielectric_mode_radial_profile_pml,
+    disk_pec_interior_dofs2, disk_tri_mesh, epsilon_r_from_region_tags,
+    solve_dielectric_modes2_analytic_cladding_bc,
+};
+
+/// SMF-28: 4.1 µm core (n = 1.4504) in cladding (n = 1.4447) at λ = 1550 nm.
+/// V ≈ 2.135 (single-mode), Δ ≈ 0.36 %, guided window n_core²−n_clad² ≈ 0.0165.
+const N_CORE: f64 = 1.4504;
+const N_CLAD: f64 = 1.4447;
+const A_UM: f64 = 4.1;
+const LAMBDA_UM: f64 = 1.55;
+const V_SINGLE_MODE: f64 = 2.405;
+
+/// Truncation radius = thin cladding collar just past the core (2·a). No PML
+/// annulus — the analytic K_l(κ·r) DtN condition represents the infinite
+/// exterior at this circle.
+const RBC_MULT: f64 = 2.0;
+
+/// Self-consistent β² loop budget / tolerance.
+const MAX_ITER: usize = 40;
+const SC_TOL: f64 = 1e-8;
+
+/// Analytic azimuthal order of LP₀₁.
+const L_ORDER: usize = 0;
+
+/// Radial-profile diagnostic parameters (m=0 / node / core-peak checks).
+const N_RADIAL_BINS: usize = 48;
+/// Azimuthal-variation ceiling for the m = 0 structural check (same family as
+/// the profile-selector test).
+const AZ_VAR_MAX: f64 = 0.5;
+
+/// Lower bound on the isolated fundamental's core-energy fraction — the SAME
+/// UNRELAXED isolation gate the SMF-28 / high-contrast PML tests use.
+const CORE_FRAC_FLOOR: f64 = 0.8;
+
+/// **Lower** bound on the isolated fundamental's b-error vs the oracle — the
+/// inverse tripwire. HONEST FINDING: removing the discretized continuum does
+/// NOT by itself drop the core-confined b to ≤1 %; the selected mode stays
+/// above this floor. If a future formulation fix ever pushes the selected
+/// (core-confined) b to ≤1 %, this trips — the intended GOOD outcome that
+/// forces the honest framing (and this epic's negative record) to be revisited.
+const SELECTED_B_ERR_MIN: f64 = 0.1;
+
+fn k0() -> f64 {
+    2.0 * std::f64::consts::PI / LAMBDA_UM
+}
+
+struct Solved {
+    /// Isolated fundamental Re(n_eff).
+    re_n_eff: f64,
+    /// Whether the self-consistent β² loop converged.
+    converged: bool,
+    /// Self-consistent loop iteration count.
+    iterations: usize,
+    /// Core-energy fraction of the isolated fundamental.
+    core_frac: f64,
+    /// Relative leakage |Im(β²)|/Re(β²) (≈ 0 for the real analytic-BC pencil).
+    rel_im_beta_sq: f64,
+    /// Azimuthal-variation figure (m = 0 diagnostic).
+    az_var: f64,
+    /// Radial-node count of the azimuthally-averaged magnitude profile.
+    radial_nodes: usize,
+    /// Whether the profile is core-peaked.
+    core_peaked: bool,
+}
+
+/// Solve the analytic-cladding-BC fiber at per-region resolution `(n_radial,
+/// n_angular)` and report the isolated fundamental's diagnostics. Returns
+/// `None` if no in-window mode is recovered.
+fn solve(res: (usize, usize)) -> Option<Solved> {
+    let k0 = k0();
+    let r_bc = RBC_MULT * A_UM;
+    // Plain core + thin cladding-collar disk mesh (NO PML annulus).
+    let (mesh, tags): (TriMesh, Vec<i32>) = disk_tri_mesh(A_UM, r_bc, res.0, res.1);
+    let eps = epsilon_r_from_region_tags(&tags, |t| {
+        if t == REGION_CORE {
+            N_CORE * N_CORE
+        } else {
+            N_CLAD * N_CLAD
+        }
+    });
+    let interior = disk_pec_interior_dofs2(&mesh, r_bc);
+    let modes = solve_dielectric_modes2_analytic_cladding_bc(
+        &mesh, &eps, &interior, r_bc, k0, L_ORDER, 8, MAX_ITER, SC_TOL,
+    )
+    .expect("analytic-cladding-BC dielectric solve");
+    let m = modes.into_iter().next()?;
+    let pml_view = m.as_pml_mode();
+    let shape = dielectric_mode_field_shape_pml(&mesh, &tags, &pml_view);
+    // Radial profile out to just short of the truncation so the boundary ring
+    // does not pollute the node/peak diagnostics.
+    let profile =
+        dielectric_mode_radial_profile_pml(&mesh, &tags, &pml_view, N_RADIAL_BINS, 0.95 * r_bc);
+    Some(Solved {
+        re_n_eff: m.n_eff.re,
+        converged: m.converged,
+        iterations: m.iterations,
+        core_frac: shape.core_energy_fraction,
+        rel_im_beta_sq: m.beta_sq.im.abs() / m.beta_sq.re.abs().max(1.0),
+        az_var: profile.azimuthal_variation,
+        radial_nodes: profile.radial_node_count(),
+        core_peaked: profile.is_core_peaked(A_UM),
+    })
+}
+
+/// **Tier 1** (default, debug-fast): structural single-mode facts + the
+/// analytic-cladding solve across ≥3 refinement levels. Asserts the
+/// self-consistent loop contracts, the isolated mode is core-confined + bound +
+/// m=0 + zero radial nodes + core-peaked, and reports the b-trend as-is. The
+/// inverse-tripwire fires if the core-confined b reaches ≤1 % (the GOOD flip).
+#[test]
+fn analytic_cladding_bc_smf28_refinement_series() {
+    let k0 = k0();
+    let v = v_number(N_CORE, N_CLAD, A_UM, k0);
+    let oracle = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 0, 1).expect("LP01 always guides");
+    let oracle11 = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 1, 1);
+    let b_oracle = normalized_b(oracle, N_CORE, N_CLAD);
+    let window = N_CORE * N_CORE - N_CLAD * N_CLAD;
+
+    // Single-mode structural facts (cheap, no solve).
+    assert!(
+        v < V_SINGLE_MODE,
+        "SMF-28 must be single-mode (V {v} < 2.405)"
+    );
+    assert!(
+        oracle11.is_none(),
+        "LP11 must be below cutoff for single-mode operation"
+    );
+    assert!(
+        oracle > N_CLAD && oracle < N_CORE,
+        "oracle LP01 n_eff {oracle} must be in the window"
+    );
+    // The razor-thin guided window this approach targets.
+    assert!(
+        window < 0.02,
+        "SMF-28 guided window {window:.4} must be the razor-thin weakly-guiding case"
+    );
+
+    // ≥3 refinement levels (debug-fast).
+    let series: &[(usize, usize)] = &[(4, 48), (6, 72), (8, 96)];
+
+    let mut bs: Vec<f64> = Vec::new();
+    let mut last_nodes = usize::MAX;
+    eprintln!("Analytic-cladding-BC SMF-28 (b_oracle = {b_oracle:.4}, V = {v:.4}):");
+    for &(nr, na) in series {
+        let s = solve((nr, na)).expect("each config must recover an in-window mode");
+        let b_fem = normalized_b(s.re_n_eff, N_CORE, N_CLAD);
+        let b_err = (b_fem - b_oracle).abs() / b_oracle;
+        bs.push(b_fem);
+        last_nodes = s.radial_nodes;
+        eprintln!(
+            "  ({nr:>2},{na:>3})  b = {b_fem:.5}  b_err = {:>7.2}%  cf = {:.3}  relIm = {:.2e}  \
+             conv = {}  iters = {}  az_var = {:.3e}  nodes = {}  core_peaked = {}",
+            100.0 * b_err,
+            s.core_frac,
+            s.rel_im_beta_sq,
+            s.converged,
+            s.iterations,
+            s.az_var,
+            s.radial_nodes,
+            s.core_peaked,
+        );
+
+        // --- Self-consistent loop must contract (approach-3 viability) ---
+        // The DtN β² fixed point is the load-bearing new machinery; it must
+        // settle for the method to be meaningful. OBSERVED: it contracts in 2
+        // iterations at every mesh.
+        assert!(
+            s.converged,
+            "the self-consistent β² (DtN) loop must contract at ({nr},{na}); it did not — the \
+             analytic-cladding fixed point is not stable (honest negative: instrument and record)"
+        );
+
+        // --- UNRELAXED isolation gates (same floors as the PML tripwires) ---
+        assert!(
+            s.core_frac >= CORE_FRAC_FLOOR,
+            "isolated fundamental core fraction {:.3} must be ≳{CORE_FRAC_FLOOR} (clean isolation)",
+            s.core_frac
+        );
+        assert!(
+            s.rel_im_beta_sq < 1e-6,
+            "isolated fundamental must be genuinely bound: |Im(β²)|/Re(β²) = {:.3e}",
+            s.rel_im_beta_sq
+        );
+
+        // --- m = 0 + core-peaked structural checks (hold at every mesh) ---
+        assert!(
+            s.az_var < AZ_VAR_MAX,
+            "isolated fundamental must be m = 0 (azimuthally symmetric): az_var {:.3e} ≥ {AZ_VAR_MAX}",
+            s.az_var
+        );
+        assert!(
+            s.core_peaked,
+            "isolated fundamental must be core-peaked (LP₀₁ peaks on axis) at ({nr},{na})"
+        );
+
+        // --- Inverse tripwire: the intended GOOD flip ---
+        // HONEST FINDING: the core-confined analytic-BC mode's b converges to
+        // ≈0.768 (≈68 % error), the SAME over-confined top-of-ladder value the
+        // PML path lands — NOT ≤1 %. We gate it stays ABOVE this floor. If a
+        // future formulation fix ever pushes the selected (core-confined,
+        // m=0, node-free) b to/below it, removing the discretized continuum
+        // reached the genuine LP₀₁ — revisit the honest framing (Epic #339
+        // negative becomes a validated win).
+        assert!(
+            b_err > SELECTED_B_ERR_MIN,
+            "isolated (core-confined, m=0) fundamental b-error {:.1}% at ({nr},{na}) dropped \
+             to/below {:.0}%: the analytic-cladding BC reached the genuine LP₀₁ — revisit the \
+             honest framing (Epic #339 negative result becomes a validated win)",
+            100.0 * b_err,
+            100.0 * SELECTED_B_ERR_MIN,
+        );
+    }
+
+    // --- Finest mesh resolves a NODE-FREE (LP₀₁-structured) profile ---
+    // The coarse-collar ringing (6 → 3 → 0 nodes) cleans up under refinement,
+    // confirming the isolated mode is a genuine node-free LP₀₁ *structure* — the
+    // decisive point: it is structurally LP₀₁ yet at the wrong b. If this ever
+    // FAILS to resolve to node-free, the collar truncation is manufacturing
+    // spurious radial structure (a distinct, also-recordable pathology).
+    assert_eq!(
+        last_nodes, 0,
+        "at the finest mesh the analytic-cladding fundamental must resolve to ZERO radial nodes \
+         (a genuine LP₀₁ structure); got {last_nodes} — the thin collar is manufacturing spurious \
+         radial structure (a distinct pathology to record)"
+    );
+
+    // Report the refinement trend as-is (no cherry-pick). Monotone-to-≤1% would
+    // be validation; OBSERVED is a plateau at b ≈ 0.768 (≈68 % error) — the
+    // clean LP₀₁ structure lands the over-confined top-of-ladder b, so removing
+    // the discretized continuum is necessary but not sufficient.
+    eprintln!("  b-trend under refinement (as-is): {bs:?}");
+}
+
+/// **Tier 2** (`#[ignore]`, release): deeper refinement sweep confirming the
+/// b-trend holds and the loop keeps contracting. Reports as-is; the inverse
+/// tripwire stays armed.
+#[test]
+#[ignore = "heavy: deeper analytic-cladding-BC refinement sweep; run with --release -- --ignored"]
+fn analytic_cladding_bc_smf28_deep_sweep() {
+    let k0 = k0();
+    let oracle = fiber_lp_neff(N_CORE, N_CLAD, A_UM, k0, 0, 1).expect("LP01 always guides");
+    let b_oracle = normalized_b(oracle, N_CORE, N_CLAD);
+
+    let series: &[(usize, usize)] = &[(4, 48), (6, 72), (8, 96), (12, 144), (16, 192)];
+
+    eprintln!("Analytic-cladding-BC SMF-28 DEEP sweep (b_oracle = {b_oracle:.4}):");
+    let mut min_core_frac = f64::INFINITY;
+    let mut max_rel_im: f64 = 0.0;
+    for &(nr, na) in series {
+        let s = solve((nr, na)).expect("each config must recover an in-window mode");
+        let b_fem = normalized_b(s.re_n_eff, N_CORE, N_CLAD);
+        let b_err = (b_fem - b_oracle).abs() / b_oracle;
+        min_core_frac = min_core_frac.min(s.core_frac);
+        max_rel_im = max_rel_im.max(s.rel_im_beta_sq);
+        eprintln!(
+            "  ({nr:>2},{na:>3})  b = {b_fem:.5}  b_err = {:>7.2}%  cf = {:.3}  conv = {}  \
+             iters = {}  nodes = {}",
+            100.0 * b_err,
+            s.core_frac,
+            s.converged,
+            s.iterations,
+            s.radial_nodes,
+        );
+        assert!(
+            s.converged,
+            "the self-consistent β² loop must contract at every mesh; failed at ({nr},{na})"
+        );
+        assert!(
+            b_err > SELECTED_B_ERR_MIN,
+            "isolated (core-confined) fundamental b-error {:.1}% at ({nr},{na}) dropped to/below \
+             {:.0}%: revisit the honest framing (Epic #339)",
+            100.0 * b_err,
+            100.0 * SELECTED_B_ERR_MIN,
+        );
+    }
+    assert!(
+        min_core_frac >= CORE_FRAC_FLOOR,
+        "every mesh must isolate a core-confined fundamental: min core fraction {min_core_frac:.3}"
+    );
+    assert!(
+        max_rel_im < 1e-6,
+        "every fundamental must be genuinely bound: max |Im(β²)|/Re(β²) = {max_rel_im:.3e}"
+    );
+}


### PR DESCRIPTION
## Summary

Epic #339 **approach 3 (analytic-cladding boundary / mode-matching)**: add a new, purely additive bounded-domain dielectric modal solver that attacks the demonstrated root cause of the SMF-28 ≤1 %-b miss — the *discretized cladding continuum* — by **removing** it. Instead of meshing a cladding annulus + UPML and letting the eigensolver find exterior modes (the ladder-spawning setup #336/#359/#365 proved is the barrier), it meshes only the core + a thin cladding collar (no PML annulus) and imposes the exact analytic exterior decay `K_l(κ·r)` as a β-dependent **DtN / Robin boundary condition** on the truncation circle, iterated to self-consistency over β².

This is a research increment designed to be **decisive either way**, gated on the actually-observed behavior (the honest-science discipline of #336/#359/#365).

## Headline numerical result (SMF-28, b_oracle ≈ 0.4581, V ≈ 2.135)

The self-consistent β² (DtN) loop **CONVERGES** (2 iterations at every mesh) and isolates a **clean fundamental** — but at the wrong b:

| Mesh (n_r, n_θ) | b (FEM) | b-error vs oracle | core frac | \|Im(β²)\|/Re(β²) | converged | iters | az_var (m=0) | radial nodes | core-peaked |
|---|---|---|---|---|---|---|---|---|---|
| (4, 48) | 0.76847 | **67.75 %** | 0.890 | 0 | ✅ | 2 | 0.042 | 6 | ✅ |
| (6, 72) | 0.76868 | **67.80 %** | 0.890 | 0 | ✅ | 2 | 0.043 | 3 | ✅ |
| (8, 96) | 0.76875 | **67.81 %** | 0.890 | 0 | ✅ | 2 | 0.039 | **0** | ✅ |

**Honest finding (the next publishable negative):** the DtN loop contracts robustly and isolates a genuinely core-confined (cf ≈ 0.89), genuinely bound (`Im(β²) = 0`, the pencil is real), m = 0, core-peaked, **node-free-at-finest-mesh** LP₀₁-*structured* mode (radial-node count 6 → 3 → 0 as the coarse-collar ringing cleans up under refinement). **But its normalized b converges to ≈ 0.768 (≈ 68 % error) — the SAME over-confined top-of-ladder value the PML path lands (b ≈ 0.77) — NOT ≤ 1 %**, and monotonically *increasing* toward it. Removing the discretized continuum is therefore **necessary but not sufficient**: the analytic-cladding BC produces a clean node-free LP₀₁ structure yet at the wrong b, so the residual barrier is deeper than the discretized exterior (points at the thin-collar / scalar-oracle fidelity floor, re-prioritizing approach 1). No cherry-picking, no relaxed physics gates.

## Changes

- `crates/geode-core/src/analytic/waveguide.rs` (+471):
  - `solve_dielectric_modes2_analytic_cladding_bc` — the additive solver + self-consistent β² loop (`K_eff = K − γ(β²)·S_bc`, resolve, update, contract).
  - `analytic_cladding_bc_gamma` — radial log-derivative `γ = κ·K_l'(κ·r_bc)/K_l(κ·r_bc)` (reuses `bessel_k`/`bessel_k1` from `analytic/fiber.rs`).
  - `assemble_boundary_tangential_mass` — interior-restricted boundary tangential mass `S_bc` on the truncation circle (3-pt Gauss–Legendre per boundary edge; same p=2 DOF numbering / orientation-sign scatter as `K`/`M`).
  - `embed_real_sparse_c64` / `sparse_axpy_c64` — real→c64 embedding + complex axpy so the proven `SparseComplexShiftInvertLanczos` path is reused unchanged (recovered β² carries `Im ≈ 0`).
  - `AnalyticCladdingBcMode` (+ `as_pml_mode`) — result type exposing the `converged` flag and viewable as a `DielectricModePml` so `dielectric_mode_field_shape_pml` / `dielectric_mode_radial_profile_pml` diagnostics apply unchanged.
- `crates/geode-core/tests/analytic_cladding_bc_fiber_benchmark.rs` (new): SMF-28 vs the exact `fiber_lp_neff` oracle across 3 refinement levels (Tier-1) + a deeper `#[ignore]`d Tier-2 sweep, with the `SELECTED_B_ERR_MIN` inverse-tripwire.

**Existing proven code paths are bit-for-bit untouched:** `solve_dielectric_modes2`, `solve_dielectric_modes2_pml`, `solve_dielectric_modes2_pml_profile_selected`, the p=2 (#318) / UPML (#334-335) / metallic / SOI machinery, and the eigensolver.

## Gates the new test enforces (unrelaxed)

- Self-consistent β² (DtN) loop **contracts** at every mesh (`converged == true`) — the load-bearing new machinery is stable.
- `core_energy_fraction ≥ 0.8` (same isolation floor as the SMF-28 / high-contrast PML tripwires).
- `|Im(β²)|/Re(β²) < 1e-6` (genuinely bound).
- `az_var < 0.5` (m = 0) and core-peaked at every mesh; **node-free (0 radial nodes) at the finest mesh** (genuine LP₀₁ structure).
- **Inverse tripwire** `SELECTED_B_ERR_MIN = 0.1`: the core-confined b-error must stay **> 10 %**. It fires (test goes red) if a future fix pushes the selected core-confined LP₀₁ b to ≤ that floor — the intended GOOD flip forcing the honest-finding records to be revisited. Observed b-error ≈ 68 % leaves comfortable margin.

## Acceptance Criteria Verification

| Criterion (from #446) | Status | Verification |
|---|---|---|
| New solver variant purely additive; existing solvers/callers bit-for-bit untouched | ✅ | Only new fns added; `git diff` touches no existing solver body; 260 lib tests + all sibling benchmarks green |
| New benchmark on SMF-28 vs exact oracle, ≥3 refinement levels, reporting m=0/nodes/core-peaked/b-error/trend | ✅ | `analytic_cladding_bc_fiber_benchmark.rs`, 3 levels (4,48)/(6,72)/(8,96), full table above |
| Honest-science inverse-tripwire (`SELECTED_B_ERR_MIN`) firing on ≤1 %; existing tripwires untouched & green | ✅ | Inverse gate at 10 %; the 3 existing tripwire tests unchanged and pass |
| No cherry-picking; b-trend reported as-is; Tier-1 in CI budget, heavy sweep `#[ignore]`d | ✅ | b plateau ≈ 0.768 reported as-is; Tier-1 ≈ 23 s debug; Tier-2 `#[ignore]`d |
| `cargo clippy -p geode-core --tests -- -D warnings` clean; `cargo fmt` applied | ✅ | clippy exit 0; fmt applied; `cargo doc -D warnings` clean; `--features arpack` compiles |
| Isolation gates unrelaxed (cf ≥ 0.8, rel-Im < 1e-6) | ✅ | Both asserted at every mesh, values 0.890 / 0 |

## Test Plan

- `cargo test -p geode-core --test analytic_cladding_bc_fiber_benchmark` — 1 passed, 1 ignored (Tier-2).
- `cargo test -p geode-core --test step_index_fiber_benchmark --test high_contrast_fiber_benchmark --test lp01_profile_selector_benchmark` — all green, untouched.
- `cargo test -p geode-core --lib` — 260 passed, 0 failed.
- `cargo clippy -p geode-core --tests -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core`, `cargo check -p geode-core --features arpack --tests` — all clean.

## Deviations from spec

None material. Two notes: (1) the target azimuthal order `l` is a solver argument (`0` for LP₀₁) rather than auto-detected, matching the oracle's per-mode convention; (2) the DtN term is added to the real `K` and the whole pencil embedded in `c64` (so the loop reuses the complex Lanczos path unchanged) — the recovered β² is real to f64 noise, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #446