### PR TITLE
feat(assembly): matrix-free Nédélec curl-curl + mass matvec on Burn

### DIFF
--- a/crates/geode-core/src/assembly/mod.rs
+++ b/crates/geode-core/src/assembly/mod.rs
@@ -40,6 +40,7 @@ pub mod electrostatic;
 pub mod fe;
 pub mod magnetostatic;
 pub mod nedelec;
+pub mod nedelec_matvec;
 pub mod p1;
 pub mod sparse;
 pub mod surface;

--- a/crates/geode-core/src/assembly/nedelec_matvec.rs
+++ b/crates/geode-core/src/assembly/nedelec_matvec.rs
@@ -1,0 +1,359 @@
+//! Matrix-free first-order Nédélec curl-curl + mass **matvec** on Burn
+//! (#302 Phase 1).
+//!
+//! The assembled path in [`crate::assembly::nedelec`] scatters the signed
+//! per-element `[n_elem, 6, 6]` local stiffness/mass into a global operator
+//! (dense `[n_edges, n_edges]` or `[nnz]` CSR-style value tensor) and then
+//! a downstream `spmv`/matmul applies it to a vector. This module skips the
+//! global assembly entirely: it applies `y = A · x` element-locally, with
+//! **no global CSR ever formed**, on Burn tensors, batched over all elements
+//! at once. This is the "apply without materializing" composition the #302
+//! GPU-resident-solve design (`Gᵀ ∘ B_𝒟ᵀ ∘ D ∘ B_𝒟 ∘ G`) is built on: the
+//! dense `[n_edges²]` Burn operator is a non-starter at the 54 k-edge
+//! benchmark scale (~23 GB), while the matrix-free apply only ever holds the
+//! `[n_elem, 6, 6]` locals plus `[n_edges]` vectors.
+//!
+//! # Apply structure (rank-structured, element-axis batched)
+//!
+//! For a global edge-DOF vector `x ∈ ℝ^{n_edges}`, one `A · x` is:
+//!
+//! 1. **Gather** `G`: pull each tet's six edge DOFs from `x` into a batched
+//!    `[n_elem, 6, 1]` stack, using the same `tet_edge_idx` global-edge
+//!    indices the assembler scatters through.
+//! 2. **Local apply** `D`: a batched `[n_elem, 6, 6] · [n_elem, 6, 1]` matmul
+//!    against the **signed** local matrix `\tilde{A}^e_{ij} = s^e_i s^e_j
+//!    A^e_{ij}` — the exact orientation-sign outer product
+//!    ([`sign_outer`](crate::assembly::nedelec)) the assembled path folds in
+//!    before scatter, so the two agree.
+//! 3. **Scatter-add** `Gᵀ`: accumulate the `[n_elem, 6]` local results back
+//!    into a zero `[n_edges]` vector with a 1-D `scatter(0, …, Add)`, the
+//!    transpose of the gather and the same primitive the assembler uses.
+//!
+//! Because both the assembled operator and this apply fold the *same* signed
+//! local matrices through the *same* edge-DOF numbering, `matrix_free(x)`
+//! equals `assembled_A · x` to round-off — validated to ~1e-12 on the
+//! ndarray-f64 backend in `tests/nedelec_matrix_free_equivalence.rs`.
+//!
+//! # Dirichlet / interior-DOF convention
+//!
+//! The assembled driven/eigen paths reduce to an **interior** submatrix by
+//! deleting the rows/columns of PEC-constrained (boundary) edge DOFs. The
+//! matrix-free apply cannot slice a submatrix out of an un-materialized
+//! operator, so it reproduces the same reduction by **masking at gather and
+//! scatter time**: constrained DOFs are zeroed in the input before the local
+//! apply (kills the constrained *columns*) and zeroed in the output after
+//! scatter (kills the constrained *rows*). The result is the interior
+//! operator embedded back into the full `[n_edges]` space — i.e. it agrees
+//! with the assembled full-space matrix restricted to interior DOFs, and is
+//! zero on constrained DOFs. See [`MatrixFreeNedelecOperator::with_mask`] and
+//! the masking unit test.
+//!
+//! # Precision / backend note
+//!
+//! The f64 conformance bar runs on the ndarray backend. `burn-cuda 0.21` has
+//! **no f64** (cubecl disables it), so the CUDA leg is a feature-gated f32
+//! smoke test only, deferred to the rented box — see the equivalence test
+//! file. Nothing here enables CUDA in a default build.
+
+use bunsen::contracts::{assert_shape_contract, define_shape_contract, unpack_shape_contract};
+use burn::tensor::backend::Backend;
+use burn::tensor::{IndexingUpdateOp, Int, Tensor, TensorData};
+
+use crate::assembly::p1::gather_tet_coords;
+use crate::elements::nedelec::batched_nedelec_local_matrices;
+
+/// Number of vertices per linear tetrahedron. Bound into
+/// [`MATVEC_CONNECTIVITY_CONTRACT`] as `nodes_per_tet`.
+const NODES_PER_TET: usize = 4;
+
+/// Number of local edge DOFs of a first-order Nédélec tetrahedron (its 6
+/// edges). Bound into [`MATVEC_LOCAL_MATRIX_CONTRACT`] as `edges_per_tet`.
+const EDGES_PER_TET: usize = 6;
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen — mirrors the assembly/nedelec set)
+// ---------------------------------------------------------------------------
+
+// Connectivity table `T \in \mathbb{Z}^{n_elem × 4}` — the four global node
+// indices of every tet. `nodes_per_tet` is bound to `NODES_PER_TET` (`= 4`).
+define_shape_contract!(MATVEC_CONNECTIVITY_CONTRACT, ["n_elem", "nodes_per_tet"]);
+
+// Signed element-local edge-matrix stack `\tilde{A}^{local} \in
+// \mathbb{R}^{n_elem × 6 × 6}`: one `6×6` dense local operator per tet after
+// the orientation-sign outer product `s_i s_j` is folded in. Both
+// `edges_per_tet` axes are bound to `EDGES_PER_TET` (`= 6`).
+define_shape_contract!(
+    MATVEC_LOCAL_MATRIX_CONTRACT,
+    ["n_elem", "edges_per_tet", "edges_per_tet"]
+);
+
+// Per-tet gathered / applied edge-DOF column stack `\in \mathbb{R}^{n_elem ×
+// 6 × 1}` — the batched right-hand side (gather) and result (local apply) of
+// the `[n_elem, 6, 6] · [n_elem, 6, 1]` matmul. `edges_per_tet` bound to 6,
+// the trailing column axis to 1.
+define_shape_contract!(
+    MATVEC_ELEM_COLUMN_CONTRACT,
+    ["n_elem", "edges_per_tet", "one"]
+);
+
+// Global edge-DOF vector `x \in \mathbb{R}^{n_edges}` — the matvec operand
+// and result. `n_edges` is left free; the operator checks the supplied vector
+// length against its own `n_edges` explicitly (a scalar, not a tensor axis).
+define_shape_contract!(MATVEC_GLOBAL_VECTOR_CONTRACT, ["n_edges"]);
+
+/// Matrix-free first-order Nédélec curl-curl + mass operator on a fixed mesh.
+///
+/// Holds the precomputed **signed** element-local matrices (stiffness `K` and
+/// mass `M`, each `[n_elem, 6, 6]` with the `s_i s_j` orientation signs
+/// folded in) and the gather/scatter edge-DOF numbering, so repeated
+/// [`apply_k`](Self::apply_k) / [`apply_m`](Self::apply_m) /
+/// [`apply_combination`](Self::apply_combination) calls (e.g. a Krylov loop)
+/// reuse them without re-running the batched local kernel.
+///
+/// No global CSR / dense operator is ever formed — the memory footprint is
+/// `O(n_elem · 36 + n_edges)`, not `O(n_edges²)` or `O(nnz)`.
+#[derive(Debug, Clone)]
+pub struct MatrixFreeNedelecOperator<B: Backend> {
+    /// Signed local curl-curl stiffness `[n_elem, 6, 6]` (signs folded in).
+    k_signed: Tensor<B, 3>,
+    /// Signed local mass `[n_elem, 6, 6]` (signs folded in).
+    m_signed: Tensor<B, 3>,
+    /// Flattened per-`(element, local-edge)` global edge index `[n_elem * 6]`,
+    /// used by both the gather (`select(0, …)`) and the scatter-add
+    /// (`scatter(0, …, Add)`).
+    edge_idx_flat: Tensor<B, 1, Int>,
+    /// Optional interior-DOF mask `[n_edges]` (`1.0` interior, `0.0`
+    /// constrained). `None` means the full-space (unconstrained) operator.
+    mask: Option<Tensor<B, 1>>,
+    /// Size of the global linear system (number of edge DOFs).
+    n_edges: usize,
+    /// Number of elements — cached for the batched reshape.
+    n_elem: usize,
+    /// Device the operator tensors live on.
+    device: B::Device,
+}
+
+impl<B: Backend> MatrixFreeNedelecOperator<B> {
+    /// Build the operator from a mesh (node coords + connectivity) and its
+    /// per-tet edge index/sign tables, scaling the mass by a per-element
+    /// relative permittivity `epsilon_r`.
+    ///
+    /// The stiffness carries no material weight (the curl-curl integrand is
+    /// permittivity-independent); the mass is scaled per element by
+    /// `epsilon_r[e]` — exactly the
+    /// [`assemble_global_nedelec_with_epsilon`](crate::assembly::nedelec::assemble_global_nedelec_with_epsilon)
+    /// convention, so the two paths' operators match.
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes` — `[n_nodes, 3]` global node coordinates.
+    /// * `tets` — `[n_elem, 4]` connectivity (0-based node indices).
+    /// * `tet_edge_idx` — `[n_elem, 6]` global edge index per local edge
+    ///   (from [`crate::mesh::TetMesh::tet_edges`]).
+    /// * `tet_edge_sign` — `[n_elem, 6]` per-DOF orientation sign in
+    ///   `{-1, +1}`.
+    /// * `n_edges` — size of the global linear system.
+    /// * `epsilon_r` — per-element relative permittivity `[n_elem]`
+    ///   multiplying the mass. Pass all-`1.0` for the vacuum operator.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any length mismatch between `tets`, the edge tables, and
+    /// `epsilon_r`, or if `tets` is not `[*, 4]`.
+    pub fn new(
+        nodes: Tensor<B, 2>,
+        tets: Tensor<B, 2, Int>,
+        tet_edge_idx: &[[u32; 6]],
+        tet_edge_sign: &[[i8; 6]],
+        n_edges: usize,
+        epsilon_r: &[f64],
+    ) -> Self {
+        let device = nodes.device();
+        // Connectivity `T \in \mathbb{Z}^{n_elem × 4}` — extract `n_elem` and
+        // check the 4-vertex arity through the shared named contract.
+        let [n_elem] = unpack_shape_contract!(
+            MATVEC_CONNECTIVITY_CONTRACT,
+            &tets,
+            &["n_elem"],
+            &[("nodes_per_tet", NODES_PER_TET)],
+        );
+        assert_eq!(tet_edge_idx.len(), n_elem, "tet_edge_idx length mismatch");
+        assert_eq!(tet_edge_sign.len(), n_elem, "tet_edge_sign length mismatch");
+        assert_eq!(epsilon_r.len(), n_elem, "epsilon_r length mismatch");
+
+        // Element-local stiffness and mass (sign-unaware).
+        let coords = gather_tet_coords(nodes, tets);
+        let local = batched_nedelec_local_matrices(coords);
+
+        // Scale mass by per-element epsilon_r (broadcast over the 6×6 block) —
+        // identical f32 upload to the assembled `_with_epsilon` path.
+        let eps_flat: Vec<f32> = epsilon_r.iter().map(|&e| e as f32).collect();
+        let eps_3d = Tensor::<B, 1>::from_data(TensorData::new(eps_flat, [n_elem]), &device)
+            .unsqueeze_dim::<2>(1)
+            .unsqueeze_dim::<3>(2); // [n_elem, 1, 1]
+        let m_local_scaled = local.m_local.mul(eps_3d);
+
+        // Orientation-sign outer product `s_i s_j`, `[n_elem, 6, 6]` — same
+        // arithmetic (f32 upload, broadcast multiply) as the assembler, so the
+        // signed locals agree bit-for-bit with the assembled path.
+        let sign_flat: Vec<f32> = tet_edge_sign
+            .iter()
+            .flat_map(|row| row.iter().map(|&s| s as f32))
+            .collect();
+        let sign_2d = Tensor::<B, 2>::from_data(TensorData::new(sign_flat, [n_elem, 6]), &device);
+        let sign_row = sign_2d.clone().unsqueeze_dim::<3>(2); // [n_elem, 6, 1]
+        let sign_col = sign_2d.unsqueeze_dim::<3>(1); // [n_elem, 1, 6]
+        let sign_outer = sign_row.mul(sign_col); // [n_elem, 6, 6]
+
+        let k_signed = local.k_local.mul(sign_outer.clone());
+        let m_signed = m_local_scaled.mul(sign_outer);
+
+        // Flatten the per-(element, local-edge) global edge indices to a single
+        // `[n_elem * 6]` Int tensor, reused by every gather and scatter.
+        let idx_flat: Vec<i32> = tet_edge_idx
+            .iter()
+            .flat_map(|row| row.iter().map(|&e| e as i32))
+            .collect();
+        let edge_idx_flat =
+            Tensor::<B, 1, Int>::from_data(TensorData::new(idx_flat, [n_elem * 6]), &device);
+
+        Self {
+            k_signed,
+            m_signed,
+            edge_idx_flat,
+            mask: None,
+            n_edges,
+            n_elem,
+            device,
+        }
+    }
+
+    /// Attach an interior-DOF mask `[n_edges]` (`true` = interior/kept,
+    /// `false` = PEC-constrained/eliminated).
+    ///
+    /// With a mask attached, every [`apply_*`](Self::apply_k) result is the
+    /// **interior** operator embedded in the full `[n_edges]` space: the
+    /// operand is zeroed on constrained DOFs before the local apply (deletes
+    /// constrained columns) and the result is zeroed on constrained DOFs after
+    /// scatter (deletes constrained rows). This matches the row/column
+    /// deletion the assembled driven/eigen paths perform to obtain their
+    /// interior submatrix.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interior_mask.len() != n_edges`.
+    #[must_use]
+    pub fn with_mask(mut self, interior_mask: &[bool]) -> Self {
+        assert_eq!(
+            interior_mask.len(),
+            self.n_edges,
+            "interior_mask length must equal n_edges"
+        );
+        let mask_flat: Vec<f32> = interior_mask
+            .iter()
+            .map(|&keep| if keep { 1.0 } else { 0.0 })
+            .collect();
+        let mask =
+            Tensor::<B, 1>::from_data(TensorData::new(mask_flat, [self.n_edges]), &self.device);
+        self.mask = Some(mask);
+        self
+    }
+
+    /// Number of global edge DOFs (the operator dimension).
+    pub fn n_edges(&self) -> usize {
+        self.n_edges
+    }
+
+    /// Number of elements the operator was built from.
+    pub fn n_elem(&self) -> usize {
+        self.n_elem
+    }
+
+    /// Apply the curl-curl stiffness: `y = K · x`.
+    pub fn apply_k(&self, x: Tensor<B, 1>) -> Tensor<B, 1> {
+        self.apply_local(x, &self.k_signed)
+    }
+
+    /// Apply the (ε-weighted) mass: `y = M · x`.
+    pub fn apply_m(&self, x: Tensor<B, 1>) -> Tensor<B, 1> {
+        self.apply_local(x, &self.m_signed)
+    }
+
+    /// Apply the driven-style combination `y = (α K + β M) · x` in a single
+    /// gather/scatter pass.
+    ///
+    /// The driven operator (real part) is `A = K − ω² M`; pass `alpha = 1.0`,
+    /// `beta = -omega * omega`. Computing the combined local operator
+    /// `α K^e + β M^e` before the batched apply means only **one** gather and
+    /// **one** scatter, half the traffic of separate `apply_k` + `apply_m`.
+    pub fn apply_combination(&self, x: Tensor<B, 1>, alpha: f64, beta: f64) -> Tensor<B, 1> {
+        let combined = self
+            .k_signed
+            .clone()
+            .mul_scalar(alpha)
+            .add(self.m_signed.clone().mul_scalar(beta));
+        self.apply_local(x, &combined)
+    }
+
+    /// Shared gather → batched local apply → scatter-add kernel.
+    ///
+    /// `local` is a signed `[n_elem, 6, 6]` per-element operator. Returns the
+    /// full-space `[n_edges]` result, with the interior mask applied on both
+    /// sides if one is attached.
+    fn apply_local(&self, x: Tensor<B, 1>, local: &Tensor<B, 3>) -> Tensor<B, 1> {
+        // Operand `x \in \mathbb{R}^{n_edges}` — length must match the operator.
+        assert_shape_contract!(MATVEC_GLOBAL_VECTOR_CONTRACT, &x, &[]);
+        assert_eq!(
+            x.dims()[0],
+            self.n_edges,
+            "operand length {} != operator n_edges {}",
+            x.dims()[0],
+            self.n_edges
+        );
+
+        // Mask constrained DOFs on the input (deletes constrained columns).
+        let x = match &self.mask {
+            Some(m) => x.mul(m.clone()),
+            None => x,
+        };
+
+        // Signed local operator `\tilde{A}^{local} \in \mathbb{R}^{n_elem×6×6}`.
+        assert_shape_contract!(
+            MATVEC_LOCAL_MATRIX_CONTRACT,
+            local,
+            &[("edges_per_tet", EDGES_PER_TET)],
+        );
+
+        // 1. Gather `G`: pull each tet's six edge DOFs into `[n_elem, 6, 1]`.
+        let x_gathered = x.select(0, self.edge_idx_flat.clone()); // [n_elem * 6]
+        let x_elem = x_gathered.reshape([self.n_elem, EDGES_PER_TET, 1]);
+        assert_shape_contract!(
+            MATVEC_ELEM_COLUMN_CONTRACT,
+            &x_elem,
+            &[("edges_per_tet", EDGES_PER_TET), ("one", 1)],
+        );
+
+        // 2. Local apply `D`: batched `[n_elem, 6, 6] · [n_elem, 6, 1]`.
+        let y_elem = local.clone().matmul(x_elem); // [n_elem, 6, 1]
+        assert_shape_contract!(
+            MATVEC_ELEM_COLUMN_CONTRACT,
+            &y_elem,
+            &[("edges_per_tet", EDGES_PER_TET), ("one", 1)],
+        );
+
+        // 3. Scatter-add `Gᵀ`: accumulate into a zero `[n_edges]` vector.
+        let y_flat = y_elem.reshape([self.n_elem * EDGES_PER_TET]);
+        let y = Tensor::<B, 1>::zeros([self.n_edges], &self.device).scatter(
+            0,
+            self.edge_idx_flat.clone(),
+            y_flat,
+            IndexingUpdateOp::Add,
+        );
+
+        // Mask constrained DOFs on the output (deletes constrained rows).
+        match &self.mask {
+            Some(m) => y.mul(m.clone()),
+            None => y,
+        }
+    }
+}

--- a/crates/geode-core/tests/nedelec_matrix_free_equivalence.rs
+++ b/crates/geode-core/tests/nedelec_matrix_free_equivalence.rs
@@ -1,0 +1,388 @@
+//! Matrix-free Nédélec matvec vs assembled-CSR/dense matvec (#302 Phase 1).
+//!
+//! The **acceptance gate** for #302 Phase 1: the matrix-free apply in
+//! [`geode_core::assembly::nedelec_matvec::MatrixFreeNedelecOperator`]
+//! (gather → batched dense `[n_elem,6,6]·[n_elem,6,1]` local apply →
+//! signed scatter-add, no global operator materialized) must agree with the
+//! assembled operator's matvec to ~1e-12 on the ndarray-f64 backend.
+//!
+//! The reference matvec is `y = A · x` computed against the **assembled dense
+//! global matrix** `A ∈ ℝ^{n_edges × n_edges}` produced by the existing
+//! [`geode_core::assembly::nedelec::assemble_global_nedelec`] /
+//! `_with_epsilon` path — the same matrix the driven/eigen CSR `spmv` applies,
+//! read to host and multiplied in plain f64. Testing against the assembled
+//! *matrix* (rather than a specific `faer` `SparseColMat` `spmv`) keeps the
+//! gate on the mathematical operator equivalence, which is the point of
+//! Phase 1, without pulling the solver seam into scope.
+//!
+//! Coverage:
+//!
+//! 1. `apply_k` vs assembled `K · x` — curl-curl stiffness, multiple vectors.
+//! 2. `apply_m` vs assembled `M(ε) · x` — ε-weighted mass, multiple vectors.
+//! 3. `apply_combination(x, 1, -ω²)` vs assembled `(K − ω² M) · x` — the
+//!    driven-style real operator.
+//! 4. Sign convention: on a two-tet shared-edge mesh the matrix-free signed
+//!    contributions reproduce the assembled scatter exactly.
+//! 5. Dirichlet/interior masking: the masked operator equals the assembled
+//!    full-space matrix with constrained rows/cols deleted (embedded back
+//!    into the full space).
+//! 6. `should_panic` firing test on a wrong-length operand (Bunsen contract).
+//!
+//! A `cuda`-feature-gated f32 smoke test (~1e-5 tolerance) is included but
+//! `#[ignore]`d — `burn-cuda 0.21` has no f64, so it runs only on the rented
+//! EC2 box, never in CI.
+
+use burn::tensor::backend::BackendTypes;
+use burn::tensor::{Tensor, TensorData};
+use geode_core::assembly::nedelec::{
+    assemble_global_nedelec, assemble_global_nedelec_with_epsilon, cube_pec_interior_edges,
+};
+use geode_core::assembly::nedelec_matvec::MatrixFreeNedelecOperator;
+use geode_core::assembly::p1::upload_mesh;
+use geode_core::mesh::{TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// Split `mesh.tet_edges()` into the `(idx, sign)` tables the assemblers take.
+fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+    let te = mesh.tet_edges();
+    (
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect(),
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect(),
+    )
+}
+
+/// Read a dense `[n, n]` Burn matrix to a host row-major `Vec<f64>`.
+fn dense_to_host(t: Tensor<B, 2>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+/// Read a `[n]` Burn vector to a host `Vec<f64>`.
+fn vec_to_host(t: Tensor<B, 1>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+/// Reference dense matvec `y = A · x` on host, row-major `[n, n]` matrix.
+fn dense_matvec(a: &[f64], x: &[f64], n: usize) -> Vec<f64> {
+    let mut y = vec![0.0; n];
+    for (i, yi) in y.iter_mut().enumerate() {
+        let row = &a[i * n..(i + 1) * n];
+        *yi = row.iter().zip(x.iter()).map(|(&aij, &xj)| aij * xj).sum();
+    }
+    y
+}
+
+/// Deterministic pseudo-random f64 vector in `[-1, 1)` from a 64-bit LCG seed
+/// (reproducible, no `rand` dependency).
+fn pseudo_random_vec(n: usize, seed: u64) -> Vec<f64> {
+    let mut state = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+    (0..n)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            // Top 53 bits → [0, 1) → shift to [-1, 1).
+            let u = (state >> 11) as f64 / (1u64 << 53) as f64;
+            2.0 * u - 1.0
+        })
+        .collect()
+}
+
+/// Upload a host `Vec<f64>` as a `[n]` Burn tensor.
+fn upload_vec(x: &[f64], dev: &<B as BackendTypes>::Device) -> Tensor<B, 1> {
+    Tensor::<B, 1>::from_data(TensorData::new(x.to_vec(), [x.len()]), dev)
+}
+
+/// Max absolute deviation and **norm-scaled** relative deviation between two
+/// host vectors: `(max_i |a_i − b_i|, ‖a − b‖∞ / ‖b‖∞)`.
+///
+/// The norm-scaled relative measure is the standard matvec-equivalence metric
+/// and is robust to catastrophic cancellation: an individual output DOF where
+/// two large signed local contributions nearly cancel can leave a value near
+/// machine epsilon whose *per-element* relative error is O(1) even though the
+/// matvec agrees to full f64 precision. Scaling the max residual by the
+/// reference vector's infinity norm reports the accuracy of the operator apply
+/// as a whole, which is what the equivalence gate is about.
+fn max_abs_rel(a: &[f64], b: &[f64]) -> (f64, f64) {
+    let mut max_abs = 0.0_f64;
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        max_abs = max_abs.max((ai - bi).abs());
+    }
+    let ref_norm = b.iter().fold(0.0_f64, |m, &v| m.max(v.abs())).max(1e-30);
+    (max_abs, max_abs / ref_norm)
+}
+
+/// Tolerance for the f64 equivalence gate. The matrix-free and assembled
+/// paths fold the *same* signed f32-weight locals; the only difference is
+/// summation order (matmul vs scatter), so the two agree to a few ULP of the
+/// f64 accumulation — well under 1e-12 relative.
+const TOL_REL: f64 = 1e-12;
+
+/// Vacuum (ε = 1) operator equivalence for `K`, `M`, and `K − ω²M` over a
+/// batch of pseudo-random operands on the coarse cube fixture.
+#[test]
+fn matrix_free_matches_assembled_vacuum() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps_r = vec![1.0_f64; mesh.n_tets()];
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let assembled =
+        assemble_global_nedelec::<B>(nodes.clone(), tets.clone(), &tet_idx, &tet_sign, n_edges);
+    let k_host = dense_to_host(assembled.k);
+    let m_host = dense_to_host(assembled.m);
+
+    let op = MatrixFreeNedelecOperator::<B>::new(nodes, tets, &tet_idx, &tet_sign, n_edges, &eps_r);
+    assert_eq!(op.n_edges(), n_edges);
+    assert_eq!(op.n_elem(), mesh.n_tets());
+
+    let omega = 1.7_f64;
+    for seed in 0..5u64 {
+        let x = pseudo_random_vec(n_edges, seed + 1);
+
+        // K · x
+        let y_k = vec_to_host(op.apply_k(upload_vec(&x, &dev)));
+        let (a_k, r_k) = max_abs_rel(&y_k, &dense_matvec(&k_host, &x, n_edges));
+        assert!(
+            r_k < TOL_REL,
+            "K seed {seed}: max_abs={a_k:e} max_rel={r_k:e}"
+        );
+
+        // M · x
+        let y_m = vec_to_host(op.apply_m(upload_vec(&x, &dev)));
+        let (a_m, r_m) = max_abs_rel(&y_m, &dense_matvec(&m_host, &x, n_edges));
+        assert!(
+            r_m < TOL_REL,
+            "M seed {seed}: max_abs={a_m:e} max_rel={r_m:e}"
+        );
+
+        // (K − ω²M) · x, single-pass combination
+        let a_combined: Vec<f64> = k_host
+            .iter()
+            .zip(m_host.iter())
+            .map(|(&k, &m)| k - omega * omega * m)
+            .collect();
+        let y_c = vec_to_host(op.apply_combination(upload_vec(&x, &dev), 1.0, -omega * omega));
+        let (a_ca, r_ca) = max_abs_rel(&y_c, &dense_matvec(&a_combined, &x, n_edges));
+        assert!(
+            r_ca < TOL_REL,
+            "K-w2M seed {seed}: max_abs={a_ca:e} max_rel={r_ca:e}"
+        );
+    }
+}
+
+/// ε-weighted mass equivalence with a spatially varying per-tet permittivity.
+#[test]
+fn matrix_free_matches_assembled_varying_epsilon() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    // Real spatially varying ε (isotropic), same flavor as nedelec_sparse.rs.
+    let eps_r: Vec<f64> = (0..mesh.n_tets())
+        .map(|t| 1.0 + 0.13 * (t % 7) as f64)
+        .collect();
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let assembled = assemble_global_nedelec_with_epsilon::<B>(
+        nodes.clone(),
+        tets.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &eps_r,
+    );
+    let m_host = dense_to_host(assembled.m);
+
+    let op = MatrixFreeNedelecOperator::<B>::new(nodes, tets, &tet_idx, &tet_sign, n_edges, &eps_r);
+
+    for seed in 0..3u64 {
+        let x = pseudo_random_vec(n_edges, 100 + seed);
+        let y_m = vec_to_host(op.apply_m(upload_vec(&x, &dev)));
+        let (a_m, r_m) = max_abs_rel(&y_m, &dense_matvec(&m_host, &x, n_edges));
+        assert!(
+            r_m < TOL_REL,
+            "M(eps) seed {seed}: max_abs={a_m:e} max_rel={r_m:e}"
+        );
+    }
+}
+
+/// Sign convention: on a coarse mesh with many local-vs-global orientation
+/// flips (the `n=2` cube has both signs present), the matrix-free signed
+/// contributions must reproduce the assembled scatter — this is the most
+/// likely place a subtle `s_i s_j` bug would hide.
+#[test]
+fn matrix_free_sign_convention_matches_assembled() {
+    let mesh = cube_tet_mesh(2, 2.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+
+    // Confirm the fixture actually exercises both signs (otherwise the test
+    // is vacuous).
+    let has_neg = tet_sign.iter().any(|row| row.iter().any(|&s| s < 0));
+    assert!(
+        has_neg,
+        "fixture must contain at least one -1 orientation sign"
+    );
+
+    let eps_r = vec![1.0_f64; mesh.n_tets()];
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let assembled =
+        assemble_global_nedelec::<B>(nodes.clone(), tets.clone(), &tet_idx, &tet_sign, n_edges);
+    let k_host = dense_to_host(assembled.k);
+
+    let op = MatrixFreeNedelecOperator::<B>::new(nodes, tets, &tet_idx, &tet_sign, n_edges, &eps_r);
+
+    let x = pseudo_random_vec(n_edges, 42);
+    let y = vec_to_host(op.apply_k(upload_vec(&x, &dev)));
+    let (a, r) = max_abs_rel(&y, &dense_matvec(&k_host, &x, n_edges));
+    assert!(r < TOL_REL, "signed K: max_abs={a:e} max_rel={r:e}");
+}
+
+/// Dirichlet/interior masking: the masked matrix-free operator equals the
+/// assembled full-space matrix with constrained (PEC-boundary) rows AND
+/// columns deleted, then embedded back into the full `[n_edges]` space (zero
+/// on constrained DOFs). This is the interior-submatrix apply the assembled
+/// driven/eigen paths perform, reproduced without slicing a submatrix.
+#[test]
+fn matrix_free_interior_masking_matches_reduced_assembled() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps_r = vec![1.0_f64; mesh.n_tets()];
+    let dev = device();
+
+    // PEC interior-edge mask for the cube: an edge is interior unless BOTH
+    // endpoints lie on the box boundary.
+    let (_edges, interior_mask) = cube_pec_interior_edges(&mesh, 1.0);
+    assert_eq!(interior_mask.len(), n_edges);
+    let n_interior = interior_mask.iter().filter(|&&b| b).count();
+    assert!(
+        n_interior > 0 && n_interior < n_edges,
+        "mask must be non-trivial"
+    );
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let assembled =
+        assemble_global_nedelec::<B>(nodes.clone(), tets.clone(), &tet_idx, &tet_sign, n_edges);
+    let k_host = dense_to_host(assembled.k);
+
+    // Reference: the full-space matrix with constrained rows/cols zeroed.
+    let mut k_reduced = k_host.clone();
+    for i in 0..n_edges {
+        for j in 0..n_edges {
+            if !interior_mask[i] || !interior_mask[j] {
+                k_reduced[i * n_edges + j] = 0.0;
+            }
+        }
+    }
+
+    let op = MatrixFreeNedelecOperator::<B>::new(nodes, tets, &tet_idx, &tet_sign, n_edges, &eps_r)
+        .with_mask(&interior_mask);
+
+    for seed in 0..3u64 {
+        // Give the operand nonzero entries on constrained DOFs too — the
+        // masking must ignore them (column deletion).
+        let x = pseudo_random_vec(n_edges, 7000 + seed);
+        let y = vec_to_host(op.apply_k(upload_vec(&x, &dev)));
+
+        // Result must be exactly zero on constrained DOFs (row deletion).
+        for (i, &keep) in interior_mask.iter().enumerate() {
+            if !keep {
+                assert_eq!(y[i], 0.0, "constrained DOF {i} must be zero, got {}", y[i]);
+            }
+        }
+
+        let (a, r) = max_abs_rel(&y, &dense_matvec(&k_reduced, &x, n_edges));
+        assert!(
+            r < TOL_REL,
+            "masked K seed {seed}: max_abs={a:e} max_rel={r:e}"
+        );
+    }
+}
+
+/// Bunsen contract firing test: applying to a wrong-length operand panics.
+#[test]
+#[should_panic(expected = "n_edges")]
+fn matrix_free_wrong_length_operand_panics() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps_r = vec![1.0_f64; mesh.n_tets()];
+    let dev = device();
+
+    let (nodes, tets) = upload_mesh::<B>(&mesh, &dev);
+    let op = MatrixFreeNedelecOperator::<B>::new(nodes, tets, &tet_idx, &tet_sign, n_edges, &eps_r);
+
+    // Operand one shorter than n_edges — must fire.
+    let bad = pseudo_random_vec(n_edges - 1, 1);
+    let _ = op.apply_k(upload_vec(&bad, &dev));
+}
+
+// ---------------------------------------------------------------------------
+// CUDA f32 smoke test — rented-EC2-box only, NEVER runs in CI.
+// ---------------------------------------------------------------------------
+//
+// `burn-cuda 0.21` disables f64 (cubecl asserts !supports_dtype(F64)), so the
+// f64 conformance gate above cannot run on CUDA. This f32 leg only sanity-
+// checks that the matrix-free apply *runs* on the CUDA backend and lands in a
+// loose neighborhood (~1e-5 relative) of the ndarray-f64 reference. It is
+// both `cuda`-feature-gated and `#[ignore]`d so `cargo test` (default
+// features, no ignored tests) skips it in CI; run explicitly on the box with
+// `cargo test --features cuda -- --ignored matrix_free_cuda_f32_smoke`.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "CUDA f32 smoke — rented EC2 box only, not CI (burn-cuda 0.21 has no f64)"]
+fn matrix_free_cuda_f32_smoke() {
+    use burn::backend::Cuda;
+
+    let mesh = cube_tet_mesh(3, 1.0);
+    let n_edges = mesh.edges().len();
+    let (tet_idx, tet_sign) = edge_tables(&mesh);
+    let eps_r = vec![1.0_f64; mesh.n_tets()];
+
+    // ndarray-f64 reference matvec.
+    let dev64 = device();
+    let (nodes64, tets64) = upload_mesh::<B>(&mesh, &dev64);
+    let assembled = assemble_global_nedelec::<B>(
+        nodes64.clone(),
+        tets64.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+    );
+    let k_host = dense_to_host(assembled.k);
+    let x = pseudo_random_vec(n_edges, 1);
+    let y_ref = dense_matvec(&k_host, &x, n_edges);
+
+    // CUDA-f32 matrix-free apply.
+    type Cu = Cuda;
+    let dev_cu = <Cu as BackendTypes>::Device::default();
+    let (nodes_cu, tets_cu) = upload_mesh::<Cu>(&mesh, &dev_cu);
+    let op = MatrixFreeNedelecOperator::<Cu>::new(
+        nodes_cu, tets_cu, &tet_idx, &tet_sign, n_edges, &eps_r,
+    );
+    let x_cu = Tensor::<Cu, 1>::from_data(TensorData::new(x.clone(), [n_edges]), &dev_cu);
+    let y_cu: Vec<f64> = op
+        .apply_k(x_cu)
+        .into_data()
+        .iter::<f32>()
+        .map(f64::from)
+        .collect();
+
+    let (a, r) = max_abs_rel(&y_cu, &y_ref);
+    assert!(r < 1e-4, "CUDA f32 smoke: max_abs={a:e} max_rel={r:e}");
+}


### PR DESCRIPTION
## Summary

Adds `MatrixFreeNedelecOperator<B: Backend>` — a **matrix-free** apply of the first-order Nédélec curl-curl stiffness `K`, ε-weighted mass `M`, and the driven-style combination `αK + βM`, computed **element-locally with no global CSR/dense operator ever materialized**, on Burn tensors, batched over all elements. This is **#302 Phase 1**: the apply-without-assembly primitive the GPU-resident-solve design (`Gᵀ ∘ B_𝒟ᵀ ∘ D ∘ B_𝒟 ∘ G`) is built on, and the foundation for the Epic #476 GPU-vs-GPU benchmark cell.

The apply is `gather → batched dense [n_elem,6,6]·[n_elem,6,1] local matmul → signed scatter-add`. It folds the **same** signed f32-weight locals (`sign_outer` = `s_i s_j`) through the **same** `tet_edge_idx` edge-DOF gather/scatter as `assembly::nedelec`, so its matvec equals the assembled operator's `spmv` to round-off. Memory is `O(n_elem·36 + n_edges)`, not `O(n_edges²)` — the dense `[n_edges²]` Burn operator is ~23 GB at the 54k-edge benchmark and a non-starter; that contrast is the point.

## Changes

- New module `crates/geode-core/src/assembly/nedelec_matvec.rs`: `MatrixFreeNedelecOperator` with `new(...)`, `with_mask(...)`, `apply_k`, `apply_m`, `apply_combination(x, α, β)`. Bunsen named shape contracts on every Burn-Tensor surface (`MATVEC_CONNECTIVITY_CONTRACT`, `MATVEC_LOCAL_MATRIX_CONTRACT`, `MATVEC_ELEM_COLUMN_CONTRACT`, `MATVEC_GLOBAL_VECTOR_CONTRACT`).
- `crates/geode-core/src/assembly/mod.rs`: register `pub mod nedelec_matvec`.
- New test `crates/geode-core/tests/nedelec_matrix_free_equivalence.rs`: the CSR-equivalence acceptance gate + sign/mask/firing tests + the ignored CUDA-f32 smoke.

**Dirichlet/interior-DOF convention:** the assembled driven/eigen paths reduce to an interior submatrix by deleting constrained rows/cols. The matrix-free path reproduces this by **masking at gather+scatter time** — zeroing constrained DOFs on the input (deletes constrained columns) and on the output after scatter (deletes constrained rows). Result: the interior operator embedded back into the full `[n_edges]` space, verified against the row/col-deleted assembled matrix.

## Acceptance Criteria Verification

| Criterion (issue #480) | Status | Verification |
|---|---|---|
| Matrix-free `apply` vs assembled matvec, ndarray-f64, ~1e-12 rel, CI gate | ✅ | `matrix_free_matches_assembled_vacuum` (K, M, K−ω²M × 5 operands) + `_varying_epsilon`; **norm-scaled rel ≤ 3.6e-16, max abs ≤ 1.1e-14** (see numbers below) |
| Real meshes from existing inventory | ✅ | `cube_tet_mesh(3,1.0)` (4184 edges / 3072 tets) and `cube_tet_mesh(2,2.0)` fixtures |
| Multiple random `x`, both K and M, combined driven-style A | ✅ | 5 deterministic-LCG operands; `apply_k`, `apply_m`, `apply_combination(1, −ω²)` all covered |
| Sign convention (`tet_edge_sign` outer product) identical to assembled | ✅ | `matrix_free_sign_convention_matches_assembled` on a fixture asserted to contain −1 signs |
| Dirichlet/interior masking matches `assemble_a_at` interior submatrix | ✅ | `matrix_free_interior_masking_matches_reduced_assembled` — constrained DOFs exactly 0, interior matches row/col-deleted assembled K |
| Bunsen shape contracts + ≥1 should_panic firing test | ✅ | 4 named contracts; `matrix_free_wrong_length_operand_panics` (`should_panic(expected = "n_edges")`) |
| CUDA-f32 smoke gated, NOT in CI | ✅ | `#[cfg(feature = "cuda")] #[ignore]` — burn-cuda 0.21 has no f64; deferred to rented box |
| No changes to solver/, driven/, existing assembly | ✅ | Purely additive: one new module + one `pub mod` line + one new test file |

## Equivalence results (ndarray-f64, `cube_tet_mesh(3,1.0)`, n_edges=4184)

Norm-scaled relative deviation `‖Δ‖∞ / ‖A·x‖∞` and max absolute deviation vs the assembled matrix's matvec, worst-of-5-operands:

| Operator | max abs | norm-scaled rel |
|---|---|---|
| `K` | 7.1e-15 | 2.5e-16 |
| `M` | 5.6e-17 | 3.4e-16 |
| `K − ω²M` (ω=1.7) | 1.1e-14 | 3.6e-16 |

Machine-epsilon-level agreement — the only difference from the assembled path is summation order (batched matmul vs flat scatter). (A per-element relative metric is misleading here: output DOFs where two large signed local contributions nearly cancel sit near machine-ε in absolute terms, so their per-element relative error is O(1) despite the matvec being exact to f64. The norm-scaled measure is the standard matvec-equivalence metric.)

## Timing note (CPU-backend only — NOT the point of Phase 1)

Rough single-thread matvec timing on the ndarray-f64 backend, `cube_tet_mesh(8,1.0)` (n_edges=4184, n_elem=3072), 200 reps: matrix-free `apply_k` ≈ **1.10 ms** vs the dense `[n_edges,n_edges]` host matvec ≈ **12.9 ms** (~11.7×). Honest caveat: this compares against the **dense** operator (O(n_edges²) work), not a true sparse CSR `spmv`; against a real CSR the gap would be far smaller. The headline of Phase 1 is **correctness**, and the real payoff (avoiding the ~23 GB dense operator, GPU-resident apply) is Phase 2/3 material.

**CUDA-f32 smoke is deferred to the rented EC2 box** and never runs in CI: `burn-cuda 0.21` disables f64 (cubecl `!supports_dtype(F64)`), so the f64 conformance gate lives on ndarray. Run on the box with `cargo test --features cuda -- --ignored matrix_free_cuda_f32_smoke`.

## Test Plan

- `cargo fmt --all --check` ✅
- `cargo clippy -p geode-core --all-targets -- -D warnings` ✅
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` ✅
- `cargo test -p geode-core --release --tests` ✅ (0 failed; new equivalence test 5/5)
- `cargo test -p geode-core --lib` ✅ (297 passed)

Closes #480