### PR TITLE
feat(geode-core): PM magnetization sources + slotless-PM air-gap field oracle

### DIFF
--- a/crates/geode-core/examples/slotless_pm.rs
+++ b/crates/geode-core/examples/slotless_pm.rs
@@ -1,0 +1,102 @@
+//! Slotless surface-PM machine cross-section: solve the air-gap field from
+//! a radially-magnetized permanent-magnet band and compare against the
+//! exact Zhu & Howe annular-harmonic oracle (Epic #448, Phase 2b).
+//!
+//! Run with:
+//!
+//! ```text
+//!   cargo run -p geode-core --example slotless_pm --release
+//! ```
+//!
+//! Prints the mid-gap `B_r(θ), B_θ(θ)` FEM-vs-oracle comparison and the
+//! peak air-gap flux density — the tearsheet numbers for the machine
+//! benchmark.
+
+use geode_core::analytic::slotless_pm::{MU_0, SlotlessPm};
+use geode_core::analytic::waveguide::{RadialGrading, disk_boundary_nodes, disk_tri_mesh_bands};
+use geode_core::assembly::magnetostatic::{
+    assemble_magnetostatic_pm, build_nu_r, radial_magnetization_source, recover_b_field,
+};
+
+const TAG_MAGNET: i32 = 1;
+
+fn main() {
+    // Four-band cross-section: bore / magnet / air-gap / outer air.
+    let (r1, r2, r3, rout) = (0.030, 0.040, 0.045, 0.20);
+    let p = 2u32;
+    let b_rem = 1.2; // NdFeB remanence (T)
+    let m0 = b_rem / MU_0;
+    let radii = [0.0, r1, r2, r3, rout];
+    let n_rad = [18usize, 20, 12, 26];
+    let gradings = [RadialGrading::Uniform; 4];
+
+    let (mesh, tags) = disk_tri_mesh_bands(&radii, 384, &n_rad, &gradings);
+    println!(
+        "slotless-PM cross-section: {} nodes, {} triangles",
+        mesh.n_nodes(),
+        mesh.n_tris()
+    );
+
+    // μ_rec = 1 everywhere (open-space oracle regime).
+    let nu = build_nu_r(&tags, &[1.0, 1.0, 1.0, 1.0]);
+    let j_z = vec![0.0; mesh.n_tris()];
+    let m = radial_magnetization_source(&mesh, &tags, TAG_MAGNET, m0, p);
+    let bc = disk_boundary_nodes(&mesh, rout);
+    let sys = assemble_magnetostatic_pm(&mesh, &nu, &j_z, &m, &bc).expect("assemble PM system");
+    let a_z = sys.solve().expect("solve PM system");
+    let b = recover_b_field(&mesh, &a_z);
+
+    let oracle = SlotlessPm::new(r1, r2, m0, p);
+    let r_gap = 0.5 * (r2 + r3);
+
+    // Sample the mid-gap contour and report the L2 error + peak field.
+    let n_contour = 180;
+    let mut num = 0.0;
+    let mut den = 0.0;
+    let mut peak = 0.0_f64;
+    for i in 0..n_contour {
+        let theta = std::f64::consts::TAU * i as f64 / n_contour as f64;
+        let (px, py) = (r_gap * theta.cos(), r_gap * theta.sin());
+        let t = locate(&mesh, px, py).expect("contour point inside mesh");
+        let (br_o, bth_o) = oracle.exterior_field(r_gap, theta);
+        let (c, s) = (theta.cos(), theta.sin());
+        let br = b[t][0] * c + b[t][1] * s;
+        let bth = -b[t][0] * s + b[t][1] * c;
+        num += (br - br_o).powi(2) + (bth - bth_o).powi(2);
+        den += br_o.powi(2) + bth_o.powi(2);
+        peak = peak.max((br * br + bth * bth).sqrt());
+    }
+    let l2 = (num / den).sqrt();
+    let peak_oracle = oracle.exterior_coeff().abs() * r_gap.powi(-3);
+    println!("mid-gap radius r_gap = {r_gap:.4} m, {p}-pole-pair magnet");
+    println!(
+        "peak mid-gap |B|: FEM = {:.4} T, oracle = {:.4} T",
+        peak, peak_oracle
+    );
+    println!(
+        "mid-gap contour L2 (FEM vs Zhu-Howe oracle) = {:.3}%",
+        l2 * 100.0
+    );
+    if l2 > 0.01 {
+        println!(
+            "(P1 piecewise-constant B: first-order convergent; ≤1% is the P2-Lagrange target)"
+        );
+    }
+}
+
+/// Locate the triangle containing `(px, py)` by barycentric test.
+fn locate(mesh: &geode_core::analytic::waveguide::TriMesh, px: f64, py: f64) -> Option<usize> {
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let [x1, y1] = mesh.nodes[tri[0] as usize];
+        let [x2, y2] = mesh.nodes[tri[1] as usize];
+        let [x3, y3] = mesh.nodes[tri[2] as usize];
+        let d = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+        let a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / d;
+        let bb = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / d;
+        let c = 1.0 - a - bb;
+        if a >= -1e-9 && bb >= -1e-9 && c >= -1e-9 {
+            return Some(t);
+        }
+    }
+    None
+}

--- a/crates/geode-core/src/analytic/mod.rs
+++ b/crates/geode-core/src/analytic/mod.rs
@@ -12,6 +12,8 @@
 //!   and analytic cutoff references.
 //! - [`spiral`] — square-spiral inductance (Mohan / modified-Wheeler).
 //! - [`patch`] — rectangular patch-antenna cavity-model resonances.
+//! - [`slotless_pm`] — exact air-gap field of a radially-magnetized
+//!   slotless surface-PM annulus (Zhu & Howe multipole; Epic #448 P2).
 //! - [`formulation_audit`] — read-only grad–div diagnostics quantifying the
 //!   ε-coupling term the reduced transverse-E_t modal pencil drops (Epic #339).
 
@@ -19,5 +21,6 @@ pub mod fiber;
 pub mod formulation_audit;
 pub mod mie;
 pub mod patch;
+pub mod slotless_pm;
 pub mod spiral;
 pub mod waveguide;

--- a/crates/geode-core/src/analytic/slotless_pm.rs
+++ b/crates/geode-core/src/analytic/slotless_pm.rs
@@ -1,0 +1,262 @@
+//! Exact closed-form air-gap field of a **slotless surface-PM annulus**
+//! (Epic #448, Phase 2 — the primary field-accuracy oracle).
+//!
+//! A radially-magnetized surface-PM band `R1 ≤ r ≤ R2` carrying the
+//! sinusoidal radial magnetization
+//!
+//! ```text
+//!   M = M_r r̂ ,   M_r(θ) = M0 cos(p θ)          (p pole-pairs, p ≥ 2)
+//! ```
+//!
+//! in an **open, homogeneous** domain (recoil permeability `μ_rec = 1`, no
+//! iron), produces a pure multipole air-gap field. This is the classic
+//! Zhu & Howe (1993) magnetic-field-analysis result, obtained here by
+//! matching a magnetic scalar potential `φ_m` (with `∇²φ_m = ∇·M` in the
+//! magnet, `0` outside, and `M·n̂` surface-charge jumps) across the three
+//! coaxial regions `r < R1`, `R1 < r < R2`, `r > R2`.
+//!
+//! # Exterior field (`r ≥ R2`, the air gap and beyond)
+//!
+//! ```text
+//!   B_r(r, θ) = C · r^{-(p+1)} · cos(p θ)
+//!   B_θ(r, θ) = C · r^{-(p+1)} · sin(p θ)
+//!   C = μ₀ M0 p (R2^{p+1} − R1^{p+1}) / [2 (p + 1)]
+//! ```
+//!
+//! Note `|B| = |C| r^{-(p+1)}` is **θ-independent** on any coaxial ring —
+//! the hallmark of a single-harmonic radial-magnetization multipole.
+//!
+//! # Self-validation (gate the oracle before the solver)
+//!
+//! In the **thin-magnet limit** `t = R2 − R1 → 0` about a mean radius
+//! `R = (R1 + R2)/2`, the annulus reduces to a `θ`-dependent bound current
+//! sheet. Expanding `C`,
+//!
+//! ```text
+//!   C → μ₀ M0 p t R^p / 2 = μ₀ K0 R^{p+1} / 2 ,   K0 = M0 p t / R
+//! ```
+//!
+//! which is **exactly** the exterior multipole coefficient of a
+//! z-directed current sheet `K_z = K0 cos(p θ)` at radius `R`, obtained
+//! from the 2-D free-space Green's function (Biot–Savart), independently
+//! of the scalar-potential matching. [`current_sheet_exterior_coeff`]
+//! encodes that Biot–Savart result and
+//! [`self_validation_rel_error`] measures the agreement — the ≤ 0.5 %
+//! gate of the test plan (#448 risk note "cross-check against the coaxial
+//! current-sheet result in a limiting case").
+
+use std::f64::consts::PI;
+
+/// Vacuum permeability `μ₀` (SI, T·m/A).
+pub const MU_0: f64 = 4.0e-7 * PI;
+
+/// Parameters of a radially-magnetized slotless surface-PM annulus.
+///
+/// The magnetization is `M = M0 cos(p θ) r̂` over the band `R1 ≤ r ≤ R2`,
+/// with recoil permeability `μ_rec = 1` (magnet magnetically indistinct
+/// from air) and an open exterior — the regime in which the exterior field
+/// is the single closed-form multipole [`SlotlessPm::exterior_field`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SlotlessPm {
+    /// Magnet inner radius `R1` (m), `0 < R1 < R2`.
+    pub r_inner: f64,
+    /// Magnet outer radius `R2` (m).
+    pub r_outer: f64,
+    /// Radial-magnetization amplitude `M0` (A/m): `M_r(θ) = M0 cos(p θ)`.
+    pub m0: f64,
+    /// Pole-pair count `p` (≥ 2; `p = 1` is excluded — its scalar-potential
+    /// particular solution is the degenerate `r ln r` branch, not the
+    /// `r/(1−p²)` branch this closed form uses).
+    pub pole_pairs: u32,
+}
+
+impl SlotlessPm {
+    /// Construct a validated slotless-PM annulus.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `0 < r_inner < r_outer` (both finite), `m0` is finite,
+    /// and `pole_pairs ≥ 2`.
+    pub fn new(r_inner: f64, r_outer: f64, m0: f64, pole_pairs: u32) -> Self {
+        assert!(
+            r_inner.is_finite() && r_outer.is_finite() && 0.0 < r_inner && r_inner < r_outer,
+            "SlotlessPm requires 0 < r_inner ({r_inner}) < r_outer ({r_outer}), both finite"
+        );
+        assert!(m0.is_finite(), "SlotlessPm requires finite m0 (got {m0})");
+        assert!(
+            pole_pairs >= 2,
+            "SlotlessPm requires pole_pairs ≥ 2 (got {pole_pairs}); p = 1 needs the \
+             degenerate r·ln r particular solution this closed form does not implement"
+        );
+        Self {
+            r_inner,
+            r_outer,
+            m0,
+            pole_pairs,
+        }
+    }
+
+    /// Exterior multipole coefficient
+    /// `C = μ₀ M0 p (R2^{p+1} − R1^{p+1}) / [2 (p + 1)]`.
+    ///
+    /// `B_r = C r^{-(p+1)} cos(p θ)`, `B_θ = C r^{-(p+1)} sin(p θ)` for
+    /// `r ≥ R2`.
+    pub fn exterior_coeff(&self) -> f64 {
+        let p = self.pole_pairs as f64;
+        MU_0 * self.m0 * p * (self.r_outer.powf(p + 1.0) - self.r_inner.powf(p + 1.0))
+            / (2.0 * (p + 1.0))
+    }
+
+    /// Exact exterior air-gap flux density `(B_r, B_θ)` at polar
+    /// `(r, θ)` for `r ≥ R2`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `r < r_outer` (the closed form here is the **exterior**
+    /// solution; the in-magnet and inner-bore branches are not exposed
+    /// because the air-gap benchmark only samples `r > R2`).
+    pub fn exterior_field(&self, r: f64, theta: f64) -> (f64, f64) {
+        assert!(
+            r >= self.r_outer,
+            "exterior_field is valid only for r ≥ r_outer ({}), got r = {r}",
+            self.r_outer
+        );
+        let p = self.pole_pairs as f64;
+        let radial = self.exterior_coeff() * r.powf(-(p + 1.0));
+        let ang = p * theta;
+        (radial * ang.cos(), radial * ang.sin())
+    }
+
+    /// Exact exterior flux density in **Cartesian** components
+    /// `(B_x, B_y)` at `(x, y)`, for `√(x²+y²) ≥ R2`. Convenience wrapper
+    /// around [`exterior_field`](Self::exterior_field) for comparison
+    /// against the FEM solver's Cartesian `B`.
+    pub fn exterior_field_xy(&self, x: f64, y: f64) -> (f64, f64) {
+        let r = (x * x + y * y).sqrt();
+        let theta = y.atan2(x);
+        let (b_r, b_th) = self.exterior_field(r, theta);
+        let (c, s) = (theta.cos(), theta.sin());
+        // (B_x, B_y) = B_r r̂ + B_θ θ̂, r̂ = (c, s), θ̂ = (−s, c).
+        (b_r * c - b_th * s, b_r * s + b_th * c)
+    }
+
+    /// Mean magnet radius `R = (R1 + R2)/2` and thickness `t = R2 − R1`.
+    pub fn mean_radius_thickness(&self) -> (f64, f64) {
+        (
+            0.5 * (self.r_inner + self.r_outer),
+            self.r_outer - self.r_inner,
+        )
+    }
+
+    /// Effective thin-band current-sheet amplitude `K0 = M0 p t / R`
+    /// (A/m) — the z-directed sheet `K_z = K0 cos(p θ)` at radius `R` this
+    /// annulus reduces to as `t → 0`.
+    pub fn equivalent_sheet_k0(&self) -> f64 {
+        let (r, t) = self.mean_radius_thickness();
+        self.m0 * self.pole_pairs as f64 * t / r
+    }
+}
+
+/// Exterior multipole coefficient of a z-directed current sheet
+/// `K_z = K0 cos(p θ)` at radius `R` in open free space, from the 2-D
+/// free-space Green's function (Biot–Savart):
+///
+/// ```text
+///   B_r = D r^{-(p+1)} sin(p θ) ,   B_θ = D r^{-(p+1)} cos(p θ) ,
+///   D = μ₀ K0 R^{p+1} / 2 .
+/// ```
+///
+/// This is an **independent** derivation (Green's function, not scalar-
+/// potential matching), so agreement with the thin-band limit of
+/// [`SlotlessPm::exterior_coeff`] cross-validates the oracle. Only the
+/// **magnitude** `|D|` is used for the phase-robust self-validation (the
+/// current-sheet pattern is 90° rotated in θ from the radial-magnet
+/// pattern, but `|B|` is θ-independent for both).
+pub fn current_sheet_exterior_coeff(k0: f64, r_sheet: f64, pole_pairs: u32) -> f64 {
+    let p = pole_pairs as f64;
+    MU_0 * k0 * r_sheet.powf(p + 1.0) / 2.0
+}
+
+/// Relative error `|C_scalar / D_sheet − 1|` between the slotless-PM
+/// exterior coefficient and its Biot–Savart current-sheet equivalent, in
+/// the thin-magnet limit. The test-plan self-validation gate (≤ 0.5 %):
+/// as `t/R → 0` this error → 0 like `O((t/R)²)`.
+pub fn self_validation_rel_error(pm: &SlotlessPm) -> f64 {
+    let c_scalar = pm.exterior_coeff();
+    let (r, _t) = pm.mean_radius_thickness();
+    let d_sheet = current_sheet_exterior_coeff(pm.equivalent_sheet_k0(), r, pm.pole_pairs);
+    ((c_scalar / d_sheet) - 1.0).abs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exterior_magnitude_is_theta_independent() {
+        let pm = SlotlessPm::new(0.030, 0.040, 1.0e6, 2);
+        let r = 0.045_f64;
+        let c = pm.exterior_coeff() * r.powf(-3.0);
+        for k in 0..16 {
+            let theta = 2.0 * PI * k as f64 / 16.0;
+            let (br, bth) = pm.exterior_field(r, theta);
+            let mag = (br * br + bth * bth).sqrt();
+            assert!(
+                (mag - c.abs()).abs() <= 1e-9 * c.abs(),
+                "|B| not θ-independent: {mag} vs {}",
+                c.abs()
+            );
+        }
+    }
+
+    #[test]
+    fn thin_band_self_validates_against_current_sheet() {
+        // Shrinking t/R drives the scalar-potential coefficient onto the
+        // independent Biot–Savart current-sheet coefficient.
+        let r_mean = 0.040;
+        let mut prev = f64::INFINITY;
+        for &tf in &[0.02, 0.01, 0.005] {
+            let t = tf * r_mean;
+            let pm = SlotlessPm::new(r_mean - t / 2.0, r_mean + t / 2.0, 1.0e6, 2);
+            let err = self_validation_rel_error(&pm);
+            assert!(
+                err <= 5e-3,
+                "self-validation err {:.4}% at t/R={tf} exceeds 0.5% gate",
+                err * 100.0
+            );
+            assert!(err < prev, "self-validation not monotone in t/R");
+            prev = err;
+        }
+    }
+
+    #[test]
+    fn cartesian_matches_polar_conversion() {
+        let pm = SlotlessPm::new(0.030, 0.040, 5.0e5, 3);
+        let r = 0.050;
+        for k in 0..8 {
+            let theta = 2.0 * PI * k as f64 / 8.0;
+            let (br, bth) = pm.exterior_field(r, theta);
+            let (c, s) = (theta.cos(), theta.sin());
+            let (bx_e, by_e) = (br * c - bth * s, br * s + bth * c);
+            let (bx, by) = pm.exterior_field_xy(r * c, r * s);
+            // Scale the tolerance by the field magnitude (individual
+            // Cartesian components can be near zero while the total is not).
+            let scale = (bx_e * bx_e + by_e * by_e).sqrt().max(1e-12);
+            assert!((bx - bx_e).abs() <= 1e-12 * scale);
+            assert!((by - by_e).abs() <= 1e-12 * scale);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "pole_pairs ≥ 2")]
+    fn rejects_p1() {
+        let _ = SlotlessPm::new(0.030, 0.040, 1.0, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "r ≥ r_outer")]
+    fn interior_field_panics() {
+        let pm = SlotlessPm::new(0.030, 0.040, 1.0, 2);
+        let _ = pm.exterior_field(0.035, 0.0);
+    }
+}

--- a/crates/geode-core/src/assembly/magnetostatic.rs
+++ b/crates/geode-core/src/assembly/magnetostatic.rs
@@ -266,6 +266,201 @@ pub fn assemble_magnetostatic(
     })
 }
 
+/// Assemble the **permanent-magnet magnetization RHS**
+/// `b_p = ∫ (μ₀ M) · (∇φ_p)^⊥` for the scalar magnetostatic operator, where
+/// `(∇φ_p)^⊥ = (∂φ_p/∂y, −∂φ_p/∂x)`.
+///
+/// # Physics
+///
+/// A permanent magnet enters Ampère's law `∇×H = J_free` through its
+/// constitutive law `H = B/(μ₀ μ_r) − M` (`M` the magnetization, A/m). In
+/// the axial-`A` reduction this adds an **equivalent bound current**
+/// `(∇×M)_z` to the free current:
+///
+/// ```text
+///   −∇·( (1/(μ₀ μ_r)) ∇A_z ) = J_z + (∇×M)_z .
+/// ```
+///
+/// This module carries the dimensionless reluctivity `ν = 1/μ_r` on the
+/// stiffness and the `μ₀` factor on the RHS (matching
+/// [`assemble_magnetostatic`]'s `μ₀ J_z` convention), so multiplying
+/// through by `μ₀` the magnetization source is `μ₀ (∇×M)_z`. Integrating
+/// by parts (test function `φ_p` vanishing on the Dirichlet boundary)
+/// gives the weak-form source
+///
+/// ```text
+///   b_p = ∫ μ₀ (∇×M)_z φ_p dA = ∫ (μ₀ M) · (∂φ_p/∂y, −∂φ_p/∂x) dA ,
+/// ```
+///
+/// which **automatically subsumes both** the bulk bound current
+/// `(∇×M)_z` and the surface bound current `K = M × n̂` on the magnet
+/// faces — no separate sheet/line-current discretization, and no thin-band
+/// volumetric approximation. This is the exact P1 weak-form magnetization
+/// source (curator's option 1, expressed as a volumetric magnetization
+/// integral rather than an interface line integral). The recoil
+/// permeability `μ_rec` enters only through `ν = 1/μ_rec` on the magnet
+/// band's stiffness, **not** through this source.
+///
+/// # Arguments
+///
+/// * `mesh` — the cross-section mesh (CCW triangles).
+/// * `m` — per-triangle **physical magnetization** `M` in Cartesian
+///   components `[M_x, M_y]` (A/m), length `mesh.n_tris()`. Zero outside
+///   the magnet band. For a radially-magnetized band build it with
+///   [`radial_magnetization_source`].
+///
+/// The result is a full-length `[n_nodes]` nodal RHS to be **added** to
+/// any free-current RHS before Dirichlet reduction; see
+/// [`assemble_magnetostatic_pm`] for the assembled-system convenience.
+///
+/// # Errors
+///
+/// [`MagnetostaticError::ShapeMismatch`] if `m.len() != mesh.n_tris()`.
+pub fn assemble_magnetization_rhs(
+    mesh: &TriMesh,
+    m: &[[f64; 2]],
+) -> Result<Vec<f64>, MagnetostaticError> {
+    let n_tris = mesh.n_tris();
+    if m.len() != n_tris {
+        return Err(MagnetostaticError::ShapeMismatch(format!(
+            "m length {} != triangle count {n_tris}",
+            m.len()
+        )));
+    }
+    let mu0 = crate::analytic::slotless_pm::MU_0;
+    let mut b_full = vec![0.0_f64; mesh.n_nodes()];
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let [mx, my] = m[t];
+        if mx == 0.0 && my == 0.0 {
+            continue;
+        }
+        let coords = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let (grad, _gram, signed_area, _abs) = tri_bary_grads(&coords);
+        let (mx0, my0) = (mu0 * mx, mu0 * my);
+        for p in 0..3 {
+            // ∇φ_p is constant on the element; ∫_T (∇φ_p)^⊥ dA = area·(g_y,−g_x).
+            let perp = [grad[p][1], -grad[p][0]];
+            b_full[tri[p] as usize] += signed_area * (mx0 * perp[0] + my0 * perp[1]);
+        }
+    }
+    Ok(b_full)
+}
+
+/// Build the per-triangle physical magnetization `M` for a
+/// **radially-magnetized surface-PM band** with sinusoidal amplitude
+/// `M_r(θ) = M0 cos(p θ)` (the slotless surface-PM magnetization matched by
+/// [`crate::analytic::slotless_pm::SlotlessPm`]).
+///
+/// `M` is evaluated at each triangle **centroid** and returned in Cartesian
+/// components `[M_x, M_y] = M_r (cos θ, sin θ)` for triangles whose
+/// `band_tags[t] == magnet_tag`, and `[0, 0]` elsewhere. Feed the result to
+/// [`assemble_magnetization_rhs`] (which applies the `μ₀` factor). The
+/// recoil permeability `μ_rec` does **not** scale this source — it enters
+/// only through the magnet band's reluctivity `ν = 1/μ_rec` in
+/// [`build_nu_r`].
+///
+/// The remanence-vs-magnetization duality: passing `M0 = B_rem / μ₀` (with
+/// `B_rem` the remanent flux density in Tesla) reproduces the same field —
+/// see [`radial_magnetization_source_from_remanence`], the `Hc`/remanence
+/// cross-check parameterization.
+///
+/// # Panics
+///
+/// Panics if `band_tags.len() != mesh.n_tris()`.
+pub fn radial_magnetization_source(
+    mesh: &TriMesh,
+    band_tags: &[i32],
+    magnet_tag: i32,
+    m0: f64,
+    pole_pairs: u32,
+) -> Vec<[f64; 2]> {
+    assert_eq!(
+        band_tags.len(),
+        mesh.n_tris(),
+        "band_tags length {} != triangle count {}",
+        band_tags.len(),
+        mesh.n_tris()
+    );
+    let p = pole_pairs as f64;
+    mesh.tris
+        .iter()
+        .enumerate()
+        .map(|(t, tri)| {
+            if band_tags[t] != magnet_tag {
+                return [0.0, 0.0];
+            }
+            let cx = (mesh.nodes[tri[0] as usize][0]
+                + mesh.nodes[tri[1] as usize][0]
+                + mesh.nodes[tri[2] as usize][0])
+                / 3.0;
+            let cy = (mesh.nodes[tri[0] as usize][1]
+                + mesh.nodes[tri[1] as usize][1]
+                + mesh.nodes[tri[2] as usize][1])
+                / 3.0;
+            let theta = cy.atan2(cx);
+            let m_r = m0 * (p * theta).cos();
+            [m_r * theta.cos(), m_r * theta.sin()]
+        })
+        .collect()
+}
+
+/// [`radial_magnetization_source`] parameterized by **remanent flux
+/// density** `B_rem` (Tesla) instead of magnetization `M0` (A/m) — the
+/// `Hc`/remanence dual formulation.
+///
+/// Physically `B_rem = μ₀ M0`, so this simply forwards `M0 = B_rem / μ₀`.
+/// It is **not** a second production path: it exists so a test can drive
+/// the identical solver two ways (magnetization-amplitude vs remanence)
+/// and confirm they agree to machine precision — the Epic #448 PM-pitfall
+/// cross-check that the two source parameterizations are the same operator.
+pub fn radial_magnetization_source_from_remanence(
+    mesh: &TriMesh,
+    band_tags: &[i32],
+    magnet_tag: i32,
+    b_rem: f64,
+    pole_pairs: u32,
+) -> Vec<[f64; 2]> {
+    let m0 = b_rem / crate::analytic::slotless_pm::MU_0;
+    radial_magnetization_source(mesh, band_tags, magnet_tag, m0, pole_pairs)
+}
+
+/// Assemble the scalar magnetostatic system driven by a **permanent-magnet
+/// magnetization source** (plus any free current `j_z`), with the boundary
+/// Dirichlet condition eliminated.
+///
+/// This is [`assemble_magnetostatic`] with the magnetization RHS
+/// `b_p += ∫ M_eff·(∇φ_p)^⊥` (from [`assemble_magnetization_rhs`]) folded
+/// into the free-current RHS before Dirichlet reduction. Pass
+/// `j_z = &[0.0; n_tris]` for a pure-PM problem.
+///
+/// # Errors
+///
+/// Propagates [`MagnetostaticError`] from either the stiffness assembly or
+/// the magnetization-RHS shape check.
+pub fn assemble_magnetostatic_pm(
+    mesh: &TriMesh,
+    nu: &[f64],
+    j_z: &[f64],
+    m_eff: &[[f64; 2]],
+    dirichlet: &[bool],
+) -> Result<MagnetostaticSystem, MagnetostaticError> {
+    // Assemble the current-driven system first (handles all shape checks and
+    // the Dirichlet reduction), then re-fold the magnetization RHS through the
+    // same free-node renumbering.
+    let mut sys = assemble_magnetostatic(mesh, nu, j_z, dirichlet)?;
+    let b_mag_full = assemble_magnetization_rhs(mesh, m_eff)?;
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            sys.b[*fi] += b_mag_full[g];
+        }
+    }
+    Ok(sys)
+}
+
 /// Build the per-triangle reluctivity vector `ν = 1/μ_r` from band tags and
 /// a per-band relative-permeability table, for a piecewise-`μ` cross-section.
 ///

--- a/crates/geode-core/tests/slotless_pm_field.rs
+++ b/crates/geode-core/tests/slotless_pm_field.rs
@@ -1,0 +1,376 @@
+//! Air-gap field benchmark for a **slotless surface-PM annulus**
+//! (Epic #448, Phase 2b — the field-accuracy half of the epic headline).
+//!
+//! Four-part test plan (matching the issue):
+//!
+//! 1. **Oracle self-validation** — the thin-magnet limit of the
+//!    [`SlotlessPm`] scalar-potential multipole matches the independent
+//!    2-D Biot–Savart current-sheet coefficient to ≤ 0.5 %. Gate the
+//!    oracle before gating the solver.
+//! 2. **PM-formulation agreement** — the magnetization-amplitude source and
+//!    the remanence (`Hc`) source drive the identical solver to ≤ 0.5 %
+//!    (in fact machine precision — same operator, two parameterizations).
+//! 3. **Air-gap field oracle** — the FEM `B_r(θ), B_θ(θ)` on the mid-gap
+//!    θ-contour vs [`SlotlessPm::exterior_field`], L2 over θ.
+//! 4. **Inverse tripwire** — a wrong magnetization sign/magnitude or a
+//!    coarse gap mesh drives the field error far above the 1 % bar.
+//!
+//! ## Honest-science note on part 3
+//!
+//! The P1 (piecewise-constant) `B` recovery converges only **first order**
+//! in `h`, and the radial-magnet field varies rapidly across the thin air
+//! gap, so on practically-sized meshes the mid-gap L2 error settles around
+//! a couple of percent (converging, but not under 1 %). Per Epic #448 the
+//! ≤ 1 % bar is a P2-Lagrange target; the P1 miss is documented honestly
+//! here ([`airgap_field_p1_convergence`] prints the convergence sequence)
+//! rather than cherry-picking a mesh to squeak under the bar.
+
+#![allow(clippy::needless_range_loop)]
+
+use geode_core::analytic::slotless_pm::{
+    MU_0, SlotlessPm, current_sheet_exterior_coeff, self_validation_rel_error,
+};
+use geode_core::analytic::waveguide::{
+    RadialGrading, TriMesh, disk_boundary_nodes, disk_tri_mesh_bands,
+};
+use geode_core::assembly::magnetostatic::{
+    assemble_magnetostatic_pm, build_nu_r, radial_magnetization_source,
+    radial_magnetization_source_from_remanence, recover_b_field,
+};
+
+// Band indices for the four-band machine cross-section
+// radii = [0, R1, R2, R3, Rout]:
+//   0 = inner bore (air), 1 = magnet, 2 = air gap, 3 = outer air.
+const TAG_MAGNET: i32 = 1;
+const TAG_GAP: i32 = 2;
+
+/// Geometry of the slotless-PM benchmark (μ_rec = 1 so the FEM matches the
+/// open-space μ_rec = 1 oracle).
+struct Geom {
+    r1: f64,
+    r2: f64,
+    r3: f64,
+    rout: f64,
+    m0: f64,
+    p: u32,
+}
+
+impl Geom {
+    fn nominal() -> Self {
+        // Remanence B_rem = 1.2 T (NdFeB), M0 = B_rem/μ₀.
+        Geom {
+            r1: 0.030,
+            r2: 0.040,
+            r3: 0.045,
+            rout: 0.20,
+            m0: 1.2 / MU_0,
+            p: 2,
+        }
+    }
+    fn radii(&self) -> [f64; 5] {
+        [0.0, self.r1, self.r2, self.r3, self.rout]
+    }
+    fn oracle(&self) -> SlotlessPm {
+        SlotlessPm::new(self.r1, self.r2, self.m0, self.p)
+    }
+    fn r_gap(&self) -> f64 {
+        0.5 * (self.r2 + self.r3)
+    }
+}
+
+/// Build the four-band machine mesh at the given angular / per-band radial
+/// resolution (μ_rec = 1 everywhere for the open-space oracle comparison).
+fn build_mesh(g: &Geom, n_ang: usize, n_rad: [usize; 4]) -> (TriMesh, Vec<i32>) {
+    let gradings = [RadialGrading::Uniform; 4];
+    disk_tri_mesh_bands(&g.radii(), n_ang, &n_rad, &gradings)
+}
+
+/// Solve the pure-PM problem (magnetization source, μ_rec = 1) and return
+/// `(mesh, band_tags, B_per_tri)`.
+fn solve_pm(
+    g: &Geom,
+    n_ang: usize,
+    n_rad: [usize; 4],
+    m0: f64,
+    p: u32,
+) -> (TriMesh, Vec<i32>, Vec<[f64; 2]>) {
+    let (mesh, tags) = build_mesh(g, n_ang, n_rad);
+    let n_tris = mesh.n_tris();
+    // μ_rec = 1 in the magnet, μ_r = 1 everywhere else → ν = 1 everywhere.
+    let nu = build_nu_r(&tags, &[1.0, 1.0, 1.0, 1.0]);
+    let j_z = vec![0.0; n_tris];
+    let m = radial_magnetization_source(&mesh, &tags, TAG_MAGNET, m0, p);
+    let bc = disk_boundary_nodes(&mesh, g.rout);
+    let sys = assemble_magnetostatic_pm(&mesh, &nu, &j_z, &m, &bc).expect("assemble PM");
+    let a_z = sys.solve().expect("PM solve");
+    let b = recover_b_field(&mesh, &a_z);
+    (mesh, tags, b)
+}
+
+/// Locate the triangle containing point `(px, py)` by barycentric test.
+fn locate(mesh: &TriMesh, px: f64, py: f64) -> Option<usize> {
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let [x1, y1] = mesh.nodes[tri[0] as usize];
+        let [x2, y2] = mesh.nodes[tri[1] as usize];
+        let [x3, y3] = mesh.nodes[tri[2] as usize];
+        let d = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+        let a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / d;
+        let b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / d;
+        let c = 1.0 - a - b;
+        let tol = -1e-9;
+        if a >= tol && b >= tol && c >= tol {
+            return Some(t);
+        }
+    }
+    None
+}
+
+/// L2 relative error of the FEM air-gap field vs the oracle, sampled on the
+/// mid-gap θ-contour (a ring at `r_gap`), locating the containing triangle
+/// for each contour point. `(B_r, B_θ)` compared component-wise.
+fn midgap_contour_l2(
+    mesh: &TriMesh,
+    b: &[[f64; 2]],
+    oracle: &SlotlessPm,
+    r_gap: f64,
+    n_contour: usize,
+) -> f64 {
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for i in 0..n_contour {
+        let theta = std::f64::consts::TAU * i as f64 / n_contour as f64;
+        let (px, py) = (r_gap * theta.cos(), r_gap * theta.sin());
+        let t = locate(mesh, px, py).expect("contour point inside mesh");
+        let (br_o, bth_o) = oracle.exterior_field(r_gap, theta);
+        let (c, s) = (theta.cos(), theta.sin());
+        let (bx, by) = (b[t][0], b[t][1]);
+        let br = bx * c + by * s;
+        let bth = -bx * s + by * c;
+        num += (br - br_o).powi(2) + (bth - bth_o).powi(2);
+        den += br_o.powi(2) + bth_o.powi(2);
+    }
+    (num / den).sqrt()
+}
+
+/// Per-triangle L2 error over the air-gap band (area-weighted continuous
+/// L2 norm), an alternative to contour sampling used by the tripwire.
+fn gap_band_l2(mesh: &TriMesh, tags: &[i32], b: &[[f64; 2]], oracle: &SlotlessPm) -> f64 {
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        if tags[t] != TAG_GAP {
+            continue;
+        }
+        let c0 = mesh.nodes[tri[0] as usize];
+        let c1 = mesh.nodes[tri[1] as usize];
+        let c2 = mesh.nodes[tri[2] as usize];
+        let cx = (c0[0] + c1[0] + c2[0]) / 3.0;
+        let cy = (c0[1] + c1[1] + c2[1]) / 3.0;
+        let r = (cx * cx + cy * cy).sqrt();
+        let theta = cy.atan2(cx);
+        let area =
+            0.5 * ((c1[0] - c0[0]) * (c2[1] - c0[1]) - (c1[1] - c0[1]) * (c2[0] - c0[0])).abs();
+        let (br_o, bth_o) = oracle.exterior_field(r, theta);
+        let (cc, ss) = (theta.cos(), theta.sin());
+        let br = b[t][0] * cc + b[t][1] * ss;
+        let bth = -b[t][0] * ss + b[t][1] * cc;
+        num += area * ((br - br_o).powi(2) + (bth - bth_o).powi(2));
+        den += area * (br_o.powi(2) + bth_o.powi(2));
+    }
+    (num / den).sqrt()
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. Oracle self-validation (≤ 0.5 %)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn oracle_self_validates_against_current_sheet() {
+    // Thin-magnet limit: scalar-potential coefficient → Biot–Savart
+    // current-sheet coefficient. Shrinking t/R drives the error down.
+    let r_mean = 0.040;
+    let m0 = 1.2 / MU_0;
+    let mut prev = f64::INFINITY;
+    for &tf in &[0.02, 0.01, 0.005] {
+        let t = tf * r_mean;
+        let pm = SlotlessPm::new(r_mean - t / 2.0, r_mean + t / 2.0, m0, 2);
+        let err = self_validation_rel_error(&pm);
+        println!("self-validation t/R={tf}: rel err = {:.5}%", err * 100.0);
+        assert!(
+            err <= 5e-3,
+            "oracle self-validation {:.4}% at t/R={tf} exceeds the 0.5% gate",
+            err * 100.0
+        );
+        assert!(err < prev, "self-validation not monotone in t/R");
+        prev = err;
+    }
+
+    // Direct coefficient identity at the thinnest band: scalar C vs the
+    // current-sheet D with K0 = M0 p t / R.
+    let t = 0.005 * r_mean;
+    let pm = SlotlessPm::new(r_mean - t / 2.0, r_mean + t / 2.0, m0, 2);
+    let c_scalar = pm.exterior_coeff();
+    let d_sheet = current_sheet_exterior_coeff(pm.equivalent_sheet_k0(), r_mean, pm.pole_pairs);
+    assert!(
+        (c_scalar / d_sheet - 1.0).abs() <= 5e-3,
+        "coefficient identity broken: C={c_scalar}, D={d_sheet}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. PM-formulation agreement (≤ 0.5 %)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn magnetization_and_remanence_sources_agree() {
+    // Same solver, two source parameterizations: M0 (A/m) vs B_rem (T)
+    // with M0 = B_rem/μ₀. They are the same operator → identical RHS →
+    // identical field to machine precision.
+    let g = Geom::nominal();
+    let (mesh, tags) = build_mesh(&g, 96, [6, 8, 4, 12]);
+    let m_from_m0 = radial_magnetization_source(&mesh, &tags, TAG_MAGNET, g.m0, g.p);
+    let b_rem = g.m0 * MU_0; // exact inverse
+    let m_from_brem =
+        radial_magnetization_source_from_remanence(&mesh, &tags, TAG_MAGNET, b_rem, g.p);
+
+    // Sources agree elementwise to machine precision.
+    let mut max_src = 0.0_f64;
+    for (a, b) in m_from_m0.iter().zip(&m_from_brem) {
+        max_src = max_src.max((a[0] - b[0]).abs()).max((a[1] - b[1]).abs());
+    }
+    let scale = g.m0.abs();
+    assert!(
+        max_src <= 1e-9 * scale,
+        "magnetization vs remanence source differ by {max_src} (scale {scale})"
+    );
+
+    // And the solved fields agree.
+    let nu = build_nu_r(&tags, &[1.0, 1.0, 1.0, 1.0]);
+    let j_z = vec![0.0; mesh.n_tris()];
+    let bc = disk_boundary_nodes(&mesh, g.rout);
+    let a1 = assemble_magnetostatic_pm(&mesh, &nu, &j_z, &m_from_m0, &bc)
+        .unwrap()
+        .solve()
+        .unwrap();
+    let a2 = assemble_magnetostatic_pm(&mesh, &nu, &j_z, &m_from_brem, &bc)
+        .unwrap()
+        .solve()
+        .unwrap();
+    let (b1, b2) = (recover_b_field(&mesh, &a1), recover_b_field(&mesh, &a2));
+    let oracle = g.oracle();
+    let e1 = gap_band_l2(&mesh, &tags, &b1, &oracle);
+    let e2 = gap_band_l2(&mesh, &tags, &b2, &oracle);
+    println!(
+        "formulation agreement: gap L2 (M0)={e1:.4}, (B_rem)={e2:.4}, |Δ|={:.2e}",
+        (e1 - e2).abs()
+    );
+    assert!(
+        (e1 - e2).abs() <= 5e-3 * e1.max(e2).max(1e-12),
+        "PM formulations disagree beyond 0.5%: {e1} vs {e2}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. Air-gap field oracle (P1 first-order convergence; ≤1% is the
+//    P2-Lagrange target — honest documented P1 miss)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn airgap_field_p1_convergence() {
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    println!("--- slotless-PM air-gap field: P1 mid-gap contour L2 convergence ---");
+    let mut prev = f64::INFINITY;
+    let mut finest = f64::INFINITY;
+    for &(n_ang, n_rad) in &[
+        (96usize, [6usize, 8, 3, 10]),
+        (192, [10, 12, 5, 14]),
+        (288, [14, 16, 8, 20]),
+        (384, [18, 20, 12, 26]),
+    ] {
+        let (mesh, _tags, b) = solve_pm(&g, n_ang, n_rad, g.m0, g.p);
+        let err = midgap_contour_l2(&mesh, &b, &oracle, g.r_gap(), 180);
+        println!(
+            "  n_ang={n_ang:3} nodes={:6} mid-gap L2 = {:.3}%",
+            mesh.n_nodes(),
+            err * 100.0
+        );
+        // Monotone refinement (first-order convergence sanity).
+        assert!(
+            err < prev * 1.02,
+            "refinement did not reduce error: {err} vs {prev}"
+        );
+        prev = err;
+        finest = err;
+    }
+    // Honest P1 outcome: the field is accurate to a few percent and
+    // converging, but the ≤1% bar is a P2-Lagrange target (Epic #448). We
+    // assert a *loose* P1 ceiling here so the test is a real guard against
+    // regressions without cherry-picking a mesh to fake a sub-1% pass.
+    assert!(
+        finest <= 0.03,
+        "finest P1 mid-gap L2 {:.3}% exceeds the 3% P1 sanity ceiling — \
+         either a regression or the mesh is under-resolved",
+        finest * 100.0
+    );
+    if finest > 0.01 {
+        println!(
+            "NOTE (honest miss): finest P1 mid-gap L2 = {:.3}% > 1% bar. \
+             The ≤1% headline needs P2-Lagrange B recovery (Epic #448 P2 fallback); \
+             P1 piecewise-constant B converges first-order and does not clear 1% at \
+             practical mesh sizes. Recommend a P2-Lagrange follow-on.",
+            finest * 100.0
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. Inverse tripwires (error above a floor > the 1% bar)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn wrong_magnetization_sign_tripwire_fires() {
+    // Flip the magnetization sign: the field flips, so relative to the
+    // correct oracle the error is ~200%.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    let (mesh, tags, b) = solve_pm(&g, 192, [10, 12, 5, 14], -g.m0, g.p);
+    let err = gap_band_l2(&mesh, &tags, &b, &oracle);
+    println!("wrong-sign tripwire: gap L2 = {:.1}%", err * 100.0);
+    assert!(
+        err > 0.5,
+        "wrong-sign error {:.2}% did not exceed the 50% floor — tripwire broken",
+        err * 100.0
+    );
+}
+
+#[test]
+fn wrong_magnitude_tripwire_fires() {
+    // Wrong magnetization magnitude (×1.5): a clean ~50% field error.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    let (mesh, tags, b) = solve_pm(&g, 192, [10, 12, 5, 14], 1.5 * g.m0, g.p);
+    let err = gap_band_l2(&mesh, &tags, &b, &oracle);
+    println!("wrong-magnitude tripwire: gap L2 = {:.1}%", err * 100.0);
+    assert!(
+        err > 0.05,
+        "wrong-magnitude error {:.2}% did not exceed the 5% floor",
+        err * 100.0
+    );
+}
+
+#[test]
+fn coarse_gap_tripwire_fires() {
+    // Correct magnetization but a very coarse gap: the point-of-comparison
+    // discretization error dominates and blows past the 1% bar.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    let (mesh, _tags, b) = solve_pm(&g, 24, [2, 2, 1, 3], g.m0, g.p);
+    let err = midgap_contour_l2(&mesh, &b, &oracle, g.r_gap(), 60);
+    println!("coarse-gap tripwire: mid-gap L2 = {:.1}%", err * 100.0);
+    assert!(
+        err > 0.05,
+        "coarse-gap error {:.2}% did not exceed the 5% floor",
+        err * 100.0
+    );
+}


### PR DESCRIPTION
## Summary

Adds permanent-magnet sources to the 2-D scalar magnetostatic solver and validates the air-gap field of a radially-magnetized slotless surface-PM annulus against the exact Zhu/Howe-style annular-harmonic closed form (Epic #448, P2b — the field-accuracy half of the epic headline).

## Source-mechanism decision (curator options)

The curator's comment correctly flagged that `assemble_magnetostatic`'s `j_z` argument is strictly per-triangle volumetric, so the issue's "sheet current on interface nodes is directly reusable" claim did not hold. **Chosen: option 1 (new RHS plumbing), implemented as the exact volumetric weak-form magnetization integral rather than interface line integrals.**

Integrating the equivalent-current source `mu0 (curl M)_z` by parts against the P1 test function gives

```
b_p = ∫ (mu0 M) · (∂φ_p/∂y, −∂φ_p/∂x) dA
```

which is constant-per-triangle for P1 (one dot product per element) and **automatically subsumes both** the bulk bound current `curl(M)` and the face sheet currents `K = M × n̂` — no line-source quadrature and, crucially, **no thin-band volumetric approximation error** (option 2's risk). Error budget for the source itself: the only discretization is evaluating `M` at the triangle centroid, an O(h²) consistency error that is negligible against the O(h) P1 field-recovery error (measured below). The recoil permeability enters only via `ν = 1/μ_rec` on the magnet band's stiffness (`build_nu_r`), not the source.

## Changes

- `crates/geode-core/src/analytic/slotless_pm.rs` (new): `SlotlessPm` exact exterior multipole `B_r = C r^{−(p+1)} cos(pθ)`, `B_θ = C r^{−(p+1)} sin(pθ)`, `C = μ₀M₀p(R2^{p+1}−R1^{p+1})/[2(p+1)]`, derived by scalar-potential matching across the three coaxial regions (p ≥ 2 asserted; p = 1 needs the degenerate `r ln r` branch and is rejected). Independent Biot–Savart current-sheet coefficient (`current_sheet_exterior_coeff`) + thin-band self-validation helper.
- `crates/geode-core/src/assembly/magnetostatic.rs`: `assemble_magnetization_rhs` (exact weak-form PM source), `radial_magnetization_source` (M₀ parameterization), `radial_magnetization_source_from_remanence` (B_rem/Hc dual — cross-check only, not a second production path), `assemble_magnetostatic_pm` (folds the PM RHS through the existing Dirichlet reduction).
- `crates/geode-core/tests/slotless_pm_field.rs` (new): the 4-part test plan.
- `crates/geode-core/examples/slotless_pm.rs` (new): tearsheet cross-section.

## Acceptance Criteria Verification

| Criterion | Bar | Measured | Status |
|-----------|-----|----------|--------|
| 1. Oracle self-validation vs current-sheet limit | ≤ 0.5% | 0.0033% at t/R=0.02, 0.0008% at t/R=0.01, 0.0002% at t/R=0.005 (monotone) — scalar-potential matching vs independent 2-D Green's-function derivation | PASS |
| 2. PM formulation agreement (M vs Hc/remanence) | ≤ 0.5% | 0.0 (bitwise-identical fields; same operator, two parameterizations — sources agree to ≤1e-9 relative elementwise) | PASS |
| 3. Air-gap field vs oracle, mid-gap contour L2 | ≤ 1% | **Honest miss on P1**: 7.69% → 4.18% → 3.65% → **2.44%** at (n_ang, nodes) = (96, 2.6k) → (192, 7.9k) → (288, 16.7k) → (384, 29.2k); clean first-order convergence, but piecewise-constant B does not clear 1% at practical mesh sizes | DOCUMENTED MISS |
| 4. Inverse tripwire above a floor > 1% | > 1% | wrong sign 199.9%, wrong magnitude (×1.5) 50.1%, coarse gap 30.7% — all asserted above 5%/50% floors | PASS |

### Honest-science note on criterion 3 (no cherry-picking)

The mid-gap L2 sequence converges monotonically first-order (as expected for piecewise-constant B from P1), from 7.7% down to 2.44% at 29k nodes. Extrapolating first-order, sub-1% would need ~100k+ nodes in this geometry — not a practical production mesh. Per the issue and Epic #448 ("P2 Lagrange as a fallback, not a prerequisite"), this is documented as an honest P1 formulation miss: the test asserts a loose 3% P1 regression ceiling plus monotone refinement, prints the miss explicitly, and **recommends a P2-Lagrange B-recovery follow-on** to hit the ≤1% headline. Prototype cross-checks (independent Python FEM) reproduce the same 1.25–2.4% floor at 44–81k nodes, ruling out an implementation bug vs a genuine P1 recovery limit.

Also verified during derivation: boundary-truncation error of the finite Dirichlet disk (R_out = 0.20 m vs the open-space oracle) is subdominant — pushing R_out from 0.15 to 0.30 changes the error by < 0.05 points; the multipole decays as r^{−(p+1)}.

## Test Plan

- `cargo fmt --all` — clean (no rustfmt hooks in repo; run explicitly).
- `cargo clippy -p geode-core --all-targets -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean.
- Debug: `slotless_pm_field` (6/6), `magnetostatic_wire` (9/9 + 1 ignored probe), `magnetostatic_heterogeneous` (9/9), `--lib` (267/267).
- Release: `cargo test -p geode-core --release --tests` — full suite green (fail-fast run completed through the last test binary).
- Example: `cargo run -p geode-core --example slotless_pm --release` — peak mid-gap |B| 0.198 T FEM vs 0.193 T oracle, contour L2 2.44%.

Closes #456