### PR TITLE
perf(eigen): cache M·v_j to drop O(k²) reorthogonalization SpMVs

### DIFF
--- a/crates/geode-core/src/eigen/complex/lanczos.rs
+++ b/crates/geode-core/src/eigen/complex/lanczos.rs
@@ -328,6 +328,10 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
         let max_k = self.max_iters.min(n).max(n_modes + 2).min(n);
 
         let mut basis: Vec<Vec<c64>> = Vec::with_capacity(max_k);
+        // Cache of `M·v_j` for each basis vector (see issue #506) — reused
+        // by the reorth loop instead of recomputing an SpMV per basis
+        // vector every iteration.
+        let mut m_basis: Vec<Vec<c64>> = Vec::with_capacity(max_k);
         let mut alpha: Vec<c64> = Vec::with_capacity(max_k);
         let mut beta: Vec<c64> = Vec::with_capacity(max_k);
 
@@ -387,12 +391,13 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
             }
 
             // Full reorthogonalization in the bilinear M-inner product.
-            // For each basis vector v_k, c = v_k^T M w = (M v_k)^T w.
-            for vk in basis.iter() {
-                spmv(m, vk, &mut work);
+            // For each basis vector v_k, c = v_k^T M w = (M v_k)^T w. Reuse
+            // the cached `M·v_k` (`m_basis[idx]`) instead of recomputing an
+            // SpMV per basis vector (issue #506).
+            for (vk, m_vk) in basis.iter().zip(m_basis.iter()) {
                 let mut c = c64::new(0.0, 0.0);
                 for i in 0..n {
-                    c += work[i] * w[i];
+                    c += m_vk[i] * w[i];
                 }
                 if c.re != 0.0 || c.im != 0.0 {
                     for i in 0..n {
@@ -400,11 +405,11 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
                     }
                 }
             }
-            // Re-project off v itself (about to enter basis).
-            spmv(m, &v, &mut work);
+            // Re-project off v itself (about to enter basis). `mv` still
+            // holds `M·v` from the top of this iteration.
             let mut c = c64::new(0.0, 0.0);
             for i in 0..n {
-                c += work[i] * w[i];
+                c += mv[i] * w[i];
             }
             for i in 0..n {
                 w[i] -= c * v[i];
@@ -415,7 +420,9 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
             let w_t_m_w = bilinear(&w, &work);
             nrm = principal_sqrt(w_t_m_w);
 
-            // Push current v as basis[j].
+            // Push current v as basis[j] (caching `M·v` alongside).
+            m_basis.push(core::mem::take(&mut mv));
+            mv = vec![c64::new(0.0, 0.0); n];
             basis.push(core::mem::take(&mut v));
 
             // Convergence probe on the complex tridiagonal.
@@ -519,6 +526,10 @@ impl SparseComplexShiftInvertLanczos {
         //    convergence formally lags).
         let max_k = self.max_iters.min(n).max(n_modes + 2).min(n);
         let mut basis: Vec<Vec<c64>> = Vec::with_capacity(max_k);
+        // Cache of `M·v_j` for each basis vector (see issue #506) — reused
+        // by the reorth loop instead of recomputing an SpMV per basis
+        // vector every iteration.
+        let mut m_basis: Vec<Vec<c64>> = Vec::with_capacity(max_k);
         let mut alpha: Vec<c64> = Vec::with_capacity(max_k);
         let mut beta: Vec<c64> = Vec::with_capacity(max_k);
 
@@ -564,11 +575,12 @@ impl SparseComplexShiftInvertLanczos {
             }
 
             // Full reorthogonalization in the bilinear M-inner product.
-            for vk in basis.iter() {
-                spmv(m, vk, &mut work);
+            // Reuse the cached `M·v_k` (`m_basis[idx]`) instead of
+            // recomputing an SpMV per basis vector (issue #506).
+            for (vk, m_vk) in basis.iter().zip(m_basis.iter()) {
                 let mut c = c64::new(0.0, 0.0);
                 for i in 0..n {
-                    c += work[i] * w[i];
+                    c += m_vk[i] * w[i];
                 }
                 if c.re != 0.0 || c.im != 0.0 {
                     for i in 0..n {
@@ -576,10 +588,11 @@ impl SparseComplexShiftInvertLanczos {
                     }
                 }
             }
-            spmv(m, &v, &mut work);
+            // Re-project off v itself. `mv` still holds `M·v` from the top
+            // of this iteration.
             let mut c = c64::new(0.0, 0.0);
             for i in 0..n {
-                c += work[i] * w[i];
+                c += mv[i] * w[i];
             }
             for i in 0..n {
                 w[i] -= c * v[i];
@@ -589,6 +602,9 @@ impl SparseComplexShiftInvertLanczos {
             let w_t_m_w = bilinear(&w, &work);
             nrm = principal_sqrt(w_t_m_w);
 
+            // Cache `M·v` alongside the basis vector before consuming `v`.
+            m_basis.push(core::mem::take(&mut mv));
+            mv = vec![c64::new(0.0, 0.0); n];
             basis.push(core::mem::take(&mut v));
 
             // Convergence probe — same Kaniel–Saad-flavored bound as the

--- a/crates/geode-core/src/eigen/lanczos.rs
+++ b/crates/geode-core/src/eigen/lanczos.rs
@@ -24,6 +24,30 @@
 //! restarted variant. The cost is O(k²·n) extra work; negligible next to
 //! the `k` sparse triangular solves.
 //!
+//! To make that O(k²) reorthogonalization cheap in practice we cache
+//! `M·v_j` alongside each basis vector `v_j` (`m_basis`), so the inner
+//! reorth loop is a stored-vector dot + axpy rather than a fresh SpMV per
+//! basis vector every outer iteration. This is an exact re-ordering of the
+//! same arithmetic (the spectrum is bit-for-bit identical), and on the
+//! 133k-DOF transmon eigensolve it collapses the reorth phase from ~9.7 s
+//! to ~0.8 s — a 1.64x end-to-end wall-time reduction on that test
+//! (34.9 s → 21.3 s). See issue #506 for the full profile.
+//!
+//! **Deferred (issue #506 Phase 0, faer-parallelism half):** the sparse LU
+//! factorization phase (`sp_lu`, ~33% of the solve) could be sped up ~1.75x
+//! by compiling faer with its `rayon` feature. That is *not* landed here.
+//! In faer 0.24 parallelism is a process-global `AtomicUsize`
+//! (`set_global_parallelism` / `get_global_parallelism`, no per-call `Par`
+//! argument), so "phase-scoped" factorization parallelism can only be a
+//! bare global toggle that (a) races other threads in the same test process
+//! — the driven/assembly paths also call `sp_lu`/`solve_in_place` — and
+//! (b) must be reverted to serial before the single-RHS triangular-solve
+//! loop, where rayon is measurably *slower* (latency-bound). The safe
+//! landing is an opt-in toggle defaulting to today's serial behavior; the
+//! M·V cache above is the dominant, risk-free win and ships alone. The
+//! parallelism knob (faer `rayon` feature + a panic-safe RAII guard around
+//! the factorization + an opt-in solver flag) is tracked for a follow-on.
+//!
 //! Convergence is declared when the residual norm
 //! `‖K x - λ M x‖_2 / ‖λ M x‖_2 < tol` for **every** requested mode.
 //!
@@ -287,6 +311,11 @@ impl SparseShiftInvertLanczos {
         //    final basis even if convergence formally lags.
         let max_k = self.max_iters.min(n).max(n_modes + 2).min(n);
         let mut basis: Vec<Vec<f64>> = Vec::with_capacity(max_k);
+        // Cache of `M·v_j` for each basis vector, filled in lockstep with
+        // `basis`. The reorth loop reuses these instead of recomputing an
+        // SpMV per basis vector every iteration (turns the O(k²) SpMV cost
+        // into O(k²) dot+axpy — see issue #506).
+        let mut m_basis: Vec<Vec<f64>> = Vec::with_capacity(max_k);
         let mut alpha: Vec<f64> = Vec::with_capacity(max_k);
         let mut beta: Vec<f64> = Vec::with_capacity(max_k);
 
@@ -325,18 +354,20 @@ impl SparseShiftInvertLanczos {
                 }
             }
 
-            // Full reorthogonalization (M-inner product).
-            for vk in basis.iter() {
-                spmv(m, vk, &mut work);
-                let c = w.iter().zip(work.iter()).map(|(a, b)| a * b).sum::<f64>();
+            // Full reorthogonalization (M-inner product). Reuse the cached
+            // `M·v_k` (`m_basis[idx]`) instead of recomputing an SpMV per
+            // basis vector (issue #506).
+            for (vk, m_vk) in basis.iter().zip(m_basis.iter()) {
+                let c = w.iter().zip(m_vk.iter()).map(|(a, b)| a * b).sum::<f64>();
                 if c.abs() > 0.0 {
                     for i in 0..n {
                         w[i] -= c * vk[i];
                     }
                 }
             }
-            spmv(m, &v, &mut work);
-            let c = w.iter().zip(work.iter()).map(|(a, b)| a * b).sum::<f64>();
+            // Re-project off v itself (the just-computed direction). `mv`
+            // still holds `M·v` from the top of this iteration.
+            let c = w.iter().zip(mv.iter()).map(|(a, b)| a * b).sum::<f64>();
             for i in 0..n {
                 w[i] -= c * v[i];
             }
@@ -346,6 +377,9 @@ impl SparseShiftInvertLanczos {
             let nrm2 = nrm2.max(0.0);
             nrm = nrm2.sqrt();
 
+            // Cache `M·v` alongside the basis vector before consuming `v`.
+            m_basis.push(core::mem::take(&mut mv));
+            mv = vec![0.0_f64; n];
             basis.push(core::mem::take(&mut v));
 
             // Convergence probe — same Kaniel–Saad bound as the
@@ -463,6 +497,10 @@ impl SparseEigenSolver for SparseShiftInvertLanczos {
 
         // Allocate workspace.
         let mut basis: Vec<Vec<f64>> = Vec::with_capacity(max_k);
+        // Cache of `M·v_j` for each basis vector (see issue #506) — reused
+        // by the reorth loop instead of recomputing an SpMV per basis
+        // vector every iteration.
+        let mut m_basis: Vec<Vec<f64>> = Vec::with_capacity(max_k);
         let mut alpha: Vec<f64> = Vec::with_capacity(max_k);
         let mut beta: Vec<f64> = Vec::with_capacity(max_k);
 
@@ -514,19 +552,20 @@ impl SparseEigenSolver for SparseShiftInvertLanczos {
 
             // Full reorthogonalization against the whole basis in the
             // M-inner product. This is O(j·n) per step but keeps the
-            // basis numerically M-orthonormal even at large k.
-            for vk in basis.iter() {
-                spmv(m, vk, &mut work);
-                let c = w.iter().zip(work.iter()).map(|(a, b)| a * b).sum::<f64>();
+            // basis numerically M-orthonormal even at large k. Reuse the
+            // cached `M·v_k` (`m_basis[idx]`) instead of recomputing an
+            // SpMV per basis vector (issue #506).
+            for (vk, m_vk) in basis.iter().zip(m_basis.iter()) {
+                let c = w.iter().zip(m_vk.iter()).map(|(a, b)| a * b).sum::<f64>();
                 if c.abs() > 0.0 {
                     for i in 0..n {
                         w[i] -= c * vk[i];
                     }
                 }
             }
-            // Also re-project off v itself (the just-added direction).
-            spmv(m, &v, &mut work);
-            let c = w.iter().zip(work.iter()).map(|(a, b)| a * b).sum::<f64>();
+            // Also re-project off v itself (the just-added direction). `mv`
+            // still holds `M·v` from the top of this iteration.
+            let c = w.iter().zip(mv.iter()).map(|(a, b)| a * b).sum::<f64>();
             for i in 0..n {
                 w[i] -= c * v[i];
             }
@@ -539,7 +578,10 @@ impl SparseEigenSolver for SparseShiftInvertLanczos {
             let nrm2 = nrm2.max(0.0);
             nrm = nrm2.sqrt();
 
-            // Push the *current* v as basis[j], then either iterate or stop.
+            // Push the *current* v as basis[j] (caching `M·v` alongside),
+            // then either iterate or stop.
+            m_basis.push(core::mem::take(&mut mv));
+            mv = vec![0.0_f64; n];
             basis.push(core::mem::take(&mut v));
 
             // Try to test convergence on the requested modes. We re-test


### PR DESCRIPTION
## Summary

Phase 0 of the GPU-eigensolve headroom tracker (#503). Shift-invert Lanczos
ran full M-inner-product reorthogonalization by recomputing `M·v_k` with a
fresh SpMV for **every** basis vector on **every** outer iteration — an
O(k²) SpMV pattern (~4.7k SpMVs per solve at k=96). Since `M·v_j` is already
computed at the top of each iteration, we cache it in a parallel `m_basis`
buffer and reuse it, turning the reorth inner loop into a stored-vector
dot + axpy. This is an **exact re-ordering of the same arithmetic** — the
spectrum is bit-for-bit identical.

Measured on the committed 133k-DOF transmon eigensolve gate
(`real_transmon_eigenmodes_release`, M3 Ultra / 28 cores): the release test
wall time drops **34.9 s → 21.3 s (1.64x)**, with the reorth phase
collapsing from ~9.7 s to ~0.8 s.

The **faer-parallelism half** of #506 (enabling faer's `rayon` feature on
the `sp_lu` factorization) is **deferred** — see disposition below. The M·V
cache is the issue's stated must-land and dominant win; it ships alone,
risk-free.

## Changes

- `eigen/lanczos.rs` — cache `M·v_j` in a parallel `m_basis: Vec<Vec<f64>>`
  in both `smallest_eigenvalues` and `smallest_eigenpairs`; reorth inner
  loop reuses `m_basis[idx]` (dot + axpy) instead of `spmv(m, vk, …)`; the
  self-projection reuses the loop's existing `mv`. Module doc updated with
  the caching rationale and the deferred-parallelism note.
- `eigen/complex/lanczos.rs` — identical M·V-caching pattern in the complex
  pencil's `smallest_complex_pencil_eigenvalues` and `smallest_eigenpairs`
  (bilinear M-inner product; `Vec<c64>` basis).
- **Not touched:** workspace `Cargo.toml` (no faer feature change),
  `eigen/transmon.rs`, `eigen/gauge.rs`, or any driven/assembly `sp_lu`
  site — the deferred parallelism half is the only thing those would need.

## faer-parallelism knob disposition: DEFERRED (documented)

Landing the M·V cache alone, per the issue's explicit priority ("THE M·V
CACHE IS THE MUST-LAND; the faer knob is the nice-to-have… if it bloats or
conflicts, land the M·V cache alone and defer the parallelism half with a
note"). Rationale, measured and reasoned:

- **The cache already delivers the full stated win** (1.64x end-to-end,
  exact spectrum) with a two-file diff, no new deps, no global state.
- The faer knob only addresses the ~33% factorization phase (~1.75x →
  ~3.8 s of a 26.7 s solve).
- faer 0.24 parallelism is a **process-global `AtomicUsize`**
  (`set_global_parallelism`/`get_global_parallelism`; `Par::Rayon` only
  exists with the `rayon` feature; no per-call `Par` argument on `sp_lu` or
  `solve_in_place`). "Phase-scoped" can therefore only be a bare global
  toggle that races the concurrent driven/assembly `sp_lu`/`solve_in_place`
  call sites within a single multi-threaded test binary, and must be
  reverted to serial before the single-RHS solve loop (where rayon is
  measurably *slower*, latency-bound).
- The safe landing the issue prescribes is an **opt-in toggle defaulting to
  today's serial behavior**, plus a panic-safe RAII guard. Implementing that
  cleanly means an opt-in solver flag whose struct-field form breaks ~10
  struct-literal construction sites across sibling lanes (incl.
  `eigen/transmon.rs`, another agent's lane this cycle), and adds the
  `spindle` crate (faer's `rayon` feature pulls `dep:rayon` [already
  in-tree], `gemm/rayon` [in-tree], and `dep:spindle` [new]).

Deferring keeps this PR to the risk-free exact-arithmetic win and inside its
lane. The deferral is recorded in-code (module doc of `eigen/lanczos.rs`) so
the follow-on is discoverable.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `real_transmon_eigenmodes_release` stays green (Palace ≤1% gate) | ✅ | Passes; worst-case per-mode Δ = **0.0289%** (bar 1%), unchanged from baseline |
| Mode frequencies identical (ideally to 1e-4 GHz) | ✅ | **Bit-for-bit identical** — all 12 modes match baseline to every printed digit (λ and f) |
| Existing eigensolver unit tests pass unchanged | ✅ | `eigen::lanczos` (2) + `eigen::complex::lanczos` (4) all pass; exact re-ordering, no tolerance change |
| Measured wall-time reduction reported (target ~1.5x+) | ✅ | **1.64x** end-to-end (34.9 s → 21.3 s); see table below |
| No new dependencies | ✅ | Two-file source diff; faer feature untouched (deferred) |
| Full workspace/crate suite green | ✅ | `cargo test -p geode-core --release --tests` + `--lib` all pass, 0 failures |

## Timing (M3 Ultra, 28 cores, `real_transmon_eigenmodes_release`)

| | in-process test time | speedup |
|---|---|---|
| **before** (origin/main @ 25874f8) | 34.88 s | — |
| **after** (M·V cache) | 21.25 s | **1.64x** |

Reorth phase: ~9.7 s → ~0.8 s (accounts for the ~13.6 s reduction, matching
the #503 design-pass profile).

## Spectrum-identity evidence (before ≡ after, same run harness)

Both runs print identical per-mode spectra and Palace deltas:

```
mode[5]:  f = 3.4528  GHz (λ = 5.2366e-9)  p = 0.9942
mode[8]:  f = 17.4901 GHz (λ = 1.3437e-7)  p = 1.0000  (junction LC)
mode[11]: f = 26.0883 GHz (λ = 2.9896e-7)  p = 0.0000
Palace 17.4901 GHz ↔ geode 17.4901 GHz → 0.0000% (WITHIN ≤1% bar)
Palace same-mesh cross-validation: worst-case per-mode Δ = 0.0289% (bar 1%)
```

Every λ, f, and participation `p` matches the baseline to all printed
digits — the cache is exact, not a tolerance relaxation.

## Test Plan

- `cargo fmt --check` — clean.
- `cargo clippy -p geode-core --all-targets` and `--all-features` — clean, no warnings.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean.
- `cargo test -p geode-core --release --lib` — 325 passed, 0 failed.
- `cargo test -p geode-core --release --tests` — all integration binaries pass, 0 failed.
- `cargo test -p geode-core --release --test transmon_eigenmode -- --ignored real_transmon_eigenmodes_release --nocapture` — passes; before/after timing + spectrum captured above.

Closes #506