### PR TITLE
docs(transmon): correct port-EPR wording, add MSH 2.2 step, commit CPU benchmark artifact

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 493
-# Branch: feature/issue-493
+# Issue: 497
+# Branch: feature/issue-497
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/benchmarks/transmon_bench_cpu/results.toml
+++ b/benchmarks/transmon_bench_cpu/results.toml
@@ -1,0 +1,92 @@
+# Transmon eigenmode CPU head-to-head: geode-fem vs Palace on the IDENTICAL
+# sha-pinned transmon fixture (Epic #476 Phase D). Measured 2026-07-14 on a
+# single EC2 instance. This artifact backs the paper's CPU-cell timing/memory
+# table (Table 3); it does NOT gate CI. Correctness (eigenvalue agreement) is
+# cross-validated in benchmarks/transmon_eigen/results.toml — this file is the
+# PERFORMANCE companion only.
+#
+# Provenance contract: every number below is a measured value from the run
+# described in [hardware]/[software]. Timing = /usr/bin/time wall clock over
+# the FULL pipeline (mesh load + assembly + solve + output). Memory = peak
+# resident set size (RSS) from /usr/bin/time (maximum resident set, kB).
+
+[meta]
+description = "CPU-cell head-to-head: geode-fem serial (faer sparse-LU shift-invert Lanczos) vs Palace distributed (MPI Krylov + AMS) on the identical sha-pinned transmon eigenmode fixture. Full-pipeline wall clock + peak RSS, measured on one EC2 instance 2026-07-14. Performance companion to benchmarks/transmon_eigen/results.toml (which carries the eigenvalue agreement)."
+measured_date = "2026-07-14"
+timing = "/usr/bin/time wall clock, full pipeline (mesh load + assembly + solve + output)"
+memory = "peak resident set size (RSS), maximum-resident-set from /usr/bin/time"
+
+[hardware]
+instance = "m6i.4xlarge"
+physical_cores = 8
+vcpus = 16          # 16 vCPU = 8 physical cores + hyperthreads
+memory_gb = 64
+region = "us-west-2"
+os = "Ubuntu 22.04.5"
+
+[software]
+geode_commit = "3174015"        # release build
+palace_commit = "fba6a5b"       # built from source
+palace_build = "cmake 3.30.5 (from source)"
+mesh = "the sha-pinned transmon fixture (crates/geode-core/tests/fixtures/transmon_smoke.msh)"
+mesh_sha256 = "5b3ff4c357a4dc905e7a2e42abc8178778b626e47582c7bbe610f95d332b33dd"
+mesh_note = "Palace runs consume the MSH 2.2 conversion of this fixture (MFEM's MSH 4.1 reader rejects the committed file — see reference/fixtures/transmon_palace/palace_config.provenance.txt); the conversion is node-preserving and physics-neutral."
+
+# ---- geode-fem: single process, serial. -------------------------------------
+[geode_fem]
+processes = 1
+mode = "serial faer sparse-LU shift-invert Lanczos"
+n_interior_dofs = 133108
+runs_s = [51.62, 51.07, 50.78]
+wall_s_mean = 51.2
+wall_s_stddev = 0.4       # 51.2 ± 0.4 s (n=3)
+n = 3
+peak_rss_kb = [3075232, 3075116, 3085712]
+peak_rss_gb = 3.1         # ≈ 3.1 GB peak RSS
+
+# ---- Palace: 8 MPI ranks (one rank per physical core). ----------------------
+[palace_8ranks]
+processes = 8
+mode = "distributed MPI Krylov + AMS"
+runs_s = [30.42, 30.61, 30.68]
+wall_s_mean = 30.6
+wall_s_stddev = 0.1       # 30.6 ± 0.1 s (n=3)
+n = 3
+# per-rank MAX single-process RSS (NOT an aggregate across ranks).
+max_single_process_rss_kb = [528228, 509716, 518164]
+max_single_process_rss_gb = 0.5   # ≈ 0.5 GB per-rank max (not aggregate)
+
+# ---- Palace: 4 MPI ranks (single sample). -----------------------------------
+[palace_4ranks]
+processes = 4
+mode = "distributed MPI Krylov + AMS"
+wall_s = 50.84
+n = 1
+max_single_process_rss_kb = 705400
+max_single_process_rss_gb = 0.69  # ≈ 0.69 GB per-rank max (not aggregate)
+
+# ---- Palace: 16 ranks — EXCLUDED (not a data point). ------------------------
+[palace_16ranks]
+excluded = true
+reason = "mpirun binding refused on 8 physical cores (16 ranks would oversubscribe hyperthreads); recorded as excluded, not measured."
+
+[notes]
+# Per-core efficiency reading (honest, not a headline claim):
+#   geode-fem serial (1 core):  51.2 s
+#   Palace 8 ranks (8 cores):   30.6 s  → 1.7× faster on the whole box,
+#     but 8× the cores, so geode-fem is ≈ 4× more efficient PER CORE
+#     (51.2 / (30.6 × 8) ≈ 4.4× core-seconds advantage; Palace 4-rank
+#     50.84 s ≈ geode-fem serial, i.e. Palace needs ~4 cores to match one
+#     geode-fem core on this problem).
+# Architecture trade-off (the honest framing, NOT a winner declaration):
+#   geode-fem uses a SERIAL DIRECT sparse factorization (faer LU shift-invert
+#   Lanczos) — no partitioning, no communication, high per-core throughput,
+#   but single-process memory (≈ 3.1 GB) and no strong scaling past one core.
+#   Palace uses a DISTRIBUTED Krylov + AMS iterative solve — it scales across
+#   ranks (lower per-rank memory ≈ 0.5 GB, faster whole-box wall time) at the
+#   cost of MPI communication and iterative-solver overhead. Neither is
+#   uniformly "better"; the numbers characterize a direct-vs-iterative,
+#   serial-vs-distributed trade-off on this 133k-DOF problem.
+per_core_efficiency = "geode-fem serial ≈ 4× more efficient per core; Palace ≈ 1.7× faster on the full box (8×  the cores)"
+architecture = "geode-fem: serial direct sparse-LU factorization (high per-core throughput, single-process ≈ 3.1 GB, no strong scaling). Palace: distributed MPI Krylov + AMS (scales across ranks, ≈ 0.5 GB per-rank, MPI + iterative overhead)."
+eigenvalue_agreement = "Correctness is NOT measured here — see benchmarks/transmon_eigen/results.toml: every geode-fem physical mode agrees with Palace to ≤0.032% on this identical mesh (≤1% bar met with 25× margin)."

--- a/benchmarks/transmon_eigen/results.toml
+++ b/benchmarks/transmon_eigen/results.toml
@@ -25,7 +25,7 @@ junction_capacitance_ff = 5.5
 solver = "SparseShiftInvertLanczos (real, faer sparse LU)"
 assembly = "sparse full-tensor Nédélec (Re parts; imag ≈ 0, lossless sapphire), K_port/M_port surface triplets added, interior reduction"
 notes = [
-  "Junction participation p = (xᵀ K_port x) / (xᵀ (K + K_port) x): the junction LC mode has p ≈ 1, all cavity modes p ≈ 0.",
+  "Junction participation (geode-fem's stiffness-participation metric) p = (xᵀ K_port x) / (xᵀ (K + K_port) x): the junction LC mode has p ≈ 1, all cavity modes p ≈ 0. This is NOT the same quantity as Palace's field-based port-EPR (see [oracles.palace] note); the two are complementary, differently-normalized diagnostics that rank modes differently, so cross-solver mode-ID rests on frequency agreement, not participation agreement.",
   "The junction LC self-resonance f_LC = 1/(2π√(LC)) = 17.60 GHz; the p ≈ 1 mode at 17.49 GHz is that physical junction mode.",
   "A spurious junction-surface-localized mode appears near 3.45 GHz below the physical band: geode-fem's Lanczos lacks the divergence-free projection Palace applies, so a gradient-nullspace-adjacent mode leaks in. It is NOT a physical mode (absent from Palace's spectrum) and is filtered by comparing against the committed oracle. Removing it is a follow-on (a div-free / tree-cotree gauge on the eigen path); it does not affect the physical-mode cross-validation.",
   "Readout ports port_1/port_2 left OPEN (lossless v1); their 50 Ω would make the pencil complex (lossy Q), which is out of scope v1.",
@@ -76,6 +76,31 @@ bar_pct = 1.0
 worst_case_rel_err_pct = 0.032
 all_physical_modes_within_bar = true
 
+# Measured values behind the paper's tripwire + spurious-mode claims
+# (Epic #476, measured 2026-07-14). Committed here so every paper number
+# traces to a committed artifact.
+[tripwires.junction_l_doubling]
+# tripwire_real_junction_l_doubling: doubling the junction inductance L
+# shifts the p ≈ 1 junction LC mode DOWN by the √L scaling (f ∝ 1/√(LC),
+# so 2L → 1/√2 ≈ 0.7071). Measured on the real 157k-DOF fixture.
+base_f_ghz = 17.4901
+doubled_f_ghz = 12.37
+ratio = 0.7071          # = 1/√2 (√L scaling), matches within slack
+prediction = 0.70710678 # 1/√2
+test = "crates/geode-core/tests/transmon_eigenmode.rs::tripwire_real_junction_l_doubling"
+
+[spurious_mode]
+# A junction-surface-localized mode below the physical band: geode-fem's
+# real Lanczos lacks the divergence-free projection Palace applies, so a
+# gradient-nullspace-adjacent mode leaks in. It has NO Palace counterpart
+# and is EXCLUDED from the physical set (and from the ≤1% gate). Its high
+# geode-fem stiffness-participation is exactly why participation alone
+# cannot identify physical modes — frequency-matching against the Palace
+# oracle is what filters it out.
+f_ghz = 3.4528
+participation = 0.9942  # geode-fem stiffness-participation (spurious, excluded)
+excluded = true
+
 [oracles.palace]
 status = "populated"
 palace_version = "fba6a5b"
@@ -87,6 +112,18 @@ config_provenance = "reference/fixtures/transmon_palace/palace_config.provenance
 results_dir = "reference/fixtures/transmon_palace/results_p1/ (eig.csv, port-EPR.csv, palace_run_v22.log)"
 # Palace eig.csv Re{f} (GHz), lowest 6 eigenmodes, Order 1, same mesh.
 palace_modes_ghz = [5.151335830348, 15.46052107794, 17.49010903536, 18.69165792915, 20.69755679425, 26.08089940472]
-# Palace port-EPR p[1] per mode: only the 17.49 GHz mode has appreciable
-# junction energy-participation ratio; matches geode-fem's p ≈ 1 there.
-note = "Palace eigenmode run on the IDENTICAL mesh (MSH 2.2 conversion, node-preserving), junction as reactive LumpedPort (L ∥ C, no R), PEC metal+exterior, readout ports open, Order 1 (matched to geode-fem first-order Nédélec). Every geode-fem physical mode agrees with Palace to ≤0.032% — the ≤1% same-mesh bar is met with 25× margin. A p=2 config (palace_config_p2.json) is committed for the non-gating Phase-D convergence preview."
+# Palace port-EPR p[1] per mode (committed results_p1/port-EPR.csv). NOTE:
+# geode-fem's participation and Palace's port-EPR are COMPLEMENTARY,
+# differently-normalized diagnostics that do NOT rank modes the same way,
+# and must not be read as a cross-solver mode-ID agreement. geode-fem's
+# metric is a stiffness-participation ratio p = xᵀ K_port x / xᵀ (K + K_port) x
+# (energy fraction stored in the junction inductor), which is ≈ 1 on the
+# 17.49 GHz junction LC mode and ≈ 0 on every cavity mode. Palace's
+# port-EPR.csv is a field-based, differently-normalized quantity: on this
+# committed run the 17.49 GHz junction mode (m=3) actually has the SMALLEST
+# |p[1]| of the six (+2.49e-08), and the LARGEST is the 5.15 GHz mode (m=1,
+# −4.71e-04) — the opposite ranking to geode-fem's stiffness participation.
+# The cross-solver mode identification therefore rests on FREQUENCY agreement
+# (the junction mode is 17.4901 GHz in BOTH solvers, matching f_LC ≈ 17.60 GHz),
+# NOT on participation agreement.
+note = "Palace eigenmode run on the IDENTICAL mesh (MSH 2.2 conversion, node-preserving), junction as reactive LumpedPort (L ∥ C, no R), PEC metal+exterior, readout ports open, Order 1 (matched to geode-fem first-order Nédélec). Every geode-fem physical mode agrees with Palace to ≤0.032% — the ≤1% same-mesh bar is met with 25× margin, and the cross-solver mode identification rests on this frequency agreement (17.4901 GHz junction mode in both solvers), NOT on participation agreement (geode-fem's stiffness-participation p and Palace's field port-EPR are complementary, differently-normalized diagnostics that rank the modes differently — see the port-EPR note above). A p=2 config (palace_config_p2.json) is committed for the non-gating Phase-D convergence preview."

--- a/crates/geode-core/tests/transmon_eigenmode.rs
+++ b/crates/geode-core/tests/transmon_eigenmode.rs
@@ -411,8 +411,12 @@ const PALACE_MODES_GHZ: [f64; 6] = [
     26.08089940472,
 ];
 
-/// Palace's junction LC mode (the one with appreciable EPR): the physical
-/// Josephson-junction resonance `f_LC = 1/(2π√(LC)) ≈ 17.60 GHz`.
+/// Palace's junction LC mode: the physical Josephson-junction resonance
+/// `f_LC = 1/(2π√(LC)) ≈ 17.60 GHz`. Cross-solver identification is by
+/// FREQUENCY (17.4901 GHz in both solvers), not by participation — geode-fem's
+/// stiffness-participation p and Palace's field port-EPR are complementary,
+/// differently-normalized diagnostics that rank the modes differently (see
+/// `benchmarks/transmon_eigen/results.toml`).
 const PALACE_JUNCTION_MODE_GHZ: f64 = 17.49010903536;
 
 /// The ≤1% same-mesh cross-validation bar.

--- a/reference/fixtures/transmon_palace/palace_config.provenance.txt
+++ b/reference/fixtures/transmon_palace/palace_config.provenance.txt
@@ -24,9 +24,19 @@ Phase-D convergence preview).
 
 operator / agent workflow (EC2 box):
 1. scp the mesh + palace_config.json to the box
-2. /home/ubuntu/palace/build/bin/palace palace_config.json
-3. Palace writes postpro/transmon_p1/eig.csv (mode frequencies).
-4. Populate benchmarks/transmon_eigen/results.toml [oracles.palace]
+2. CONVERT the mesh to MSH 2.2 first — MFEM's MSH 4.1 reader REJECTS the
+committed DeviceLayout fixture with
+'Gmsh file: vertices indices are not unique'
+(the multi-entity-block MSH 4.1 file repeats vertex indices across
+entity blocks). Required prior step:
+gmsh <fixture>.msh -0 -save -format msh2 -o <mesh22>.msh
+This is physics-neutral: the node set is unchanged (22684 nodes,
+1..22684) and physical groups are preserved, so eig.csv reproduces
+bit-for-bit across the conversion. palace_config.json must point at
+the CONVERTED <mesh22>.msh.
+3. /home/ubuntu/palace/build/bin/palace palace_config.json
+4. Palace writes postpro/transmon_p1/eig.csv (mode frequencies).
+5. Populate benchmarks/transmon_eigen/results.toml [oracles.palace]
 with the per-mode f_ghz + this provenance SHA, then gate the
 <= 1% same-mesh comparison in tests/transmon_eigenmode.rs.
 

--- a/reference/palace/geode_transmon_baseline/src/main.rs
+++ b/reference/palace/geode_transmon_baseline/src/main.rs
@@ -223,9 +223,19 @@ fn main() {
          \n\
          operator / agent workflow (EC2 box):\n\
            1. scp the mesh + palace_config.json to the box\n\
-           2. /home/ubuntu/palace/build/bin/palace palace_config.json\n\
-           3. Palace writes postpro/transmon_p1/eig.csv (mode frequencies).\n\
-           4. Populate benchmarks/transmon_eigen/results.toml [oracles.palace]\n\
+           2. CONVERT the mesh to MSH 2.2 first — MFEM's MSH 4.1 reader\n\
+              REJECTS the committed DeviceLayout fixture with\n\
+              'Gmsh file: vertices indices are not unique' (the\n\
+              multi-entity-block MSH 4.1 file repeats vertex indices across\n\
+              entity blocks). Required prior step:\n\
+                gmsh <fixture>.msh -0 -save -format msh2 -o <mesh22>.msh\n\
+              This is physics-neutral: the node set is unchanged (22684\n\
+              nodes, 1..22684) and physical groups are preserved, so eig.csv\n\
+              reproduces bit-for-bit. palace_config.json must point at the\n\
+              CONVERTED <mesh22>.msh.\n\
+           3. /home/ubuntu/palace/build/bin/palace palace_config.json\n\
+           4. Palace writes postpro/transmon_p1/eig.csv (mode frequencies).\n\
+           5. Populate benchmarks/transmon_eigen/results.toml [oracles.palace]\n\
               with the per-mode f_ghz + this provenance SHA, then gate the\n\
               <= 1% same-mesh comparison in tests/transmon_eigenmode.rs.\n\
          \n\


### PR DESCRIPTION
Closes #497

Resolves **audit flags 4 and 5** from the transmon-benchmark paper audit (`papers/transmon-benchmark/transmon-benchmark.1.audit/`). All deliverables are data/docs — **no solver code**.

## Four deliverables

**1. Port-EPR prose corrected (PR #496 judge finding).** The committed `results_p1/port-EPR.csv` shows the 17.49 GHz junction mode with the SMALLEST `|p[1]|` (+2.49e-08); the LARGEST is mode 1 (−4.71e-04). geode-fem's stiffness-participation `p = xᵀK_port x / xᵀ(K+K_port)x` and Palace's field port-EPR are **complementary, differently-normalized diagnostics that do NOT rank modes the same way**. The cross-solver mode identification rests on **FREQUENCY agreement** (17.4901 GHz in both solvers), not participation agreement. Rewritten in `benchmarks/transmon_eigen/results.toml` (both the `[meta]` participation note and the `[oracles.palace]` note) and the `PALACE_JUNCTION_MODE_GHZ` doc comment in the test.

**2. MSH 2.2 step added** to `reference/fixtures/transmon_palace/palace_config.provenance.txt`'s operator workflow (and its generator source `reference/palace/geode_transmon_baseline/src/main.rs`, so a regenerate won't drop it): MFEM rejects the committed MSH 4.1 fixture (`'Gmsh file: vertices indices are not unique'`); required prior step `gmsh <fixture>.msh -0 -save -format msh2 -o <mesh22>.msh`, verified physics-neutral / node-preserving / bit-for-bit eig.csv.

**3. New artifact `benchmarks/transmon_bench_cpu/results.toml`** — the 2026-07-14 EC2 CPU head-to-head (house style: provenance header + structured tables):
- Hardware: m6i.4xlarge (8 physical cores/16 vCPU, 64 GB), us-west-2, Ubuntu 22.04.5. Timing = `/usr/bin/time` wall clock, full pipeline. geode @ `3174015` release; palace @ `fba6a5b` from source (cmake 3.30.5); the sha-pinned fixture (MSH 2.2 for Palace).
- geode-fem serial (faer sparse-LU shift-invert Lanczos, 133,108 interior DOFs): 51.62/51.07/50.78 → **51.2 ± 0.4 s**; peak RSS ≈ **3.1 GB**.
- Palace 8 ranks: 30.42/30.61/30.68 → **30.6 ± 0.1 s**; max single-process RSS ≈ **0.5 GB** (per-rank max, not aggregate).
- Palace 4 ranks: **50.84 s**, ≈ 0.69 GB (n=1). Palace 16 ranks: **EXCLUDED** (mpirun binding refused on 8 physical cores — recorded, not a data point).
- Per-core efficiency reading + honest direct-vs-distributed architecture framing + eigenvalue-agreement cross-reference.
- Tripwire + spurious-mode measured values committed in `transmon_eigen/results.toml` (`[tripwires.junction_l_doubling]`: 17.4901 → 12.37 GHz, ratio 0.7071 = 1/√2; `[spurious_mode]`: 3.4528 GHz, p=0.9942, excluded). **Choice:** these live with the eigenmode artifact they annotate (frequencies + participation belong beside the mode table), not in the CPU-timing file.

**4. Consistency check.** Grepped the repo outside `papers/` for stale `≤0.03%`-style or port-EPR-agreement wording — none remaining (the `≤0.03%` sites the audit flagged as flags 1–3 are all in `main.tex`, which is out of scope for this issue; the artifacts already record 0.032%/0.001% correctly).

## Paper-pipeline consumer note

`papers/transmon-benchmark/main.tex` Table 3 (CPU cell) now has a committed artifact behind every number (`benchmarks/transmon_bench_cpu/results.toml`), and the L-doubling / spurious-mode citations now trace to committed measured values in `transmon_eigen/results.toml` — closing the reproducibility-contract gap the audit flagged. The paper's port-EPR "assignments agree" prose (main.tex L345–347, L408–410) should be revised to the frequency-agreement framing now recorded in the artifacts (paper edits are a separate `papers/` task).

## Gates
- `cargo fmt --all -- --check`: clean (Rust edits are doc-comment + string-literal only)
- `cargo test -p geode-core --release --test transmon_eigenmode` (CI-fast tier): **4 passed, 2 ignored (release-only), 0 failed** — gated numbers untouched, only prose changed
- `cargo clippy` on the touched generator crate: clean
- Both `results.toml` files parse