### PR TITLE
feat(driven): SolverMode::IterativeMatrixFree — GPU-resident COCG on the driven pencil

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 484
-# Branch: feature/issue-484
+# Issue: 493
+# Branch: feature/issue-493
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/driven/extraction.rs
+++ b/crates/geode-core/src/driven/extraction.rs
@@ -425,7 +425,7 @@ pub fn driven_frequency_sweep_with_mode<B: Backend>(
     omegas
         .iter()
         .map(|&omega| {
-            let solver = op.prepare_at(omega, solver_mode)?;
+            let solver = op.prepare_at::<B>(omega, solver_mode, device)?;
             let (sol, report) = solver.solve()?;
             let ports = (0..op.n_ports())
                 .map(|p| {
@@ -576,7 +576,7 @@ pub fn s_parameter_frequency_sweep_with_mode<B: Backend>(
             // One solver-handle prep (LU factor on direct, Jacobi build
             // on iterative), N back-substitutions per excitation
             // (issue #214 multi-RHS pattern; issue #264 solver-mode knob).
-            let solver = op.prepare_at(omega, solver_mode)?;
+            let solver = op.prepare_at::<B>(omega, solver_mode, device)?;
             let mut residual_rel = 0.0_f64;
             let mut iters_per_rhs: Vec<usize> = Vec::with_capacity(n);
             // v_mat[k][j] / i_mat[k][j]: port-k readback under excitation j.

--- a/crates/geode-core/src/driven/matrix_free.rs
+++ b/crates/geode-core/src/driven/matrix_free.rs
@@ -1,0 +1,593 @@
+//! GPU-resident **matrix-free** back-solve for the driven pencil
+//! ([`crate::driven::solve::SolverMode::IterativeMatrixFree`], issue #302 Phase 3).
+//!
+//! [`crate::driven::solve::SolverMode::Iterative`] (PR #243) runs COCG against the assembled sparse
+//! `A(ω)`; [`crate::driven::solve::SolverMode::Direct`] factors it. This module wires PR #487's
+//! **matrix-free** COCG ([`crate::solver::ksp_burn::BurnCocg`] over
+//! [`crate::solver::ksp_burn::ComplexMatrixFreeOperator`]) into the same
+//! [`crate::driven::solve::DrivenLinearSolver`] back-solve seam — so it reuses
+//! every sweep entry point (`driven_frequency_sweep_with_mode`,
+//! `s_parameter_frequency_sweep_with_mode`) unchanged.
+//!
+//! # What the matrix-free path is
+//!
+//! The full driven pencil is
+//!
+//! ```text
+//! A(ω) = K − ω²M(ε) + iωC(σ) + Σ_p (iω/Z_p)·S_p + Σ_Γ (iω/Z_s,Γ(ω))·S_Γ.
+//! ```
+//!
+//! `ComplexMatrixFreeOperator` applies the first three (**volume**) terms
+//! element-locally on Burn tensors, never assembling a global matrix. The
+//! tet-only operator structurally cannot absorb the last two (**surface**)
+//! terms — they are triangle surface masses on the port / conductor faces.
+//!
+//! # B1: on-device COO surface correction (this file)
+//!
+//! Each surface term is `(complex scalar) · (real COO matrix)`:
+//!
+//! - **Port** `p`: scalar `iω/Z_p` (`Z_p = R·w/ℓ`, ω-independent), matrix the
+//!   real tangential surface mass `S_p` (interior-remapped
+//!   `port.mass_triplets`).
+//! - **Leontovich** `Γ`: scalar `iω/Z_s,Γ(ω)` (ω-**dependent**, e.g.
+//!   `∝ √ω·(1+i)` for the good-conductor model), matrix the real surface mass
+//!   `S_Γ` (interior-remapped `s_vals`).
+//!
+//! Both matrices are **small** — O(surface edges), 36–288 triplets on the
+//! patch / spiral fixtures vs. 6k–54k edges — so they upload once at setup.
+//! A COO SpMV `y = S·x` is the same two Burn primitives PR #483 validated for
+//! the volume apply: `x.select(0, col_idx)` (gather) → `·val` → a
+//! `zeros(...).scatter(0, row_idx, ·, Add)` (scatter-add). The composite
+//! [`SurfaceCorrectedOperator`] folds `Σ scalar_g · (S_g · x)` onto the
+//! volume apply, keeping the Krylov vectors on-device — the port/Leontovich
+//! coupling never crosses the host boundary inside the iteration.
+//!
+//! # Index space
+//!
+//! `ComplexMatrixFreeOperator` runs in **full-edge** `[n_edges]` space with an
+//! interior mask (PR #487's convention); the stored surface triplets are
+//! **interior-remapped**. This module lifts them interior→full **once** at
+//! setup via the crate-internal `DrivenOperator::interior_to_full`, then
+//! the full-edge COO applies alongside the masked volume operator. The RHS is
+//! lifted interior→full for the upload and the solution filtered full→interior
+//! on the way out.
+//!
+//! # Jacobi preconditioner parity
+//!
+//! To keep iteration counts tracking the assembled COCG (whose Jacobi
+//! preconditioner sees the full `A(ω)` diagonal, surface terms included), the
+//! composite operator adds the surface COO **diagonal** (`scalar_g · S_g[i,i]`)
+//! to the volume complex diagonal and forms its own inverse-diagonal through
+//! the shared [`crate::solver::ksp_burn::safe_complex_inv_diag`].
+//!
+//! # Host-sync budget
+//!
+//! The per-iteration host-sync budget is exactly PR #487's — O(1) scalars per
+//! COCG iteration (`ρ`, `pᵀq`, the residual norm), no `[n]`-sized transfer.
+//! The COO correction adds **no** new host sync: the triplet tensors are
+//! uploaded once at setup, and the per-matvec gather/scatter/scale is entirely
+//! on-device. Vectors cross the boundary exactly twice per back-solve (`b`
+//! lifted+uploaded in, `x` downloaded+filtered out), same as the direct path's
+//! per-RHS transfer.
+//!
+//! # Scope (v1)
+//!
+//! Scalar-**real** ε only ([`crate::driven::solve::DrivenMaterials::Scalar`]
+//! with `Im ε = 0`); anisotropic / matched-UPML materials and wave-port sweeps
+//! are rejected upstream with clean [`crate::driven::solve::DrivenError`]s (the
+//! wave-port guard lives at the `solve_wave_port_sweep_with_mode` call site,
+//! the material guard in `prepare_at`). The equivalence gate runs ndarray-f64
+//! in CI; the CUDA f32 leg is deferred to the rented box (PR #487 precision
+//! plan).
+
+use bunsen::contracts::{assert_shape_contract, define_shape_contract};
+use burn::tensor::backend::Backend;
+use burn::tensor::{Int, Tensor, TensorData};
+use faer::c64;
+
+use crate::driven::solve::{DrivenError, DrivenOperator, SurfaceImpedanceModel};
+use crate::solver::ksp_burn::{
+    BurnCocg, ComplexMatrixFreeOperator, MatrixFreeComplexOperator, SplitComplex,
+    safe_complex_inv_diag,
+};
+
+// ---------------------------------------------------------------------------
+// Named static shape contracts (Bunsen)
+// ---------------------------------------------------------------------------
+
+// Flattened COO triplet arrays `∈ ℝ^{nnz}` (row indices / col indices /
+// values) of one on-device surface correction term. `nnz` is left free.
+define_shape_contract!(MATRIX_FREE_COO_CONTRACT, ["nnz"]);
+
+// Global diagonal / edge-DOF vector `∈ ℝ^{n_edges}` — the surface term's
+// `scalar · diag(S)` contribution to the composite Jacobi diagonal.
+define_shape_contract!(MATRIX_FREE_DIAG_CONTRACT, ["n_edges"]);
+
+/// Host-side ingredients retained on a [`DrivenOperator`] to rebuild the Burn
+/// matrix-free operator per ω without re-uploading the mesh (issue #302
+/// Phase 3). Populated only for scalar-**real** ε materials.
+#[derive(Debug, Clone)]
+pub struct MatrixFreeIngredients {
+    /// Global node coordinates `[n_nodes][3]`.
+    pub nodes: Vec<[f64; 3]>,
+    /// Tet connectivity `[n_elem][4]` (0-based).
+    pub tets: Vec<[u32; 4]>,
+    /// Per-tet global edge index `[n_elem][6]`.
+    pub tet_edge_idx: Vec<[u32; 6]>,
+    /// Per-tet orientation sign `[n_elem][6]` in `{-1, +1}`.
+    pub tet_edge_sign: Vec<[i8; 6]>,
+    /// Number of global edge DOFs.
+    pub n_edges: usize,
+    /// Per-tet real relative permittivity `[n_elem]`.
+    pub epsilon_r: Vec<f64>,
+    /// Per-tet real conductivity `[n_elem]` (all-zero ⇒ lossless).
+    pub sigma: Vec<f64>,
+    /// Full-edge PEC interior mask `[n_edges]` (`true` = kept).
+    pub interior_mask: Vec<bool>,
+}
+
+/// One on-device COO surface term `(complex scalar) · S`, in **full-edge**
+/// index space: gather at `col_idx`, scale by the real `val`, scatter-add to
+/// `row_idx`, then scale the accumulated result by the complex `scalar`.
+#[derive(Debug, Clone)]
+struct CooSurfaceTerm<B: Backend> {
+    /// Flattened row indices `[nnz]` (full-edge).
+    row_idx: Tensor<B, 1, Int>,
+    /// Flattened column indices `[nnz]` (full-edge).
+    col_idx: Tensor<B, 1, Int>,
+    /// Flattened real values `[nnz]`.
+    vals: Tensor<B, 1>,
+    /// Complex scalar coefficient (`iω/Z_p` or `iω/Z_s,Γ(ω)`).
+    scalar: c64,
+    /// Contribution of this term to the global complex diagonal
+    /// `scalar · diag(S)`, as an on-device `(re, im)` pair `[n_edges]` — added
+    /// into the composite Jacobi diagonal for preconditioner parity.
+    diag_re: Tensor<B, 1>,
+    diag_im: Tensor<B, 1>,
+    /// Operator dimension (for the scatter target length).
+    n_edges: usize,
+    /// Device.
+    device: B::Device,
+}
+
+impl<B: Backend> CooSurfaceTerm<B> {
+    /// Build a COO term from full-edge interior-lifted triplets and its complex
+    /// scalar coefficient.
+    fn new(
+        triplets: &[(usize, usize, f64)],
+        scalar: c64,
+        n_edges: usize,
+        device: &B::Device,
+    ) -> Self {
+        let nnz = triplets.len();
+        let rows: Vec<i32> = triplets.iter().map(|&(r, _, _)| r as i32).collect();
+        let cols: Vec<i32> = triplets.iter().map(|&(_, c, _)| c as i32).collect();
+        let vals: Vec<f64> = triplets.iter().map(|&(_, _, v)| v).collect();
+
+        // Real diagonal of S: Σ_{r == c} val, scattered into [n_edges].
+        let mut diag = vec![0.0_f64; n_edges];
+        for &(r, c, v) in triplets {
+            if r == c {
+                diag[r] += v;
+            }
+        }
+        let diag_t = Tensor::<B, 1>::from_data(TensorData::new(diag, [n_edges]), device);
+        // scalar · diag(S) as (re, im).
+        let diag_re = diag_t.clone().mul_scalar(scalar.re);
+        let diag_im = diag_t.mul_scalar(scalar.im);
+        assert_shape_contract!(MATRIX_FREE_DIAG_CONTRACT, &diag_re, &[]);
+        assert_shape_contract!(MATRIX_FREE_DIAG_CONTRACT, &diag_im, &[]);
+
+        let row_idx = Tensor::<B, 1, Int>::from_data(TensorData::new(rows, [nnz]), device);
+        let col_idx = Tensor::<B, 1, Int>::from_data(TensorData::new(cols, [nnz]), device);
+        let vals = Tensor::<B, 1>::from_data(TensorData::new(vals, [nnz]), device);
+        assert_shape_contract!(MATRIX_FREE_COO_CONTRACT, &row_idx, &[]);
+        assert_shape_contract!(MATRIX_FREE_COO_CONTRACT, &col_idx, &[]);
+        assert_shape_contract!(MATRIX_FREE_COO_CONTRACT, &vals, &[]);
+
+        Self {
+            row_idx,
+            col_idx,
+            vals,
+            scalar,
+            diag_re,
+            diag_im,
+            n_edges,
+            device: device.clone(),
+        }
+    }
+
+    /// Real COO SpMV `y = S · x` (gather → scale → scatter-add), for one
+    /// real component of the split-complex operand.
+    fn spmv_real(&self, x: &Tensor<B, 1>) -> Tensor<B, 1> {
+        let gathered = x.clone().select(0, self.col_idx.clone());
+        let scaled = gathered.mul(self.vals.clone());
+        Tensor::<B, 1>::zeros([self.n_edges], &self.device).scatter(
+            0,
+            self.row_idx.clone(),
+            scaled,
+            burn::tensor::IndexingUpdateOp::Add,
+        )
+    }
+
+    /// Apply `scalar · (S · x)` to a split-complex vector and add it onto
+    /// `(y_re, y_im)`. `S` is real symmetric, so `(scalar·S)·x` is the
+    /// complex scalar times the real matvec of each component:
+    /// `re += s_re·(S·x_re) − s_im·(S·x_im)`,
+    /// `im += s_re·(S·x_im) + s_im·(S·x_re)`.
+    fn accumulate(
+        &self,
+        x: &SplitComplex<B>,
+        y_re: Tensor<B, 1>,
+        y_im: Tensor<B, 1>,
+    ) -> (Tensor<B, 1>, Tensor<B, 1>) {
+        let s_xre = self.spmv_real(&x.re);
+        let s_xim = self.spmv_real(&x.im);
+        let y_re = y_re
+            .add(s_xre.clone().mul_scalar(self.scalar.re))
+            .sub(s_xim.clone().mul_scalar(self.scalar.im));
+        let y_im = y_im
+            .add(s_xim.mul_scalar(self.scalar.re))
+            .add(s_xre.mul_scalar(self.scalar.im));
+        (y_re, y_im)
+    }
+}
+
+/// The volume [`ComplexMatrixFreeOperator`] plus the on-device COO port /
+/// Leontovich surface correction, implementing the
+/// [`MatrixFreeComplexOperator`] seam [`BurnCocg`] iterates against.
+///
+/// `apply` composes the surface COO SpMVs onto the volume apply; the Jacobi
+/// inverse-diagonal is rebuilt from the volume diagonal **plus** the surface
+/// diagonal so the preconditioner matches the assembled `A(ω)` diagonal.
+pub struct SurfaceCorrectedOperator<B: Backend> {
+    volume: ComplexMatrixFreeOperator<B>,
+    surface_terms: Vec<CooSurfaceTerm<B>>,
+    inv_diag_re: Tensor<B, 1>,
+    inv_diag_im: Tensor<B, 1>,
+}
+
+impl<B: Backend> SurfaceCorrectedOperator<B> {
+    fn new(volume: ComplexMatrixFreeOperator<B>, surface_terms: Vec<CooSurfaceTerm<B>>) -> Self {
+        // Composite complex diagonal = volume diagonal + Σ surface diagonals.
+        let (mut d_re, mut d_im) = volume.complex_diagonal();
+        for t in &surface_terms {
+            d_re = d_re.add(t.diag_re.clone());
+            d_im = d_im.add(t.diag_im.clone());
+        }
+        let (inv_diag_re, inv_diag_im) = safe_complex_inv_diag(d_re, d_im, volume.interior_mask());
+        Self {
+            volume,
+            surface_terms,
+            inv_diag_re,
+            inv_diag_im,
+        }
+    }
+}
+
+impl<B: Backend> MatrixFreeComplexOperator<B> for SurfaceCorrectedOperator<B> {
+    fn n_edges(&self) -> usize {
+        self.volume.n_edges()
+    }
+
+    fn device(&self) -> &B::Device {
+        self.volume.device()
+    }
+
+    fn project_interior(&self, v: &SplitComplex<B>) -> SplitComplex<B> {
+        self.volume.project_interior(v)
+    }
+
+    fn apply(&self, x: &SplitComplex<B>) -> SplitComplex<B> {
+        // Volume pencil apply, then fold each surface COO term on top.
+        let y = self.volume.apply(x);
+        let (mut y_re, mut y_im) = (y.re, y.im);
+        for t in &self.surface_terms {
+            let (nr, ni) = t.accumulate(x, y_re, y_im);
+            y_re = nr;
+            y_im = ni;
+        }
+        // Re-mask so constrained DOFs stay identically zero (the surface COO
+        // touches only interior DOFs, but re-masking is cheap and defensive).
+        let mask = self.volume.interior_mask();
+        SplitComplex {
+            re: y_re.mul(mask.clone()),
+            im: y_im.mul(mask),
+        }
+    }
+
+    fn jacobi_apply(&self, r: &SplitComplex<B>) -> SplitComplex<B> {
+        // z = r · inv_diag (complex elementwise multiply) with the composite
+        // (volume + surface) inverse-diagonal.
+        let z_re =
+            r.re.clone()
+                .mul(self.inv_diag_re.clone())
+                .sub(r.im.clone().mul(self.inv_diag_im.clone()));
+        let z_im =
+            r.re.clone()
+                .mul(self.inv_diag_im.clone())
+                .add(r.im.clone().mul(self.inv_diag_re.clone()));
+        SplitComplex { re: z_re, im: z_im }
+    }
+}
+
+/// A per-ω matrix-free back-solve handle: the composite operator plus the COCG
+/// knobs and the interior↔full index map. Built once per ω by
+/// [`crate::driven::solve::DrivenOperator::prepare_at`] and reused across every
+/// RHS at that ω.
+pub struct MatrixFreeSolver<B: Backend> {
+    op: SurfaceCorrectedOperator<B>,
+    cocg: BurnCocg,
+    /// `interior_to_full[i]` = full-edge index of the `i`-th interior DOF.
+    interior_to_full: Vec<usize>,
+    n_edges: usize,
+    n_interior: usize,
+    device: B::Device,
+}
+
+impl<B: Backend> MatrixFreeSolver<B> {
+    /// Build the per-ω matrix-free solver from the driven operator's retained
+    /// ingredients and its surface terms, evaluating the ω-dependent
+    /// Leontovich coefficients at `omega`.
+    ///
+    /// # Errors
+    ///
+    /// [`DrivenError::SurfaceImpedanceSingular`] if a Leontovich model
+    /// evaluates to a singular `Z_s(ω)`.
+    pub fn new(
+        driven: &DrivenOperator,
+        ing: &MatrixFreeIngredients,
+        omega: f64,
+        tol: f64,
+        max_iters: usize,
+        device: &B::Device,
+    ) -> Result<Self, DrivenError> {
+        // Upload the mesh + build the volume pencil at ω.
+        let n_nodes = ing.nodes.len();
+        let n_elem = ing.tets.len();
+        let node_data: Vec<f64> = ing.nodes.iter().flat_map(|n| n.iter().copied()).collect();
+        let nodes = Tensor::<B, 2>::from_data(TensorData::new(node_data, [n_nodes, 3]), device);
+        let tet_data: Vec<i32> = ing
+            .tets
+            .iter()
+            .flat_map(|t| t.iter().map(|&i| i as i32))
+            .collect();
+        let tets = Tensor::<B, 2, Int>::from_data(TensorData::new(tet_data, [n_elem, 4]), device);
+
+        let volume = ComplexMatrixFreeOperator::<B>::new(
+            nodes,
+            tets,
+            &ing.tet_edge_idx,
+            &ing.tet_edge_sign,
+            ing.n_edges,
+            &ing.epsilon_r,
+            &ing.sigma,
+            omega,
+            &ing.interior_mask,
+        );
+
+        // Lift interior-remapped surface triplets → full-edge space, once.
+        let interior_to_full = driven.interior_to_full();
+        let lift = |r: usize, c: usize| (interior_to_full[r], interior_to_full[c]);
+
+        let mut surface_terms = Vec::new();
+
+        // Port admittance: scalar iω/Z_p, matrix S_p.
+        for p in 0..driven.n_ports() {
+            let pd = driven.port_transient_data(p);
+            let scalar = c64::new(0.0, omega / pd.z_s);
+            let full: Vec<(usize, usize, f64)> = pd
+                .mass_triplets
+                .iter()
+                .map(|&(r, c, v)| {
+                    let (rf, cf) = lift(r, c);
+                    (rf, cf, v)
+                })
+                .collect();
+            surface_terms.push(CooSurfaceTerm::new(&full, scalar, ing.n_edges, device));
+        }
+
+        // Leontovich surfaces: scalar iω/Z_s,Γ(ω), matrix S_Γ.
+        for i in 0..driven.n_surfaces() {
+            let (triplets, model) = driven.surface_mass_triplets(i);
+            let scalar = surface_weak_coefficient(&model, omega)?;
+            let full: Vec<(usize, usize, f64)> = triplets
+                .iter()
+                .map(|&(r, c, v)| {
+                    let (rf, cf) = lift(r, c);
+                    (rf, cf, v)
+                })
+                .collect();
+            surface_terms.push(CooSurfaceTerm::new(&full, scalar, ing.n_edges, device));
+        }
+
+        let op = SurfaceCorrectedOperator::new(volume, surface_terms);
+        Ok(Self {
+            op,
+            cocg: BurnCocg::new(tol, max_iters),
+            interior_to_full,
+            n_edges: ing.n_edges,
+            n_interior: driven.n_interior(),
+            device: device.clone(),
+        })
+    }
+
+    /// Solve `A(ω) x = b` for one interior-length complex RHS, writing the
+    /// interior-length solution into `out`. Returns the COCG report.
+    ///
+    /// Mirrors the direct / assembled-iterative back-solve semantics: a zero
+    /// RHS is a trivial all-zero solution (zero iterations reported).
+    ///
+    /// # Errors
+    ///
+    /// [`DrivenError::Solve`] wrapping a COCG breakdown / non-convergence.
+    pub fn back_solve(
+        &self,
+        b_int: &[c64],
+        out: &mut [c64],
+    ) -> Result<crate::solver::ksp::KspReport, DrivenError> {
+        assert_eq!(b_int.len(), self.n_interior, "b length mismatch");
+        assert_eq!(out.len(), self.n_interior, "out length mismatch");
+
+        // Zero RHS ⇒ x = 0 (mirror the direct/assembled-iterative paths).
+        let b_norm2: f64 = b_int.iter().map(|c| c.re * c.re + c.im * c.im).sum();
+        if b_norm2 == 0.0 {
+            for o in out.iter_mut() {
+                *o = c64::new(0.0, 0.0);
+            }
+            return Ok(crate::solver::ksp::KspReport {
+                iters: 0,
+                residual_rel: 0.0,
+                converged: true,
+            });
+        }
+
+        // Lift interior RHS → full-edge and upload.
+        let mut b_full = vec![c64::new(0.0, 0.0); self.n_edges];
+        for (i, &full_idx) in self.interior_to_full.iter().enumerate() {
+            b_full[full_idx] = b_int[i];
+        }
+        let b = SplitComplex::<B>::upload(&b_full, &self.device);
+
+        let (x, report) = self
+            .cocg
+            .solve(&self.op, &b)
+            .map_err(|e| DrivenError::Solve(format!("matrix-free COCG: {e}")))?;
+
+        // Download full-edge solution and filter → interior.
+        let x_full = x.download();
+        for (i, &full_idx) in self.interior_to_full.iter().enumerate() {
+            out[i] = x_full[full_idx];
+        }
+        Ok(report)
+    }
+}
+
+/// Evaluate `iω/Z_s(ω)` for a Leontovich model, mapping a singular `Z_s(ω)`
+/// to [`DrivenError::SurfaceImpedanceSingular`] — the same coefficient the
+/// assembled path computes via `SurfaceImpedanceModel::weak_coefficient` (kept
+/// here so the matrix-free path folds bit-for-bit the same complex scalar).
+fn surface_weak_coefficient(model: &SurfaceImpedanceModel, omega: f64) -> Result<c64, DrivenError> {
+    model.weak_coefficient(omega)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestBackend;
+    use burn::tensor::backend::BackendTypes;
+
+    type Bk = TestBackend;
+
+    fn dev() -> <Bk as BackendTypes>::Device {
+        <Bk as BackendTypes>::Device::default()
+    }
+
+    /// The on-device COO term applies `scalar · (S · x)` bit-for-bit like a
+    /// host COO SpMV over the same triplets — the Bunsen contracts fire on
+    /// construction, and the gather/scatter/complex-scale composition matches
+    /// dense host arithmetic. This is the independent cross-check the issue
+    /// asks B1 to carry (and that B2's triangle gather/scatter would be gated
+    /// against once it lands).
+    #[test]
+    fn coo_surface_term_matches_host_spmv() {
+        let d = dev();
+        let n_edges = 5;
+        // A small symmetric real COO S over 5 edges, with a diagonal.
+        let triplets: Vec<(usize, usize, f64)> = vec![
+            (0, 0, 2.0),
+            (0, 1, -1.0),
+            (1, 0, -1.0),
+            (1, 1, 3.0),
+            (1, 4, 0.5),
+            (4, 1, 0.5),
+            (4, 4, 1.5),
+        ];
+        // Complex scalar coefficient (like iω/Z_p).
+        let scalar = c64::new(0.0, 0.7);
+        let term = CooSurfaceTerm::<Bk>::new(&triplets, scalar, n_edges, &d);
+
+        // Operand x (full-edge split-complex).
+        let x_host: Vec<c64> = vec![
+            c64::new(1.0, -0.5),
+            c64::new(-2.0, 0.25),
+            c64::new(0.0, 0.0),
+            c64::new(0.0, 0.0),
+            c64::new(0.75, 1.0),
+        ];
+        let x = SplitComplex::<Bk>::upload(&x_host, &d);
+
+        // Device apply onto zero accumulators.
+        let (y_re, y_im) = term.accumulate(
+            &x,
+            Tensor::<Bk, 1>::zeros([n_edges], &d),
+            Tensor::<Bk, 1>::zeros([n_edges], &d),
+        );
+        let got = SplitComplex { re: y_re, im: y_im }.download();
+
+        // Host reference: y = scalar · (S · x).
+        let mut sx = vec![c64::new(0.0, 0.0); n_edges];
+        for &(r, c, v) in &triplets {
+            sx[r] += x_host[c] * v;
+        }
+        let want: Vec<c64> = sx.iter().map(|&z| scalar * z).collect();
+
+        for (g, w) in got.iter().zip(want.iter()) {
+            assert!(
+                (g.re - w.re).abs() < 1e-12 && (g.im - w.im).abs() < 1e-12,
+                "COO term mismatch: got {g:?} want {w:?}"
+            );
+        }
+    }
+
+    /// The composite operator's `apply` = volume apply + surface correction,
+    /// and its Jacobi diagonal folds the surface diagonal in — smoke-tested
+    /// on a single-tet mesh with a synthetic COO surface term so the
+    /// composition plumbing (mask, diagonal blend, complex scale) exercises
+    /// end-to-end without a full driven fixture.
+    #[test]
+    fn surface_corrected_operator_composes_volume_and_surface() {
+        use crate::assembly::p1::upload_mesh;
+        use crate::mesh::cube_tet_mesh;
+
+        let mesh = cube_tet_mesh(2, 1.0);
+        let n_edges = mesh.edges().len();
+        let te = mesh.tet_edges();
+        let tet_idx: Vec<[u32; 6]> = te.iter().map(|r| std::array::from_fn(|i| r[i].0)).collect();
+        let tet_sign: Vec<[i8; 6]> = te.iter().map(|r| std::array::from_fn(|i| r[i].1)).collect();
+        let eps = vec![1.0_f64; mesh.n_tets()];
+        let sigma = vec![0.0_f64; mesh.n_tets()];
+        let mask = vec![true; n_edges];
+        let d = dev();
+        let (nodes, tets) = upload_mesh::<Bk>(&mesh, &d);
+
+        let volume = ComplexMatrixFreeOperator::<Bk>::new(
+            nodes, tets, &tet_idx, &tet_sign, n_edges, &eps, &sigma, 0.5, &mask,
+        );
+
+        // A one-entry diagonal surface term on edge 0.
+        let scalar = c64::new(0.0, 0.3);
+        let term = CooSurfaceTerm::<Bk>::new(&[(0, 0, 2.0)], scalar, n_edges, &d);
+        let composite = SurfaceCorrectedOperator::new(volume.clone(), vec![term]);
+
+        // apply(e_0): volume·e_0 plus scalar·2·e_0 on row 0.
+        let mut e0 = vec![c64::new(0.0, 0.0); n_edges];
+        e0[0] = c64::new(1.0, 0.0);
+        let x = SplitComplex::<Bk>::upload(&e0, &d);
+        let y_comp = MatrixFreeComplexOperator::apply(&composite, &x).download();
+        let y_vol = volume.apply(&x).download();
+
+        // The surface correction adds exactly scalar·2 to entry 0.
+        let delta = y_comp[0] - y_vol[0];
+        let want = scalar * 2.0;
+        assert!(
+            (delta.re - want.re).abs() < 1e-10 && (delta.im - want.im).abs() < 1e-10,
+            "surface correction on diagonal edge mismatch: Δ = {delta:?}, want {want:?}"
+        );
+        // Off the surface, the composite matches the volume operator.
+        for i in 1..n_edges {
+            let dv = y_comp[i] - y_vol[i];
+            assert!(dv.re.abs() < 1e-10 && dv.im.abs() < 1e-10);
+        }
+    }
+}

--- a/crates/geode-core/src/driven/mod.rs
+++ b/crates/geode-core/src/driven/mod.rs
@@ -12,6 +12,10 @@
 //!   self-resonance extraction built on the driven solver.
 //! - [`scattering`] — plane-wave scattering with a matched UPML, Mie
 //!   polarization sources, and radiated/extinction power integrals.
+//! - [`matrix_free`] — the GPU-resident matrix-free Krylov back-solve
+//!   ([`crate::driven::solve::SolverMode::IterativeMatrixFree`]): the Burn
+//!   volume pencil ([`crate::solver::ksp_burn`]) plus an on-device COO
+//!   correction for the small lumped-port / Leontovich surface terms.
 //! - [`transient`] — implicit second-order (generalized-α / Newmark-β)
 //!   time integration of the same `K`/`C`/`M` matrices the driven path
 //!   assembles, with a lumped-port time-domain drive and broadband
@@ -22,6 +26,7 @@
 //! a level, matching [`crate::eigen`].
 
 pub mod extraction;
+pub mod matrix_free;
 pub mod ports;
 pub mod scattering;
 pub mod solve;

--- a/crates/geode-core/src/driven/ports/wave.rs
+++ b/crates/geode-core/src/driven/ports/wave.rs
@@ -501,6 +501,18 @@ pub fn solve_wave_port_sweep_with_mode<B: burn::tensor::backend::Backend>(
             reason: "wave-port S-parameter extraction needs at least one port".to_string(),
         });
     }
+    // The rank-N SMW modal-Robin post-step composes over the assembled
+    // `A(ω)` via `DrivenLinearSolver::spmv_a` / `back_solve`; wiring it to the
+    // matrix-free `BurnCocg` is an explicit follow-on (issue #302 Phase 3).
+    // Guard here at the call site (not inside the shared `prepare_at`) so the
+    // lumped-port / Leontovich matrix-free path stays available.
+    if matches!(solver_mode, SolverMode::IterativeMatrixFree(_)) {
+        return Err(DrivenError::UnsupportedMatrixFree {
+            reason: "wave-port sweeps (rank-N SMW modal-Robin) are not yet wired to the \
+                     matrix-free path; use SolverMode::Direct or SolverMode::Iterative"
+                .to_string(),
+        });
+    }
     let edges = mesh.edges();
     let n_edges = edges.len();
 
@@ -619,7 +631,7 @@ pub fn solve_wave_port_sweep_with_mode<B: burn::tensor::backend::Backend>(
             // `DrivenLinearSolver::back_solve` (issue #264) so the
             // SMW arithmetic composes with both direct LU and
             // iterative COCG without touching the post-step pieces.
-            let solver = op.prepare_at(omega, solver_mode)?;
+            let solver = op.prepare_at::<B>(omega, solver_mode, device)?;
             let mut iters_per_rhs: Vec<usize> = Vec::with_capacity(2 * n_channels);
             let mut ainv_u: Vec<Vec<c64>> = Vec::with_capacity(n_channels);
             for col in fluxes_int.iter() {

--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -144,6 +144,11 @@ pub enum DrivenError {
     Factorization(String),
     #[error("sparse solve failed: {0}")]
     Solve(String),
+    #[error(
+        "matrix-free solver (SolverMode::IterativeMatrixFree) does not support this \
+         configuration: {reason}"
+    )]
+    UnsupportedMatrixFree { reason: String },
 }
 
 /// Linear-solver selection for the per-ω back-solves used by the
@@ -197,6 +202,23 @@ pub enum SolverMode {
     /// cached sparse `A(ω)`, with the Jacobi preconditioner built once
     /// per ω and reused across RHS.
     Iterative(IterativeSettings),
+    /// **GPU-resident matrix-free** COCG path (issue #302 Phase 3 / PR
+    /// #487's [`crate::solver::ksp_burn::BurnCocg`]). Like
+    /// [`SolverMode::Iterative`] it never factors `A(ω)`, but it also
+    /// never *assembles* the volume pencil: the `K − ω²M(ε) + iωC(σ)`
+    /// matvec runs element-locally on Burn tensors
+    /// ([`crate::solver::ksp_burn::ComplexMatrixFreeOperator`]) with the
+    /// small port / Leontovich surface terms applied as an on-device COO
+    /// correction ([`crate::driven::matrix_free`]). The Krylov vectors
+    /// stay on-device; only O(1) scalars cross the host boundary per
+    /// iteration.
+    ///
+    /// **Opt-in and restricted (v1)**: only scalar **real** ε materials
+    /// are supported — [`DrivenMaterials::DiagTensor`] /
+    /// [`DrivenMaterials::MatchedUpml`] and wave-port sweeps are rejected
+    /// with a clean [`DrivenError`]; lumped ports and Leontovich surfaces
+    /// are handled. The default remains [`SolverMode::Direct`].
+    IterativeMatrixFree(IterativeSettings),
 }
 
 /// Tunable knobs for [`SolverMode::Iterative`].
@@ -875,6 +897,34 @@ pub struct DrivenOperator {
     /// parts), full edge length; `b(ω) = iω (rhs_re + i·rhs_im)`.
     rhs_re: Vec<f64>,
     rhs_im: Vec<f64>,
+    /// Which [`DrivenMaterials`] variant this operator was assembled
+    /// with. The matrix-free path ([`SolverMode::IterativeMatrixFree`])
+    /// only supports scalar-real ε; the guard reads this flag rather than
+    /// sniffing `k_vals` for a nonzero imaginary part (issue #493).
+    materials_kind: MaterialsKind,
+    /// Host-side ingredients for the matrix-free Krylov path, retained
+    /// only when the material is scalar-**real** (so the Burn
+    /// [`crate::solver::ksp_burn::ComplexMatrixFreeOperator`] — which
+    /// takes real per-tet ε/σ — can be rebuilt per ω without re-uploading
+    /// the mesh). `None` for tensor / matched-UPML materials, which the
+    /// matrix-free path rejects.
+    matrix_free: Option<crate::driven::matrix_free::MatrixFreeIngredients>,
+}
+
+/// Which [`DrivenMaterials`] variant a [`DrivenOperator`] was assembled
+/// with — a small stored flag so [`SolverMode::IterativeMatrixFree`] can
+/// reject anisotropic / matched-UPML materials at solver-prep time
+/// without inspecting the already-combined value tensors (issue #493).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MaterialsKind {
+    /// Scalar complex relative permittivity (may still be complex-valued;
+    /// the matrix-free path additionally requires it to be purely real,
+    /// tracked separately by whether `matrix_free` is populated).
+    Scalar,
+    /// Diagonal anisotropic ε tensor.
+    DiagTensor,
+    /// Matched (full Sacks) UPML materials.
+    MatchedUpml,
 }
 
 /// Borrowed view of one port's ω-independent data, handed to the
@@ -957,6 +1007,11 @@ impl DrivenOperator {
                 want: n_tets,
             });
         }
+        let materials_kind = match materials {
+            DrivenMaterials::Scalar(_) => MaterialsKind::Scalar,
+            DrivenMaterials::DiagTensor(_) => MaterialsKind::DiagTensor,
+            DrivenMaterials::MatchedUpml { .. } => MaterialsKind::MatchedUpml,
+        };
         let material_len = match materials {
             DrivenMaterials::Scalar(eps) => eps.len(),
             DrivenMaterials::DiagTensor(eps) => eps.len(),
@@ -1283,6 +1338,33 @@ impl DrivenOperator {
             })
             .collect();
 
+        // --- Matrix-free ingredients (issue #302 Phase 3) ---------------------
+        // Retain the host-side mesh + real per-tet ε/σ + interior mask needed
+        // to rebuild the Burn `ComplexMatrixFreeOperator` per ω, but only for
+        // scalar-**real** ε: the Burn operator takes real scalar ε/σ, so
+        // complex-ε (scalar PML), anisotropic, and matched-UPML materials are
+        // out of scope for the matrix-free path and leave `matrix_free = None`
+        // (the guard in `prepare_at` rejects them with a clean error).
+        let matrix_free = match materials {
+            DrivenMaterials::Scalar(eps) if eps.iter().all(|e| e.im == 0.0) => {
+                let epsilon_r: Vec<f64> = eps.iter().map(|e| e.re).collect();
+                let sigma = sigma_tet
+                    .map(|s| s.to_vec())
+                    .unwrap_or_else(|| vec![0.0_f64; n_tets]);
+                Some(crate::driven::matrix_free::MatrixFreeIngredients {
+                    nodes: mesh.nodes.clone(),
+                    tets: mesh.tets.clone(),
+                    tet_edge_idx: tet_idx.clone(),
+                    tet_edge_sign: tet_sign.clone(),
+                    n_edges,
+                    epsilon_r,
+                    sigma,
+                    interior_mask: bcs.pec_interior_mask.to_vec(),
+                })
+            }
+            _ => None,
+        };
+
         Ok(DrivenOperator {
             n_edges,
             n_interior,
@@ -1297,6 +1379,8 @@ impl DrivenOperator {
             ports: operator_ports,
             rhs_re,
             rhs_im,
+            materials_kind,
+            matrix_free,
         })
     }
 
@@ -1598,6 +1682,54 @@ impl DrivenOperator {
             length: port.length,
             resistance: port.resistance,
         }
+    }
+
+    /// Interior → full edge-index map: `interior_to_full()[i]` is the
+    /// full `[n_edges]` edge index of the `i`-th kept interior DOF, in
+    /// contiguous interior order (the inverse of the private `remap`
+    /// full→interior table on its non-eliminated entries).
+    ///
+    /// The matrix-free Krylov path ([`crate::driven::matrix_free`]) runs
+    /// in **full-edge** space (with an interior mask), while every stored
+    /// surface triplet (`port.mass_triplets`, [`OperatorSurface::s_vals`])
+    /// is **interior-remapped**; this map lifts those interior indices
+    /// back to full-edge space at setup time (issue #493 Gap 1).
+    pub(crate) fn interior_to_full(&self) -> Vec<usize> {
+        let mut inv = vec![0_usize; self.n_interior];
+        for (full_idx, &ri) in self.remap.iter().enumerate() {
+            if ri >= 0 {
+                inv[ri as usize] = full_idx;
+            }
+        }
+        inv
+    }
+
+    /// Number of Leontovich impedance surfaces.
+    pub(crate) fn n_surfaces(&self) -> usize {
+        self.surfaces.len()
+    }
+
+    /// Leontovich surface `i` as interior-remapped `(row, col, value)`
+    /// triplets of its real, ω-independent mass `S_Γ` (the nonzero subset
+    /// of the dense `s_vals` aligned with [`DrivenOperator::rows`] /
+    /// [`DrivenOperator::cols`]), together with its ω-dependent surface
+    /// model. The complex weak coefficient `iω/Z_s(ω)` is obtained from
+    /// the model via [`SurfaceImpedanceModel::weak_coefficient`] per ω, so
+    /// the matrix-free path re-applies it exactly as `assemble_a_at` does
+    /// (issue #493 Gap 2).
+    pub(crate) fn surface_mass_triplets(
+        &self,
+        i: usize,
+    ) -> (Vec<(usize, usize, f64)>, SurfaceImpedanceModel) {
+        let s = &self.surfaces[i];
+        let triplets = self
+            .rows
+            .iter()
+            .zip(self.cols.iter())
+            .zip(s.s_vals.iter())
+            .filter_map(|((&r, &c), &v)| if v != 0.0 { Some((r, c, v)) } else { None })
+            .collect();
+        (triplets, s.model)
     }
 
     /// Interior-filter a full-length real vector through the PEC mask,
@@ -1929,14 +2061,14 @@ pub struct BackSolveReport {
 /// every RHS; on the iterative path the Jacobi preconditioner is built
 /// once at construction and reused across every
 /// [`DrivenLinearSolver::back_solve`] call.
-pub struct DrivenLinearSolver<'a> {
+pub struct DrivenLinearSolver<'a, B: Backend> {
     op: &'a DrivenOperator,
     omega: f64,
     a_int: SparseColMat<usize, c64>,
-    backend: SolverBackend,
+    backend: SolverBackend<B>,
 }
 
-enum SolverBackend {
+enum SolverBackend<B: Backend> {
     Direct {
         // Boxed because the faer `Lu` factorization is large (~300 B);
         // boxing keeps the `SolverBackend` enum compact so the
@@ -1948,18 +2080,29 @@ enum SolverBackend {
         precond: crate::solver::ksp::JacobiPreconditioner,
         ksp: crate::solver::ksp::Cocg,
     },
+    /// GPU-resident matrix-free COCG (issue #302 Phase 3): the Burn
+    /// volume pencil plus the on-device COO surface correction, boxed to
+    /// keep the enum compact.
+    MatrixFree {
+        solver: Box<crate::driven::matrix_free::MatrixFreeSolver<B>>,
+    },
 }
 
-impl<'a> DrivenLinearSolver<'a> {
+impl<'a, B: Backend> DrivenLinearSolver<'a, B> {
     /// The frequency `ω` this handle was prepared at.
     pub fn omega(&self) -> f64 {
         self.omega
     }
 
-    /// `true` if this handle uses the iterative (COCG) back-solve path,
-    /// `false` for the direct LU path.
+    /// `true` if this handle uses an iterative (COCG) back-solve path —
+    /// either the assembled-CSR [`SolverMode::Iterative`] or the
+    /// matrix-free [`SolverMode::IterativeMatrixFree`] — `false` for the
+    /// direct LU path.
     pub fn is_iterative(&self) -> bool {
-        matches!(self.backend, SolverBackend::Iterative { .. })
+        matches!(
+            self.backend,
+            SolverBackend::Iterative { .. } | SolverBackend::MatrixFree { .. }
+        )
     }
 
     /// Solve with **all** baked excitations active (volume current
@@ -2063,6 +2206,15 @@ impl<'a> DrivenLinearSolver<'a> {
                     residual_rel: report.residual_rel,
                 })
             }
+            SolverBackend::MatrixFree { solver } => {
+                // The matrix-free solver handles the zero-RHS shortcut and
+                // the interior↔full lift internally (issue #302 Phase 3).
+                let report = solver.back_solve(b, out)?;
+                Ok(BackSolveReport {
+                    iters: report.iters,
+                    residual_rel: report.residual_rel,
+                })
+            }
         }
     }
 
@@ -2109,22 +2261,40 @@ impl DrivenOperator {
     /// - [`SolverMode::Iterative`]: build the Jacobi preconditioner from
     ///   `A(ω)`; the handle's `back_solve` runs a fresh
     ///   [`crate::solver::ksp::Cocg`] iteration per RHS.
+    /// - [`SolverMode::IterativeMatrixFree`]: build the Burn matrix-free
+    ///   volume pencil plus the on-device COO surface correction at ω
+    ///   ([`crate::driven::matrix_free`]); the handle's `back_solve` runs
+    ///   a [`crate::solver::ksp_burn::BurnCocg`] iteration per RHS with the
+    ///   Krylov vectors on-device.
     ///
-    /// In both cases the cached sparse `A(ω)` is held by the handle, so
-    /// [`DrivenLinearSolver::spmv_a`] is identical across modes (and
-    /// the same as [`FactoredDrivenOperator::spmv_a`]).
+    /// The cached sparse `A(ω)` is held by the handle in all three modes,
+    /// so [`DrivenLinearSolver::spmv_a`] is identical across modes. On the
+    /// matrix-free path the *solve* never touches `a_int` — it is retained
+    /// only so `spmv_a` (the wave-port residual check) keeps working; the
+    /// volume matvec runs element-locally on Burn tensors.
+    ///
+    /// # Matrix-free restrictions (v1)
+    ///
+    /// [`SolverMode::IterativeMatrixFree`] requires a scalar-**real** ε
+    /// material — [`DrivenMaterials::DiagTensor`] and
+    /// [`DrivenMaterials::MatchedUpml`] are rejected with
+    /// [`DrivenError::UnsupportedMatrixFree`]. Wave-port sweeps are guarded
+    /// at the `solve_wave_port_sweep_with_mode` call site, not here.
     ///
     /// # Errors
     ///
     /// [`DrivenError::SurfaceImpedanceSingular`], the sparse assembly
-    /// failures, the LU-factorization failure on the direct path, or
+    /// failures, the LU-factorization failure on the direct path,
     /// [`DrivenError::Solve`] wrapping a Jacobi-preconditioner setup
-    /// error (a zero / non-finite diagonal) on the iterative path.
-    pub fn prepare_at(
+    /// error (a zero / non-finite diagonal) on the iterative path, or
+    /// [`DrivenError::UnsupportedMatrixFree`] for an unsupported material
+    /// on the matrix-free path.
+    pub fn prepare_at<B: Backend>(
         &self,
         omega: f64,
         mode: SolverMode,
-    ) -> Result<DrivenLinearSolver<'_>, DrivenError> {
+        device: &B::Device,
+    ) -> Result<DrivenLinearSolver<'_, B>, DrivenError> {
         let a_int = self.assemble_a_at(omega)?;
         let backend = match mode {
             SolverMode::Direct => {
@@ -2139,6 +2309,38 @@ impl DrivenOperator {
                     .map_err(|e| DrivenError::Solve(format!("Jacobi preconditioner setup: {e}")))?;
                 let ksp = crate::solver::ksp::Cocg::new(settings.tol, settings.max_iters);
                 SolverBackend::Iterative { precond, ksp }
+            }
+            SolverMode::IterativeMatrixFree(settings) => {
+                let ing = self.matrix_free.as_ref().ok_or_else(|| {
+                    DrivenError::UnsupportedMatrixFree {
+                        reason: match self.materials_kind {
+                            MaterialsKind::Scalar => {
+                                "complex (lossy / PML) scalar ε is not supported by the \
+                                 matrix-free path (v1): it takes real per-tet ε only"
+                            }
+                            MaterialsKind::DiagTensor => {
+                                "anisotropic (DiagTensor) ε is not supported by the \
+                                 matrix-free path (v1)"
+                            }
+                            MaterialsKind::MatchedUpml => {
+                                "matched-UPML materials are not supported by the \
+                                 matrix-free path (v1)"
+                            }
+                        }
+                        .to_string(),
+                    }
+                })?;
+                let solver = crate::driven::matrix_free::MatrixFreeSolver::<B>::new(
+                    self,
+                    ing,
+                    omega,
+                    settings.tol,
+                    settings.max_iters,
+                    device,
+                )?;
+                SolverBackend::MatrixFree {
+                    solver: Box::new(solver),
+                }
             }
         };
         Ok(DrivenLinearSolver {

--- a/crates/geode-core/src/solver/ksp_burn.rs
+++ b/crates/geode-core/src/solver/ksp_burn.rs
@@ -320,6 +320,13 @@ pub struct ComplexMatrixFreeOperator<B: Backend> {
     op_sigma: MatrixFreeNedelecOperator<B>,
     /// Angular frequency ω.
     omega: f64,
+    /// Real part of the complex diagonal `d = diag(K) − ω²diag(M) + iω diag(C)`
+    /// (**before** inversion) — exposed via [`Self::complex_diagonal`] so the
+    /// surface-corrected composite operator ([`crate::driven::matrix_free`])
+    /// can add its surface-mass diagonal and form its own Jacobi inverse.
+    diag_re: Tensor<B, 1>,
+    /// Imag part of the complex diagonal (before inversion).
+    diag_im: Tensor<B, 1>,
     /// Real part of the complex inverse-diagonal (for Jacobi apply).
     inv_diag_re: Tensor<B, 1>,
     /// Imag part of the complex inverse-diagonal.
@@ -420,43 +427,23 @@ impl<B: Backend> ComplexMatrixFreeOperator<B> {
         let d_re = dk.sub(dm.mul_scalar(omega * omega));
         let d_im = dc.mul_scalar(omega);
 
-        // Masked (constrained) DOFs have a zero diagonal — set their
-        // inverse-diagonal to a safe (1 + 0i) so the Jacobi apply never divides
-        // by zero; the operator masking keeps those DOFs identically zero in
-        // every Krylov vector regardless.
         let mask_f: Vec<f64> = interior_mask
             .iter()
             .map(|&k| if k { 1.0 } else { 0.0 })
             .collect();
-        let mask = Tensor::<B, 1>::from_data(TensorData::new(mask_f.clone(), [n_edges]), &device);
-        let not_mask = Tensor::<B, 1>::from_data(
-            TensorData::new(
-                mask_f.iter().map(|&k| 1.0 - k).collect::<Vec<f64>>(),
-                [n_edges],
-            ),
-            &device,
-        );
+        let mask = Tensor::<B, 1>::from_data(TensorData::new(mask_f, [n_edges]), &device);
 
-        // On interior DOFs: inv = conj(d)/|d|². On constrained DOFs: inv = 1.
-        // Guard |d|² against underflow-to-zero on interior DOFs (a genuinely
-        // zero interior diagonal is a degenerate operator — fall back to 1 so
-        // the loop reports NotConverged rather than producing NaNs).
-        let mag2 = d_re.clone().powi_scalar(2).add(d_im.clone().powi_scalar(2));
-        // where mag2 == 0 within interior, replace with 1 to avoid NaN.
-        let mag2_safe = mag2.clone().add(not_mask.clone()); // constrained → +1 (nonzero)
-        let mag2_safe = mag2_safe
-            .clone()
-            .mask_fill(mag2_safe.clone().equal_elem(0.0), 1.0);
-        let inv_re_interior = d_re.div(mag2_safe.clone());
-        let inv_im_interior = d_im.neg().div(mag2_safe);
-        // Blend: interior keeps the reciprocal, constrained gets (1, 0).
-        let inv_diag_re = inv_re_interior.mul(mask.clone()).add(not_mask.clone());
-        let inv_diag_im = inv_im_interior.mul(mask.clone());
+        // Jacobi inverse-diagonal from the complex diagonal (safe on the
+        // masked DOFs). Shared with the surface-corrected composite operator.
+        let (inv_diag_re, inv_diag_im) =
+            safe_complex_inv_diag(d_re.clone(), d_im.clone(), mask.clone());
 
         Self {
             op_eps,
             op_sigma,
             omega,
+            diag_re: d_re,
+            diag_im: d_im,
             inv_diag_re,
             inv_diag_im,
             interior_mask: mask,
@@ -483,6 +470,27 @@ impl<B: Backend> ComplexMatrixFreeOperator<B> {
     /// Device the operator lives on.
     pub fn device(&self) -> &B::Device {
         &self.device
+    }
+
+    /// Angular frequency ω the pencil was built at.
+    pub fn omega(&self) -> f64 {
+        self.omega
+    }
+
+    /// The interior mask `[n_edges]` (`1.0` kept, `0.0` constrained).
+    pub fn interior_mask(&self) -> Tensor<B, 1> {
+        self.interior_mask.clone()
+    }
+
+    /// The complex diagonal `d = diag(K) − ω²diag(M) + iω diag(C)` of the
+    /// **volume** pencil (before inversion), as an on-device `(re, im)`
+    /// pair. The surface-corrected composite operator
+    /// ([`crate::driven::matrix_free`]) adds its surface-mass diagonal to
+    /// this before forming its own Jacobi inverse-diagonal (via
+    /// [`safe_complex_inv_diag`]), so the matrix-free Jacobi preconditioner
+    /// matches the assembled-`A(ω)` diagonal the CPU COCG path sees.
+    pub fn complex_diagonal(&self) -> (Tensor<B, 1>, Tensor<B, 1>) {
+        (self.diag_re.clone(), self.diag_im.clone())
     }
 
     /// Apply the complex pencil: `y = A(ω) · x`, four real block-applies.
@@ -584,6 +592,85 @@ fn scatter_elem_diag<B: Backend>(
     out
 }
 
+/// Form the safe complex Jacobi inverse-diagonal `inv = conj(d)/|d|²` from a
+/// complex diagonal `d = (d_re, d_im)` and an interior `mask` (`1.0` kept,
+/// `0.0` constrained).
+///
+/// Masked (constrained) DOFs have a zero diagonal, so their inverse is set to
+/// a safe `(1 + 0i)`; the operator masking keeps those DOFs identically zero
+/// in every Krylov vector regardless. A genuinely zero *interior* diagonal
+/// (a degenerate operator) also falls back to `1` so the loop reports
+/// non-convergence rather than producing NaNs. Shared between the volume
+/// [`ComplexMatrixFreeOperator`] and the surface-corrected composite operator
+/// ([`crate::driven::matrix_free`]) so both build their preconditioner the
+/// same way.
+pub fn safe_complex_inv_diag<B: Backend>(
+    d_re: Tensor<B, 1>,
+    d_im: Tensor<B, 1>,
+    mask: Tensor<B, 1>,
+) -> (Tensor<B, 1>, Tensor<B, 1>) {
+    // not_mask = 1 − mask (constrained DOFs).
+    let not_mask = mask.clone().neg().add_scalar(1.0);
+
+    let mag2 = d_re.clone().powi_scalar(2).add(d_im.clone().powi_scalar(2));
+    // Constrained → +1 (nonzero); then replace any remaining zeros with 1.
+    let mag2_safe = mag2.add(not_mask.clone());
+    let mag2_safe = mag2_safe
+        .clone()
+        .mask_fill(mag2_safe.clone().equal_elem(0.0), 1.0);
+
+    let inv_re_interior = d_re.div(mag2_safe.clone());
+    let inv_im_interior = d_im.neg().div(mag2_safe);
+    // Blend: interior keeps the reciprocal, constrained gets (1, 0).
+    let inv_diag_re = inv_re_interior.mul(mask.clone()).add(not_mask);
+    let inv_diag_im = inv_im_interior.mul(mask);
+    (inv_diag_re, inv_diag_im)
+}
+
+// ---------------------------------------------------------------------------
+// MatrixFreeComplexOperator — the operator seam BurnCocg iterates against
+// ---------------------------------------------------------------------------
+
+/// The on-device complex-symmetric operator interface [`BurnCocg`] drives.
+///
+/// [`ComplexMatrixFreeOperator`] is the volume-only implementation; the
+/// surface-corrected composite in [`crate::driven::matrix_free`] wraps a
+/// volume operator plus the small on-device COO port / Leontovich correction
+/// and implements the same trait, so `BurnCocg::solve` iterates against either
+/// without change (issue #302 Phase 3). The Jacobi apply and interior
+/// projection are part of the seam because the loop preconditions and
+/// sanitizes the RHS through them.
+pub trait MatrixFreeComplexOperator<B: Backend> {
+    /// Operator dimension (number of edge DOFs).
+    fn n_edges(&self) -> usize;
+    /// Device the operator tensors live on.
+    fn device(&self) -> &B::Device;
+    /// Project a split-complex vector onto the interior subspace.
+    fn project_interior(&self, v: &SplitComplex<B>) -> SplitComplex<B>;
+    /// Apply the complex operator `y = A(ω) · x`.
+    fn apply(&self, x: &SplitComplex<B>) -> SplitComplex<B>;
+    /// Jacobi preconditioner apply `z = M⁻¹ r`.
+    fn jacobi_apply(&self, r: &SplitComplex<B>) -> SplitComplex<B>;
+}
+
+impl<B: Backend> MatrixFreeComplexOperator<B> for ComplexMatrixFreeOperator<B> {
+    fn n_edges(&self) -> usize {
+        self.n_edges
+    }
+    fn device(&self) -> &B::Device {
+        &self.device
+    }
+    fn project_interior(&self, v: &SplitComplex<B>) -> SplitComplex<B> {
+        ComplexMatrixFreeOperator::project_interior(self, v)
+    }
+    fn apply(&self, x: &SplitComplex<B>) -> SplitComplex<B> {
+        ComplexMatrixFreeOperator::apply(self, x)
+    }
+    fn jacobi_apply(&self, r: &SplitComplex<B>) -> SplitComplex<B> {
+        ComplexMatrixFreeOperator::jacobi_apply(self, r)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // BurnCocg — the on-device COCG loop
 // ---------------------------------------------------------------------------
@@ -663,9 +750,9 @@ impl BurnCocg {
     /// Only O(1) scalars cross the host boundary per iteration; `b` is uploaded
     /// once by the caller and `x` downloaded once by the caller after this
     /// returns (see [`SplitComplex::upload`] / [`download`](SplitComplex::download)).
-    pub fn solve<B: Backend>(
+    pub fn solve<B: Backend, Op: MatrixFreeComplexOperator<B>>(
         &self,
-        op: &ComplexMatrixFreeOperator<B>,
+        op: &Op,
         b: &SplitComplex<B>,
     ) -> Result<(SplitComplex<B>, KspReport), KspError> {
         let n = op.n_edges();
@@ -766,8 +853,8 @@ impl BurnCocg {
 /// Recompute `‖A x − b‖₂ / ‖b‖₂` with an explicit on-device matvec (the same
 /// reliable figure the CPU path reports; the recursively-maintained `r` can
 /// drift on ill-conditioned systems).
-fn true_residual_rel<B: Backend>(
-    op: &ComplexMatrixFreeOperator<B>,
+fn true_residual_rel<B: Backend, Op: MatrixFreeComplexOperator<B>>(
+    op: &Op,
     x: &SplitComplex<B>,
     b: &SplitComplex<B>,
     b_norm: f64,

--- a/crates/geode-core/tests/driven_matrix_free_equivalence.rs
+++ b/crates/geode-core/tests/driven_matrix_free_equivalence.rs
@@ -1,0 +1,531 @@
+//! Matrix-free driven solve equivalence gates (issue #302 Phase 3 / PR #493).
+//!
+//! [`SolverMode::IterativeMatrixFree`] wires PR #487's GPU-resident
+//! [`geode_core::solver::ksp_burn::BurnCocg`] (over the Burn volume pencil plus
+//! an on-device COO surface correction) into the driven back-solve seam. These
+//! regressions verify that the matrix-free path:
+//!
+//! 1. produces `DrivenSolution`s / port circuit quantities matching the
+//!    `Direct` (faer sparse-LU) path on the existing cube lumped-port and
+//!    two-port fixtures to the tolerances `iterative_sweep.rs` already asserts
+//!    for the assembled `Iterative` path (a σ-lossy cube keeps the pencil
+//!    well-conditioned);
+//! 2. records BurnCocg iteration counts **consistent** with the assembled-CSR
+//!    Jacobi COCG on the same fixtures (the port `S_p` diagonal is folded into
+//!    the matrix-free Jacobi preconditioner, so the two preconditioners match);
+//! 3. rejects the unsupported configurations (wave-port sweeps, anisotropic /
+//!    matched-UPML materials) with a clean [`DrivenError::UnsupportedMatrixFree`];
+//! 4. leaves the existing `Direct` / `Iterative` modes untouched (they are
+//!    exercised unchanged by `iterative_sweep.rs`).
+//!
+//! Fixtures are the *same* cube lumped-port / two-port meshes as
+//! `iterative_sweep.rs` (extended, not reinvented) — ndarray-f64 in CI. The
+//! observed iteration counts are printed to stderr so future runs surface
+//! convergence degradation (matching the `iterative_sweep.rs` convention).
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use geode_core::driven::extraction::{
+    driven_frequency_sweep, driven_frequency_sweep_with_mode, s_parameter_frequency_sweep,
+    s_parameter_frequency_sweep_with_mode,
+};
+use geode_core::driven::ports::{LumpedPort, WavePort, solve_wave_port_sweep_with_mode};
+use geode_core::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, IterativeSettings,
+    SolverMode, SurfaceImpedanceBc, SurfaceImpedanceModel,
+};
+use geode_core::mesh::{TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+fn zero_source(mesh: &TetMesh) -> CurrentSource {
+    CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    }
+}
+
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+// ===========================================================================
+// 1. driven_frequency_sweep: matrix-free vs direct (cube lumped port)
+// ===========================================================================
+
+/// **Acceptance criterion 1 (single lumped port)**: matrix-free
+/// `driven_frequency_sweep` matches the direct LU path's port impedance
+/// `Z(ω)` on the σ-lossy parallel-plate resistor fixture — the same fixture
+/// `driven_frequency_sweep_iterative_matches_direct` uses for the assembled
+/// COCG path.
+#[test]
+fn driven_frequency_sweep_matrix_free_matches_direct() {
+    let mesh = cube_tet_mesh(4, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let sigma = 2.0;
+    let eps = vacuum(&mesh);
+    let sigma_tet = vec![sigma; mesh.n_tets()];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.05_f64, 0.10, 0.20];
+
+    let direct = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("direct sweep");
+
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let matrix_free = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    )
+    .expect("matrix-free sweep");
+
+    assert_eq!(direct.len(), matrix_free.len());
+    for (pt_d, pt_m) in direct.iter().zip(matrix_free.iter()) {
+        assert_eq!(pt_d.iters_per_rhs, vec![0]);
+        assert_eq!(pt_m.iters_per_rhs.len(), 1);
+        let iters = pt_m.iters_per_rhs[0];
+        assert!(iters > 0, "matrix-free path must record iterations");
+
+        let z_d = pt_d.ports[0].z;
+        let z_m = pt_m.ports[0].z;
+        let rel_diff = (z_d - z_m).norm() / z_d.norm().max(1e-30);
+        eprintln!(
+            "[#493 / driven_frequency_sweep] ω = {:.3}: Z_direct = {z_d}, \
+             Z_matrix_free = {z_m}, rel_diff = {:.3e}, BurnCOCG iters = {iters}",
+            pt_d.omega, rel_diff,
+        );
+        assert!(
+            rel_diff < 1e-6,
+            "ω = {}: Z agreement |Z_d − Z_mf| / |Z_d| = {} (tol 1e-6)",
+            pt_d.omega,
+            rel_diff
+        );
+        assert!(
+            pt_m.residual_rel < 1e-8,
+            "matrix-free residual too large at ω = {}: {}",
+            pt_m.omega,
+            pt_m.residual_rel
+        );
+    }
+}
+
+// ===========================================================================
+// 2. s_parameter_frequency_sweep: matrix-free vs direct (two lumped ports)
+// ===========================================================================
+
+/// **Acceptance criterion 1 (two ports)**: matrix-free
+/// `s_parameter_frequency_sweep` matches the direct LU S-matrix on the
+/// two-port matched-stub cube fixture (same fixture as
+/// `s_parameter_sweep_iterative_matches_direct`).
+#[test]
+fn s_parameter_sweep_matrix_free_matches_direct() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let edges = mesh.edges();
+    let port1_faces = plane_faces(&mesh, 2, 0.0);
+    let port2_faces = plane_faces(&mesh, 2, 1.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    // A little volumetric σ sharpens conditioning for the Jacobi COCG so the
+    // two-port cavity is not near-singular at these low ω.
+    let sigma_tet = vec![0.5_f64; mesh.n_tets()];
+    let port1 = LumpedPort {
+        faces: &port1_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let port2 = LumpedPort {
+        faces: &port2_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.10_f64, 0.20];
+
+    let direct = s_parameter_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[port1.clone(), port2.clone()],
+        &[],
+        &omegas,
+        &device(),
+    )
+    .expect("direct S sweep");
+
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let matrix_free = s_parameter_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[port1.clone(), port2.clone()],
+        &[],
+        &omegas,
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    )
+    .expect("matrix-free S sweep");
+
+    assert_eq!(direct.len(), matrix_free.len());
+    for (pt_d, pt_m) in direct.iter().zip(matrix_free.iter()) {
+        assert_eq!(pt_d.iters_per_rhs.len(), 2);
+        assert!(pt_d.iters_per_rhs.iter().all(|&i| i == 0));
+        assert_eq!(pt_m.iters_per_rhs.len(), 2);
+        assert!(pt_m.iters_per_rhs.iter().all(|&i| i > 0));
+
+        let n = 2;
+        let mut max_rel_diff = 0.0_f64;
+        for k in 0..n * n {
+            let s_d = pt_d.s.s[k];
+            let s_m = pt_m.s.s[k];
+            let rel_diff = (s_d - s_m).norm() / s_d.norm().max(1e-30);
+            if rel_diff > max_rel_diff {
+                max_rel_diff = rel_diff;
+            }
+        }
+        eprintln!(
+            "[#493 / s_parameter_sweep] ω = {:.3}: max |ΔS|/|S| = {:.3e}, \
+             BurnCOCG iters per RHS = {:?}",
+            pt_d.omega, max_rel_diff, pt_m.iters_per_rhs,
+        );
+        assert!(
+            max_rel_diff < 1e-5,
+            "ω = {}: max S-matrix rel_diff = {} (tol 1e-5)",
+            pt_d.omega,
+            max_rel_diff
+        );
+    }
+}
+
+// ===========================================================================
+// 3. Iteration-count consistency: matrix-free BurnCocg vs assembled Cocg
+// ===========================================================================
+
+/// **Acceptance criterion 2**: the matrix-free BurnCocg iteration count is
+/// consistent (within a small band) with the assembled-CSR Jacobi COCG on the
+/// same σ-lossy cube lumped-port fixture — both precondition with the same
+/// complex diagonal (volume + port surface), so the counts should be close.
+#[test]
+fn iteration_counts_track_assembled_cocg() {
+    let mesh = cube_tet_mesh(4, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let sigma_tet = vec![2.0_f64; mesh.n_tets()];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.05_f64, 0.10, 0.20];
+    let settings = IterativeSettings::new(1e-10, 5_000);
+
+    let assembled = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        SolverMode::Iterative(settings),
+        &device(),
+    )
+    .expect("assembled iterative sweep");
+
+    let matrix_free = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    )
+    .expect("matrix-free sweep");
+
+    for (pt_a, pt_m) in assembled.iter().zip(matrix_free.iter()) {
+        let it_a = pt_a.iters_per_rhs[0] as i64;
+        let it_m = pt_m.iters_per_rhs[0] as i64;
+        eprintln!(
+            "[#493 / iteration-parity] ω = {:.3}: assembled Cocg iters = {it_a}, \
+             matrix-free BurnCocg iters = {it_m}, Δ = {}",
+            pt_a.omega,
+            (it_m - it_a).abs(),
+        );
+        // Same preconditioner diagonal, same complex-symmetric pencil, same
+        // tol — the two COCG recurrences track closely, but the substrates
+        // differ (assembled Cocg iterates in interior `n_interior` space on
+        // faer `c64`; BurnCocg iterates in full-edge masked space over
+        // split-complex Burn tensors with batched-bmm summation order), so
+        // exact iteration equality is not expected. Measured Δ on this fixture
+        // is ≤ 9 (ω = 0.05: 545 vs 543; ω = 0.10: 496 vs 505; ω = 0.20 close);
+        // a ±15 band flags a genuine convergence regression while tolerating
+        // the substrate-level reordering (PR #487 measured exact-to-±4 on the
+        // volume-only pencil; the port surface term widens it modestly).
+        assert!(
+            (it_m - it_a).abs() <= 15,
+            "ω = {}: matrix-free iters {it_m} diverge from assembled {it_a} by > 15",
+            pt_a.omega
+        );
+    }
+}
+
+// ===========================================================================
+// 4. Leontovich surface (S_Γ) equivalence — the ω-dependent COO term
+// ===========================================================================
+
+/// **Acceptance criterion 1 (Leontovich surface)**: with a good-conductor
+/// Leontovich wall (whose weak coefficient `iω/Z_s(ω) ∝ √ω·(1+i)` is
+/// ω-dependent), the matrix-free full-field solution matches the direct LU
+/// path — exercising the `S_Γ` COO correction (issue #493 Gap-2 accessor) and
+/// its per-ω complex scalar folding. Driven by a volumetric current source
+/// (no lumped ports), comparing the full `[n_edges]` `e_edges` vector.
+#[test]
+fn leontovich_surface_matrix_free_matches_direct() {
+    let mesh = cube_tet_mesh(3, 1.0);
+    let edges = mesh.edges();
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let bcs = DrivenBcs {
+        pec_interior_mask: &mask,
+    };
+    let wall = plane_faces(&mesh, 2, 1.0);
+    let surfaces = [SurfaceImpedanceBc {
+        triangles: &wall,
+        model: SurfaceImpedanceModel::GoodConductor { sigma: 40.0 },
+    }];
+    let source = CurrentSource::from_centroids(&mesh, |c| {
+        [
+            c64::new(0.0, 0.0),
+            c64::new((std::f64::consts::PI * c[2]).sin(), 0.0),
+            c64::new(0.1, 0.0),
+        ]
+    });
+
+    let op = DrivenOperator::assemble::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &bcs,
+        &[],
+        &surfaces,
+        &source,
+        &device(),
+    )
+    .expect("operator assembly");
+
+    let settings = IterativeSettings::new(1e-11, 10_000);
+    for omega in [0.9_f64, 1.7] {
+        let sol_direct = op.solve_at(omega).expect("direct solve_at");
+
+        let solver = op
+            .prepare_at::<B>(omega, SolverMode::IterativeMatrixFree(settings), &device())
+            .expect("matrix-free prepare_at");
+        let (sol_mf, report) = solver.solve().expect("matrix-free solve");
+
+        // Full-field relative error against the direct solution.
+        let mut num = 0.0_f64;
+        let mut den = 0.0_f64;
+        for (d, m) in sol_direct.e_edges.iter().zip(sol_mf.e_edges.iter()) {
+            let diff = *d - *m;
+            num += diff.re * diff.re + diff.im * diff.im;
+            den += d.re * d.re + d.im * d.im;
+        }
+        let rel = (num / den.max(1e-30)).sqrt();
+        eprintln!(
+            "[#493 / leontovich] ω = {:.2}: full-field rel err = {:.3e}, \
+             BurnCOCG iters = {}, residual_rel = {:.3e}",
+            omega, rel, report.iters, report.residual_rel,
+        );
+        assert!(
+            rel < 1e-6,
+            "ω = {omega}: Leontovich matrix-free full-field rel err = {rel} (tol 1e-6)"
+        );
+    }
+}
+
+// ===========================================================================
+// 5. Guard tests: unsupported configurations reject cleanly
+// ===========================================================================
+
+/// **Acceptance criterion 4 (material guard)**: an anisotropic `DiagTensor`
+/// material request on the matrix-free path returns
+/// `DrivenError::UnsupportedMatrixFree` — no silent degradation.
+#[test]
+fn matrix_free_rejects_diag_tensor_material() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps_diag: Vec<[c64; 3]> =
+        vec![[c64::new(1.0, 0.0), c64::new(1.0, 0.0), c64::new(1.0, 0.0)]; mesh.n_tets()];
+    let source = CurrentSource::from_centroids(&mesh, |_| {
+        [c64::new(0.0, 0.0), c64::new(0.0, 0.0), c64::new(1.0, 0.0)]
+    });
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let res = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::DiagTensor(&eps_diag),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[],
+        &[],
+        &[1.0],
+        &source,
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    );
+    assert!(
+        matches!(res, Err(DrivenError::UnsupportedMatrixFree { .. })),
+        "expected UnsupportedMatrixFree, got {res:?}"
+    );
+}
+
+/// **Acceptance criterion 4 (complex-ε guard)**: a lossy *complex* scalar ε
+/// (scalar-PML class) is also out of matrix-free v1 scope and rejects cleanly
+/// — the guard reads the retained-ingredient flag, not a heuristic.
+#[test]
+fn matrix_free_rejects_complex_scalar_epsilon() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let edges = mesh.edges();
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps: Vec<c64> = vec![c64::new(1.0, -0.2); mesh.n_tets()];
+    let source = CurrentSource::from_centroids(&mesh, |_| {
+        [c64::new(0.0, 0.0), c64::new(0.0, 0.0), c64::new(1.0, 0.0)]
+    });
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let res = driven_frequency_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        &[],
+        &[],
+        &[1.0],
+        &source,
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    );
+    assert!(
+        matches!(res, Err(DrivenError::UnsupportedMatrixFree { .. })),
+        "expected UnsupportedMatrixFree, got {res:?}"
+    );
+}
+
+/// **Acceptance criterion 4 (wave-port guard)**: a wave-port sweep on the
+/// matrix-free path is rejected at the `solve_wave_port_sweep_with_mode` call
+/// site (the rank-N SMW modal-Robin composition is a deferred follow-on).
+#[test]
+fn matrix_free_rejects_wave_port_sweep() {
+    // An empty-mesh / trivially-constructed call is enough: the guard fires
+    // before any assembly. Build a minimal valid single wave port so the
+    // "needs at least one port" check passes and the mode guard is reached.
+    let mesh = cube_tet_mesh(2, 1.0);
+    let n_edges = mesh.edges().len();
+    let faces = plane_faces(&mesh, 2, 0.0);
+    let eps = vacuum(&mesh);
+    let mask = vec![true; n_edges];
+    // A dummy single-mode wave port (profile length = n_edges, nonzero a_inc).
+    let mode_profile = vec![0.0_f64; n_edges];
+    let port = WavePort::single_mode(faces, mode_profile, 1.0, c64::new(1.0, 0.0));
+    let settings = IterativeSettings::new(1e-10, 5_000);
+    let res = solve_wave_port_sweep_with_mode::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[2.5],
+        SolverMode::IterativeMatrixFree(settings),
+        &device(),
+    );
+    assert!(
+        matches!(res, Err(DrivenError::UnsupportedMatrixFree { .. })),
+        "expected UnsupportedMatrixFree for wave-port matrix-free, got {res:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Wires PR #487's GPU-resident matrix-free COCG (`BurnCocg` over
`ComplexMatrixFreeOperator`, the `K − ω²M(ε) + iωC(σ)` volume pencil) into the
driven solve layer as an **opt-in** `SolverMode::IterativeMatrixFree`, alongside
`Direct` (faer sparse-LU) and `Iterative` (assembled-CSR CPU COCG). The small
lumped-port (`S_p`) and Leontovich (`S_Γ`) surface terms are applied as an
**on-device COO correction** (Milestone B1). Krylov vectors stay on-device;
only O(1) scalars cross the host boundary per iteration. Completes #302 Phase 3's
CPU-side story.

## B1 / B2 landing decision

**Landed B1 (on-device COO correction) + wiring + full equivalence gates.**
B2 (`MatrixFreeSurfaceMassOperator<B>` with batched `[n_tri,3,3]` Whitney
triangle locals + triangle gather/scatter mirroring PR #483) is scoped as an
**immediate follow-on**: B1 is a fully honest resting state — the COO apply is
principled (two Burn primitives, same op set PR #483 validated), preserves the
O(1)-scalar sync budget, and its host-COO-vs-device-COO cross-check test is
exactly the independent gate B2's triangle gather/scatter would be validated
against. The port/Leontovich triplet counts are genuinely small (36–288 vs
6k–54k edges per the curator's measurements), so the COO artifact is negligible.

## Changes

- **`solver/ksp_burn.rs`**: extract the volume complex diagonal (pre-inversion)
  + `complex_diagonal()` / `interior_mask()` / `omega()` accessors; factor the
  safe Jacobi reciprocal into a shared `safe_complex_inv_diag()`; add the
  `MatrixFreeComplexOperator<B>` trait and make `BurnCocg::solve` generic over
  it so a surface-corrected composite plugs in unchanged.
- **`driven/matrix_free.rs`** (new): `MatrixFreeIngredients` (host-side mesh +
  real ε/σ + mask retained on `DrivenOperator`); `CooSurfaceTerm<B>` (on-device
  `select` gather → scale → `scatter(Add)` COO SpMV, per-ω complex scalar,
  Bunsen contracts + firing test); `SurfaceCorrectedOperator<B>` (volume apply +
  surface COO, composite Jacobi diagonal); `MatrixFreeSolver<B>` (per-ω
  back-solve with interior↔full lift).
- **`driven/solve.rs`**: `SolverMode::IterativeMatrixFree`; `MaterialsKind` flag
  + `matrix_free` ingredients; `interior_to_full()` / `n_surfaces()` /
  `surface_mass_triplets()` accessors (Gap 1 / Gap 2 from the curator note);
  `prepare_at` generic over `B` (+ `device`); `SolverBackend::MatrixFree`;
  `DrivenError::UnsupportedMatrixFree`.
- **`driven/ports/wave.rs`**: reject `IterativeMatrixFree` at the
  `solve_wave_port_sweep_with_mode` call site (deferred rank-N SMW follow-on).
- **`driven/extraction.rs`**: thread `B` / `device` through the two `prepare_at`
  call sites.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `IterativeMatrixFree` matches `Direct` on cube + surface fixtures | ✅ | `driven_matrix_free_equivalence.rs`: single lumped-port Z rel_diff < 1e-6, two-port S-matrix < 1e-5, Leontovich full-field < 1e-6 |
| Iteration counts consistent with assembled-CSR COCG | ✅ | `iteration_counts_track_assembled_cocg`: measured Δ ≤ 9 (545/543, 496/505); ±15 band |
| Ports + Leontovich handled on-device, O(1) host sync preserved | ✅ | COO tensors uploaded once at setup; per-matvec gather/scatter/scale on-device; no `[n]`-sized per-iteration transfer |
| No behavior change to existing modes | ✅ | `iterative_sweep.rs` (Direct/Iterative) green unchanged; full release suite 0 failures |
| Tensor/UPML + wave-port rejected with clean errors | ✅ | Guard tests: `matrix_free_rejects_{diag_tensor,complex_scalar_epsilon,wave_port_sweep}` all assert `UnsupportedMatrixFree` |

## Sync-point documentation

Per back-solve, vectors cross the host boundary exactly **twice** (`b`
lifted-interior→full + uploaded in; `x` downloaded + filtered full→interior
out). Inside the COCG loop the budget is PR #487's unchanged: O(1) scalars per
iteration (`ρ = rᵀz`, `pᵀq`, the Hermitian residual norm). The COO correction
adds **zero** new host sync — its triplet tensors upload once at
`MatrixFreeSolver::new`, and `CooSurfaceTerm::accumulate` is entirely on-device
(`select` / `mul` / `scatter(Add)` / complex scale). See the `# Host-sync
budget` section of `driven/matrix_free.rs`.

## Equivalence + iteration tables

| Fixture | ω | metric | value | tol |
|---|---|---|---|---|
| cube single lumped-port | 0.05–0.20 | \|ΔZ\|/\|Z\| | < 1e-6 | 1e-6 |
| cube two-port | 0.10, 0.20 | max \|ΔS\|/\|S\| | < 1e-5 | 1e-5 |
| cube Leontovich (good-conductor) | 0.9, 1.7 | full-field rel err | < 1e-6 | 1e-6 |

| ω | assembled Cocg iters | matrix-free BurnCocg iters | Δ |
|---|---|---|---|
| 0.05 | 545 | 543 | 2 |
| 0.10 | 496 | 505 | 9 |

Substrate difference (interior-space faer c64 vs full-edge masked split-complex
Burn tensors with batched-bmm summation order) accounts for the small Δ; PR #487
measured exact-to-±4 on the volume-only pencil, the port surface term widens it
modestly.

## Gate results

- `cargo fmt --all --check` ✅
- `cargo clippy -p geode-core --all-targets -- -D warnings` ✅
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` ✅
- new + `iterative_sweep` + `--lib` (`driven::matrix_free`, `solver::ksp_burn`) ✅
- `cargo test -p geode-core --release --tests` — **0 failures**

## Honest-negative escape hatch

Iteration counts are close to the assembled path (Δ ≤ 9) on these fixtures — no
prohibitive-count finding to report. The band assertion documents the measured
substrate spread rather than forcing exact equality.

Closes #493