### PR TITLE
feat(geode-core): Maxwell-stress + Arkkio torque extractors vs loop T=m×B oracle

### DIFF
--- a/crates/geode-core/src/assembly/mod.rs
+++ b/crates/geode-core/src/assembly/mod.rs
@@ -24,6 +24,10 @@
 //!   optional Dirichlet reduction.
 //! - [`surface`]: Silver–Müller and surface-mass boundary assembly on
 //!   the mesh's exterior triangle faces.
+//! - [`torque`]: electromagnetic torque extraction from a per-triangle
+//!   air-gap flux density — the Maxwell stress-tensor line integral and
+//!   Arkkio's volume-averaged variant (Epic #448 Phase 3), with the shared
+//!   contour/triangle-location sampler they build on.
 
 pub mod fe;
 pub mod magnetostatic;
@@ -31,3 +35,4 @@ pub mod nedelec;
 pub mod p1;
 pub mod sparse;
 pub mod surface;
+pub mod torque;

--- a/crates/geode-core/src/assembly/torque.rs
+++ b/crates/geode-core/src/assembly/torque.rs
@@ -1,0 +1,317 @@
+//! Electromagnetic **torque extraction** from a piecewise-constant air-gap
+//! flux density (Epic #448, Phase 3a).
+//!
+//! Torque is a *derived* quantity: a nonlinear (`B_r·B_θ`) integral of the
+//! field over the gap, notoriously noisy on coarse meshes. This module
+//! implements the two standard 2-D machine estimators and is validated
+//! against the closed-form **torque-on-a-current-loop** oracle
+//! (`T = m × B`) *before* it is trusted on a real machine solve, so a
+//! torque miss on the machine can be attributed to the field or the mesh
+//! rather than a buggy extractor.
+//!
+//! ## Estimators
+//!
+//! **Maxwell stress-tensor air-gap line integral.** Torque per axial length
+//! `L` on a circular contour of radius `r_gap` through the air gap:
+//!
+//! ```text
+//!   T = (L r_gap² / μ₀) ∫_0^{2π} B_r(θ) B_θ(θ) dθ
+//! ```
+//!
+//! [`maxwell_stress_torque`] samples `(B_r, B_θ)` on the mid-gap contour by
+//! locating the containing triangle for each sample point and evaluating the
+//! per-triangle constant `B`, then integrates in `θ` with the periodic
+//! trapezoid rule (exact for the truncated Fourier series of a smooth
+//! periodic integrand).
+//!
+//! **Arkkio's volume-averaged variant (strongly preferred on coarse
+//! meshes).** Instead of one contour, average the stress over the whole gap
+//! annulus `[r_i, r_o]`:
+//!
+//! ```text
+//!   T = (L / (μ₀ (r_o − r_i))) ∫∫_{gap} B_r B_θ r  dr dθ
+//! ```
+//!
+//! [`arkkio_torque`] computes the per-triangle constant `B_r B_θ r`, weights
+//! by triangle area, and sums over the gap-band triangles selected by their
+//! band tag. Volume-averaging cancels the pointwise product noise, so this
+//! is the recommended production estimator.
+//!
+//! ## Shared contour sampler
+//!
+//! [`locate_triangle`] (barycentric point-in-triangle search) and
+//! [`sample_b_polar_on_contour`] (mid-gap ring sampler returning the polar
+//! `(B_r, B_θ)` components) are `pub` here so the torque extractor, field
+//! benchmarks, and examples share one implementation instead of each keeping
+//! a private copy.
+
+use crate::analytic::slotless_pm::MU_0;
+use crate::analytic::waveguide::TriMesh;
+
+/// Locate the triangle of `mesh` that contains the point `(px, py)` by a
+/// barycentric point-in-triangle test, returning its 0-based triangle index
+/// (or `None` if the point lies outside every triangle).
+///
+/// A small negative tolerance (`-1e-9`) admits points exactly on an edge or
+/// vertex, so a contour sample that lands on a shared triangle boundary is
+/// still assigned to a neighbouring triangle rather than being reported as
+/// outside the mesh. When a point is shared by several triangles the first
+/// in mesh order wins — fine for evaluating a per-triangle constant field,
+/// which is (nearly) continuous across the gap.
+pub fn locate_triangle(mesh: &TriMesh, px: f64, py: f64) -> Option<usize> {
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let [x1, y1] = mesh.nodes[tri[0] as usize];
+        let [x2, y2] = mesh.nodes[tri[1] as usize];
+        let [x3, y3] = mesh.nodes[tri[2] as usize];
+        let d = (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3);
+        let a = ((y2 - y3) * (px - x3) + (x3 - x2) * (py - y3)) / d;
+        let b = ((y3 - y1) * (px - x3) + (x1 - x3) * (py - y3)) / d;
+        let c = 1.0 - a - b;
+        let tol = -1e-9;
+        if a >= tol && b >= tol && c >= tol {
+            return Some(t);
+        }
+    }
+    None
+}
+
+/// Rotate a Cartesian per-triangle field `[B_x, B_y]` into the local polar
+/// frame at angle `theta`, returning `(B_r, B_θ)`:
+/// `B_r =  B_x cosθ + B_y sinθ`, `B_θ = −B_x sinθ + B_y cosθ`.
+#[inline]
+pub fn cartesian_to_polar_b(bxy: [f64; 2], theta: f64) -> (f64, f64) {
+    let (c, s) = (theta.cos(), theta.sin());
+    let br = bxy[0] * c + bxy[1] * s;
+    let bth = -bxy[0] * s + bxy[1] * c;
+    (br, bth)
+}
+
+/// Sample the piecewise-constant flux density `b` on a circular contour of
+/// radius `r_gap`, at `n_contour` equal-angle points `θ_i = 2πi/n_contour`,
+/// returning the polar components `(B_r(θ_i), B_θ(θ_i))`.
+///
+/// For each sample point the containing triangle is located with
+/// [`locate_triangle`] and its constant `B` rotated into the polar frame.
+///
+/// # Panics
+///
+/// Panics if any contour point falls outside the mesh (the caller passed an
+/// `r_gap` that is not inside the meshed domain) or if `b.len()` does not
+/// equal the triangle count.
+pub fn sample_b_polar_on_contour(
+    mesh: &TriMesh,
+    b: &[[f64; 2]],
+    r_gap: f64,
+    n_contour: usize,
+) -> Vec<(f64, f64)> {
+    assert_eq!(
+        b.len(),
+        mesh.n_tris(),
+        "sample_b_polar_on_contour: b length {} != triangle count {}",
+        b.len(),
+        mesh.n_tris()
+    );
+    assert!(n_contour >= 3, "sample_b_polar_on_contour: need ≥3 samples");
+    (0..n_contour)
+        .map(|i| {
+            let theta = std::f64::consts::TAU * i as f64 / n_contour as f64;
+            let (px, py) = (r_gap * theta.cos(), r_gap * theta.sin());
+            let t = locate_triangle(mesh, px, py).unwrap_or_else(|| {
+                panic!(
+                    "sample_b_polar_on_contour: contour point r_gap={r_gap} θ={theta} \
+                     is outside the mesh"
+                )
+            });
+            cartesian_to_polar_b(b[t], theta)
+        })
+        .collect()
+}
+
+/// Maxwell stress-tensor air-gap **line-integral** torque per axial length
+/// `L`, on a circular contour of radius `r_gap` sampled at `n_contour`
+/// equal-angle points:
+///
+/// ```text
+///   T = (L r_gap² / μ₀) ∫_0^{2π} B_r(θ) B_θ(θ) dθ
+///     ≈ (L r_gap² / μ₀) · Δθ · Σ_i B_r(θ_i) B_θ(θ_i),   Δθ = 2π/n_contour
+/// ```
+///
+/// The periodic trapezoid rule (a plain average times `2π`) is spectrally
+/// accurate for the smooth periodic integrand `B_r B_θ`, so quadrature error
+/// is negligible against the field-recovery error on any reasonable
+/// `n_contour`.
+///
+/// `b` is the per-triangle constant flux density `[B_x, B_y]` (e.g. from
+/// [`crate::assembly::magnetostatic::recover_b_field`]); `r_gap` must lie
+/// inside the meshed air gap.
+///
+/// # Panics
+///
+/// Panics if a contour point falls outside the mesh, if `b.len()` ≠ triangle
+/// count, or if `n_contour < 3`.
+pub fn maxwell_stress_torque(
+    mesh: &TriMesh,
+    b: &[[f64; 2]],
+    r_gap: f64,
+    l_axial: f64,
+    n_contour: usize,
+) -> f64 {
+    let samples = sample_b_polar_on_contour(mesh, b, r_gap, n_contour);
+    maxwell_stress_torque_from_samples(&samples, r_gap, l_axial)
+}
+
+/// Pure θ-quadrature core of [`maxwell_stress_torque`]: given the polar field
+/// samples `(B_r(θ_i), B_θ(θ_i))` at `n = samples.len()` equal-angle points
+/// on the contour of radius `r_gap`, return
+/// `(L r_gap²/μ₀) · Δθ · Σ_i B_r B_θ` with `Δθ = 2π/n` (the periodic
+/// trapezoid rule).
+///
+/// Exposed separately so a benchmark can feed *analytic* contour samples
+/// (evaluated at the exact contour points) and isolate the quadrature +
+/// prefactor from any triangle-location / piecewise-constant sampling error.
+///
+/// # Panics
+///
+/// Panics if fewer than 3 samples are supplied.
+pub fn maxwell_stress_torque_from_samples(samples: &[(f64, f64)], r_gap: f64, l_axial: f64) -> f64 {
+    assert!(
+        samples.len() >= 3,
+        "maxwell_stress_torque_from_samples: need ≥3 samples"
+    );
+    let dtheta = std::f64::consts::TAU / samples.len() as f64;
+    let integral: f64 = samples.iter().map(|&(br, bth)| br * bth).sum::<f64>() * dtheta;
+    l_axial * r_gap * r_gap / MU_0 * integral
+}
+
+/// Arkkio volume-averaged air-gap torque per axial length `L`, summed over
+/// the gap-band triangles (those with `tags[t] == gap_tag`) lying in the
+/// annulus `[r_inner, r_outer]`:
+///
+/// ```text
+///   T = (L / (μ₀ (r_o − r_i))) ∫∫_{gap} B_r B_θ r dr dθ
+///     ≈ (L / (μ₀ (r_o − r_i))) Σ_{t ∈ gap} area_t · r_t · B_r(t) B_θ(t)
+/// ```
+///
+/// where `r_t`, `θ_t` are the centroid radius / angle of triangle `t` and
+/// `B_r(t), B_θ(t)` its per-triangle constant field in the polar frame at
+/// `θ_t`. Averaging over the whole annulus cancels the pointwise `B_r B_θ`
+/// noise that makes the single-contour line integral jittery on coarse
+/// meshes, so this is the preferred estimator.
+///
+/// `b` is the per-triangle constant flux density; `tags` the band tags from
+/// [`crate::analytic::waveguide::disk_tri_mesh_bands`]; `gap_tag` the band
+/// index of the air gap.
+///
+/// # Panics
+///
+/// Panics if `b.len()` or `tags.len()` ≠ triangle count, or if
+/// `r_outer <= r_inner`.
+pub fn arkkio_torque(
+    mesh: &TriMesh,
+    tags: &[i32],
+    b: &[[f64; 2]],
+    gap_tag: i32,
+    r_inner: f64,
+    r_outer: f64,
+    l_axial: f64,
+) -> f64 {
+    assert_eq!(
+        b.len(),
+        mesh.n_tris(),
+        "arkkio_torque: b length {} != triangle count {}",
+        b.len(),
+        mesh.n_tris()
+    );
+    assert_eq!(
+        tags.len(),
+        mesh.n_tris(),
+        "arkkio_torque: tags length {} != triangle count {}",
+        tags.len(),
+        mesh.n_tris()
+    );
+    assert!(
+        r_outer > r_inner,
+        "arkkio_torque: r_outer ({r_outer}) must exceed r_inner ({r_inner})"
+    );
+
+    let mut acc = 0.0;
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        if tags[t] != gap_tag {
+            continue;
+        }
+        let c0 = mesh.nodes[tri[0] as usize];
+        let c1 = mesh.nodes[tri[1] as usize];
+        let c2 = mesh.nodes[tri[2] as usize];
+        let cx = (c0[0] + c1[0] + c2[0]) / 3.0;
+        let cy = (c0[1] + c1[1] + c2[1]) / 3.0;
+        let r = (cx * cx + cy * cy).sqrt();
+        let theta = cy.atan2(cx);
+        let area =
+            0.5 * ((c1[0] - c0[0]) * (c2[1] - c0[1]) - (c1[1] - c0[1]) * (c2[0] - c0[0])).abs();
+        let (br, bth) = cartesian_to_polar_b(b[t], theta);
+        acc += area * r * br * bth;
+    }
+    l_axial / (MU_0 * (r_outer - r_inner)) * acc
+}
+
+/// Vector potential of a set of straight axial line currents at a field
+/// point, plus a uniform external field's contribution, in the 2-D
+/// (per-unit-length) reduction.
+///
+/// A line current `I` on the axis through `(x₀, y₀)` has
+/// `A_z(x,y) = −(μ₀ I)/(2π) · ln r`, `r = |(x,y) − (x₀,y₀)|`, giving the
+/// circulating field `B = ∇×(A_z ẑ) = (∂A_z/∂y, −∂A_z/∂x)`. This is used to
+/// build the analytic loop field for the `T = m × B` oracle test; it lives
+/// in the crate (not just the test) so it is exercised by doctests and can
+/// be reused by future machine-torque examples.
+///
+/// `sources` is a slice of `(x₀, y₀, I)` line currents. `b_uniform` is the
+/// uniform external field `[B_x, B_y]` added on top (superposition, exact for
+/// linear materials). Returns the total `B = [B_x, B_y]` at `(px, py)`.
+pub fn line_currents_plus_uniform_b(
+    sources: &[(f64, f64, f64)],
+    b_uniform: [f64; 2],
+    px: f64,
+    py: f64,
+) -> [f64; 2] {
+    let mut bx = b_uniform[0];
+    let mut by = b_uniform[1];
+    for &(x0, y0, i) in sources {
+        let dx = px - x0;
+        let dy = py - y0;
+        let r2 = dx * dx + dy * dy;
+        // B of a line current: B = (μ₀ I)/(2π r) θ̂, i.e.
+        //   B_x = −(μ₀ I)/(2π) · dy/r²,  B_y = (μ₀ I)/(2π) · dx/r².
+        let k = MU_0 * i / (std::f64::consts::TAU * r2);
+        bx += -k * dy;
+        by += k * dx;
+    }
+    [bx, by]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytic::waveguide::{RadialGrading, disk_tri_mesh_bands};
+
+    #[test]
+    fn cartesian_polar_roundtrip() {
+        let theta = 0.7;
+        let (br, bth) = cartesian_to_polar_b([1.0, 2.0], theta);
+        // Inverse rotation recovers the Cartesian components.
+        let (c, s) = (theta.cos(), theta.sin());
+        let bx = br * c - bth * s;
+        let by = br * s + bth * c;
+        assert!((bx - 1.0).abs() < 1e-12 && (by - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn locate_triangle_inside_and_outside() {
+        // Two-band disk; a point at the origin is inside, a point far
+        // outside the outer radius is not.
+        let (mesh, _tags) =
+            disk_tri_mesh_bands(&[0.0, 0.5, 1.0], 12, &[2, 2], &[RadialGrading::Uniform; 2]);
+        assert!(locate_triangle(&mesh, 0.0, 0.0).is_some());
+        assert!(locate_triangle(&mesh, 10.0, 10.0).is_none());
+    }
+}

--- a/crates/geode-core/tests/torque_loop_oracle.rs
+++ b/crates/geode-core/tests/torque_loop_oracle.rs
@@ -1,0 +1,407 @@
+//! Torque-extractor acceptance benchmark (Epic #448, Phase 3a).
+//!
+//! Validates the two torque estimators — [`maxwell_stress_torque`] (Maxwell
+//! stress-tensor air-gap line integral) and [`arkkio_torque`] (volume-averaged
+//! Arkkio variant) — against the closed-form **torque-on-a-current-loop**
+//! oracle, *before* they are trusted on a real machine solve.
+//!
+//! A current loop of moment (per axial length) `m = I d` in a uniform
+//! external field `B` feels a torque `T = m × B`, `|T| = m B sinφ`, where φ
+//! is the angle between the moment vector and `B`. In the 2-D per-unit-length
+//! reduction the loop is a pair of antiparallel axial line currents `±I`
+//! separated by `d`.
+//!
+//! Four-part plan (matching the issue):
+//! 1. **Synthetic-field unit test** — both estimators integrate a hand-coded
+//!    analytic total field to ≤0.1 % of the exact `m × B` (isolates the
+//!    integrator from FE error; no solve).
+//! 2. **Loop oracle, line integral** — FE-solved loop field + analytic
+//!    uniform field, swept φ ∈ [0, π]: line-integral torque ≤2 %.
+//! 3. **Loop oracle, Arkkio** — same sweep, tighter ≤1 % (averaging).
+//! 4. **Inverse tripwire** — a wrong extraction radius (contour outside the
+//!    enclosing gap, so it no longer encloses the loop currents) or a
+//!    flipped current sign drives the error above a floor > the pass bar.
+//!
+//! ## Design decisions
+//!
+//! **Uniform imposed field by superposition (not a solver change).** The
+//! merged `assemble_magnetostatic` only supports the `A_z = 0` Dirichlet BC.
+//! Rather than extend it with nonzero-Dirichlet support, the uniform external
+//! field is added *analytically* to the FE-recovered loop field before torque
+//! extraction. This is exact for linear materials (ν = 1 uniform air here) —
+//! the loop field and the uniform field superpose — and the torque integrand
+//! needs the *total* field. Zero solver changes.
+//!
+//! **Finite-radius wires, not delta filaments.** A line current is a delta
+//! source the piecewise-constant `j_z` assembler cannot represent. Each
+//! current is instead a small uniform-`J_z` disk (`∫ J_z dA = ±I`). By
+//! Ampère's law the field *outside* a uniform-current disk is identical to
+//! the ideal line current, so on the extraction contour (which encloses both
+//! wire disks) the FE field matches the ideal loop field and the extracted
+//! torque matches `m × B`. The antiparallel pair carries *zero* net current,
+//! so its far field decays like a dipole (~1/r²) and the finite-domain
+//! `A_z = 0` truncation error at the outer boundary is small.
+
+use geode_core::analytic::slotless_pm::MU_0;
+use geode_core::analytic::waveguide::{
+    RadialGrading, TriMesh, disk_boundary_nodes, disk_tri_mesh_bands,
+};
+use geode_core::assembly::magnetostatic::{assemble_magnetostatic, recover_b_field};
+use geode_core::assembly::torque::{
+    arkkio_torque, cartesian_to_polar_b, line_currents_plus_uniform_b, maxwell_stress_torque,
+    maxwell_stress_torque_from_samples,
+};
+
+// Band layout of the loop-oracle disk mesh, radii = [0, r1, r2, r3, rout]:
+//   band 0 = [0, r1)     inner region holding the two current wires
+//   band 1 = [r1, r2)    buffer air
+//   band 2 = [r2, r3)    EXTRACTION annulus (the "air gap" for Arkkio)
+//   band 3 = [r3, rout)  outer air to the Dirichlet boundary
+const TAG_GAP: i32 = 2;
+
+/// Loop-oracle geometry and physical constants.
+struct Loop {
+    /// Wire-pair half-separation: `+I` and `−I` sit at radius `d/2` from
+    /// centre, so the separation is `d`.
+    d: f64,
+    /// Current magnitude (A).
+    current: f64,
+    /// Wire disk radius (finite, so `j_z` can represent it).
+    r_wire: f64,
+    /// Uniform external field magnitude (T), directed along `+x̂`.
+    b_ext: f64,
+    /// Mesh band radii.
+    radii: [f64; 5],
+}
+
+impl Loop {
+    fn nominal() -> Self {
+        Loop {
+            d: 0.10,
+            current: 100.0,
+            r_wire: 0.02,
+            b_ext: 0.5,
+            radii: [0.0, 0.20, 0.35, 0.50, 1.20],
+        }
+    }
+    /// Moment per axial length, `m = I d`.
+    fn moment(&self) -> f64 {
+        self.current * self.d
+    }
+    /// Mid-extraction-annulus radius (the line-integral contour).
+    fn r_gap(&self) -> f64 {
+        0.5 * (self.radii[2] + self.radii[3])
+    }
+    fn rout(&self) -> f64 {
+        self.radii[4]
+    }
+    /// Line-current sources `(x, y, I)` for moment angle φ (from `+x̂`).
+    ///
+    /// The moment `m` points at angle φ; the current-separation vector is
+    /// therefore at `φ − 90°`, so `+I` sits at `(d/2)(sinφ, −cosφ)` and
+    /// `−I` diametrically opposite. Then `m` at angle φ crossed into
+    /// `B = B x̂` gives `|T| = m B sinφ`.
+    fn sources(&self, phi: f64) -> [(f64, f64, f64); 2] {
+        let h = 0.5 * self.d;
+        let (sp, cp) = (phi.sin(), phi.cos());
+        [
+            (h * sp, -h * cp, self.current),
+            (-h * sp, h * cp, -self.current),
+        ]
+    }
+}
+
+/// Build the four-band loop-oracle mesh (μ_r = 1 everywhere → ν = 1).
+fn build_mesh(l: &Loop, n_ang: usize, n_rad: [usize; 4]) -> (TriMesh, Vec<i32>) {
+    disk_tri_mesh_bands(&l.radii, n_ang, &n_rad, &[RadialGrading::Uniform; 4])
+}
+
+/// Solve the FE loop field for moment angle φ and add the uniform external
+/// field analytically. Returns `(mesh, tags, b_total)` with `b_total` the
+/// per-triangle total flux density `[B_x, B_y]`.
+fn solve_loop_total_field(
+    l: &Loop,
+    phi: f64,
+    n_ang: usize,
+    n_rad: [usize; 4],
+) -> (TriMesh, Vec<i32>, Vec<[f64; 2]>) {
+    let (mesh, tags) = build_mesh(l, n_ang, n_rad);
+    let n_tris = mesh.n_tris();
+    let nu = vec![1.0; n_tris];
+
+    // Assign the two finite-radius wires: uniform J_z over the triangles
+    // whose centroid lies within r_wire of each current centre, scaled so
+    // ∫ J_z dA = ±I exactly (using the actual summed area of the tagged
+    // triangles, so the enclosed current is exact regardless of meshing).
+    let src = l.sources(phi);
+    let mut in_wire: Vec<Option<usize>> = vec![None; n_tris];
+    let mut area_sum = [0.0_f64; 2];
+    let centroid = |tri: &[u32; 3]| {
+        let c0 = mesh.nodes[tri[0] as usize];
+        let c1 = mesh.nodes[tri[1] as usize];
+        let c2 = mesh.nodes[tri[2] as usize];
+        let cx = (c0[0] + c1[0] + c2[0]) / 3.0;
+        let cy = (c0[1] + c1[1] + c2[1]) / 3.0;
+        let area =
+            0.5 * ((c1[0] - c0[0]) * (c2[1] - c0[1]) - (c1[1] - c0[1]) * (c2[0] - c0[0])).abs();
+        (cx, cy, area)
+    };
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let (cx, cy, area) = centroid(tri);
+        for (w, &(x0, y0, _)) in src.iter().enumerate() {
+            let dr = ((cx - x0).powi(2) + (cy - y0).powi(2)).sqrt();
+            if dr <= l.r_wire {
+                in_wire[t] = Some(w);
+                area_sum[w] += area;
+                break;
+            }
+        }
+    }
+    assert!(
+        area_sum[0] > 0.0 && area_sum[1] > 0.0,
+        "wire regions empty — mesh too coarse for r_wire={}",
+        l.r_wire
+    );
+    // The scalar magnetostatic assembler solves −∇·(ν∇A_z) = J_z with the
+    // μ₀ folded into the SOURCE (convention shared with the straight-wire
+    // oracle: `density = μ₀ · I / area`), so the recovered A_z/B come out in
+    // physical SI (Tesla). Scale each wire's uniform density accordingly so
+    // the enclosed current is exactly ±I.
+    let mut j_z = vec![0.0; n_tris];
+    for (t, w) in in_wire.iter().enumerate() {
+        if let Some(w) = w {
+            let (_, _, cur) = src[*w];
+            j_z[t] = MU_0 * cur / area_sum[*w];
+        }
+    }
+
+    let bc = disk_boundary_nodes(&mesh, l.rout());
+    let sys = assemble_magnetostatic(&mesh, &nu, &j_z, &bc).expect("assemble loop");
+    let a_z = sys.solve().expect("loop solve");
+    let b_loop = recover_b_field(&mesh, &a_z);
+
+    // Superpose the uniform external field B = (b_ext, 0) analytically.
+    let b_total: Vec<[f64; 2]> = b_loop.iter().map(|&[bx, by]| [bx + l.b_ext, by]).collect();
+    (mesh, tags, b_total)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. Synthetic-field unit test (≤0.1 %, no FE solve)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn synthetic_field_estimators_match_oracle() {
+    // Hand-build the analytic total field (ideal line currents + uniform B)
+    // sampled per triangle on a fine mesh, and feed it straight to both
+    // estimators — bypassing the FE solve entirely. This isolates the
+    // integrators from any finite-element error: they must reproduce the
+    // exact m × B to numerical-quadrature tolerance.
+    let l = Loop::nominal();
+    let m = l.moment();
+    let n_ang = 720;
+    let n_rad = [24, 8, 6, 20];
+    let (mesh, tags) = build_mesh(&l, n_ang, n_rad);
+
+    let mut worst_line = 0.0_f64;
+    let mut worst_arkkio = 0.0_f64;
+    for k in 0..=8 {
+        let phi = std::f64::consts::PI * k as f64 / 8.0;
+        let src = l.sources(phi);
+
+        // LINE INTEGRAL: sample the analytic total field at the EXACT contour
+        // points (not via triangle centroids), so the only error is the
+        // θ-quadrature + prefactor — the true "integrator isolated from FE
+        // error" test the issue calls for.
+        let n_contour = 360;
+        let r_gap = l.r_gap();
+        let samples: Vec<(f64, f64)> = (0..n_contour)
+            .map(|i| {
+                let theta = std::f64::consts::TAU * i as f64 / n_contour as f64;
+                let (px, py) = (r_gap * theta.cos(), r_gap * theta.sin());
+                let bxy = line_currents_plus_uniform_b(&src, [l.b_ext, 0.0], px, py);
+                cartesian_to_polar_b(bxy, theta)
+            })
+            .collect();
+        let t_line = maxwell_stress_torque_from_samples(&samples, r_gap, 1.0);
+
+        // ARKKIO: hand-coded analytic field array per triangle centroid on a
+        // fine mesh, fed to the volume-averaging estimator.
+        let b: Vec<[f64; 2]> = mesh
+            .tris
+            .iter()
+            .map(|tri| {
+                let c0 = mesh.nodes[tri[0] as usize];
+                let c1 = mesh.nodes[tri[1] as usize];
+                let c2 = mesh.nodes[tri[2] as usize];
+                let cx = (c0[0] + c1[0] + c2[0]) / 3.0;
+                let cy = (c0[1] + c1[1] + c2[1]) / 3.0;
+                line_currents_plus_uniform_b(&src, [l.b_ext, 0.0], cx, cy)
+            })
+            .collect();
+
+        let t_exact = m * l.b_ext * phi.sin();
+        let t_ark = arkkio_torque(&mesh, &tags, &b, TAG_GAP, l.radii[2], l.radii[3], 1.0);
+
+        let denom = m * l.b_ext; // peak |T|; robust near φ = 0, π
+        let e_line = (t_line - t_exact).abs() / denom;
+        let e_ark = (t_ark - t_exact).abs() / denom;
+        println!(
+            "synthetic φ={:.3}π  T_exact={:+.4e}  line err={:.4}%  arkkio err={:.4}%",
+            k as f64 / 8.0,
+            t_exact,
+            e_line * 100.0,
+            e_ark * 100.0
+        );
+        worst_line = worst_line.max(e_line);
+        worst_arkkio = worst_arkkio.max(e_ark);
+    }
+    println!(
+        "synthetic worst: line={:.4}%  arkkio={:.4}%",
+        worst_line * 100.0,
+        worst_arkkio * 100.0
+    );
+    assert!(
+        worst_line <= 1e-3,
+        "synthetic line-integral worst error {:.4}% exceeds 0.1% quadrature bar",
+        worst_line * 100.0
+    );
+    assert!(
+        worst_arkkio <= 1e-3,
+        "synthetic Arkkio worst error {:.4}% exceeds 0.1% quadrature bar",
+        worst_arkkio * 100.0
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2 & 3. Loop oracle: line integral (≤2 %) and Arkkio (≤1 %)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn loop_torque_line_and_arkkio_vs_m_cross_b() {
+    let l = Loop::nominal();
+    let m = l.moment();
+    let denom = m * l.b_ext; // peak torque, for robust rel error near φ=0,π
+    let n_ang = 600;
+    let n_rad = [24, 8, 7, 20];
+    // Sample the contour finer than the mesh angular resolution: matching
+    // n_contour to n_ang aliases the sample ring against the radial mesh
+    // lines and makes the single-contour line integral jitter (a known
+    // coarse-mesh sensitivity of the pointwise Maxwell-stress estimator).
+    // Oversampling in θ decouples the quadrature from the mesh and the line
+    // integral converges smoothly.
+    let n_contour = 720;
+
+    let mut worst_line = 0.0_f64;
+    let mut worst_arkkio = 0.0_f64;
+    println!(
+        "--- loop torque T(φ) vs m B sinφ  (m={m}, B={}) ---",
+        l.b_ext
+    );
+    for k in 0..=8 {
+        let phi = std::f64::consts::PI * k as f64 / 8.0;
+        let (mesh, tags, b) = solve_loop_total_field(&l, phi, n_ang, n_rad);
+        let t_exact = m * l.b_ext * phi.sin();
+        let t_line = maxwell_stress_torque(&mesh, &b, l.r_gap(), 1.0, n_contour);
+        let t_ark = arkkio_torque(&mesh, &tags, &b, TAG_GAP, l.radii[2], l.radii[3], 1.0);
+        let e_line = (t_line - t_exact).abs() / denom;
+        let e_ark = (t_ark - t_exact).abs() / denom;
+        println!(
+            "φ={:.3}π  T_exact={:+.4e}  T_line={:+.4e} ({:.3}%)  T_ark={:+.4e} ({:.3}%)",
+            k as f64 / 8.0,
+            t_exact,
+            t_line,
+            e_line * 100.0,
+            t_ark,
+            e_ark * 100.0
+        );
+        worst_line = worst_line.max(e_line);
+        worst_arkkio = worst_arkkio.max(e_ark);
+    }
+    println!(
+        "loop worst: line={:.3}%  arkkio={:.3}%",
+        worst_line * 100.0,
+        worst_arkkio * 100.0
+    );
+    assert!(
+        worst_line <= 0.02,
+        "loop line-integral worst error {:.3}% exceeds the 2% bar",
+        worst_line * 100.0
+    );
+    assert!(
+        worst_arkkio <= 0.01,
+        "loop Arkkio worst error {:.3}% exceeds the 1% bar",
+        worst_arkkio * 100.0
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. Inverse tripwires (error above a floor > the pass bar)
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn wrong_current_sign_tripwire_fires() {
+    // Flip BOTH currents' sign: the loop field (and hence its cross term
+    // with B) flips, so the extracted torque flips sign. At the peak φ=π/2
+    // that is a ~200% relative error — far above the 2%/1% pass bars.
+    let mut l = Loop::nominal();
+    l.current = -l.current; // sign flip
+    let m = l.current.abs() * l.d;
+    let denom = m * l.b_ext;
+    let n_ang = 360;
+    let n_rad = [18, 6, 5, 16];
+    let phi = std::f64::consts::FRAC_PI_2;
+    let (mesh, tags, b) = solve_loop_total_field(&l, phi, n_ang, n_rad);
+    // Oracle for the CORRECT (positive) current at this φ.
+    let t_exact = m * l.b_ext * phi.sin();
+    let t_line = maxwell_stress_torque(&mesh, &b, l.r_gap(), 1.0, 360);
+    let t_ark = arkkio_torque(&mesh, &tags, &b, TAG_GAP, l.radii[2], l.radii[3], 1.0);
+    let e_line = (t_line - t_exact).abs() / denom;
+    let e_ark = (t_ark - t_exact).abs() / denom;
+    println!(
+        "wrong-sign tripwire: line err={:.1}%  arkkio err={:.1}%",
+        e_line * 100.0,
+        e_ark * 100.0
+    );
+    assert!(
+        e_line > 0.5 && e_ark > 0.5,
+        "wrong-sign error (line {:.1}%, arkkio {:.1}%) did not exceed the 50% floor — \
+         tripwire broken",
+        e_line * 100.0,
+        e_ark * 100.0
+    );
+}
+
+#[test]
+fn wrong_extraction_radius_tripwire_fires() {
+    // Move the line-integral contour OUTSIDE the meshed extraction annulus
+    // is impossible (it would leave the mesh); instead move it INSIDE the
+    // wire pair (r_gap < d/2) so the contour no longer encloses both
+    // currents. Ampère/stress-tensor then reports a wrong (much smaller)
+    // enclosed torque — a gross error above the 2% pass bar. This proves a
+    // passing extractor test is not trivially satisfiable by any r_gap.
+    let l = Loop::nominal();
+    let m = l.moment();
+    let denom = m * l.b_ext;
+    let n_ang = 360;
+    let n_rad = [18, 6, 5, 16];
+    let phi = std::f64::consts::FRAC_PI_2;
+    let (mesh, _tags, b) = solve_loop_total_field(&l, phi, n_ang, n_rad);
+    let t_exact = m * l.b_ext * phi.sin();
+    // Contour at r = d/4 < d/2 = wire radius-of-placement: encloses no net
+    // current arrangement resembling the full loop.
+    let r_bad = 0.25 * l.d;
+    let t_bad = maxwell_stress_torque(&mesh, &b, r_bad, 1.0, 360);
+    let e_bad = (t_bad - t_exact).abs() / denom;
+    println!(
+        "wrong-radius tripwire: r_bad={r_bad} T_bad={:+.4e} T_exact={:+.4e} err={:.1}%",
+        t_bad,
+        t_exact,
+        e_bad * 100.0
+    );
+    assert!(
+        e_bad > 0.05,
+        "wrong-radius error {:.1}% did not exceed the 5% floor (> the 2% pass bar) — \
+         tripwire broken",
+        e_bad * 100.0
+    );
+}


### PR DESCRIPTION
## Summary

Epic #448 Phase 3a: adds the two standard 2-D machine torque estimators — the Maxwell stress-tensor mid-gap **line integral** and **Arkkio's** volume-averaged variant — as a new `assembly/torque` module, and validates both against the exact torque-on-a-current-loop oracle `T = m × B` before they are trusted on the machine capstone.

## Changes

- **`crates/geode-core/src/assembly/torque.rs`** (new):
  - `maxwell_stress_torque(mesh, b, r_gap, L, n_contour)` — `T = (L r_gap²/μ₀) ∮ B_r B_θ dθ` on the mid-gap contour, periodic-trapezoid quadrature in θ; the pure θ-quadrature core is exposed separately as `maxwell_stress_torque_from_samples` so tests can isolate the integrator from FE sampling error.
  - `arkkio_torque(mesh, tags, b, gap_tag, r_i, r_o, L)` — `T = (L/(μ₀(r_o−r_i))) ∬ B_r B_θ r dA` per gap-band triangle, area-weighted (the noise-robust production estimator).
  - Shared **pub** contour/point-location sampler: `locate_triangle`, `sample_b_polar_on_contour`, `cartesian_to_polar_b`, plus `line_currents_plus_uniform_b` (analytic loop + uniform field).
- **`crates/geode-core/src/assembly/mod.rs`**: register + document the new module.
- **`crates/geode-core/tests/torque_loop_oracle.rs`** (new): the 4-part validation plan (below).

## Design decisions

**Sampler reuse (per the curator's correction).** Nothing reusable existed: `locate()`/`midgap_contour_l2` are private to `tests/slotless_pm_field.rs` and `examples/slotless_pm.rs` duplicates an inline loop. I promoted the triangle-locate + polar contour sampler to **pub in the new torque module** (`assembly/torque.rs`), where the torque estimators are its first consumer. I deliberately did **not** rewrite the existing test/example to import it in this PR — that de-duplication is a mechanical drive-by that would triple the review surface of a physics-bearing PR; it can land as a trivial follow-on. No third private copy was added: the new test uses the shared pub sampler exclusively.

**Uniform imposed field by superposition, not a solver extension.** `assemble_magnetostatic` supports only `A_z = 0` Dirichlet. Instead of adding nonzero-Dirichlet support, the uniform external field `B x̂` is added *analytically* to the FE-recovered loop field before extraction (`B_total = B_loop + B_uniform`). This is exact for linear materials — ν = 1 uniform air everywhere here, so the fields superpose — and the torque integrand needs the total field. Zero solver changes; the FE part exercises exactly the merged machinery (`assemble_magnetostatic` → `solve` → `recover_b_field`).

**Finite-radius wires.** A delta line current can't be represented by the piecewise-constant `j_z`; each current is a small uniform-`J_z` disk with `∫J_z dA = ±I` (exact via the actual tagged-triangle area). By Ampère's law its exterior field equals the ideal line current, so the extraction contour (enclosing both wires) sees the ideal loop field. The antiparallel pair has zero net current → dipole far-field decay → negligible outer-truncation error. `J_z` folds μ₀ in, matching the straight-wire-oracle convention (`density = μ₀·I/area` in `magnetostatic_wire.rs`).

**Contour oversampling.** Matching `n_contour` to the mesh's angular resolution aliases the sample ring against the radial mesh lines and makes the single-contour estimator jitter (worst-case swung 0.09–2.4% across resolutions). Sampling the contour finer than the mesh (n_contour=720 vs n_ang=600) decouples quadrature from mesh and the line integral converges smoothly. This is documented in the test.

## Measured results vs bars

| Test | Bar | Measured (worst over φ∈[0,π], 9 points) | Status |
|---|---|---|---|
| 1. Synthetic field, line integral | ≤0.1% | **0.0000%** (analytic samples at exact contour points) | pass |
| 1. Synthetic field, Arkkio | ≤0.1% | **0.0202%** (analytic field array on fine mesh) | pass |
| 2. FE loop T(φ), line integral | ≤2% | **0.216%** | pass |
| 3. FE loop T(φ), Arkkio | ≤1% | **0.142%** | pass |
| 4a. Wrong contour radius (r=d/4, inside the wire pair) | floor >5% | **100.0%** | fires |
| 4b. Wrong current sign | floor >50% | line **203.2%**, Arkkio **199.5%** | fires |

No honest-miss clause needed: the uniform-imposed-field loop geometry is (as the curator predicted) far kinder to P1 piecewise-constant B recovery than the #463 PM gap field — both estimators clear their bars with ~10× margin, no mesh cherry-picking (the config is robust across the gap-radial/contour sweep tested during development: line 0.13–0.65% for n_contour ≥ 720 across gap-band radial counts 5–11).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Both `maxwell_stress_torque` and `arkkio_torque` exist and pass the synthetic-field unit test ≤0.1% | ✅ | `synthetic_field_estimators_match_oracle`: line 0.0000%, Arkkio 0.0202% |
| 2. Loop `T(φ)` ≤2% (line integral), ≤1% (Arkkio) vs `m×B` | ✅ | `loop_torque_line_and_arkkio_vs_m_cross_b`: worst line 0.216%, worst Arkkio 0.142%, φ∈[0,π] in π/8 steps |
| 3. Inverse tripwire fires above a floor > the pass bar | ✅ | `wrong_extraction_radius_tripwire_fires` (100% > 5% floor), `wrong_current_sign_tripwire_fires` (203%/199% > 50% floor) |

## Test Plan / Gates

- `cargo fmt --all --check` — clean
- `cargo clippy -p geode-core --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean
- Debug: `--lib` (269 pass), `torque_loop_oracle` (4), `magnetostatic_wire` (9), `magnetostatic_heterogeneous` (9), `slotless_pm_field` (6) — all pass
- Full `cargo test -p geode-core --release --tests` — all binaries green, 0 failures

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)