### PR TITLE
feat(geode-core): named Bunsen shape contracts across the basis + eigensolver path

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 451
-# Branch: feature/issue-451
+# Issue: 454
+# Branch: feature/issue-454
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/eigen/dense.rs
+++ b/crates/geode-core/src/eigen/dense.rs
@@ -12,10 +12,29 @@
 //! intentional and matches the curator's #3 plan ("dense for v0 as a
 //! correctness oracle").
 
+use bunsen::contracts::{define_shape_contract, unpack_shape_contract};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
 use faer::Mat;
 use faer::mat::MatRef;
+
+// ---------------------------------------------------------------------------
+// Named static shape contract (Bunsen, Epic #355 Phase 3)
+// ---------------------------------------------------------------------------
+//
+// The one Burn-`Tensor` shape on the eigensolver surface: the 2-D matrix
+// bridged out to `faer` by `burn_matrix_to_faer`. The K/M pencil square/
+// agreement asserts elsewhere in this file operate on `faer::Mat`, which is
+// outside Bunsen's `Tensor<B, R, K>` surface, so they stay plain (see
+// `smallest_eigenpairs` / `smallest_eigenvalues`). Follows the Phase 2 template
+// from `crate::assembly` (PR #467).
+
+// Dense operator matrix `A \in \mathbb{R}^{rows × cols}` handed to the
+// Burn→faer bridge. Both axes are left free (any 2-D shape is a valid dense
+// matrix); the contract's role is to name the `[rows, cols]` read that drives
+// the row-major `from_fn` reconstruction, replacing the anonymous
+// `let dims = t.dims();` with a checked, self-documenting unpack.
+define_shape_contract!(BURN_MATRIX_BRIDGE_CONTRACT, ["rows", "cols"]);
 
 /// Errors produced by the eigensolver layer.
 #[derive(Debug, thiserror::Error)]
@@ -261,9 +280,13 @@ impl EigenSolver for FaerDenseEigensolver {
 /// so this is genuinely backend-agnostic — the f32 GPU path upcasts and
 /// the f64 CPU path is read losslessly.
 pub fn burn_matrix_to_faer<B: Backend>(t: Tensor<B, 2>) -> Mat<f64> {
-    let dims = t.dims();
+    // Dense operator `A \in \mathbb{R}^{rows × cols}` — name the `[rows, cols]`
+    // read via the shared contract so the row-major `from_fn` reconstruction
+    // below is driven by checked axis bindings rather than an anonymous
+    // `.dims()` destructure.
+    let [rows, cols] = unpack_shape_contract!(BURN_MATRIX_BRIDGE_CONTRACT, &t, &["rows", "cols"]);
     let data: Vec<f64> = t.into_data().iter::<f64>().collect();
-    Mat::<f64>::from_fn(dims[0], dims[1], |i, j| data[i * dims[1] + j])
+    Mat::<f64>::from_fn(rows, cols, |i, j| data[i * cols + j])
 }
 
 /// Apply homogeneous Dirichlet boundary conditions by extracting the
@@ -314,4 +337,31 @@ pub fn cube_interior_mask(nodes: &[[f64; 3]], side: f64) -> Vec<bool> {
                 || (n[2] - side).abs() < tol)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod contract_tests {
+    //! Bunsen shape-contract firing test (Epic #355, Phase 3).
+    //!
+    //! The one Burn-`Tensor` site on the eigensolver surface,
+    //! [`burn_matrix_to_faer`], takes a `Tensor<B, 2>` whose rank-2-ness is
+    //! type-enforced and whose two axes (`BURN_MATRIX_BRIDGE_CONTRACT`'s
+    //! `rows`/`cols`) are left free, so the *function path* can never receive a
+    //! mis-shaped input to reject. This test instead exercises the named static
+    //! contract directly with a wrong-rank shape, proving the contract that
+    //! drives `burn_matrix_to_faer`'s `[rows, cols]` unpack is genuinely
+    //! trip-able (a `Shape Error`) rather than a no-op — the crate-internal
+    //! analogue of the `should_panic` firing tests the assembly and element
+    //! modules carry in `tests/`.
+    use super::BURN_MATRIX_BRIDGE_CONTRACT;
+    use bunsen::contracts::assert_shape_contract;
+
+    #[test]
+    #[should_panic(expected = "Shape Error")]
+    fn burn_matrix_bridge_contract_wrong_rank_fires() {
+        // A rank-3 shape cannot satisfy the rank-2 `[rows, cols]` bridge
+        // contract; bunsen must reject it with a `Shape Error`.
+        let bad_rank: [usize; 3] = [4, 4, 4];
+        assert_shape_contract!(BURN_MATRIX_BRIDGE_CONTRACT, &bad_rank, &[]);
+    }
 }

--- a/crates/geode-core/src/elements/nedelec.rs
+++ b/crates/geode-core/src/elements/nedelec.rs
@@ -94,8 +94,65 @@
 //! against a CPU reference, (c) rigid-motion / dilation invariants,
 //! and (d) symmetry / sign-flip behavior on a two-tet shared-edge mesh.
 
+use bunsen::contracts::{assert_shape_contract, define_shape_contract, unpack_shape_contract};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
+
+/// Number of vertices per linear tetrahedron. Bound into
+/// `NEDELEC_TET_COORDS_CONTRACT` as `nodes_per_tet`.
+const NODES_PER_TET: usize = 4;
+
+/// Spatial dimension of the vertex coordinates (3-D). Bound into the coordinate
+/// / per-tet-vector / weight-tensor contracts as `spatial`.
+const SPATIAL: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen, Epic #355 Phase 3)
+// ---------------------------------------------------------------------------
+//
+// The recurring FEM tensor shapes of the Nédélec basis-evaluation path, named
+// once so the same machine-checked invariant is reused across the six kernels
+// below instead of being re-spelled as a bare `let dims = coords.dims();
+// assert_eq!(dims[1], 4, …)` destructure at each entry point. Follows the
+// Phase 2 template established in `crate::assembly::nedelec` (PR #467).
+
+// Batched per-tet vertex-coordinate stack
+// `X^e \in \mathbb{R}^{n_elem × 4 × 3}`: one `4 × 3` block per element, row `i`
+// the 3-D coordinates of vertex `i`, feeding the affine element Jacobian. The
+// `nodes_per_tet` axis is bound to `NODES_PER_TET` (`= 4`) and `spatial` to
+// `SPATIAL` (`= 3`) at the call site.
+define_shape_contract!(
+    NEDELEC_TET_COORDS_CONTRACT,
+    ["n_elem", "nodes_per_tet", "spatial"]
+);
+
+// Per-tet 3-vector field paired with `coords`
+// `J^e \in \mathbb{R}^{n_elem × 3}`: one Cartesian 3-vector per element (e.g. a
+// per-tet-constant current density). The `n_elem` axis is bound to the value
+// extracted from the companion `coords` contract, so a length mismatch between
+// the coordinate stack and its derived per-tet vector fires a named-axis
+// `Shape Error` rather than the former paired `assert_eq!(j_dims, [n_elem, 3])`.
+define_shape_contract!(NEDELEC_TET_VEC3_CONTRACT, ["n_elem", "spatial"]);
+
+// Per-tet quadrature-point 3-vector stack paired with `coords`
+// `J^e_q \in \mathbb{R}^{n_elem × 4 × 3}`: one 3-vector per element per degree-2
+// quadrature point (4 points). Shares the `nodes_per_tet` / `spatial` axes with
+// the coordinate stack; `n_elem` is bound from the companion `coords` read.
+define_shape_contract!(
+    NEDELEC_TET_QUAD_VEC3_CONTRACT,
+    ["n_elem", "nodes_per_tet", "spatial"]
+);
+
+// Per-tet full 3×3 constitutive weight tensor paired with `coords`
+// `W^e \in \mathbb{R}^{n_elem × 3 × 3}`: one dense `3 × 3` Cartesian weight per
+// element (the real or imaginary part of a UPML constitutive tensor). Both
+// spatial axes are bound to `SPATIAL` (`= 3`); `n_elem` is bound from the
+// companion `coords` read, encoding the shape *agreement* between `coords` and
+// its derived weight tensor as a single named contract.
+define_shape_contract!(
+    NEDELEC_TET_WEIGHT3X3_CONTRACT,
+    ["n_elem", "spatial", "spatial"]
+);
 
 /// Canonical local edge → (local vertex pair) ordering on a tet.
 ///
@@ -152,12 +209,18 @@ pub struct NedelecLocalMatrices<B: Backend> {
 ///
 /// # Panics
 ///
-/// Panics if `coords` does not have shape `[*, 4, 3]`.
+/// Panics if `coords` does not have shape `[*, 4, 3]` — validated via Bunsen's
+/// `NEDELEC_TET_COORDS_CONTRACT` (a cold, one-shot check: one call per
+/// assembly, not per element).
 pub fn batched_nedelec_local_matrices<B: Backend>(coords: Tensor<B, 3>) -> NedelecLocalMatrices<B> {
-    let dims = coords.dims();
-    let n_elem = dims[0];
-    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
-    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` — extract
+    // `n_elem` and check the `nodes_per_tet = 4` / `spatial = 3` axes.
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
 
     // Extract per-vertex coordinate tensors of shape [n_elem, 3].
     let v0 = coords
@@ -321,16 +384,20 @@ pub fn batched_nedelec_local_rhs<B: Backend>(
     coords: Tensor<B, 3>,
     j_tet: Tensor<B, 2>,
 ) -> Tensor<B, 2> {
-    let dims = coords.dims();
-    let n_elem = dims[0];
-    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
-    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
-    let j_dims = j_tet.dims();
-    assert_eq!(
-        j_dims,
-        [n_elem, 3],
-        "expected j_tet shape [n_elem, 3], got {:?}",
-        j_dims
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` and the
+    // paired per-tet current 3-vector `J^e \in \mathbb{R}^{n_elem × 3}` — the
+    // `n_elem` axis is bound once from `coords` and re-asserted on `j_tet`, so a
+    // length disagreement fires a named-axis `Shape Error`.
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
+    assert_shape_contract!(
+        NEDELEC_TET_VEC3_CONTRACT,
+        &j_tet,
+        &[("n_elem", n_elem), ("spatial", SPATIAL)],
     );
 
     // Same per-vertex / edge / cofactor / det machinery as the matrix
@@ -421,16 +488,20 @@ pub fn batched_nedelec_local_mass_anisotropic_diag<B: Backend>(
     coords: Tensor<B, 3>,
     eps_diag: Tensor<B, 2>,
 ) -> Tensor<B, 3> {
-    let dims = coords.dims();
-    let n_elem = dims[0];
-    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
-    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
-    let eps_dims = eps_diag.dims();
-    assert_eq!(
-        eps_dims,
-        [n_elem, 3],
-        "expected eps_diag shape [n_elem, 3], got {:?}",
-        eps_dims
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` and the
+    // paired per-tet, per-axis permittivity `\varepsilon^e \in
+    // \mathbb{R}^{n_elem × 3}` — `n_elem` is bound once from `coords` and
+    // re-asserted on `eps_diag`.
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
+    assert_shape_contract!(
+        NEDELEC_TET_VEC3_CONTRACT,
+        &eps_diag,
+        &[("n_elem", n_elem), ("spatial", SPATIAL)],
     );
 
     // Reuse the same per-vertex / edge / cofactor / det machinery as
@@ -552,10 +623,14 @@ pub const TET_QUAD4_B: f64 = 0.138_196_601_125_010_5;
 /// and the per-element determinant `det(J)` (`[n_elem]`) shared by the
 /// tensor-weighted kernels below. `∇λ_p = g_p / det(J)`.
 fn cofactor_rows_and_det<B: Backend>(coords: Tensor<B, 3>) -> (Tensor<B, 3>, Tensor<B, 1>) {
-    let dims = coords.dims();
-    let n_elem = dims[0];
-    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
-    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` — extract
+    // `n_elem` and check the `nodes_per_tet = 4` / `spatial = 3` axes.
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
 
     let v0 = coords
         .clone()
@@ -618,13 +693,21 @@ pub fn batched_nedelec_local_stiffness_weighted<B: Backend>(
     coords: Tensor<B, 3>,
     weight: Tensor<B, 3>,
 ) -> Tensor<B, 3> {
-    let n_elem = coords.dims()[0];
-    let w_dims = weight.dims();
-    assert_eq!(
-        w_dims,
-        [n_elem, 3, 3],
-        "expected weight shape [n_elem, 3, 3], got {:?}",
-        w_dims
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` and the
+    // paired full 3×3 curl weight `W^e \in \mathbb{R}^{n_elem × 3 × 3}` —
+    // `n_elem` is bound once from `coords` and re-asserted on `weight`, encoding
+    // the coords↔weight shape agreement as a single named contract. (`coords`'s
+    // interior axes are re-checked by `cofactor_rows_and_det` below.)
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
+    assert_shape_contract!(
+        NEDELEC_TET_WEIGHT3X3_CONTRACT,
+        &weight,
+        &[("n_elem", n_elem), ("spatial", SPATIAL)],
     );
 
     let (g_mat, det) = cofactor_rows_and_det(coords);
@@ -699,13 +782,20 @@ pub fn batched_nedelec_local_mass_anisotropic_full<B: Backend>(
     coords: Tensor<B, 3>,
     weight: Tensor<B, 3>,
 ) -> Tensor<B, 3> {
-    let n_elem = coords.dims()[0];
-    let w_dims = weight.dims();
-    assert_eq!(
-        w_dims,
-        [n_elem, 3, 3],
-        "expected weight shape [n_elem, 3, 3], got {:?}",
-        w_dims
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` and the
+    // paired full 3×3 mass weight `W^e \in \mathbb{R}^{n_elem × 3 × 3}` —
+    // `n_elem` is bound once from `coords` and re-asserted on `weight`.
+    // (`coords`'s interior axes are re-checked by `cofactor_rows_and_det`.)
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
+    assert_shape_contract!(
+        NEDELEC_TET_WEIGHT3X3_CONTRACT,
+        &weight,
+        &[("n_elem", n_elem), ("spatial", SPATIAL)],
     );
 
     let (g_mat, det) = cofactor_rows_and_det(coords);
@@ -788,13 +878,25 @@ pub fn batched_nedelec_local_rhs_quad4<B: Backend>(
     coords: Tensor<B, 3>,
     j_quad: Tensor<B, 3>,
 ) -> Tensor<B, 2> {
-    let n_elem = coords.dims()[0];
-    let j_dims = j_quad.dims();
-    assert_eq!(
-        j_dims,
-        [n_elem, 4, 3],
-        "expected j_quad shape [n_elem, 4, 3], got {:?}",
-        j_dims
+    // Vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` and the
+    // paired per-quadrature-point current `J^e_q \in \mathbb{R}^{n_elem × 4 ×
+    // 3}` (4 degree-2 points × 3 Cartesian components) — `n_elem` is bound once
+    // from `coords` and re-asserted on `j_quad`. (`coords`'s interior axes are
+    // re-checked by `cofactor_rows_and_det`.)
+    let [n_elem] = unpack_shape_contract!(
+        NEDELEC_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
+    assert_shape_contract!(
+        NEDELEC_TET_QUAD_VEC3_CONTRACT,
+        &j_quad,
+        &[
+            ("n_elem", n_elem),
+            ("nodes_per_tet", NODES_PER_TET),
+            ("spatial", SPATIAL),
+        ],
     );
 
     let (g_mat, det) = cofactor_rows_and_det(coords);

--- a/crates/geode-core/src/elements/p1.rs
+++ b/crates/geode-core/src/elements/p1.rs
@@ -30,8 +30,40 @@
 //! M_{ij} = (V / 20) (1 + δ_{ij})    (consistent mass).
 //! ```
 
+use bunsen::contracts::{define_shape_contract, unpack_shape_contract};
 use burn::tensor::Tensor;
 use burn::tensor::backend::Backend;
+
+/// Number of vertices per linear tetrahedral (P1) element. Bound into
+/// `P1_TET_COORDS_CONTRACT` as `nodes_per_tet` so the 4-vertex arity is
+/// machine-checked rather than left implicit in a `4` literal.
+const NODES_PER_TET: usize = 4;
+
+/// Spatial dimension of the vertex coordinates (3-D). Bound into
+/// `P1_TET_COORDS_CONTRACT` as `spatial`.
+const SPATIAL: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen, Epic #355 Phase 3)
+// ---------------------------------------------------------------------------
+//
+// The recurring FEM tensor shape of the P1 basis-evaluation path, named once so
+// the machine-checked invariant is reused instead of being re-spelled as a bare
+// `let dims = coords.dims(); assert_eq!(dims[1], 4, …)` destructure. Follows the
+// Phase 2 template established in `crate::assembly::p1` (PR #467).
+
+// Batched per-tet vertex-coordinate stack
+// `X^e \in \mathbb{R}^{n_elem × 4 × 3}`: one `4 × 3` block per element, row `i`
+// the 3-D coordinates of the tet's vertex `i` (`X^e[i, :]`), feeding the affine
+// element Jacobian `J = [v_1 - v_0 | v_2 - v_0 | v_3 - v_0]`. The
+// `nodes_per_tet` axis is bound to `NODES_PER_TET` (`= 4`) and `spatial` to
+// `SPATIAL` (`= 3`) at the call site, so coordinates built with the wrong tet
+// arity or spatial dimension panic with a named-axis diagnostic instead of
+// silently mis-slicing the per-vertex extraction below.
+define_shape_contract!(
+    P1_TET_COORDS_CONTRACT,
+    ["n_elem", "nodes_per_tet", "spatial"]
+);
 
 /// Batched P1 element-local matrices.
 #[derive(Debug, Clone)]
@@ -65,13 +97,23 @@ pub struct P1LocalMatrices<B: Backend> {
 ///
 /// # Panics
 ///
-/// Panics if `coords` does not have shape `[*, 4, 3]`.
+/// Panics if `coords` does not have shape `[*, 4, 3]` — validated via Bunsen's
+/// `P1_TET_COORDS_CONTRACT`, which fires a `Shape Error` naming the offending
+/// axis (`nodes_per_tet` or `spatial`) instead of the former bare
+/// `assert_eq!(dims[1], 4, …)` / `assert_eq!(dims[2], 3, …)` pair. This is a
+/// cold, one-shot check (one call per assembly, not per element), so the plain
+/// `unpack_shape_contract!` variant is used rather than the periodic one.
 pub fn batched_p1_local_matrices<B: Backend>(coords: Tensor<B, 3>) -> P1LocalMatrices<B> {
     let device = coords.device();
-    let dims = coords.dims();
-    let n_elem = dims[0];
-    assert_eq!(dims[1], 4, "expected 4 vertices per tet, got {}", dims[1]);
-    assert_eq!(dims[2], 3, "expected 3-D coordinates, got {}", dims[2]);
+    // Batched vertex-coordinate stack `X^e \in \mathbb{R}^{n_elem × 4 × 3}` —
+    // extract `n_elem` and check the `nodes_per_tet = 4` / `spatial = 3` axes
+    // through the shared named contract.
+    let [n_elem] = unpack_shape_contract!(
+        P1_TET_COORDS_CONTRACT,
+        &coords,
+        &["n_elem"],
+        &[("nodes_per_tet", NODES_PER_TET), ("spatial", SPATIAL)],
+    );
 
     // Extract per-vertex coordinate tensors of shape [n_elem, 3].
     let v0 = coords

--- a/crates/geode-core/tests/nedelec.rs
+++ b/crates/geode-core/tests/nedelec.rs
@@ -15,7 +15,9 @@ use burn::tensor::{Int, Tensor, TensorData};
 
 use geode_core::assembly::nedelec::{assemble_global_nedelec, cube_pec_interior_edges};
 use geode_core::assembly::p1::upload_mesh;
-use geode_core::elements::nedelec::{batched_nedelec_local_matrices, tet_edges};
+use geode_core::elements::nedelec::{
+    batched_nedelec_local_matrices, batched_nedelec_local_rhs, tet_edges,
+};
 use geode_core::mesh::{TetMesh, cube_tet_mesh};
 use geode_core::testing::TestBackend;
 
@@ -706,4 +708,34 @@ fn assemble_global_nedelec_wrong_arity_fires_contract() {
     let tet_edge_idx = vec![[0u32, 1, 2, 3, 4, 5]];
     let tet_edge_sign = vec![[1i8; 6]];
     let _ = assemble_global_nedelec::<B>(nodes, bad_tets, &tet_edge_idx, &tet_edge_sign, 6);
+}
+
+// --- Bunsen shape-contract firing tests (Epic #355, Phase 3) -----------------
+//
+// Prove the named contracts in `elements/nedelec.rs` are genuinely wired (not
+// no-ops): a mis-shaped coordinate stack, and a paired per-tet vector whose
+// element count disagrees with `coords`, must each trip a Bunsen `Shape Error`
+// rather than silently mis-slicing the kernel.
+
+/// `batched_nedelec_local_matrices` binds `coords`'s `nodes_per_tet` axis to 4
+/// via `NEDELEC_TET_COORDS_CONTRACT`. A `[n_elem, 3, 3]` stack (triangle arity)
+/// must fire the contract.
+#[test]
+#[should_panic(expected = "Shape Error")]
+fn batched_nedelec_local_matrices_wrong_arity_fires_contract() {
+    let bad = Tensor::<B, 3>::from_data(TensorData::new(vec![0.0f32; 9], [1, 3, 3]), &device());
+    let _ = batched_nedelec_local_matrices(bad);
+}
+
+/// `batched_nedelec_local_rhs` binds `n_elem` from `coords` and re-asserts it on
+/// `j_tet` via `NEDELEC_TET_VEC3_CONTRACT`. A `j_tet` with a different element
+/// count than the (valid) 1-element `coords` must fire the agreement contract.
+#[test]
+#[should_panic(expected = "Shape Error")]
+fn batched_nedelec_local_rhs_j_tet_count_mismatch_fires_contract() {
+    // Valid single-element coordinate stack [1, 4, 3].
+    let coords = Tensor::<B, 3>::from_data(TensorData::new(vec![0.0f32; 12], [1, 4, 3]), &device());
+    // Mismatched current: 2 elements' worth where coords has 1.
+    let bad_j = Tensor::<B, 2>::from_data(TensorData::new(vec![0.0f32; 6], [2, 3]), &device());
+    let _ = batched_nedelec_local_rhs(coords, bad_j);
 }

--- a/crates/geode-core/tests/p1_local_matrices.rs
+++ b/crates/geode-core/tests/p1_local_matrices.rs
@@ -293,3 +293,19 @@ fn unit_cube_fixture_invariants() {
         }
     }
 }
+
+// --- Bunsen shape-contract firing test (Epic #355, Phase 3) ------------------
+//
+// Proves the named `P1_TET_COORDS_CONTRACT` in `elements/p1.rs` is genuinely
+// wired: a coordinate stack with the wrong `nodes_per_tet` arity must trip the
+// contract and panic with a Bunsen `Shape Error` diagnostic, rather than
+// silently mis-slicing the per-vertex extraction (as the former bare
+// `assert_eq!(dims[1], 4, …)` guarded against, but without a named axis).
+#[test]
+#[should_panic(expected = "Shape Error")]
+fn batched_p1_local_matrices_wrong_arity_fires_contract() {
+    // Deliberately mis-shaped: 3 vertices per element (triangle arity) where
+    // the P1 tet contract demands `nodes_per_tet = 4`.
+    let bad = Tensor::<B, 3>::from_data(TensorData::new(vec![0.0f32; 9], [1, 3, 3]), &device());
+    let _ = batched_p1_local_matrices(bad);
+}


### PR DESCRIPTION
## Summary

Epic #355 **Phase 3**: extend the machine-checked Bunsen shape contracts from the assembly path (Phase 2, PR #467) to the element-basis kernels (`elements/p1.rs`, `elements/nedelec.rs`) and the dense eigensolver's Burn→faer bridge (`eigen/dense.rs`). All 14 Burn-`Tensor` `.dims()` shape-check sites are converted to named `define_shape_contract!` statics with FEM math-notation docs; the 6 `faer::Mat` asserts stay plain (stated decision). Follows the Phase 2 template exactly — same naming style, doc style, and judgment rule.

**No numerical or control-flow changes.** All existing basis/eigensolver tests pass unmodified.

## Contracts defined (5 new; none reusable from `assembly` — those statics are module-private, so siblings are defined here)

| Contract | Axes | Module |
|----------|------|--------|
| `P1_TET_COORDS_CONTRACT` | `["n_elem","nodes_per_tet","spatial"]` | elements/p1.rs |
| `NEDELEC_TET_COORDS_CONTRACT` | `["n_elem","nodes_per_tet","spatial"]` | elements/nedelec.rs |
| `NEDELEC_TET_VEC3_CONTRACT` | `["n_elem","spatial"]` | elements/nedelec.rs |
| `NEDELEC_TET_QUAD_VEC3_CONTRACT` | `["n_elem","nodes_per_tet","spatial"]` | elements/nedelec.rs |
| `NEDELEC_TET_WEIGHT3X3_CONTRACT` | `["n_elem","spatial","spatial"]` | elements/nedelec.rs |
| `BURN_MATRIX_BRIDGE_CONTRACT` | `["rows","cols"]` | eigen/dense.rs |

## Site-by-site conversion (35 candidate sites)

### elements/p1.rs — 1 `.dims()` + 2 `assert_eq!` → converted
| Site | Was | Now |
|------|-----|-----|
| `batched_p1_local_matrices` L71-74 | `let dims=coords.dims(); assert_eq!(dims[1],4); assert_eq!(dims[2],3)` | `unpack_shape_contract!(P1_TET_COORDS_CONTRACT, …)` binding `nodes_per_tet=4`, `spatial=3` |

### elements/nedelec.rs — 12 `.dims()` + 13 `assert_eq!` → converted
| Function | coords check | paired check |
|----------|--------------|--------------|
| `batched_nedelec_local_matrices` (L157) | `NEDELEC_TET_COORDS_CONTRACT` (unpack) | — |
| `batched_nedelec_local_rhs` (L324/328) | `NEDELEC_TET_COORDS_CONTRACT` | `NEDELEC_TET_VEC3_CONTRACT` on `j_tet` (n_elem agreement) |
| `batched_nedelec_local_mass_anisotropic_diag` (L424/428) | `NEDELEC_TET_COORDS_CONTRACT` | `NEDELEC_TET_VEC3_CONTRACT` on `eps_diag` |
| `cofactor_rows_and_det` (L555) | `NEDELEC_TET_COORDS_CONTRACT` | — |
| `batched_nedelec_local_stiffness_weighted` (L621/622) | `NEDELEC_TET_COORDS_CONTRACT` | `NEDELEC_TET_WEIGHT3X3_CONTRACT` on `weight` |
| `batched_nedelec_local_mass_anisotropic_full` (L702/703) | `NEDELEC_TET_COORDS_CONTRACT` | `NEDELEC_TET_WEIGHT3X3_CONTRACT` on `weight` |
| `batched_nedelec_local_rhs_quad4` (L791/792) | `NEDELEC_TET_COORDS_CONTRACT` | `NEDELEC_TET_QUAD_VEC3_CONTRACT` on `j_quad` |

The `coords.dims()[0]`-only sites (weighted/quad4 kernels) now bind `n_elem` through the full coords contract; `coords`' interior axes were already re-checked downstream in `cofactor_rows_and_det`, so this adds validation without behavior change.

### eigen/dense.rs — 1 `Tensor` `.dims()` → converted; 6 `faer::Mat` asserts → **left plain**
| Site | Decision |
|------|----------|
| `burn_matrix_to_faer` L264 (`Tensor<B,2>`) | Converted to `BURN_MATRIX_BRIDGE_CONTRACT` `["rows","cols"]` (both axes free — any 2-D matrix is valid; requiring square would add a new panic path = behavior change) |
| `smallest_eigenpairs` L107-109 (`faer::Mat` K/M square + agreement) | **Plain** — faer `Mat` is outside Bunsen's `Tensor<B,R,K>` surface |
| `smallest_eigenvalues` L201-203 (`faer::Mat` K/M square + agreement) | **Plain** — same rationale |

## Firing tests (4 new `should_panic`, one+ per module)

| Test | Module | Fires on |
|------|--------|----------|
| `batched_p1_local_matrices_wrong_arity_fires_contract` | tests/p1_local_matrices.rs | `[1,3,3]` coords (triangle arity) |
| `batched_nedelec_local_matrices_wrong_arity_fires_contract` | tests/nedelec.rs | `[1,3,3]` coords |
| `batched_nedelec_local_rhs_j_tet_count_mismatch_fires_contract` | tests/nedelec.rs | `j_tet` element count ≠ `coords` |
| `burn_matrix_bridge_contract_wrong_rank_fires` | eigen/dense.rs `#[cfg(test)]` | rank-3 shape vs rank-2 bridge contract |

The eigen test is crate-internal (inline `mod contract_tests`) because `burn_matrix_to_faer`'s rank-2 type signature means the *function path* can never receive a mis-ranked input; the test exercises the named static directly, proving it is trip-able rather than a no-op. All four fire `Shape Error`.

## Gate results

| Gate | Result |
|------|--------|
| `cargo build -p geode-core` (default) | ✅ |
| `cargo build -p geode-core --features arpack` | ✅ |
| `cargo clippy -p geode-core --all-targets -- -D warnings` | ✅ |
| `cargo clippy --tests -p geode-core --features arpack -- -D warnings` | ✅ |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` | ✅ |
| `cargo fmt --all --check` | ✅ |
| `cargo test -p geode-core --features testing --lib` | ✅ 275 passed, 2 ignored |
| `cargo test -p geode-core --release --tests` | ✅ exit 0 |
| affected binaries in release (p1_local_matrices, nedelec) | ✅ 22 passed incl. 4 firing tests |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 35 candidate Tensor sites reviewed; recurring FEM shapes → named contracts | ✅ | 14 `.dims()` converted; table above |
| faer-`Mat` asserts given named treatment OR left plain with rationale | ✅ | Left plain — faer outside Bunsen tensor surface (stated) |
| Hot-loop basis contracts use `assert_shape_contract_periodically!` | ✅ | N/A — basis kernels are cold (one call/assembly, not per-element); documented in `# Panics`. Periodic variant lives in the assembly hot loops (Phase 2, unchanged) |
| Both CI feature combos build + clippy clean | ✅ | default + arpack gates green |
| Existing tests pass unmodified; ≥1 new test proves a contract fires | ✅ | 4 new firing tests; existing suite unchanged |
| `cargo fmt --check` + `cargo doc -D warnings` green | ✅ | gates above |

Closes #454