### PR TITLE
[#355] Bunsen Phase 2 — named shape contracts across the assembly path

### DIFF
--- a/crates/geode-core/src/assembly/nedelec.rs
+++ b/crates/geode-core/src/assembly/nedelec.rs
@@ -19,6 +19,10 @@
 
 use std::collections::BTreeSet;
 
+use bunsen::contracts::{
+    assert_shape_contract, assert_shape_contract_periodically, define_shape_contract,
+    unpack_shape_contract,
+};
 use burn::tensor::ElementConversion;
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
@@ -31,6 +35,51 @@ use crate::elements::nedelec::{
     batched_nedelec_local_matrices, batched_nedelec_local_stiffness_weighted,
 };
 use crate::mesh::TetMesh;
+
+/// Number of vertices per linear tetrahedron — the column count of the
+/// `[n_elem, 4]` connectivity table fed to every Nédélec assembler. Bound
+/// into [`NEDELEC_CONNECTIVITY_CONTRACT`] so the tet arity is machine-checked
+/// rather than left implicit in the ignored `_` of a `let [n_elem, _] =
+/// tets.dims();` destructure.
+const NODES_PER_TET: usize = 4;
+
+/// Number of local edge DOFs of a first-order Nédélec tetrahedron (its 6
+/// edges). Bound into [`NEDELEC_LOCAL_MATRIX_CONTRACT`] as `edges_per_tet`.
+const EDGES_PER_TET: usize = 6;
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen, Epic #355 Phase 2)
+// ---------------------------------------------------------------------------
+//
+// The recurring FEM tensor shapes of the Nédélec assembly path, named once so
+// the same machine-checked invariant is reused across the dozen assemblers
+// below instead of being re-spelled as a bare `let [n_elem, _] = tets.dims();`
+// destructure at each entry point. Each carries the FEM math notation it
+// enforces. See PR #466's `gather_tet_coords` for the inline (ad-hoc) form.
+
+// Connectivity table `T \in \mathbb{Z}^{n_elem × 4}`: one row per tetrahedron,
+// each row the 4 global node indices of the element's vertices. `nodes_per_tet`
+// is bound to `NODES_PER_TET` (`= 4`) at the call site.
+define_shape_contract!(NEDELEC_CONNECTIVITY_CONTRACT, ["n_elem", "nodes_per_tet"]);
+
+// Signed element-local edge matrix stack
+// `\tilde{M}^{local} \in \mathbb{R}^{n_elem × 6 × 6}`: one `6×6` dense local
+// system per tet (first-order Nédélec has 6 edge DOFs), after the per-DOF
+// orientation-sign outer product `s_i s_j` has been folded in. The two
+// `edges_per_tet` axes are bound to `EDGES_PER_TET` (`= 6`). Checked
+// periodically in the per-element scatter hot path before the `[n_elem*36]`
+// flatten.
+define_shape_contract!(
+    NEDELEC_LOCAL_MATRIX_CONTRACT,
+    ["n_elem", "edges_per_tet", "edges_per_tet"]
+);
+
+// Global (or `[nnz]`-packed) square operator `A \in \mathbb{R}^{n × n}` — used
+// to check that the real and imaginary halves of a complex-split matrix
+// (`M = M_re + j\,M_im`) carry identical `[n, n]` shapes before they are zipped
+// into a `faer::c64` matrix. `n` is left free (any square shape agrees with
+// itself).
+define_shape_contract!(NEDELEC_SQUARE_OPERATOR_CONTRACT, ["n", "n"]);
 
 /// Assembled global Nédélec linear system in dense Burn-tensor form.
 #[derive(Debug, Clone)]
@@ -113,7 +162,16 @@ pub fn assemble_global_nedelec<B: Backend>(
     n_edges: usize,
 ) -> NedelecGlobalSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
 
@@ -142,6 +200,15 @@ pub fn assemble_global_nedelec<B: Backend>(
     let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
     let n_edges_i32 = n_edges as i32;
     for row in tet_edge_idx {
+        // Per-element hot loop: guard the signed local edge-matrix stack
+        // `[n_elem, 6, 6]` under exponential backoff so the O(n_elem)
+        // iteration pays a full contract check only on the first handful of
+        // elements, not every element.
+        assert_shape_contract_periodically!(
+            NEDELEC_LOCAL_MATRIX_CONTRACT,
+            &k_signed,
+            &[("edges_per_tet", EDGES_PER_TET)],
+        );
         for i in 0..6 {
             for j in 0..6 {
                 linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
@@ -332,7 +399,16 @@ fn scatter_to_pattern_vals<B: Backend>(
     nnz: usize,
     device: &B::Device,
 ) -> Tensor<B, 1> {
-    let [n_elem, _, _] = signed_local.dims();
+    // Signed local edge-matrix stack `\tilde{M}^{local} \in
+    // \mathbb{R}^{n_elem × 6 × 6}` — extract `n_elem` and check both
+    // `edges_per_tet = 6` axes through the shared named contract (replaces the
+    // former bare `let [n_elem, _, _] = signed_local.dims();`).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_LOCAL_MATRIX_CONTRACT,
+        &signed_local,
+        &["n_elem"],
+        &[("edges_per_tet", EDGES_PER_TET)],
+    );
     Tensor::<B, 1>::zeros([nnz], device).scatter(
         0,
         slot_indices.clone(),
@@ -802,7 +878,16 @@ pub fn assemble_global_nedelec_with_epsilon<B: Backend>(
     epsilon_r: &[f64],
 ) -> NedelecGlobalSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(epsilon_r.len(), n_elem, "epsilon_r length mismatch");
@@ -838,6 +923,14 @@ pub fn assemble_global_nedelec_with_epsilon<B: Backend>(
     let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
     let n_edges_i32 = n_edges as i32;
     for row in tet_edge_idx {
+        // Per-element hot loop: guard the signed local edge-matrix stack
+        // `[n_elem, 6, 6]` under exponential backoff (see
+        // [`assemble_global_nedelec`]).
+        assert_shape_contract_periodically!(
+            NEDELEC_LOCAL_MATRIX_CONTRACT,
+            &k_signed,
+            &[("edges_per_tet", EDGES_PER_TET)],
+        );
         for i in 0..6 {
             for j in 0..6 {
                 linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
@@ -1052,7 +1145,16 @@ pub fn assemble_global_nedelec_with_complex_epsilon_sparse<B: Backend>(
     epsilon_r_complex: &[faer::c64],
 ) -> NedelecSparseComplexSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
         scatter.n_elem(),
@@ -1113,7 +1215,16 @@ pub fn assemble_nedelec_sigma_damping_sparse<B: Backend>(
     sigma_tet: &[f64],
 ) -> Tensor<B, 1> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
         scatter.n_elem(),
@@ -1293,7 +1404,16 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
     epsilon_tensor_diag: &[[faer::c64; 3]],
 ) -> NedelecComplexGlobalSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
@@ -1341,6 +1461,14 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon<B: Backend>(
     let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
     let n_edges_i32 = n_edges as i32;
     for row in tet_edge_idx {
+        // Per-element hot loop: guard the signed local edge-matrix stack
+        // `[n_elem, 6, 6]` under exponential backoff (see
+        // [`assemble_global_nedelec`]).
+        assert_shape_contract_periodically!(
+            NEDELEC_LOCAL_MATRIX_CONTRACT,
+            &k_signed,
+            &[("edges_per_tet", EDGES_PER_TET)],
+        );
         for i in 0..6 {
             for j in 0..6 {
                 linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
@@ -1395,7 +1523,16 @@ pub fn assemble_global_nedelec_with_anisotropic_epsilon_sparse<B: Backend>(
     epsilon_tensor_diag: &[[faer::c64; 3]],
 ) -> NedelecSparseComplexSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
         scatter.n_elem(),
@@ -1504,7 +1641,16 @@ pub fn assemble_global_nedelec_with_full_tensors<B: Backend>(
     nu_tensor: &[[[faer::c64; 3]; 3]],
 ) -> NedelecFullTensorGlobalSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
@@ -1540,6 +1686,14 @@ pub fn assemble_global_nedelec_with_full_tensors<B: Backend>(
     let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 36);
     let n_edges_i32 = n_edges as i32;
     for row in tet_edge_idx {
+        // Per-element hot loop: guard one representative local edge-matrix
+        // stack `[n_elem, 6, 6]` (the four weighted locals share this shape)
+        // under exponential backoff (see [`assemble_global_nedelec`]).
+        assert_shape_contract_periodically!(
+            NEDELEC_LOCAL_MATRIX_CONTRACT,
+            &k_local_re,
+            &[("edges_per_tet", EDGES_PER_TET)],
+        );
         for i in 0..6 {
             for j in 0..6 {
                 linear_idx.push(row[i] as i32 * n_edges_i32 + row[j] as i32);
@@ -1595,7 +1749,16 @@ pub fn assemble_global_nedelec_with_full_tensors_sparse<B: Backend>(
     nu_tensor: &[[[faer::c64; 3]; 3]],
 ) -> NedelecSparseFullTensorSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(
         scatter.n_elem(),
@@ -1669,7 +1832,16 @@ pub fn assemble_nedelec_current_rhs<B: Backend>(
     j_tet: &[[f64; 3]],
 ) -> Tensor<B, 1> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(j_tet.len(), n_elem, "j_tet length mismatch");
@@ -1734,7 +1906,16 @@ pub fn assemble_nedelec_current_rhs_quad4<B: Backend>(
     j_quad: &[[[f64; 3]; 4]],
 ) -> Tensor<B, 1> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract (replaces the
+    // former bare `let [n_elem, _] = tets.dims();`, which ignored the column
+    // count).
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
     assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
     assert_eq!(j_quad.len(), n_elem, "j_quad length mismatch");
@@ -1786,14 +1967,18 @@ pub fn burn_complex_mass_to_faer<B: Backend>(
     m_re: Tensor<B, 2>,
     m_im: Tensor<B, 2>,
 ) -> faer::Mat<faer::c64> {
-    let dims_re = m_re.dims();
-    let dims_im = m_im.dims();
-    assert_eq!(dims_re, dims_im, "M_re and M_im must have matching dims");
+    // Complex-split square operator `M = M_re + j\,M_im`, each
+    // `\in \mathbb{R}^{n × n}`. Bind `n` from `M_re` through the named
+    // square-operator contract, then re-assert the same contract on `M_im`
+    // with `n` already bound — this forces both halves to be square *and*
+    // mutually equal in one machine-checked step (replaces the bare
+    // `assert_eq!(dims_re, dims_im, ...)` plus two `.dims()` reads).
+    let [n] = unpack_shape_contract!(NEDELEC_SQUARE_OPERATOR_CONTRACT, &m_re, &["n"]);
+    assert_shape_contract!(NEDELEC_SQUARE_OPERATOR_CONTRACT, &m_im, &[("n", n)]);
     let data_re: Vec<f64> = m_re.into_data().iter::<f64>().collect();
     let data_im: Vec<f64> = m_im.into_data().iter::<f64>().collect();
-    let n = dims_re[0];
-    faer::Mat::<faer::c64>::from_fn(n, dims_re[1], |i, j| {
-        let idx = i * dims_re[1] + j;
+    faer::Mat::<faer::c64>::from_fn(n, n, |i, j| {
+        let idx = i * n + j;
         faer::c64::new(data_re[idx], data_im[idx])
     })
 }

--- a/crates/geode-core/src/assembly/p1.rs
+++ b/crates/geode-core/src/assembly/p1.rs
@@ -28,7 +28,10 @@
 
 use std::collections::BTreeSet;
 
-use bunsen::contracts::{assert_shape_contract, unpack_shape_contract};
+use bunsen::contracts::{
+    assert_shape_contract, assert_shape_contract_periodically, define_shape_contract,
+    unpack_shape_contract,
+};
 use burn::tensor::ElementConversion;
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
@@ -45,6 +48,34 @@ use crate::mesh::TetMesh;
 /// arity is checked machine-side rather than left implicit in a `4`
 /// literal scattered across reshapes.
 const NODES_PER_TET: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen, Epic #355 Phase 2)
+// ---------------------------------------------------------------------------
+//
+// These `static` contracts encode the recurring FEM tensor shapes of the P1
+// assembly path once, so the same machine-checked invariant is reused at every
+// call site instead of being re-spelled as a bare `.dims()` destructure. Each
+// carries the FEM math notation it enforces. See PR #466's `gather_tet_coords`
+// for the inline (ad-hoc) form; this module is the first to name them.
+
+// P1 connectivity table `T \in \mathbb{Z}^{n_elem × 4}`: one row per
+// tetrahedron, each row the 4 global node indices of the element's vertices.
+// The `nodes_per_tet` axis is bound to `NODES_PER_TET` (`= 4`) at the call
+// site, so a mesh whose connectivity was built with the wrong arity panics
+// with a named-axis diagnostic instead of silently mis-reshaping downstream.
+define_shape_contract!(P1_CONNECTIVITY_CONTRACT, ["n_elem", "nodes_per_tet"]);
+
+// Batched P1 element-local matrix stack
+// `M^{local}, K^{local} \in \mathbb{R}^{n_elem × 4 × 4}`: one `4×4` dense
+// element system per tetrahedron (P1 has 4 nodal DOFs, so the local pencil is
+// `nodes_per_tet × nodes_per_tet`). Checked periodically in the assembly hot
+// path before the `[n_elem*16]` flatten, so a kernel that returned the wrong
+// local arity is caught with a named-axis diagnostic rather than a bad reshape.
+define_shape_contract!(
+    P1_LOCAL_MATRIX_CONTRACT,
+    ["n_elem", "nodes_per_tet", "nodes_per_tet"]
+);
 
 /// Assembled global linear system in dense Burn-tensor form.
 #[derive(Debug, Clone)]
@@ -156,9 +187,10 @@ pub fn upload_mesh<B: Backend>(
 /// gather downstream.
 pub fn gather_tet_coords<B: Backend>(nodes: Tensor<B, 2>, tets: Tensor<B, 2, Int>) -> Tensor<B, 3> {
     // Validate the connectivity `[n_elem, nodes_per_tet=4]` and extract
-    // `n_elem`; validate the node table carries 3 spatial coordinates.
+    // `n_elem` via the shared named contract; validate the node table carries
+    // 3 spatial coordinates.
     let [n_elem] = unpack_shape_contract!(
-        ["n_elem", "nodes_per_tet"],
+        P1_CONNECTIVITY_CONTRACT,
         &tets,
         &["n_elem"],
         &[("nodes_per_tet", NODES_PER_TET)],
@@ -194,7 +226,14 @@ pub fn assemble_global_p1<B: Backend>(
     n_dof: usize,
 ) -> GlobalSystem<B> {
     let device = nodes.device();
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+    // check the 4-vertex arity through the shared named contract.
+    let [n_elem] = unpack_shape_contract!(
+        P1_CONNECTIVITY_CONTRACT,
+        &tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
 
     // 1. Pull the connectivity host-side once. We use it both to build
     //    the sparsity pattern and to construct the scatter indices. The
@@ -218,6 +257,15 @@ pub fn assemble_global_p1<B: Backend>(
     let mut linear_idx: Vec<i32> = Vec::with_capacity(n_elem * 16);
     let n_dof_i32 = n_dof as i32;
     for tet in &tets_host {
+        // Per-element hot loop: guard the local-matrix stack
+        // `[n_elem, 4, 4]` under exponential backoff (`assert_shape_contract_
+        // periodically!`) so the O(n_elem) iteration pays a full contract
+        // check only on the first handful of elements, not every element.
+        assert_shape_contract_periodically!(
+            P1_LOCAL_MATRIX_CONTRACT,
+            &p1.k_local,
+            &[("nodes_per_tet", NODES_PER_TET)],
+        );
         for i in 0..4 {
             for j in 0..4 {
                 linear_idx.push(tet[i] as i32 * n_dof_i32 + tet[j] as i32);
@@ -254,7 +302,15 @@ pub fn assemble_global_p1<B: Backend>(
 /// of `[u32; 4]` rows. Used both for index construction and for the
 /// sparsity pattern.
 fn tets_to_cpu<B: Backend>(tets: &Tensor<B, 2, Int>) -> Vec<[u32; 4]> {
-    let [n_elem, _] = tets.dims();
+    // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — reuse the shared named
+    // contract to extract `n_elem` and check the 4-vertex arity before the
+    // fixed-stride `raw[e*4 + k]` readback below relies on it.
+    let [n_elem] = unpack_shape_contract!(
+        P1_CONNECTIVITY_CONTRACT,
+        tets,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET)],
+    );
     let raw: Vec<i32> = tets.clone().into_data().to_vec().expect("readback i32");
     (0..n_elem)
         .map(|e| {

--- a/crates/geode-core/tests/assembly.rs
+++ b/crates/geode-core/tests/assembly.rs
@@ -18,7 +18,7 @@ use burn::tensor::ElementConversion;
 use burn::tensor::backend::BackendTypes;
 use burn::tensor::{Int, Tensor, TensorData};
 
-use geode_core::assembly::p1::{assemble_global_p1, upload_mesh};
+use geode_core::assembly::p1::{assemble_global_p1, gather_tet_coords, upload_mesh};
 use geode_core::mesh::cube_tet_mesh;
 use geode_core::testing::TestBackend;
 
@@ -309,4 +309,35 @@ fn assembly_preserves_autodiff() {
         rel_err < 0.05,
         "FD gradient {fd_grad} vs autodiff {analytic_grad}: rel err {rel_err}"
     );
+}
+
+// --- Bunsen shape-contract firing tests (Epic #355, Phase 2) -----------------
+//
+// These prove the named `shape_contract!`s introduced in `assembly/p1.rs` are
+// genuinely wired (not no-ops): a deliberately mis-shaped connectivity tensor
+// must trip the contract and panic with a Bunsen diagnostic, rather than
+// silently mis-reshaping the gather downstream.
+
+/// `gather_tet_coords` binds the connectivity's `nodes_per_tet` axis to 4 via
+/// `P1_CONNECTIVITY_CONTRACT`. A `[n_elem, 3]` tensor (triangle-arity
+/// connectivity) must fire the contract, not produce a wrongly-shaped gather.
+#[test]
+#[should_panic(expected = "Shape Error")]
+fn gather_tet_coords_wrong_arity_fires_contract() {
+    let dev = device();
+    // A valid node table [n_nodes=4, spatial=3] so the failure is unambiguously
+    // the connectivity arity, not the node coordinate dimension.
+    let nodes = Tensor::<B, 2>::from_data(
+        TensorData::new(
+            vec![
+                0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+            ],
+            [4, 3],
+        ),
+        &dev,
+    );
+    // Deliberately mis-shaped connectivity: 3 columns (a triangle) where the P1
+    // contract demands `nodes_per_tet = 4`.
+    let bad_tets = Tensor::<B, 2, Int>::from_data(TensorData::new(vec![0i32, 1, 2], [1, 3]), &dev);
+    let _ = gather_tet_coords(nodes, bad_tets);
 }

--- a/crates/geode-core/tests/nedelec.rs
+++ b/crates/geode-core/tests/nedelec.rs
@@ -679,3 +679,31 @@ fn assembly_preserves_autodiff_smoke() {
     assert_eq!(finite, dnodes_vec.len(), "all gradients must be finite");
     assert!(nonzero > 0, "gradient should be non-zero somewhere");
 }
+
+// --- Bunsen shape-contract firing test (Epic #355, Phase 2) ------------------
+//
+// Proves the named `NEDELEC_CONNECTIVITY_CONTRACT` in `assembly/nedelec.rs` is
+// genuinely wired: a mis-shaped connectivity tensor must trip the contract and
+// panic with a Bunsen diagnostic instead of silently ignoring the column count
+// (as the former bare `let [n_elem, _] = tets.dims();` did).
+#[test]
+#[should_panic(expected = "Shape Error")]
+fn assemble_global_nedelec_wrong_arity_fires_contract() {
+    let dev = device();
+    // Valid node table [n_nodes=4, spatial=3].
+    let nodes = Tensor::<B, 2>::from_data(
+        TensorData::new(
+            vec![
+                0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+            ],
+            [4, 3],
+        ),
+        &dev,
+    );
+    // Deliberately mis-shaped connectivity: 3 columns where the Nédélec
+    // contract demands `nodes_per_tet = 4`.
+    let bad_tets = Tensor::<B, 2, Int>::from_data(TensorData::new(vec![0i32, 1, 2], [1, 3]), &dev);
+    let tet_edge_idx = vec![[0u32, 1, 2, 3, 4, 5]];
+    let tet_edge_sign = vec![[1i8; 6]];
+    let _ = assemble_global_nedelec::<B>(nodes, bad_tets, &tet_edge_idx, &tet_edge_sign, 6);
+}


### PR DESCRIPTION
Closes #453.

Epic #355 Phase 2. Migrates the recurring FEM tensor shapes of the P1 and Nédélec global-assembly path from ad-hoc `.dims()` destructures + bare `assert*` to **named `static` Bunsen shape contracts** (`define_shape_contract!`), each documented with the FEM math notation it encodes. Builds on PR #466's inline-contract template (`gather_tet_coords`); this is the first PR to use the named/`static` form.

Contracts are a **checked-invariant layer, not a behavior change** — no numerical or control-flow changes; all existing tests pass unmodified.

## Named contracts introduced

| Contract | Shape | FEM object |
|---|---|---|
| `P1_CONNECTIVITY_CONTRACT` | `[n_elem, nodes_per_tet=4]` | connectivity `T ∈ ℤ^{n_elem×4}` |
| `P1_LOCAL_MATRIX_CONTRACT` | `[n_elem, 4, 4]` | P1 local mass/stiffness stack `M^local, K^local` |
| `NEDELEC_CONNECTIVITY_CONTRACT` | `[n_elem, nodes_per_tet=4]` | connectivity `T ∈ ℤ^{n_elem×4}` |
| `NEDELEC_LOCAL_MATRIX_CONTRACT` | `[n_elem, 6, 6]` | signed local edge-matrix stack `M̃^local` (6 edge DOFs) |
| `NEDELEC_SQUARE_OPERATOR_CONTRACT` | `[n, n]` | complex Re/Im pair agreement `M = M_re + j·M_im` |

## Site-by-site conversion (all 55 candidate sites reviewed)

### `p1.rs` — 2 remaining code `.dims()` sites (gather_tet_coords already done by #466)
| Site | → |
|---|---|
| `assemble_global_p1` `tets.dims()` | `unpack_shape_contract!(P1_CONNECTIVITY_CONTRACT, …)` |
| `tets_to_cpu` `tets.dims()` | `unpack_shape_contract!(P1_CONNECTIVITY_CONTRACT, …)` |
| `gather_tet_coords` (already inline from #466) | retargeted onto the named `P1_CONNECTIVITY_CONTRACT` |

### `nedelec.rs` — 13 `.dims()` sites (all converted)
| Site | → |
|---|---|
| 10× `let [n_elem, _] = tets.dims();` (`assemble_global_nedelec`, `_with_epsilon`, `_with_complex_epsilon_sparse`, `assemble_nedelec_sigma_damping_sparse`, `_with_anisotropic_epsilon`, `_..._sparse`, `_with_full_tensors`, `_..._sparse`, `assemble_nedelec_current_rhs`, `_quad4`) | `unpack_shape_contract!(NEDELEC_CONNECTIVITY_CONTRACT, …)` |
| `scatter_to_pattern_vals` `signed_local.dims()` `[n_elem,_,_]` | `unpack_shape_contract!(NEDELEC_LOCAL_MATRIX_CONTRACT, …)` |
| `burn_complex_mass_to_faer` `m_re.dims()` / `m_im.dims()` + `assert_eq!(dims_re, dims_im)` | `unpack_shape_contract!(NEDELEC_SQUARE_OPERATOR_CONTRACT, m_re)` binds `n`, then `assert_shape_contract!(…, m_im, &[("n", n)])` — forces both halves square *and* mutually equal in one checked step |

### Hot-loop periodic guards (5 total)
`assert_shape_contract_periodically!` (exponential backoff) on the local-matrix stack inside each per-element loop, so the O(n_elem) iteration pays a full check only on the first ~10 elements:
- `assemble_global_p1` (`P1_LOCAL_MATRIX_CONTRACT`)
- `assemble_global_nedelec`, `_with_epsilon`, `_with_anisotropic_epsilon`, `_with_full_tensors` (`NEDELEC_LOCAL_MATRIX_CONTRACT`)

### Left plain `assert_eq!` / `assert!` (40 `assert*` in nedelec.rs) — with reason
Every remaining assert is a **host-side `Vec::len()` check** (`tet_edge_idx.len() == n_elem`, `tet_edge_sign.len()`, `epsilon_r.len()`, `sigma_tet.len()`, `j_tet.len()`, `nu_tensor.len()`, mask-alignment `edges.len() == edge_mask.len()`, `physical_tags.len() == centroids.len()`, …) **or a scalar/scalar-range check** (`omega > 0.0`, `pattern.nnz() <= i32::MAX`). These operate on Rust slices/scalars, not Burn tensor `.dims()` — Bunsen's `shape_contract!` DSL only matches tensor shapes, so a named contract does not apply and would add ceremony without value. Per the issue's judgment rule, they stay plain.

Out of scope (curator-flagged for a future Phase 3): `assembly/magnetostatic.rs`, `assembly/torque.rs` (new from Epic #448).

## New firing tests (prove the contracts are wired, not no-ops)
- `tests/assembly.rs::gather_tet_coords_wrong_arity_fires_contract` — feeds a `[1, 3]` (triangle-arity) connectivity into `gather_tet_coords`; `#[should_panic(expected = "Shape Error")]`.
- `tests/nedelec.rs::assemble_global_nedelec_wrong_arity_fires_contract` — feeds a `[1, 3]` connectivity into `assemble_global_nedelec`; `#[should_panic(expected = "Shape Error")]`.

Both fire (`should panic ... ok`); all pre-existing assembly/nedelec/nedelec_sparse/nedelec_cavity tests pass **unmodified**.

## Gate results
- `cargo build -p geode-core` (default) — clean
- `cargo build -p geode-core --features arpack` (CI arpack combo) — clean
- `cargo clippy -p geode-core --all-targets -- -D warnings` — clean
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` (CI arpack combo) — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p geode-core --release --tests` — all pass (exit 0)

> Note on CI feature combos: the issue AC cited `--no-default-features --features arpack,ndarray`, but `geode-core` unconditionally pulls `burn` with `ndarray` and the real `arpack.yml` lane uses `--features arpack`. Verified against `.github/workflows/arpack.yml` and used the real invocation.

## Timing note (periodic overhead is noise-level)
`benches/assembly_nedelec.rs` `assembly_nedelec_real` (before vs after, `--sample-size 20 --measurement-time 3`):

| n | before | after |
|---|---|---|
| 5 | ~13.9 ms | ~13.0 ms |
| 8 | ~129 ms | ~138 ms |
| 10 | ~408 ms | ~432 ms |

Deltas straddle zero with overlapping confidence intervals and flip direction across sizes — within run-to-run noise. The dominant cost is the O(n_edges²) dense scatter, not the per-element loop, exactly as the periodic-backoff design intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)