### PR TITLE
docs: document bunsen shape-contract + ops convention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,19 @@ carry auto-generated `results*.toml` files paired with `tests/` cases that
 either compare within a documented tolerance band or skip-with-note when an
 external oracle (e.g. Palace) is `pending_operator_run`.
 
+### Bunsen conventions
+
+`geode-core` depends on [`bunsen`](https://github.com/zspacelabs/bunsen)
+(git-pinned, `default-features = false, features = ["std"]`) for
+machine-checked tensor **shape contracts**: the `define_shape_contract!` /
+`unpack_shape_contract!` / `assert_shape_contract!` family
+(`bunsen::contracts::*`) — see `crates/geode-core/src/assembly/p1.rs` for the
+template. New tensor-index / sequence code should prefer `bunsen::ops`
+(`float_arange`, `float_linspace`, tensor `ClampOp`, `repeat_interleave`) over
+hand-rolling the Burn-primitive equivalents. Note that `ClampOp` operates on
+`Tensor<B, D>` only; scalar (non-`Tensor`) math is out of scope for this
+convention.
+
 ## Regression fixtures
 
 Numerical baselines for the unit-cube Dirichlet Laplacian ground-mode


### PR DESCRIPTION
## Summary

Phase 4 of Epic #355 is **evaluate-only** ("May be closed as 'convention documented, no refactor needed'"). This PR records the evaluation and lands the `bunsen::ops`-first convention in the top-level `README.md` — no `crates/geode-core/src` source changes, since there is nothing to refactor.

## Verification evidence (re-derived on this branch, `origin/main` @ `ebd57c6`)

**`arange`/`linspace` call sites in `crates/geode-core/src`: 0**
```
$ grep -rn -E '\b(arange|linspace)\b' crates/geode-core/src
(no output)
```

**Tensor-level clamp candidates: 0** — `.clamp(` finds 8 hits, all **scalar** `f64`/`f32` clamps in per-element loop bodies (`ClampOp::clamp()` wraps `Tensor<B, D>` only, so none qualify):
```
$ grep -rn '\.clamp' crates/geode-core/src
mesh/patch.rs:386:        let u = (depth / w).clamp(0.0, 1.0);
driven/scattering.rs:736:    let u = ((r - R_PML_INNER) / (R_BUFFER - R_PML_INNER)).clamp(0.0, 1.0);
driven/scattering.rs:1217:            .clamp(0.0, 1.0);
assembly/nedelec.rs:851:                let u = ((r_c - R_PML_INNER) / width).clamp(0.0, 1.0);
assembly/nedelec.rs:1328:            let u = ((r_c - R_PML_INNER) / width).clamp(0.0, 1.0);
postproc/ntff.rs:333:    directivity * eta.clamp(0.0, 1.0)
analytic/waveguide.rs:2238:    let u = ((r - r_pml_inner) / d).clamp(0.0, 1.0);
analytic/waveguide.rs:9326:        let ub = ((rr - r_in) / (r_out - r_in)).clamp(0.0, 1.0);
```

Conclusion: **0 refactor sites**. No changes to assembly/basis/eigensolver files — closed as "convention documented, no refactor needed" per the epic's escape hatch.

## Changes

- `README.md`: new **"Bunsen conventions"** subsection under Build, pointing future tensor-index/sequence code at `bunsen::ops` (`float_arange`, `float_linspace`, tensor `ClampOp`, `repeat_interleave`) over hand-rolled Burn primitives; references the `bunsen::contracts::*` shape-contract macro family (`define_shape_contract!` / `unpack_shape_contract!` / `assert_shape_contract!`, template in `assembly/p1.rs`); notes `ClampOp` is `Tensor`-only so scalar math is out of scope.
- No `.rs` source changes. (No `CONTRIBUTING.md` exists anywhere in the repo, so the README is the closest contributor-facing doc — consistent with the issue's own hedge.)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Re-verified arange/linspace/clamp call-site count at issue-work time | ✅ | 0 arange/linspace; 8 `.clamp` all scalar (ClampOp is Tensor-only) → 0 candidates. Greps above. |
| `bunsen::ops`-first convention note added to contributor docs | ✅ | README "Bunsen conventions" subsection |
| Epic #355 out-of-scope/ops section reflects the outcome | ✅ | [Outcome comment](https://github.com/rjwalters/geode-fem/issues/355#issuecomment-4961602911) posted on #355 |
| Closed noting "convention documented, no refactor needed" | ✅ | This PR, no code refactor |

## Test Plan

Docs-only change; ran the gates anyway:
- `cargo fmt --all -- --check` → clean (no Rust touched).
- `cargo build -p geode-core` → `Finished` (no-op sanity, bunsen `1ff74cd` compiles).
- No test changes expected or made.

Closes #455