### PR TITLE
feat(geode-core): quadratic (P2) scalar magnetostatic solver for second-order B recovery

### DIFF
--- a/crates/geode-core/src/analytic/waveguide.rs
+++ b/crates/geode-core/src/analytic/waveguide.rs
@@ -1331,6 +1331,32 @@ pub fn disk_boundary_nodes(mesh: &TriMesh, outer_radius: f64) -> Vec<bool> {
         .collect()
 }
 
+/// Build the **P2 Dirichlet mask** for a [`disk_tri_mesh`] of outer radius
+/// `outer_radius`: the length-`n_nodes + n_edges` boolean mask over the
+/// quadratic-Lagrange DOFs (vertex DOFs first, then edge-midpoint DOFs in
+/// [`TriMesh::edges`] order) that pins every DOF on the outer boundary.
+///
+/// A vertex DOF is pinned when its node lies on the outer circle (exactly
+/// [`disk_boundary_nodes`]); an edge-midpoint DOF is pinned when **both**
+/// endpoints of the edge lie on the outer circle — i.e. the edge runs along
+/// the boundary, so its midpoint is on the boundary too. Getting the
+/// boundary-edge midpoints right is essential: leaving a boundary-edge
+/// midpoint free would under-constrain the P2 system (the outer ring would
+/// no longer be a closed Dirichlet contour). This is the P2 analogue of
+/// [`disk_pec_interior_edges`]'s both-endpoints-on-boundary edge test.
+pub fn disk_p2_boundary_dofs(mesh: &TriMesh, outer_radius: f64) -> Vec<bool> {
+    let on_boundary = disk_boundary_nodes(mesh, outer_radius);
+    let edges = mesh.edges();
+    let mut mask = Vec::with_capacity(mesh.n_nodes() + edges.len());
+    // Vertex DOFs: pinned iff the node is on the outer circle.
+    mask.extend_from_slice(&on_boundary);
+    // Edge-midpoint DOFs: pinned iff both endpoints are on the outer circle.
+    for e in &edges {
+        mask.push(on_boundary[e[0] as usize] && on_boundary[e[1] as usize]);
+    }
+    mask
+}
+
 /// Build the PEC interior-edge mask for a [`disk_tri_mesh`] of outer radius
 /// `outer_radius`: an edge is **interior** (mask `true`) unless **both** of
 /// its endpoints lie on the outer (far-wall) circle — i.e. the edge runs
@@ -1672,6 +1698,83 @@ pub fn tri_nedelec2_local(coords: &[[f64; 2]; 3]) -> ([[f64; 8]; 8], [[f64; 8]; 
     }
 
     (k_local, m_local, area)
+}
+
+/// Closed-form local **quadratic (P2) scalar Lagrange** stiffness and mass
+/// matrices for an affine triangle — the second-order element kernel of the
+/// 2-D scalar-Poisson operator `−∇·(ν∇u) = f`.
+///
+/// Second-order sibling of [`tri_p1_local`]. The six DOFs are the three
+/// vertices plus the three edge midpoints, in the order
+/// `[v0, v1, v2, e0, e1, e2]` where the edges follow [`TRI_LOCAL_EDGES`]
+/// (`e0 = (0,1)`, `e1 = (0,2)`, `e2 = (1,2)`). This matches the global
+/// DOF numbering the P2 magnetostatic assembler uses: vertex DOFs keep the
+/// node index; edge-midpoint DOFs are offset by `n_nodes` via
+/// [`TriMesh::edges`]/[`TriMesh::tri_edges`] (the edge *sign* is irrelevant
+/// for unsigned scalar Lagrange DOFs, unlike the signed Nédélec assembler).
+///
+/// The quadratic basis in barycentric coordinates is
+///
+/// ```text
+///   vertex p:   φ_p   = λ_p (2 λ_p − 1) ,   ∇φ_p  = (4 λ_p − 1) ∇λ_p
+///   edge (a,b): φ_ab  = 4 λ_a λ_b ,         ∇φ_ab = 4 (λ_a ∇λ_b + λ_b ∇λ_a)
+/// ```
+///
+/// so the basis gradients are **linear** in the barycentrics; the stiffness
+/// integrand `∇φ_i·∇φ_j` is degree-2 and the mass integrand `φ_i φ_j` is
+/// degree-4. Both are integrated exactly by the shared degree-4 rule
+/// [`TRI_QUAD_DEG4`] (the same rule [`tri_nedelec2_local`] uses), and the
+/// barycentric gradients / signed area come from the shared
+/// `tri_bary_grads` helper so the P1, P2, and Nédélec element geometry
+/// cannot drift apart.
+///
+/// Returns `(k_local, m_local, signed_area)` where `k_local` (6×6) is the
+/// Dirichlet-energy stiffness `∫ ∇φ_p·∇φ_q dA`, `m_local` (6×6) is the
+/// consistent mass `∫ φ_p φ_q dA`, and the signed area is positive for CCW
+/// vertex order. As with [`tri_p1_local`], the per-element reluctivity
+/// `ν = 1/μ_r` weights the stiffness at assembly time.
+pub fn tri_p2_local(coords: &[[f64; 2]; 3]) -> ([[f64; 6]; 6], [[f64; 6]; 6], f64) {
+    let (grad, _gram, signed_area, area_abs) = tri_bary_grads(coords);
+
+    // Evaluate the six P2 basis values and gradients at a barycentric point
+    // `lam = (λ0, λ1, λ2)`. Ordering: [v0, v1, v2, e0, e1, e2].
+    let eval = |lam: [f64; 3]| -> ([f64; 6], [[f64; 2]; 6]) {
+        let mut val = [0.0_f64; 6];
+        let mut gr = [[0.0_f64; 2]; 6];
+        // Vertex DOFs.
+        for p in 0..3 {
+            let lp = lam[p];
+            val[p] = lp * (2.0 * lp - 1.0);
+            let c = 4.0 * lp - 1.0;
+            gr[p] = [c * grad[p][0], c * grad[p][1]];
+        }
+        // Edge-midpoint DOFs, in TRI_LOCAL_EDGES order.
+        for (e, &(a, b)) in TRI_LOCAL_EDGES.iter().enumerate() {
+            let (la, lb) = (lam[a], lam[b]);
+            val[3 + e] = 4.0 * la * lb;
+            gr[3 + e] = [
+                4.0 * (la * grad[b][0] + lb * grad[a][0]),
+                4.0 * (la * grad[b][1] + lb * grad[a][1]),
+            ];
+        }
+        (val, gr)
+    };
+
+    let mut k_local = [[0.0_f64; 6]; 6];
+    let mut m_local = [[0.0_f64; 6]; 6];
+    for row in TRI_QUAD_DEG4.iter() {
+        let lam = [row[0], row[1], row[2]];
+        let w = row[3] * area_abs; // physical-area quadrature weight
+        let (val, gr) = eval(lam);
+        for i in 0..6 {
+            for j in 0..6 {
+                k_local[i][j] += w * (gr[i][0] * gr[j][0] + gr[i][1] * gr[j][1]);
+                m_local[i][j] += w * val[i] * val[j];
+            }
+        }
+    }
+
+    (k_local, m_local, signed_area)
 }
 
 /// Assemble dense global Whitney/Nédélec stiffness `K` (curl-curl) and

--- a/crates/geode-core/src/assembly/magnetostatic.rs
+++ b/crates/geode-core/src/assembly/magnetostatic.rs
@@ -37,7 +37,9 @@
 use faer::Mat;
 use faer::sparse::{SparseColMat, Triplet};
 
-use crate::analytic::waveguide::{TriMesh, tri_bary_grads, tri_p1_local};
+use crate::analytic::waveguide::{
+    TRI_LOCAL_EDGES, TRI_QUAD_DEG4, TriMesh, tri_bary_grads, tri_p1_local, tri_p2_local,
+};
 
 pub use crate::assembly::p1::SparsityPattern;
 
@@ -647,4 +649,467 @@ pub fn recover_b_field(mesh: &TriMesh, a_z: &[f64]) -> Vec<[f64; 2]> {
             [gy, -gx]
         })
         .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Quadratic (P2) scalar-Lagrange magnetostatic path (Epic #448 follow-on,
+// issue #472). Fully additive alongside the P1 path above — the P1 functions
+// are untouched so the merged torque benchmarks keep their bit-for-bit
+// fixtures. The P2 solve lifts the mid-gap air-gap |B| accuracy from P1's
+// first-order (piecewise-constant B) to second-order (piecewise-linear B),
+// retiring the honest ≤1% field miss documented in `tests/slotless_pm_field.rs`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Global P2 DOF count for a mesh: `n_nodes + n_edges`. Vertex DOFs keep
+/// their node index; the edge-midpoint DOF of global edge `k` is at
+/// `n_nodes + k` (edge indices from [`TriMesh::edges`]). This is the size
+/// of the potential vector [`MagnetostaticP2System::solve`] returns and the
+/// [`crate::analytic::waveguide::disk_p2_boundary_dofs`] mask expects.
+#[inline]
+pub fn p2_dof_count(mesh: &TriMesh) -> usize {
+    mesh.n_nodes() + mesh.edges().len()
+}
+
+/// Assembled 2-D **quadratic (P2)** scalar magnetostatic system, indexed on
+/// the `n_nodes + n_edges` quadratic-Lagrange DOFs of a [`TriMesh`], with
+/// the boundary Dirichlet condition already eliminated.
+///
+/// Second-order sibling of [`MagnetostaticSystem`]. The solve returns the
+/// full-length `[n_dof]` quadratic potential (vertex values followed by
+/// edge-midpoint values); feed it to [`recover_b_field_p2`] for the
+/// piecewise-**linear** flux density.
+#[derive(Debug, Clone)]
+pub struct MagnetostaticP2System {
+    /// Reduced SPD stiffness `K` on the free (interior) DOFs.
+    pub k: SparseColMat<usize, f64>,
+    /// Reduced right-hand side `b` on the free DOFs.
+    pub b: Vec<f64>,
+    /// Global → free-DOF renumber: `Some(free_idx)` for interior DOFs,
+    /// `None` for pinned boundary DOFs. Length `n_dof`.
+    pub free_of_global: Vec<Option<usize>>,
+    /// Number of free (unpinned) DOFs = order of `k`.
+    pub n_free: usize,
+    /// Total P2 DOF count of the source mesh (`n_nodes + n_edges`).
+    pub n_dof: usize,
+    /// Node count of the source mesh (the vertex-DOF block size; edge DOFs
+    /// start at this offset).
+    pub n_nodes: usize,
+}
+
+impl MagnetostaticP2System {
+    /// Solve `K u = b` on the free DOFs via faer's sparse LU and scatter the
+    /// solution back to a full-length `[n_dof]` quadratic potential (pinned
+    /// boundary DOFs carry the Dirichlet value `0`). A successful
+    /// factorization is the SPD / solvability certificate.
+    pub fn solve(&self) -> Result<Vec<f64>, MagnetostaticError> {
+        use faer::linalg::solvers::Solve;
+
+        let lu = self
+            .k
+            .as_ref()
+            .sp_lu()
+            .map_err(|e| MagnetostaticError::Factorization(format!("{e:?}")))?;
+
+        let mut rhs: Mat<f64> = Mat::from_fn(self.n_free, 1, |i, _| self.b[i]);
+        lu.solve_in_place(rhs.as_mut());
+
+        let mut u = vec![0.0_f64; self.n_dof];
+        for (g, slot) in self.free_of_global.iter().enumerate() {
+            if let Some(fi) = slot {
+                u[g] = rhs[(*fi, 0)];
+            }
+        }
+        Ok(u)
+    }
+}
+
+/// Assemble the reduced SPD **quadratic (P2)** scalar magnetostatic system
+/// for `−∇·(ν∇A_z) = J_z` with `A_z = 0` pinned on the masked boundary DOFs.
+///
+/// Second-order sibling of [`assemble_magnetostatic`]. DOF numbering is
+/// `n_nodes + n_edges`: vertex DOFs keep their node index, and the
+/// edge-midpoint DOF of global edge `k` (from [`TriMesh::edges`]) sits at
+/// `n_nodes + k`. The per-triangle edge indices come from
+/// [`TriMesh::tri_edges`] — the *sign* field is ignored (scalar Lagrange
+/// DOFs are unsigned, unlike the signed Nédélec assembler).
+///
+/// # Arguments
+///
+/// * `mesh` — triangular cross-section mesh (CCW triangles).
+/// * `nu` — per-triangle reluctivity `ν = 1/μ_r`, length `mesh.n_tris()`.
+/// * `j_z` — per-triangle axial current density `J_z`, length
+///   `mesh.n_tris()` (piecewise-constant source).
+/// * `dirichlet` — per-**DOF** mask, length `n_nodes + n_edges`: `true`
+///   pins the DOF to `A_z = 0`. Build it with
+///   [`crate::analytic::waveguide::disk_p2_boundary_dofs`], which pins both
+///   boundary vertex DOFs and boundary-edge midpoint DOFs.
+///
+/// The consistent element mass `M` weights the current RHS
+/// (`b_p += Σ_q M_pq · J_z = J_z · ∫ φ_p`), the physically-correct
+/// `∫ J_z φ_p` for a piecewise-constant source; `ν` weights the element
+/// stiffness before the scatter.
+///
+/// # Errors
+///
+/// [`MagnetostaticError::ShapeMismatch`] on any length mismatch;
+/// [`MagnetostaticError::Assembly`] if faer rejects the triplets.
+pub fn assemble_magnetostatic_p2(
+    mesh: &TriMesh,
+    nu: &[f64],
+    j_z: &[f64],
+    dirichlet: &[bool],
+) -> Result<MagnetostaticP2System, MagnetostaticError> {
+    let n_nodes = mesh.n_nodes();
+    let n_tris = mesh.n_tris();
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+    let n_dof = n_nodes + n_edges;
+    if nu.len() != n_tris {
+        return Err(MagnetostaticError::ShapeMismatch(format!(
+            "nu length {} != triangle count {n_tris}",
+            nu.len()
+        )));
+    }
+    if j_z.len() != n_tris {
+        return Err(MagnetostaticError::ShapeMismatch(format!(
+            "j_z length {} != triangle count {n_tris}",
+            j_z.len()
+        )));
+    }
+    if dirichlet.len() != n_dof {
+        return Err(MagnetostaticError::ShapeMismatch(format!(
+            "dirichlet mask length {} != P2 DOF count {n_dof} (= n_nodes {n_nodes} + n_edges {n_edges})",
+            dirichlet.len()
+        )));
+    }
+
+    let tri_edges = mesh.tri_edges();
+
+    // Map a triangle's local P2 DOF (0..6) to a global DOF index.
+    // Local order [v0, v1, v2, e0, e1, e2] matches `tri_p2_local`.
+    let global_dof = |tri: &[u32; 3], tri_edge: &[(u32, i8); 3], local: usize| -> usize {
+        if local < 3 {
+            tri[local] as usize
+        } else {
+            // Edge-midpoint DOF: offset the global edge index by n_nodes.
+            // The sign from tri_edges() is irrelevant for unsigned scalar
+            // Lagrange DOFs, so it is deliberately discarded here.
+            n_nodes + tri_edge[local - 3].0 as usize
+        }
+    };
+
+    let mut full_trips: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(n_tris * 36);
+    let mut b_full = vec![0.0_f64; n_dof];
+
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let coords = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let (k_local, m_local, signed_area) = tri_p2_local(&coords);
+        debug_assert!(
+            signed_area > 0.0,
+            "magnetostatic P2 assembler expects CCW triangles; got signed area {signed_area}"
+        );
+        let te = &tri_edges[t];
+        let nu_t = nu[t];
+        let jz_t = j_z[t];
+        for p in 0..6 {
+            let gp = global_dof(tri, te, p);
+            let mut bp = 0.0;
+            for q in 0..6 {
+                bp += m_local[p][q] * jz_t;
+                let gq = global_dof(tri, te, q);
+                full_trips.push(Triplet::new(gp, gq, nu_t * k_local[p][q]));
+            }
+            b_full[gp] += bp;
+        }
+    }
+
+    let sys = reduce_p2_system(n_dof, n_nodes, &full_trips, &b_full, dirichlet)?;
+    Ok(sys)
+}
+
+/// Symmetric Dirichlet elimination + faer sparse-matrix build shared by the
+/// P2 current-driven and PM-driven assemblers. Folds pinned columns into the
+/// RHS (pinned value 0, so the fold is a no-op, but the reduction is exact).
+fn reduce_p2_system(
+    n_dof: usize,
+    n_nodes: usize,
+    full_trips: &[Triplet<usize, usize, f64>],
+    b_full: &[f64],
+    dirichlet: &[bool],
+) -> Result<MagnetostaticP2System, MagnetostaticError> {
+    let k_full = SparseColMat::<usize, f64>::try_new_from_triplets(n_dof, n_dof, full_trips)
+        .map_err(|e| MagnetostaticError::Assembly(format!("{e:?}")))?;
+
+    let mut free_of_global = vec![None; n_dof];
+    let mut n_free = 0usize;
+    for (g, &pinned) in dirichlet.iter().enumerate() {
+        if !pinned {
+            free_of_global[g] = Some(n_free);
+            n_free += 1;
+        }
+    }
+
+    let mut b_free = vec![0.0_f64; n_free];
+    for (i, slot) in free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            b_free[*fi] = b_full[i];
+        }
+    }
+
+    let mut red_trips: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(full_trips.len());
+    let k_ref = k_full.as_ref();
+    let cp = k_ref.col_ptr();
+    let row_idx = k_ref.row_idx();
+    let vals = k_ref.val();
+    for j in 0..n_dof {
+        for k in cp[j]..cp[j + 1] {
+            let i = row_idx[k];
+            let v = vals[k];
+            if let (Some(fi), Some(fj)) = (free_of_global[i], free_of_global[j]) {
+                red_trips.push(Triplet::new(fi, fj, v));
+            }
+            // (Some, None): pinned column with value 0 → no RHS fold needed.
+        }
+    }
+
+    let k = SparseColMat::<usize, f64>::try_new_from_triplets(n_free, n_free, &red_trips)
+        .map_err(|e| MagnetostaticError::Assembly(format!("{e:?}")))?;
+
+    Ok(MagnetostaticP2System {
+        k,
+        b: b_free,
+        free_of_global,
+        n_free,
+        n_dof,
+        n_nodes,
+    })
+}
+
+/// Assemble the **P2 permanent-magnet magnetization RHS**
+/// `b_p = ∫ (μ₀ M) · (∇φ_p)^⊥ dA` for the quadratic scalar operator, where
+/// `(∇φ_p)^⊥ = (∂φ_p/∂y, −∂φ_p/∂x)`.
+///
+/// Second-order sibling of [`assemble_magnetization_rhs`]. The physics is
+/// identical (the integration-by-parts weak form of the equivalent bound
+/// current `μ₀(∇×M)_z`, subsuming both the bulk and surface bound currents
+/// exactly). The one discretization difference matters: for P2 the test
+/// functions' gradients `∇φ_p` are **linear** per triangle (not constant as
+/// for P1), so the element integral `∫_T (∇φ_p)^⊥ dA` is evaluated with the
+/// degree-4 rule [`TRI_QUAD_DEG4`] rather than P1's constant-gradient
+/// `area · (∇φ_p)^⊥` shortcut. `M` is piecewise-constant per triangle.
+///
+/// Returns a full-length `[n_dof]` (`n_nodes + n_edges`) RHS to be **added**
+/// to any free-current RHS before Dirichlet reduction; see
+/// [`assemble_magnetostatic_pm_p2`] for the assembled-system convenience.
+///
+/// # Errors
+///
+/// [`MagnetostaticError::ShapeMismatch`] if `m.len() != mesh.n_tris()`.
+pub fn assemble_magnetization_rhs_p2(
+    mesh: &TriMesh,
+    m: &[[f64; 2]],
+) -> Result<Vec<f64>, MagnetostaticError> {
+    let n_tris = mesh.n_tris();
+    if m.len() != n_tris {
+        return Err(MagnetostaticError::ShapeMismatch(format!(
+            "m length {} != triangle count {n_tris}",
+            m.len()
+        )));
+    }
+    let mu0 = crate::analytic::slotless_pm::MU_0;
+    let n_nodes = mesh.n_nodes();
+    let edges = mesh.edges();
+    let n_dof = n_nodes + edges.len();
+    let tri_edges = mesh.tri_edges();
+
+    let mut b_full = vec![0.0_f64; n_dof];
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let [mx, my] = m[t];
+        if mx == 0.0 && my == 0.0 {
+            continue;
+        }
+        let coords = [
+            mesh.nodes[tri[0] as usize],
+            mesh.nodes[tri[1] as usize],
+            mesh.nodes[tri[2] as usize],
+        ];
+        let (grad, _gram, _signed_area, area_abs) = tri_bary_grads(&coords);
+        let (mx0, my0) = (mu0 * mx, mu0 * my);
+        let te = &tri_edges[t];
+
+        // ∫_T ∇φ_p dA per DOF, accumulated at the degree-4 quadrature points
+        // (∇φ_p is linear in barycentrics for P2, so this is exact).
+        let mut int_grad = [[0.0_f64; 2]; 6];
+        for row in TRI_QUAD_DEG4.iter() {
+            let lam = [row[0], row[1], row[2]];
+            let w = row[3] * area_abs;
+            // Vertex gradients: ∇φ_p = (4λ_p − 1) ∇λ_p.
+            for p in 0..3 {
+                let c = 4.0 * lam[p] - 1.0;
+                int_grad[p][0] += w * c * grad[p][0];
+                int_grad[p][1] += w * c * grad[p][1];
+            }
+            // Edge gradients: ∇φ_ab = 4(λ_a ∇λ_b + λ_b ∇λ_a).
+            for (e, &(a, b)) in TRI_LOCAL_EDGES.iter().enumerate() {
+                let (la, lb) = (lam[a], lam[b]);
+                int_grad[3 + e][0] += w * 4.0 * (la * grad[b][0] + lb * grad[a][0]);
+                int_grad[3 + e][1] += w * 4.0 * (la * grad[b][1] + lb * grad[a][1]);
+            }
+        }
+
+        for p in 0..6 {
+            let gp = if p < 3 {
+                tri[p] as usize
+            } else {
+                n_nodes + te[p - 3].0 as usize
+            };
+            // (∇φ_p)^⊥ = (∂φ_p/∂y, −∂φ_p/∂x); integrated form uses int_grad.
+            let perp = [int_grad[p][1], -int_grad[p][0]];
+            b_full[gp] += mx0 * perp[0] + my0 * perp[1];
+        }
+    }
+    Ok(b_full)
+}
+
+/// Assemble the **P2** scalar magnetostatic system driven by a
+/// permanent-magnet magnetization source (plus any free current `j_z`),
+/// with the boundary Dirichlet condition eliminated.
+///
+/// Second-order sibling of [`assemble_magnetostatic_pm`]: it is
+/// [`assemble_magnetostatic_p2`] with the P2 magnetization RHS
+/// (from [`assemble_magnetization_rhs_p2`]) folded into the free-current RHS
+/// before Dirichlet reduction. Pass `j_z = &[0.0; n_tris]` for a pure-PM
+/// problem.
+///
+/// # Errors
+///
+/// Propagates [`MagnetostaticError`] from either the stiffness assembly or
+/// the magnetization-RHS shape check.
+pub fn assemble_magnetostatic_pm_p2(
+    mesh: &TriMesh,
+    nu: &[f64],
+    j_z: &[f64],
+    m_eff: &[[f64; 2]],
+    dirichlet: &[bool],
+) -> Result<MagnetostaticP2System, MagnetostaticError> {
+    let mut sys = assemble_magnetostatic_p2(mesh, nu, j_z, dirichlet)?;
+    let b_mag_full = assemble_magnetization_rhs_p2(mesh, m_eff)?;
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            sys.b[*fi] += b_mag_full[g];
+        }
+    }
+    Ok(sys)
+}
+
+/// Recover the **piecewise-linear** flux density `B = (∂A_z/∂y, −∂A_z/∂x)`
+/// per triangle from a P2 quadratic potential, evaluated at each triangle
+/// **centroid** — the P2-compatible analogue of [`recover_b_field`]'s
+/// per-triangle output (which the existing centroid-based samplers consume).
+///
+/// For P2 the potential `A_z = Σ_p u_p φ_p` is quadratic per triangle, so
+/// `∇A_z = Σ_p u_p ∇φ_p` is **linear** — first-order accurate field, a full
+/// order better than P1's piecewise-constant `B`. Returns `b[t] = [B_x, B_y]`
+/// at triangle `t`'s centroid `(λ = 1/3, 1/3, 1/3)`. For sampling at an
+/// arbitrary point (e.g. the mid-gap contour) use [`sample_b_field_p2`].
+pub fn recover_b_field_p2(mesh: &TriMesh, u: &[f64]) -> Vec<[f64; 2]> {
+    let n_nodes = mesh.n_nodes();
+    let edges = mesh.edges();
+    assert_eq!(
+        u.len(),
+        n_nodes + edges.len(),
+        "P2 potential length {} != n_dof {} (n_nodes {} + n_edges {})",
+        u.len(),
+        n_nodes + edges.len(),
+        n_nodes,
+        edges.len()
+    );
+    let tri_edges = mesh.tri_edges();
+    mesh.tris
+        .iter()
+        .enumerate()
+        .map(|(t, tri)| {
+            let coords = [
+                mesh.nodes[tri[0] as usize],
+                mesh.nodes[tri[1] as usize],
+                mesh.nodes[tri[2] as usize],
+            ];
+            let dofs = p2_tri_dofs(tri, &tri_edges[t], n_nodes, u);
+            eval_b_p2(&coords, &dofs, [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+        })
+        .collect()
+}
+
+/// Sample the P2 flux density `B = (∂A_z/∂y, −∂A_z/∂x)` at an arbitrary
+/// point `(px, py)` by locating the containing triangle (barycentric test)
+/// and evaluating the linear per-triangle gradient there. Returns
+/// `Some([B_x, B_y])`, or `None` if the point lies outside the mesh.
+///
+/// This is the point-evaluation companion to [`recover_b_field_p2`] the
+/// mid-gap contour comparison against the `SlotlessPm` oracle needs (the P1
+/// path sampled the piecewise-constant per-triangle `B`; at P2 the field is
+/// linear, so sampling at the actual contour point — not the centroid — is
+/// what earns the second-order accuracy).
+pub fn sample_b_field_p2(mesh: &TriMesh, u: &[f64], px: f64, py: f64) -> Option<[f64; 2]> {
+    let n_nodes = mesh.n_nodes();
+    let tri_edges = mesh.tri_edges();
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let c0 = mesh.nodes[tri[0] as usize];
+        let c1 = mesh.nodes[tri[1] as usize];
+        let c2 = mesh.nodes[tri[2] as usize];
+        let d = (c1[1] - c2[1]) * (c0[0] - c2[0]) + (c2[0] - c1[0]) * (c0[1] - c2[1]);
+        let l0 = ((c1[1] - c2[1]) * (px - c2[0]) + (c2[0] - c1[0]) * (py - c2[1])) / d;
+        let l1 = ((c2[1] - c0[1]) * (px - c2[0]) + (c0[0] - c2[0]) * (py - c2[1])) / d;
+        let l2 = 1.0 - l0 - l1;
+        let tol = -1e-9;
+        if l0 >= tol && l1 >= tol && l2 >= tol {
+            let coords = [c0, c1, c2];
+            let dofs = p2_tri_dofs(tri, &tri_edges[t], n_nodes, u);
+            return Some(eval_b_p2(&coords, &dofs, [l0, l1, l2]));
+        }
+    }
+    None
+}
+
+/// Gather the six local P2 DOF values `[v0, v1, v2, e0, e1, e2]` for a
+/// triangle from the global potential vector.
+#[inline]
+fn p2_tri_dofs(tri: &[u32; 3], tri_edge: &[(u32, i8); 3], n_nodes: usize, u: &[f64]) -> [f64; 6] {
+    let mut dofs = [0.0_f64; 6];
+    for p in 0..3 {
+        dofs[p] = u[tri[p] as usize];
+    }
+    for e in 0..3 {
+        dofs[3 + e] = u[n_nodes + tri_edge[e].0 as usize];
+    }
+    dofs
+}
+
+/// Evaluate `B = (∂A_z/∂y, −∂A_z/∂x)` for a P2 element at barycentric point
+/// `lam`, given the six local DOF values. `∇A_z = Σ_p u_p ∇φ_p` with the
+/// quadratic basis gradients (linear per triangle).
+#[inline]
+fn eval_b_p2(coords: &[[f64; 2]; 3], dofs: &[f64; 6], lam: [f64; 3]) -> [f64; 2] {
+    let (grad, _gram, _signed_area, _abs) = tri_bary_grads(coords);
+    let mut gx = 0.0;
+    let mut gy = 0.0;
+    // Vertex gradients: ∇φ_p = (4λ_p − 1) ∇λ_p.
+    for p in 0..3 {
+        let c = (4.0 * lam[p] - 1.0) * dofs[p];
+        gx += c * grad[p][0];
+        gy += c * grad[p][1];
+    }
+    // Edge gradients: ∇φ_ab = 4(λ_a ∇λ_b + λ_b ∇λ_a).
+    for (e, &(a, b)) in TRI_LOCAL_EDGES.iter().enumerate() {
+        let (la, lb) = (lam[a], lam[b]);
+        let d = dofs[3 + e];
+        gx += 4.0 * d * (la * grad[b][0] + lb * grad[a][0]);
+        gy += 4.0 * d * (la * grad[b][1] + lb * grad[a][1]);
+    }
+    // B = (∂A_z/∂y, −∂A_z/∂x).
+    [gy, -gx]
 }

--- a/crates/geode-core/tests/magnetostatic_wire.rs
+++ b/crates/geode-core/tests/magnetostatic_wire.rs
@@ -17,9 +17,13 @@
 //!  4. Inverse tripwire: wrong-ν or coarse-mesh error > 5 %.
 
 use geode_core::analytic::waveguide::{
-    TriMesh, disk_boundary_nodes, disk_tri_mesh, tri_nedelec_local, tri_p1_local,
+    TriMesh, disk_boundary_nodes, disk_p2_boundary_dofs, disk_tri_mesh, tri_nedelec_local,
+    tri_p1_local, tri_p2_local,
 };
-use geode_core::assembly::magnetostatic::{assemble_magnetostatic, recover_b_field};
+use geode_core::assembly::magnetostatic::{
+    assemble_magnetostatic, assemble_magnetostatic_p2, p2_dof_count, recover_b_field,
+    recover_b_field_p2,
+};
 
 const MU_0: f64 = 4.0e-7 * std::f64::consts::PI;
 
@@ -409,6 +413,274 @@ fn coarse_mesh_tripwire_fires() {
         err > 0.05,
         "coarse-mesh error {:.2}% did not exceed the 5% tripwire floor",
         err * 100.0
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 5. tri_p2_local unit tests (issue #472)
+// ─────────────────────────────────────────────────────────────────────
+
+/// The six P2 basis values `[φ_v0, φ_v1, φ_v2, φ_e0, φ_e1, φ_e2]` at a
+/// barycentric point — used to probe partition of unity independently of
+/// the element kernel. Ordering matches `tri_p2_local`.
+fn p2_basis_values(lam: [f64; 3]) -> [f64; 6] {
+    const EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
+    let mut v = [0.0_f64; 6];
+    for p in 0..3 {
+        v[p] = lam[p] * (2.0 * lam[p] - 1.0);
+    }
+    for (e, &(a, b)) in EDGES.iter().enumerate() {
+        v[3 + e] = 4.0 * lam[a] * lam[b];
+    }
+    v
+}
+
+#[test]
+fn tri_p2_local_row_sums_zero() {
+    // Constant potential ⇒ zero stiffness force: each row of the 6×6 K sums
+    // to 0 (Σ_q ∇φ_q = ∇(Σ φ_q) = ∇1 = 0 by partition of unity).
+    let (k, _m, _a) = tri_p2_local(&sample_triangle());
+    for p in 0..6 {
+        let row_sum: f64 = (0..6).map(|q| k[p][q]).sum();
+        assert!(
+            row_sum.abs() < 1e-11,
+            "P2 K row {p} sum {row_sum} not ≈ 0 (constant nullspace)"
+        );
+    }
+}
+
+#[test]
+fn tri_p2_local_symmetric_psd() {
+    let (k, _m, _a) = tri_p2_local(&sample_triangle());
+    for p in 0..6 {
+        for q in 0..6 {
+            assert!(
+                (k[p][q] - k[q][p]).abs() < 1e-12,
+                "P2 K not symmetric at ({p},{q})"
+            );
+        }
+    }
+    // PSD: xᵀKx ≥ 0 for a spread of probe vectors (K has a 1-D constant
+    // nullspace, so it is PSD, not PD).
+    let probes = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        [1.0, -1.0, 0.0, 0.3, -0.2, 0.5],
+        [0.3, -0.7, 1.4, -1.1, 0.9, 0.2],
+        [-2.0, 1.1, 0.9, 0.4, -0.6, 1.3],
+    ];
+    for x in probes {
+        let mut q = 0.0;
+        for p in 0..6 {
+            for r in 0..6 {
+                q += x[p] * k[p][r] * x[r];
+            }
+        }
+        assert!(q >= -1e-11, "xᵀKx = {q} < 0 for x = {x:?} (P2 K not PSD)");
+    }
+}
+
+#[test]
+fn tri_p2_local_mass_sums_to_area() {
+    // Σ_pq M_pq = ∫ (Σ_p φ_p)(Σ_q φ_q) dA = ∫ 1·1 dA = area (partition of
+    // unity: the six P2 shape functions sum to 1 everywhere).
+    let tri = sample_triangle();
+    let (_k, m, area) = tri_p2_local(&tri);
+    let mass_sum: f64 = m.iter().flatten().sum();
+    assert!(
+        (mass_sum - area).abs() < 1e-12,
+        "sum(P2 M) = {mass_sum} != area {area}"
+    );
+}
+
+#[test]
+fn tri_p2_partition_of_unity_at_quadrature_points() {
+    // The six P2 shape functions sum to 1 at every point — check at the
+    // degree-4 quadrature nodes the kernel integrates over, plus centroid.
+    let sample_pts = [
+        [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+        [
+            0.108_103_018_168_070,
+            0.445_948_490_915_965,
+            0.445_948_490_915_965,
+        ],
+        [
+            0.816_847_572_980_459,
+            0.091_576_213_509_771,
+            0.091_576_213_509_771,
+        ],
+        [0.6, 0.25, 0.15],
+    ];
+    for lam in sample_pts {
+        let s: f64 = p2_basis_values(lam).iter().sum();
+        assert!(
+            (s - 1.0).abs() < 1e-13,
+            "P2 partition of unity broken at {lam:?}: Σφ = {s}"
+        );
+    }
+}
+
+#[test]
+fn tri_p2_local_reduces_to_p1_on_vertex_subspace_stiffness() {
+    // A globally-linear potential A_z(x,y) is exactly representable by both
+    // P1 and P2. Its edge-midpoint DOF equals the average of the two vertex
+    // DOFs, so injecting a linear field into the P2 element and into the P1
+    // element must yield the identical Dirichlet energy xᵀKx.
+    let tri = sample_triangle();
+    let (kp1, _m1, _a1) = tri_p1_local(&tri);
+    let (kp2, _m2, _a2) = tri_p2_local(&tri);
+    // Linear field A(x,y) = 2 + 3x − 1.5y sampled at the six P2 nodes.
+    let field = |x: f64, y: f64| 2.0 + 3.0 * x - 1.5 * y;
+    let vx: [f64; 3] = [
+        field(tri[0][0], tri[0][1]),
+        field(tri[1][0], tri[1][1]),
+        field(tri[2][0], tri[2][1]),
+    ];
+    // Edge midpoints in TRI_LOCAL_EDGES order (0,1),(0,2),(1,2).
+    let mid =
+        |a: usize, b: usize| field(0.5 * (tri[a][0] + tri[b][0]), 0.5 * (tri[a][1] + tri[b][1]));
+    let vp2 = [vx[0], vx[1], vx[2], mid(0, 1), mid(0, 2), mid(1, 2)];
+
+    let energy_p1 = {
+        let mut e = 0.0;
+        for p in 0..3 {
+            for q in 0..3 {
+                e += vx[p] * kp1[p][q] * vx[q];
+            }
+        }
+        e
+    };
+    let energy_p2 = {
+        let mut e = 0.0;
+        for p in 0..6 {
+            for q in 0..6 {
+                e += vp2[p] * kp2[p][q] * vp2[q];
+            }
+        }
+        e
+    };
+    assert!(
+        (energy_p1 - energy_p2).abs() < 1e-12 * energy_p1.abs().max(1e-12),
+        "P2 Dirichlet energy {energy_p2} != P1 energy {energy_p1} on a linear field"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 6. Wire-oracle P2 O(h²) convergence proof (issue #472, AC #2)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Solve the straight-wire problem with the **P2** solver and return
+/// `(mesh, u)` where `u` is the length-`(n_nodes + n_edges)` quadratic
+/// potential. Mirrors `solve_wire` (P1) exactly on inputs.
+fn solve_wire_p2(
+    core_radius: f64,
+    outer_radius: f64,
+    n_radial: usize,
+    n_angular: usize,
+    nu_value: f64,
+    current: f64,
+) -> (TriMesh, Vec<f64>) {
+    let (mesh, region_tags) = disk_tri_mesh(core_radius, outer_radius, n_radial, n_angular);
+    let n_tris = mesh.n_tris();
+    let nu = vec![nu_value; n_tris];
+    let core_area = std::f64::consts::PI * core_radius * core_radius;
+    let density = MU_0 * current / core_area;
+    let j_z: Vec<f64> = region_tags
+        .iter()
+        .map(|&tag| if tag == 1 { density } else { 0.0 })
+        .collect();
+    let bc = disk_p2_boundary_dofs(&mesh, outer_radius);
+    assert_eq!(bc.len(), p2_dof_count(&mesh));
+    let sys = assemble_magnetostatic_p2(&mesh, &nu, &j_z, &bc).expect("assemble P2");
+    let u = sys.solve().expect("wire P2 solve");
+    (mesh, u)
+}
+
+/// L2 relative error of the P2 `|B|` vs the annular closed form
+/// `B_θ = μ₀ I/(2π r)`, per-triangle centroid over the band r∈[r_lo,r_hi].
+fn wire_l2_error_p2(mesh: &TriMesh, u: &[f64], current: f64, r_lo: f64, r_hi: f64) -> f64 {
+    let b = recover_b_field_p2(mesh, u);
+    let mut num = 0.0;
+    let mut den = 0.0;
+    let mut count = 0usize;
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        let cx = (mesh.nodes[tri[0] as usize][0]
+            + mesh.nodes[tri[1] as usize][0]
+            + mesh.nodes[tri[2] as usize][0])
+            / 3.0;
+        let cy = (mesh.nodes[tri[0] as usize][1]
+            + mesh.nodes[tri[1] as usize][1]
+            + mesh.nodes[tri[2] as usize][1])
+            / 3.0;
+        let r = (cx * cx + cy * cy).sqrt();
+        if r < r_lo || r > r_hi {
+            continue;
+        }
+        let area = 0.5
+            * ((mesh.nodes[tri[1] as usize][0] - mesh.nodes[tri[0] as usize][0])
+                * (mesh.nodes[tri[2] as usize][1] - mesh.nodes[tri[0] as usize][1])
+                - (mesh.nodes[tri[1] as usize][1] - mesh.nodes[tri[0] as usize][1])
+                    * (mesh.nodes[tri[2] as usize][0] - mesh.nodes[tri[0] as usize][0]))
+                .abs();
+        let b_mag = (b[t][0] * b[t][0] + b[t][1] * b[t][1]).sqrt();
+        let exact = MU_0 * current / (2.0 * std::f64::consts::PI * r);
+        num += area * (b_mag - exact).powi(2);
+        den += area * exact.powi(2);
+        count += 1;
+    }
+    assert!(count > 0, "no triangles in the comparison band");
+    (num / den).sqrt()
+}
+
+#[test]
+fn wire_p2_second_order_convergence() {
+    // AC #2: P2 field converges at O(h²) on the wire oracle. Refine the mesh
+    // by ~2× in both radial and angular resolution and fit a log-log slope of
+    // error vs mean element size h ∝ 1/√(n_tris). Mirrors the #318 Phase 2.5C
+    // convergence-proof pattern; P1's slope on the same geometry is ≈1.
+    let outer = 1.0;
+    let current = 3.0;
+    let core = 0.05;
+    let schedule = [(12usize, 48usize), (24, 96), (48, 192)];
+
+    let mut hs = Vec::new();
+    let mut errs = Vec::new();
+    println!("--- wire oracle: P2 |B| L2 convergence (band r∈[0.3,0.7]R) ---");
+    for &(nr, na) in &schedule {
+        let (mesh, u) = solve_wire_p2(core, outer, nr, na, 1.0, current);
+        let err = wire_l2_error_p2(&mesh, &u, current, 0.3 * outer, 0.7 * outer);
+        // Mean element size h ∝ 1/√(n_tris).
+        let h = 1.0 / (mesh.n_tris() as f64).sqrt();
+        println!(
+            "  nr={nr:3} na={na:3} nodes={:6} n_tris={:6} h={h:.5} L2={:.4}%",
+            mesh.n_nodes(),
+            mesh.n_tris(),
+            err * 100.0
+        );
+        hs.push(h.ln());
+        errs.push(err.ln());
+    }
+
+    // Least-squares log-log slope of ln(err) vs ln(h).
+    let n = hs.len() as f64;
+    let sx: f64 = hs.iter().sum();
+    let sy: f64 = errs.iter().sum();
+    let sxx: f64 = hs.iter().map(|x| x * x).sum();
+    let sxy: f64 = hs.iter().zip(&errs).map(|(x, y)| x * y).sum();
+    let slope = (n * sxy - sx * sy) / (n * sxx - sx * sx);
+    println!("  fitted log-log convergence slope = {slope:.3} (P2 target ≥ 1.8)");
+    assert!(
+        slope >= 1.8,
+        "P2 wire convergence slope {slope:.3} < 1.8 — not second order"
+    );
+
+    // Sanity: the finest P2 error should be well under P1's ~0.77% at a
+    // comparable mesh, confirming the order improvement is real.
+    let finest = errs.last().unwrap().exp();
+    assert!(
+        finest < 0.005,
+        "finest P2 wire L2 {:.4}% unexpectedly large",
+        finest * 100.0
     );
 }
 

--- a/crates/geode-core/tests/slotless_pm_field.rs
+++ b/crates/geode-core/tests/slotless_pm_field.rs
@@ -31,11 +31,12 @@ use geode_core::analytic::slotless_pm::{
     MU_0, SlotlessPm, current_sheet_exterior_coeff, self_validation_rel_error,
 };
 use geode_core::analytic::waveguide::{
-    RadialGrading, TriMesh, disk_boundary_nodes, disk_tri_mesh_bands,
+    RadialGrading, TriMesh, disk_boundary_nodes, disk_p2_boundary_dofs, disk_tri_mesh_bands,
 };
 use geode_core::assembly::magnetostatic::{
-    assemble_magnetostatic_pm, build_nu_r, radial_magnetization_source,
-    radial_magnetization_source_from_remanence, recover_b_field,
+    assemble_magnetostatic_pm, assemble_magnetostatic_pm_p2, build_nu_r,
+    radial_magnetization_source, radial_magnetization_source_from_remanence, recover_b_field,
+    sample_b_field_p2,
 };
 
 // Band indices for the four-band machine cross-section
@@ -105,6 +106,58 @@ fn solve_pm(
     let a_z = sys.solve().expect("PM solve");
     let b = recover_b_field(&mesh, &a_z);
     (mesh, tags, b)
+}
+
+/// Solve the pure-PM problem with the **P2** (quadratic) solver and return
+/// `(mesh, band_tags, u)` where `u` is the length-`(n_nodes + n_edges)`
+/// quadratic potential. Mirrors [`solve_pm`] on inputs; the field is
+/// recovered by point-sampling the P2 solution (see [`midgap_contour_l2_p2`]).
+fn solve_pm_p2(
+    g: &Geom,
+    n_ang: usize,
+    n_rad: [usize; 4],
+    m0: f64,
+    p: u32,
+) -> (TriMesh, Vec<i32>, Vec<f64>) {
+    let (mesh, tags) = build_mesh(g, n_ang, n_rad);
+    let n_tris = mesh.n_tris();
+    let nu = build_nu_r(&tags, &[1.0, 1.0, 1.0, 1.0]);
+    let j_z = vec![0.0; n_tris];
+    let m = radial_magnetization_source(&mesh, &tags, TAG_MAGNET, m0, p);
+    let bc = disk_p2_boundary_dofs(&mesh, g.rout);
+    let sys = assemble_magnetostatic_pm_p2(&mesh, &nu, &j_z, &m, &bc).expect("assemble PM P2");
+    let u = sys.solve().expect("PM P2 solve");
+    (mesh, tags, u)
+}
+
+/// L2 relative error of the **P2** FEM air-gap field vs the oracle, sampled
+/// on the mid-gap θ-contour. Unlike the P1 sampler (which reads the
+/// piecewise-constant per-triangle `B`), this evaluates the P2 field at the
+/// actual contour point via [`sample_b_field_p2`] — the linear-per-triangle
+/// `B` earns its second-order accuracy only when sampled at the point, not a
+/// centroid. `(B_r, B_θ)` compared component-wise.
+fn midgap_contour_l2_p2(
+    mesh: &TriMesh,
+    u: &[f64],
+    oracle: &SlotlessPm,
+    r_gap: f64,
+    n_contour: usize,
+) -> f64 {
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for i in 0..n_contour {
+        let theta = std::f64::consts::TAU * i as f64 / n_contour as f64;
+        let (px, py) = (r_gap * theta.cos(), r_gap * theta.sin());
+        let bxy = sample_b_field_p2(mesh, u, px, py).expect("contour point inside mesh");
+        let (br_o, bth_o) = oracle.exterior_field(r_gap, theta);
+        let (c, s) = (theta.cos(), theta.sin());
+        let (bx, by) = (bxy[0], bxy[1]);
+        let br = bx * c + by * s;
+        let bth = -bx * s + by * c;
+        num += (br - br_o).powi(2) + (bth - bth_o).powi(2);
+        den += br_o.powi(2) + bth_o.powi(2);
+    }
+    (num / den).sqrt()
 }
 
 /// Locate the triangle containing point `(px, py)` by barycentric test.
@@ -322,6 +375,140 @@ fn airgap_field_p1_convergence() {
             finest * 100.0
         );
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3b. Air-gap field oracle — P2 (quadratic) HEADLINE: ≤1% (issue #472,
+//     AC #1). Retires the honest P1 miss documented above.
+// ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn airgap_field_p2_within_one_percent() {
+    // THE HEADLINE (issue #472 AC #1): the P2 (quadratic-Lagrange) solver's
+    // mid-gap air-gap |B_r, B_θ| contour L2 vs the SlotlessPm exact oracle
+    // must clear the ≤1% bar on a *practical* mesh — the bar P1 could not
+    // reach.
+    //
+    // Apples-to-apples with the P1 convergence table in
+    // `airgap_field_p1_convergence` (same Geom::nominal geometry, same
+    // (n_ang, n_rad) refinement schedule, same 180-point mid-gap contour):
+    //
+    //   P1 (piecewise-constant B):  7.692 → 4.180 → 3.646 → 2.444%
+    //     at nodes 2593 → 7873 → 16705 → 29185 (n_ang 96/192/288/384).
+    //
+    // P1 never cleared 1%; first-order extrapolation put sub-1% at ~100k+
+    // nodes. P2's piecewise-linear B is second order, so it clears the bar
+    // well below the 384-angular / ~29k-node mesh where P1 sat at 2.44%.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    println!("--- slotless-PM air-gap field: P2 mid-gap contour L2 (headline) ---");
+    let mut prev = f64::INFINITY;
+    let mut finest = f64::INFINITY;
+    let mut finest_nodes = 0usize;
+    for &(n_ang, n_rad) in &[
+        (96usize, [6usize, 8, 3, 10]),
+        (192, [10, 12, 5, 14]),
+        (288, [14, 16, 8, 20]),
+        (384, [18, 20, 12, 26]),
+    ] {
+        let (mesh, _tags, u) = solve_pm_p2(&g, n_ang, n_rad, g.m0, g.p);
+        let err = midgap_contour_l2_p2(&mesh, &u, &oracle, g.r_gap(), 180);
+        println!(
+            "  n_ang={n_ang:3} nodes={:6} mid-gap L2 = {:.3}%   (P1 was 7.69/4.18/3.65/2.44%)",
+            mesh.n_nodes(),
+            err * 100.0
+        );
+        // Monotone refinement (second-order convergence sanity).
+        assert!(
+            err < prev * 1.02,
+            "P2 refinement did not reduce error: {err} vs {prev}"
+        );
+        prev = err;
+        finest = err;
+        finest_nodes = mesh.n_nodes();
+    }
+    // AC #1: the finest practical mesh (≤ ~30k nodes, at/below the 384-angular
+    // mesh where P1 sat at 2.44%) clears the ≤1% bar.
+    assert!(
+        finest <= 0.01,
+        "finest P2 mid-gap L2 {:.3}% at {finest_nodes} nodes exceeds the 1% headline bar \
+         — the P2 field floor was not lifted below 1%",
+        finest * 100.0
+    );
+    assert!(
+        finest_nodes <= 30_000,
+        "finest mesh {finest_nodes} nodes exceeds the ~30k practical-mesh cap"
+    );
+    println!(
+        "HEADLINE PASS: P2 mid-gap L2 = {:.3}% at {finest_nodes} nodes (≤1% bar; \
+         P1 sat at 2.44% at 29185 nodes). Epic #448's only missed bar is retired.",
+        finest * 100.0
+    );
+}
+
+/// Per-triangle-centroid L2 error over the air-gap band for the **P2**
+/// solution (area-weighted continuous L2), an alternative to contour
+/// sampling used by the P2 tripwire. Uses centroid `B` from the P2 field.
+fn gap_band_l2_p2(mesh: &TriMesh, tags: &[i32], u: &[f64], oracle: &SlotlessPm) -> f64 {
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (t, tri) in mesh.tris.iter().enumerate() {
+        if tags[t] != TAG_GAP {
+            continue;
+        }
+        let c0 = mesh.nodes[tri[0] as usize];
+        let c1 = mesh.nodes[tri[1] as usize];
+        let c2 = mesh.nodes[tri[2] as usize];
+        let cx = (c0[0] + c1[0] + c2[0]) / 3.0;
+        let cy = (c0[1] + c1[1] + c2[1]) / 3.0;
+        let r = (cx * cx + cy * cy).sqrt();
+        let theta = cy.atan2(cx);
+        let area =
+            0.5 * ((c1[0] - c0[0]) * (c2[1] - c0[1]) - (c1[1] - c0[1]) * (c2[0] - c0[0])).abs();
+        let bxy = sample_b_field_p2(mesh, u, cx, cy).expect("centroid inside mesh");
+        let (br_o, bth_o) = oracle.exterior_field(r, theta);
+        let (cc, ss) = (theta.cos(), theta.sin());
+        let br = bxy[0] * cc + bxy[1] * ss;
+        let bth = -bxy[0] * ss + bxy[1] * cc;
+        num += area * ((br - br_o).powi(2) + (bth - bth_o).powi(2));
+        den += area * (br_o.powi(2) + bth_o.powi(2));
+    }
+    (num / den).sqrt()
+}
+
+#[test]
+fn p2_wrong_sign_tripwire_fires() {
+    // Inverse tripwire (issue #472 AC #4): flip the magnetization sign and
+    // the P2 field error must blow far past the 1% pass bar — the ≤1%
+    // headline is not trivially satisfiable.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    let (mesh, tags, u) = solve_pm_p2(&g, 192, [10, 12, 5, 14], -g.m0, g.p);
+    let err = gap_band_l2_p2(&mesh, &tags, &u, &oracle);
+    println!("P2 wrong-sign tripwire: gap L2 = {:.1}%", err * 100.0);
+    assert!(
+        err > 0.5,
+        "P2 wrong-sign error {:.2}% did not exceed the 50% floor — tripwire broken",
+        err * 100.0
+    );
+}
+
+#[test]
+fn p2_coarse_gap_tripwire_fires() {
+    // Correct magnetization but a very coarse gap: even P2's second-order
+    // recovery cannot resolve the rapidly-varying field, so the error stays
+    // well above the 1% bar — confirming the headline pass is earned by
+    // resolution, not by a solver that reports low error unconditionally.
+    let g = Geom::nominal();
+    let oracle = g.oracle();
+    let (mesh, _tags, u) = solve_pm_p2(&g, 24, [2, 2, 1, 3], g.m0, g.p);
+    let err = midgap_contour_l2_p2(&mesh, &u, &oracle, g.r_gap(), 60);
+    println!("P2 coarse-gap tripwire: mid-gap L2 = {:.1}%", err * 100.0);
+    assert!(
+        err > 0.05,
+        "P2 coarse-gap error {:.2}% did not exceed the 5% floor",
+        err * 100.0
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds an **additive quadratic-Lagrange (P2)** path to the 2-D scalar magnetostatic Poisson solver, lifting air-gap `|B|` recovery from P1's first-order (piecewise-constant `B`) to **second order** (piecewise-linear `B`). This retires the single honest miss from Epic #448: the mid-gap air-gap field L2 vs the `SlotlessPm` exact oracle, where P1 sat at **2.44%** at 29k nodes against a ≤1% bar.

**Headline result (AC #1):** P2 mid-gap contour L2 = **0.211% at 29185 nodes** (P1 was 2.44% at the same mesh) — a ~12× accuracy improvement. P2 clears the ≤1% bar even at the **coarsest 2593-node mesh** (0.383%), far below the ~30k practical-mesh cap.

Apples-to-apples with the P1 convergence table (same `Geom::nominal` geometry, same `(n_ang, n_rad)` schedule, same 180-point contour):

| n_ang | nodes | P1 mid-gap L2 | P2 mid-gap L2 |
|------:|------:|--------------:|--------------:|
| 96  | 2593  | 7.692% | **0.383%** |
| 192 | 7873  | 4.180% | **0.235%** |
| 288 | 16705 | 3.646% | **0.226%** |
| 384 | 29185 | 2.444% | **0.211%** |

## Changes

**Element kernel (`analytic/waveguide.rs`):**
- `tri_p2_local` — 6-DOF quadratic scalar Lagrange kernel (3 vertex + 3 edge-midpoint), 6×6 stiffness `∫∇φ·∇φ` and consistent mass `∫φφ`, integrated with the shared degree-4 rule `TRI_QUAD_DEG4` and the shared `tri_bary_grads` geometry (P1/P2/Nédélec geometry cannot drift).
- `disk_p2_boundary_dofs` — P2 Dirichlet mask over the `n_nodes + n_edges` DOFs, pinning both boundary **vertex** DOFs and boundary-**edge midpoint** DOFs.

**Global assembler (`assembly/magnetostatic.rs`, all additive):**
- `assemble_magnetostatic_p2` / `assemble_magnetostatic_pm_p2` — DOF numbering `n_nodes + n_edges` reusing the existing `TriMesh::edges()`/`tri_edges()` (the Nédélec `sign` field is deliberately ignored — scalar Lagrange DOFs are unsigned), ν-weighted `K`, consistent-mass current RHS, symmetric Dirichlet elimination.
- `assemble_magnetization_rhs_p2` — the same IBP weak-form magnetization source as P1, but with the P2 test-functions' **linear** gradients integrated by quadrature (no constant-gradient shortcut).
- `recover_b_field_p2` (per-triangle centroid) and `sample_b_field_p2` (arbitrary point) for the linear-per-triangle `B`; `p2_dof_count` helper.

**P1 path untouched:** `assemble_magnetostatic*`, `recover_b_field`, `tri_p1_local` are bit-for-bit unchanged (the only source deletion is expanding one `use` line). The merged torque benchmarks and their committed fixtures depend on the P1 path.

This is host-side slice/faer code with zero Burn-Tensor sites (per the #470 audit the magnetostatic module has no Tensor sites), so the Bunsen `define_shape_contract!` convention does not apply here — plain asserts are correct, matching the P1 kernel's style.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| AC #1 — mid-gap `|B_r,B_θ|` L2 ≤ 1% vs `SlotlessPm` on a practical mesh (≤~30k nodes) | ✅ | `airgap_field_p2_within_one_percent`: **0.211% at 29185 nodes**; passes even at 2593 nodes (0.383%) |
| AC #2 — O(h²) convergence on the wire oracle (slope ≥ ~1.8) | ✅ | `wire_p2_second_order_convergence`: fitted log-log slope **1.961** (P1 ≈ 1) |
| AC #3 — P1 path bit-for-bit unchanged; all existing binaries green | ✅ | No edits to P1 functions; `magnetostatic_wire`, `slotless_pm_field` (P1 tests), `magnetostatic_heterogeneous`, `torque_loop_oracle`, `motor_torque_benchmark`, `--lib` (275 tests) all pass; full `--release --tests` suite green |
| AC #4 — inverse tripwire above the 1% bar | ✅ | `p2_wrong_sign_tripwire_fires` (200%), `p2_coarse_gap_tripwire_fires` (16.9%) |
| AC #5 — stretch (P2 torque re-run) | ⏸️ | Not pursued: the headline landed with wide margin (0.211% ≪ 1%); torque was already CLEAN POSITIVE (0.71% Arkkio) and is unaffected. Left as an optional future follow-on to keep this PR scoped. |

Plus unit tests: `tri_p2_local` row-sums 0, symmetric PSD, `sum(M)=area`, partition of unity at quadrature points, and reduction to the P1 Dirichlet energy on a linear field.

## Test Plan

Gates run in the worktree (all green):
- `cargo fmt --all --check` ✅
- `cargo clippy -p geode-core --all-targets -- -D warnings` ✅
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` ✅
- `cargo test -p geode-core --lib` — 275 passed ✅
- New + regression binaries: `magnetostatic_wire` (15 passed inc. P2 unit + O(h²)), `slotless_pm_field` (9 passed inc. P2 headline + tripwires), `magnetostatic_heterogeneous`, `torque_loop_oracle` (4), `motor_torque_benchmark` (5) ✅
- `cargo test -p geode-core --release --tests` — full suite green, 0 failed ✅

Closes #472