### PR TITLE
chore(deps): swap bunsen git pin to crates.io 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -521,8 +521,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bunsen"
-version = "0.25.0"
-source = "git+https://github.com/zspacelabs/bunsen?rev=1ff74cd9814d10953e79a995d19db468df4a43ed#1ff74cd9814d10953e79a995d19db468df4a43ed"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96cf7b59bfac61a78068fd6a429350a9bbb92902651ddc4fd29ebaa5e39fbf8"
 dependencies = [
  "bunsen-contracts-macros",
  "burn",
@@ -537,8 +538,9 @@ dependencies = [
 
 [[package]]
 name = "bunsen-contracts-macros"
-version = "0.25.0"
-source = "git+https://github.com/zspacelabs/bunsen?rev=1ff74cd9814d10953e79a995d19db468df4a43ed#1ff74cd9814d10953e79a995d19db468df4a43ed"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6ff3f13fd456677039b0a11d8f745820d3e1268a548f7b8342443e99320c88"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4647,7 +4649,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6676,10 +6678,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ rust-version = "1.96.0"
 # reference and are unioned with the base settings declared here.
 burn = { version = "0.21", default-features = false, features = ["std"] }
 # Bunsen standard library — machine-checked shape contracts for the FEM
-# tensor pipeline (Epic #355, Phase 1: #358). Pinned to the zspacelabs/bunsen
-# main commit that carries both upstream fixes this integration depends on:
+# tensor pipeline (Epic #355, Phase 1: #358). Pinned to the crates.io release
+# that carries both upstream fixes this integration depends on:
 #   - #95 (hashbrown gated behind `train`, shipped in 0.25.0) — required so a
 #     `default-features = false, features = ["std"]` build compiles at all.
-#   - #112 (downloader + directories-next made optional behind `cache`, merged
-#     2026-07-13) — required so the no-drag gate holds (no network-download
-#     machinery in a deterministic solver's dep tree).
+#   - #112 (downloader + directories-next made optional behind `cache`, first
+#     released in 0.26.0) — required so the no-drag gate holds (no
+#     network-download machinery in a deterministic solver's dep tree).
 # Built `std`-only: NOT the `testing` feature (would pull `burn/flex`) and NOT
 # default features (would pull `reflection`/`train`/`xot`/`xee-xpath`/…).
-# FOLLOW-UP: swap this git pin for `version = "0.25.1"` once a 0.25.1+ patch
-# with the optional downloader lands on crates.io (mechanical one-line change).
-bunsen = { git = "https://github.com/zspacelabs/bunsen", rev = "1ff74cd9814d10953e79a995d19db468df4a43ed", default-features = false, features = ["std"] }
+# `burn` req stayed `^0.21.0` across the whole 0.21.0→0.28.0 range, so 0.28.0
+# (latest, superset of the 0.26.0 fix) keeps the burn 0.21 pin intact.
+bunsen = { version = "0.28.0", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
 criterion = "0.5"
 # Base faer feature set shared by every consumer; geode-core additionally


### PR DESCRIPTION
## Summary

Retires the `zspacelabs/bunsen` main-commit git pin (rev `1ff74cd`) in favor of the crates.io release `bunsen = "0.28.0"`. The git pin existed only to carry upstream #112 (downloader + directories-next made optional behind a `cache` feature) ahead of any published tag. That fix has now shipped: it first appeared in **0.26.0**, and **0.28.0** (current latest) is a strict superset — 0.27.0/0.28.0 touch only unrelated speech-kit/silero-vad/whisper and dead-util code, with no change to the dependency surface relevant to our `default-features = false, features = ["std"]` build. The `burn` requirement stayed `^0.21.0` across the entire 0.21.0→0.28.0 range, so the burn 0.21 pin is untouched.

## Changes

- `Cargo.toml`: `bunsen = { git = ".../zspacelabs/bunsen", rev = "1ff74cd...", ... }` → `bunsen = { version = "0.28.0", default-features = false, features = ["std"] }`; dropped the stale `# FOLLOW-UP: swap this git pin for version = "0.25.1"...` note (no 0.25.1 was ever cut — release-plz went 0.25.0 → 0.26.0) and refreshed the rationale comment to reference the crates.io release.
- `Cargo.lock`: `bunsen` and `bunsen-contracts-macros` move `0.25.0 (git+.../zspacelabs)` → `0.28.0 (registry+crates.io)`; zero remaining `zspacelabs/bunsen` git-source references.

## Resolved versions

| crate | before | after |
|---|---|---|
| `bunsen` | 0.25.0 (git rev 1ff74cd) | **0.28.0 (crates.io)** |
| `bunsen-contracts-macros` | 0.25.0 (git rev 1ff74cd) | **0.28.0 (crates.io)** |
| `burn` (+ all burn* crates) | 0.21.0 | 0.21.0 (unchanged) |

## No-drag gate re-run (PR #466 methodology)

Inverse `cargo tree -p geode-core -i <crate>` on both the default and `--features arpack` combos:

| forbidden crate | default | arpack | interpretation |
|---|---|---|---|
| downloader | not in graph | not in graph | absent (ghost) |
| directories-next | not in graph | not in graph | absent (ghost) |
| xot | not in graph | not in graph | absent (ghost) |
| xee-xpath | not in graph | not in graph | absent (ghost) |
| cuda | not in graph | not in graph | absent (ghost) |
| metal | not in graph | not in graph | absent (ghost) |
| burn-train | nothing to print | nothing to print | present in lock, unreachable |
| burn-store | nothing to print | nothing to print | present in lock, unreachable |
| wgpu | nothing to print | nothing to print | present in lock, unreachable |

`cargo tree -p geode-core -i bunsen` → `bunsen v0.28.0`. Every reachable `burn*` crate is `v0.21.0`. This reproduces PR #466's no-drag shape exactly against the crates.io release.

## Lock-diff summary

Minimal: `+11 / -9` lines. The two bunsen crates flip from `git+https://github.com/zspacelabs/bunsen?rev=1ff74cd...` to `registry+https://github.com/rust-lang/crates.io-index` with 0.28.0 checksums. (The ~1558-line git-workspace dev-tooling ghost shed the curator anticipated did not apply here — the git dependency was already resolved `default-features=false`, so those entries were never in this lock to begin with.) A handful of incidental `windows-sys`/`getrandom` dependency-edge consolidations came in from the index refresh during re-lock; they are Windows/`getrandom`-only edges, not introduced by this change and not reachable on the solver's build path.

## Shape-contract macro drift

None. `bunsen-contracts-macros` moved 0.25.0 → 0.28.0 with no API churn (release-plz version-syncs it to the main crate; its changelog shows no new commits across 0.26–0.28). All `assert_shape_contract!` / `unpack_shape_contract!` call sites (assembly/p1.rs, nedelec.rs, elements/*, eigen/dense.rs, etc.) compiled and their contract-firing tests passed with **zero source edits**.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Swap git pin → crates.io release with #112 fix | ✅ | `bunsen = "0.28.0"` (first-fixed 0.26.0, latest 0.28.0) |
| `burn` compatibility preserved | ✅ | burn req `^0.21.0` unchanged; all burn* crates 0.21.0 |
| Stale FOLLOW-UP comment removed | ✅ | Cargo.toml comment block updated |
| Lock sheds git-workspace entries | ✅ | zero `zspacelabs/bunsen` refs remain in Cargo.lock |
| No-drag gate holds (PR #466 shape) | ✅ | inverse cargo tree table above, both feature combos |
| No shape-contract call-site drift | ✅ | zero source edits; contract-firing tests pass |

## Test Plan / Gate results

- `cargo build -p geode-core` (default) — clean
- `cargo build -p geode-core --features arpack` — clean
- `cargo fmt --check` — clean
- `cargo clippy -p geode-core --all-targets -- -D warnings` — clean
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean
- `cargo test -p geode-core --lib` (debug, incl. shape-contract firing tests) — **322 passed, 0 failed, 2 ignored**
- `cargo test -p geode-core --release --tests` — all pass, 0 failed

Closes #471