### PR TITLE
bench(driven): GPU-vs-CPU driven-solve scaling benchmark with same-host L40S results

### DIFF
--- a/benchmarks/gpu_driven_scaling/results.toml
+++ b/benchmarks/gpu_driven_scaling/results.toml
@@ -1,0 +1,419 @@
+# GPU-vs-CPU driven-solve wall-clock scaling benchmark (issue #501, Epic #476
+# Phase D). One physical problem — the σ-lossy parallel-plate cube with a
+# single lumped port (tests/iterative_sweep.rs fixture family) — solved at the
+# same ω by four solver configurations while the mesh is refined via
+# cube_tet_mesh(n), n ∈ {6, 9, 12, 15} (1 854 → 25 695 edges).
+#
+# Produced by `crates/geode-core/tests/gpu_driven_scaling.rs`
+# (`gpu_driven_scaling_benchmark`, #[ignore] release tier). CI runs only the
+# ndarray (CPU) leg; the CUDA leg requires `--features cuda` and a GPU host.
+#
+# ALL numbers in this file — CPU baselines AND the GPU cell — were produced on
+# the SAME rented host (see [meta.host]) so the GPU-vs-CPU comparison is
+# same-host. Development runs on other machines (Apple Silicon dev laptop,
+# m6i) are NOT in this file; note the host is a 4-vCPU g6e.xlarge, so these
+# CPU baselines are NOT comparable to the m6i CPU numbers elsewhere in
+# benchmarks/ and cross-box comparison is discouraged.
+#
+# THIS IS THE DRIVEN-SOLVE SCALING CELL ONLY. It must not be conflated with
+# the eigensolve headline of Epic #476: the eigensolver has no GPU code path
+# (issue #302-future) and no eigensolve number appears in this file.
+
+[meta]
+description = "Wall-clock scaling of the lumped-port driven solve A(ω)x = b across four solver configs on one physical fixture: (1) Direct faer sparse LU (CPU f64), (2) assembled-CSR COCG + Jacobi (CPU f64), (3) matrix-free BurnCocg on ndarray (CPU f64), (4) matrix-free BurnCocg on Cuda (GPU f32; same source path as (3), different Burn backend). Solve-only excludes assembly; end-to-end includes it. Accuracy column = full-field relative L2 of e_edges vs the Direct-f64 reference at the same size."
+fixture = "sigma-lossy parallel-plate cube, single LumpedPort (e_hat = y, R = 1), eps_r = 1 (real), sigma = 2.0, PEC on y-planes — the tests/iterative_sweep.rs / driven_matrix_free_equivalence.rs family"
+omega_single = 0.10
+omegas_sweep5 = [0.05, 0.075, 0.10, 0.15, 0.20]
+iter_tol_f64 = 1e-8
+iter_tol_f32 = 1e-6
+iter_max = 20000
+statistic = "median of 3 timed repetitions per cell (warm-up run excluded); 5-point sweep is a single timed pass after a full warm-up pass"
+
+[meta.host]
+instance = "AWS g6e.xlarge (rented benchmark box)"
+cpu = "AMD EPYC 7R13, 4 vCPU"
+ram_gb = 30
+gpu = "NVIDIA L40S, 46068 MiB, compute capability 8.9"
+gpu_driver = "595.71.05"
+cuda = "13.2 (nvcc V13.2.51)"
+os = "Ubuntu 22.04.5 LTS, kernel 6.8.0-1060-aws"
+rustc = "1.97.0 (2d8144b78 2026-07-07)"
+caveat = "4-vCPU host: the CPU baselines here are for same-host GPU comparison only, NOT comparable to m6i CPU numbers elsewhere in benchmarks/"
+
+[meta.provenance]
+branch = "feature/issue-501"
+base_main_commit = "ad2a3f8"
+generator_test = "crates/geode-core/tests/gpu_driven_scaling.rs"
+cpu_leg_cmd = "cargo test -p geode-core --release --test gpu_driven_scaling -- --ignored --nocapture"
+gpu_leg_cmd = "cargo test -p geode-core --release --features cuda --test gpu_driven_scaling -- --ignored --nocapture"
+notes = [
+  "Configs 1-3 below are from the box's ndarray-leg run; config 4 is from the box's cuda-leg run. The cuda-leg run re-measured configs 1-2 (they are backend-independent CPU paths) and agreed with the ndarray-leg values within ~3% — the duplicates are omitted.",
+  "The f32 GPU leg runs at tol = 1e-6, not the f64 legs' 1e-8: 1e-8 is below the f32 recurrence floor (requesting it stalls COCG at max_iters; observed stagnation at ~1e-2 relative residual at n=15). Iteration counts between the f32 and f64 iterative cells are therefore not exactly comparable (the f32 cells stop earlier).",
+  "Even at tol = 1e-6 the f32 recurrence estimate is optimistic: the TRUE (recomputed) relative residual of the GPU cells floors at 6.2e-4 (n=6) to 5.4e-3 (n=15) — orders of magnitude above the requested tolerance. The residual_rel column is always the recomputed true residual.",
+  "GPU-f32 convergence at n=15 is NONDETERMINISTIC (CUDA reduction order varies run-to-run at the f32 floor): in one run of the identical code an end-to-end repetition stagnated at 3.3e-2 while the other six attempts converged; in the committed run all seven single-omega attempts converged but the 5-point sweep did not (sweep5_converged = false, higher omegas are harder). The test records such outcomes as DNF/flaky cells instead of failing.",
+  "Sizes are the issue's specified n in {6, 9, 12, 15}. The issue header estimated ~15k-200k edges for this range; actual cube_tet_mesh edge counts are 1854/5859/13428/25695 — no size was shrunk; memory was never a constraint (peak well under both 30 GB host RAM and 46 GB GPU).",
+]
+
+# ---------------------------------------------------------------------------
+# HONEST READ (issue #501 acceptance: where the GPU wins/loses vs size)
+# ---------------------------------------------------------------------------
+# GPU-f32 matrix-free LOSES to every CPU configuration at every measured size
+# on this host. At the single omega = 0.1 (solve-only medians): the assembled
+# CSR COCG (CPU f64) is 136x faster at n=6 (0.032 s vs 4.39 s) and still 44x
+# faster at n=15 (1.86 s vs 81.8 s); even Direct LU is 13x faster at n=15
+# (6.04 s). The GPU's per-iteration cost is kernel-launch dominated at these
+# sizes (~28 ms/iter at n=15 vs ~0.63 ms/iter for assembled CSR on CPU) —
+# 25.7k edges is far too small to fill an L40S.
+#
+# The only crossover in the measured range is GPU-f32 vs the SAME matrix-free
+# algorithm on CPU (ndarray f64): the ratio falls monotonically from 2.7x
+# slower (n=6: 4.39 s vs 1.65 s) to parity at n=15 (81.8 s vs 82.1 s), i.e.
+# the GPU catches the CPU matrix-free path at ~26k edges and would pass it
+# beyond. But that crossover is moot in f32: n=15 already sits at the f32
+# convergence ceiling (nondeterministic stagnation, sweep DNF, true residual
+# 5.4e-3), so larger problems are not reachable at this precision. Scaling
+# the GPU path further requires f64 (or mixed-precision/iterative-refinement)
+# GPU support — note the L40S has 1/64-rate f64, so f64-on-L40S would trade
+# the convergence ceiling for raw-rate loss.
+#
+# Accuracy (full-field rel-L2 vs Direct-f64): both f64 iterative configs sit
+# at 6e-9..2e-8 (documented equivalence-class agreement). The f32 GPU cells
+# degrade with size: 1.26e-4 (n=6) -> 2.93e-4 (n=9) -> 4.60e-4 (n=12) ->
+# 1.20e-3 (n=15) — usable for ~0.1%-class field quantities at these sizes,
+# but the trend is the wrong direction for refinement studies.
+#
+# Practical conclusion for this size range: the assembled-CSR COCG (config 2)
+# is the best iterative option on CPU (beats Direct LU from n >= 9 and is
+# 3.2x faster than LU at n=15), and the GPU matrix-free path is not yet
+# competitive for driven solves. This does NOT contradict PR #495/#487's
+# motivation (keeping Krylov vectors device-resident for problems that fill
+# the GPU); it bounds where that pays off: well above 26k edges, and only
+# once the pencil can be iterated in f64 on device.
+
+# ---------------------------------------------------------------------------
+# Config 1: Direct (faer sparse LU), CPU f64 — accuracy reference
+# ---------------------------------------------------------------------------
+
+[[cell]]
+size_n = 6
+n_edges = 1854
+n_interior = 1614
+config = "1_direct"
+method = "faer_lu"
+device = "cpu"
+dtype = "f64"
+converged = true
+reps = 3
+solve_only_s = 0.024149
+end_to_end_s = 0.066047
+iterations = 0
+residual_rel = 1.854e-13
+accuracy_rel_l2_vs_direct = 0.0
+sweep5_solve_only_s = 0.123170
+sweep5_total_iters = 0
+
+[[cell]]
+size_n = 9
+n_edges = 5859
+n_interior = 5337
+config = "1_direct"
+method = "faer_lu"
+device = "cpu"
+dtype = "f64"
+converged = true
+reps = 3
+solve_only_s = 0.202736
+end_to_end_s = 0.339608
+iterations = 0
+residual_rel = 4.008e-13
+accuracy_rel_l2_vs_direct = 0.0
+sweep5_solve_only_s = 1.020275
+sweep5_total_iters = 0
+
+[[cell]]
+size_n = 12
+n_edges = 13428
+n_interior = 12516
+config = "1_direct"
+method = "faer_lu"
+device = "cpu"
+dtype = "f64"
+converged = true
+reps = 3
+solve_only_s = 1.540170
+end_to_end_s = 1.866322
+iterations = 0
+residual_rel = 6.510e-13
+accuracy_rel_l2_vs_direct = 0.0
+sweep5_solve_only_s = 8.009202
+sweep5_total_iters = 0
+
+[[cell]]
+size_n = 15
+n_edges = 25695
+n_interior = 24285
+config = "1_direct"
+method = "faer_lu"
+device = "cpu"
+dtype = "f64"
+converged = true
+reps = 3
+solve_only_s = 6.036479
+end_to_end_s = 6.695204
+iterations = 0
+residual_rel = 1.070e-12
+accuracy_rel_l2_vs_direct = 0.0
+sweep5_solve_only_s = 30.151195
+sweep5_total_iters = 0
+
+# ---------------------------------------------------------------------------
+# Config 2: Iterative assembled-CSR COCG + Jacobi, CPU f64 (tol 1e-8)
+# ---------------------------------------------------------------------------
+
+[[cell]]
+size_n = 6
+n_edges = 1854
+n_interior = 1614
+config = "2_iterative_csr"
+method = "cocg_jacobi"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 0.032302
+end_to_end_s = 0.073604
+iterations = 800
+residual_rel = 8.233e-9
+accuracy_rel_l2_vs_direct = 1.433e-8
+sweep5_solve_only_s = 0.163188
+sweep5_total_iters = 4004
+
+[[cell]]
+size_n = 9
+n_edges = 5859
+n_interior = 5337
+config = "2_iterative_csr"
+method = "cocg_jacobi"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 0.198008
+end_to_end_s = 0.334962
+iterations = 1463
+residual_rel = 9.202e-9
+accuracy_rel_l2_vs_direct = 1.070e-8
+sweep5_solve_only_s = 0.999570
+sweep5_total_iters = 7343
+
+[[cell]]
+size_n = 12
+n_edges = 13428
+n_interior = 12516
+config = "2_iterative_csr"
+method = "cocg_jacobi"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 0.708840
+end_to_end_s = 1.033251
+iterations = 2187
+residual_rel = 8.843e-9
+accuracy_rel_l2_vs_direct = 1.482e-8
+sweep5_solve_only_s = 3.475408
+sweep5_total_iters = 10800
+
+[[cell]]
+size_n = 15
+n_edges = 25695
+n_interior = 24285
+config = "2_iterative_csr"
+method = "cocg_jacobi"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 1.864723
+end_to_end_s = 2.520596
+iterations = 2940
+residual_rel = 9.922e-9
+accuracy_rel_l2_vs_direct = 1.635e-8
+sweep5_solve_only_s = 9.312205
+sweep5_total_iters = 14672
+
+# ---------------------------------------------------------------------------
+# Config 3: IterativeMatrixFree (BurnCocg), ndarray backend, CPU f64
+# (tol 1e-8) — same source path as config 4, CPU substrate
+# ---------------------------------------------------------------------------
+
+[[cell]]
+size_n = 6
+n_edges = 1854
+n_interior = 1614
+config = "3_matrix_free_ndarray"
+method = "burn_cocg"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 1.652218
+end_to_end_s = 1.691032
+iterations = 800
+residual_rel = 9.875e-9
+accuracy_rel_l2_vs_direct = 1.438e-8
+sweep5_solve_only_s = 8.191763
+sweep5_total_iters = 3924
+
+[[cell]]
+size_n = 9
+n_edges = 5859
+n_interior = 5337
+config = "3_matrix_free_ndarray"
+method = "burn_cocg"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 8.884869
+end_to_end_s = 9.017679
+iterations = 1454
+residual_rel = 9.924e-9
+accuracy_rel_l2_vs_direct = 1.067e-8
+sweep5_solve_only_s = 44.878891
+sweep5_total_iters = 7312
+
+[[cell]]
+size_n = 12
+n_edges = 13428
+n_interior = 12516
+config = "3_matrix_free_ndarray"
+method = "burn_cocg"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 30.234288
+end_to_end_s = 31.305811
+iterations = 2185
+residual_rel = 8.891e-9
+accuracy_rel_l2_vs_direct = 1.475e-8
+sweep5_solve_only_s = 150.934120
+sweep5_total_iters = 10742
+
+[[cell]]
+size_n = 15
+n_edges = 25695
+n_interior = 24285
+config = "3_matrix_free_ndarray"
+method = "burn_cocg"
+device = "cpu"
+dtype = "f64"
+tol = 1e-8
+converged = true
+reps = 3
+solve_only_s = 82.056014
+end_to_end_s = 82.485752
+iterations = 2975
+residual_rel = 7.842e-9
+accuracy_rel_l2_vs_direct = 6.419e-9
+sweep5_solve_only_s = 404.535934
+sweep5_total_iters = 14560
+
+# ---------------------------------------------------------------------------
+# Config 4: IterativeMatrixFree (BurnCocg), Cuda backend, GPU f32 (tol 1e-6)
+# — same source path as config 3, GPU substrate. residual_rel is the TRUE
+# recomputed residual (the f32 recurrence estimate is optimistic).
+# ---------------------------------------------------------------------------
+
+[[cell]]
+size_n = 6
+n_edges = 1854
+n_interior = 1614
+config = "4_matrix_free_cuda"
+method = "burn_cocg"
+device = "gpu"
+dtype = "f32"
+tol = 1e-6
+converged = true
+flaky = false
+reps = 3
+solve_only_s = 4.388126
+end_to_end_s = 4.484934
+iterations = 770
+residual_rel = 6.181e-4
+accuracy_rel_l2_vs_direct = 1.256e-4
+sweep5_converged = true
+sweep5_solve_only_s = 22.065634
+sweep5_total_iters = 3853
+
+[[cell]]
+size_n = 9
+n_edges = 5859
+n_interior = 5337
+config = "4_matrix_free_cuda"
+method = "burn_cocg"
+device = "gpu"
+dtype = "f32"
+tol = 1e-6
+converged = true
+flaky = false
+reps = 3
+solve_only_s = 13.350620
+end_to_end_s = 13.020092
+iterations = 1398
+residual_rel = 2.073e-3
+accuracy_rel_l2_vs_direct = 2.933e-4
+sweep5_converged = true
+sweep5_solve_only_s = 64.349191
+sweep5_total_iters = 6886
+
+[[cell]]
+size_n = 12
+n_edges = 13428
+n_interior = 12516
+config = "4_matrix_free_cuda"
+method = "burn_cocg"
+device = "gpu"
+dtype = "f32"
+tol = 1e-6
+converged = true
+flaky = false
+reps = 3
+solve_only_s = 34.380736
+end_to_end_s = 33.491142
+iterations = 2016
+residual_rel = 2.705e-3
+accuracy_rel_l2_vs_direct = 4.596e-4
+sweep5_converged = true
+sweep5_solve_only_s = 168.248858
+sweep5_total_iters = 10313
+
+[[cell]]
+size_n = 15
+n_edges = 25695
+n_interior = 24285
+config = "4_matrix_free_cuda"
+method = "burn_cocg"
+device = "gpu"
+dtype = "f32"
+tol = 1e-6
+converged = true
+flaky = false
+reps = 3
+solve_only_s = 81.763958
+end_to_end_s = 85.451962
+iterations = 2919
+residual_rel = 5.358e-3
+accuracy_rel_l2_vs_direct = 1.197e-3
+# The 5-point sweep did NOT converge at this size (higher omegas sit past
+# the f32 recurrence floor); single-omega convergence here is itself
+# marginal/nondeterministic across runs — see [meta.provenance] notes.
+sweep5_converged = false

--- a/crates/geode-core/tests/gpu_driven_scaling.rs
+++ b/crates/geode-core/tests/gpu_driven_scaling.rs
@@ -1,0 +1,715 @@
+//! GPU-vs-CPU driven-solve wall-clock scaling benchmark (issue #501, Epic
+//! #476 Phase D).
+//!
+//! This is the *measurable* GPU cell of the transmon-benchmark epic: how the
+//! wall-clock time of a single physical driven problem scales across solver
+//! backends as the mesh is refined. It corrects the earlier "GPU performance =
+//! future work" deferral on #476 — only the eigensolve-on-GPU (no code path)
+//! and the Palace-libCEED cell are genuinely future work.
+//!
+//! ## What it measures
+//!
+//! One physical fixture — a σ-lossy parallel-plate cube with a single
+//! lumped port (the `iterative_sweep.rs` / `driven_matrix_free_equivalence.rs`
+//! family) — scaled via [`cube_tet_mesh`]`(n)` at `n ∈ {6, 9, 12, 15}`. At
+//! each size, four solver configurations solve the *same* assembled pencil at
+//! the *same* ω:
+//!
+//! | # | Config                         | Backend / dtype        | CI |
+//! |---|--------------------------------|------------------------|----|
+//! | 1 | `Direct` (faer sparse LU)      | CPU f64 (faer, backend-independent) | yes |
+//! | 2 | `Iterative` (assembled COCG + Jacobi) | CPU f64 (faer, backend-independent) | yes |
+//! | 3 | `IterativeMatrixFree`          | Burn backend (`ndarray` f64 on CI, `Cuda` f32 on the rented box) | yes (ndarray) |
+//! | 4 | `IterativeMatrixFree`          | `Cuda` f32 (same code as #3, GPU leg) | no — `--features cuda`, rented box only |
+//!
+//! Configs 3 and 4 are the *same source path*: the matrix-free solver is
+//! generic over the Burn backend, so this test emits config #3 on whatever
+//! [`TestBackend`] the active feature flags select — `ndarray`-f64 in CI (the
+//! CPU matrix-free cell) and `Cuda`-f32 on the rented box (the GPU cell). The
+//! `cfg!(feature = "cuda")` branch only changes the emitted backend label /
+//! dtype, the COCG tolerance, and the accuracy expectation; the timing loop is
+//! shared.
+//!
+//! ## f32 tolerance and DNF cells
+//!
+//! The COCG stopping tolerance is **dtype-aware**: the f64 legs request a
+//! relative residual of `1e-8`; the Cuda-f32 leg requests `1e-6` because
+//! `1e-8` is below the f32 recurrence floor (f32 ε ≈ 1.2e-7; requesting a
+//! tighter tolerance stalls the recurrence at `max_iters`). Even at `1e-6`
+//! the *true* (recomputed) residual of the f32 leg floors around `1e-4`–`1e-3`
+//! on this fixture, and at the largest size the recurrence can stagnate above
+//! tolerance entirely. A non-converged (size × config) cell is recorded
+//! honestly as `converged = false` (a **DNF cell**: the wall time of the
+//! failed attempt, `iterations = max_iters`, the stagnated residual, and no
+//! accuracy value) rather than crashing the benchmark — the f32 convergence
+//! ceiling *is* one of the measured results.
+//!
+//! Convergence on the GPU is additionally **nondeterministic near the f32
+//! floor**: CUDA reduction order varies run-to-run, so at a marginal size the
+//! same solve can converge on one attempt and stagnate on the next (observed
+//! at n=15 on the L40S: warm-up + solve-only reps converged, an end-to-end
+//! rep stagnated at 3.3e-2). Every timed repetition is therefore fallible;
+//! cells report `solve_reps_ok` / `e2e_reps_ok` out of `reps`, medians are
+//! taken over the successful repetitions only, and `flaky = true` marks cells
+//! where some — but not all — attempts converged.
+//!
+//! ## Honesty rails (see the emitted TOML header)
+//!
+//! * The CPU baselines and the GPU cell in a *single committed TOML* must come
+//!   from the **same host** (the g6e.xlarge rented box, 4 vCPU) so the
+//!   GPU-vs-CPU comparison is apples-to-apples. Numbers produced on a laptop or
+//!   an m6i are for development only and are labelled as such.
+//! * The warm-up run is excluded from the reported statistics; headline sizes
+//!   report the median of 3 timed runs.
+//! * The f32 GPU cell carries an explicit accuracy disclosure (relative L2 of
+//!   the full edge-field solution vs the Direct-f64 reference).
+//! * This is the **driven-solve** scaling cell. It is explicitly *not* the
+//!   eigensolve headline of #476 and must not be conflated with it.
+//!
+//! ## Running
+//!
+//! CPU legs (configs 1–3, ndarray-f64), locally or on the box:
+//! ```text
+//! cargo test -p geode-core --release --test gpu_driven_scaling -- --ignored --nocapture
+//! ```
+//! GPU leg (config 4, Cuda-f32) on the rented box:
+//! ```text
+//! cargo test -p geode-core --release --features cuda --test gpu_driven_scaling -- --ignored --nocapture
+//! ```
+//! Both print a TOML fragment to stdout; the committed
+//! `benchmarks/gpu_driven_scaling/results.toml` is assembled from the two runs
+//! on the same host.
+
+use std::time::Instant;
+
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use geode_core::driven::ports::LumpedPort;
+use geode_core::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenMaterials, DrivenOperator, IterativeSettings, SolverMode,
+};
+use geode_core::mesh::{TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// Mesh sizes swept. `cube_tet_mesh(n)` yields (edges): n=6 → 1854,
+/// n=9 → 5859, n=12 → 13428, n=15 → 25695. These are the issue's specified
+/// `{6, 9, 12, 15}` set. (The issue header estimated ~15k–200k edges; the
+/// actual `cube_tet_mesh` edge counts are lower — n=15 is ~25.7k edges — so
+/// no size was shrunk. The top size is comfortably within both the L40S 46 GB
+/// and a 16 GB CPU RSS budget: the direct LU on ~25k complex DOFs is seconds,
+/// not minutes.)
+const SIZES: &[usize] = &[6, 9, 12, 15];
+
+/// Headline sizes get the median of 3 timed runs; other sizes run once
+/// (plus a warm-up) to keep total wall-clock bounded. All sizes here are cheap
+/// enough that we can afford 3 everywhere, so `MEDIAN_SIZES` covers them all —
+/// but the machinery honors a subset if a future larger top size is added.
+const MEDIAN_SIZES: &[usize] = &[6, 9, 12, 15];
+
+/// Timed repetitions for a headline size (median reported).
+const N_REPS_MEDIAN: usize = 3;
+
+/// Drive frequency for the single-ω cell. Low ω keeps the σ-lossy pencil
+/// well-conditioned (the equivalence tests use this same regime).
+const OMEGA_SINGLE: f64 = 0.10;
+
+/// 5-point ω sweep for the sweep variant.
+const OMEGAS_SWEEP: &[f64] = &[0.05, 0.075, 0.10, 0.15, 0.20];
+
+/// COCG stopping tolerance for the f64 configs (assembled CSR and
+/// matrix-free-on-ndarray).
+const ITER_TOL_F64: f64 = 1e-8;
+
+/// COCG stopping tolerance for the Cuda-f32 matrix-free leg. `1e-8` is below
+/// the f32 recurrence floor (the recurrence stalls at `max_iters`); `1e-6` is
+/// the tightest request that converges on the small/mid sizes of this fixture.
+/// The *true* residual is recomputed post-solve and reported per cell — in f32
+/// it floors well above the requested tolerance (~1e-4..1e-3 here).
+const ITER_TOL_F32: f64 = 1e-6;
+
+/// Maximum COCG iterations per RHS.
+const ITER_MAX: usize = 20_000;
+
+// ---------------------------------------------------------------------------
+// Fixture construction (σ-lossy parallel-plate cube, single lumped port)
+// ---------------------------------------------------------------------------
+
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+/// Everything the four solver configs share at one mesh size: the assembled
+/// operator plus provenance the reporter prints.
+struct Fixture {
+    op: DrivenOperator,
+    n_edges: usize,
+    n_interior: usize,
+    n_tets: usize,
+}
+
+/// Build the σ-lossy parallel-plate cube fixture at refinement `n` and
+/// assemble the driven operator once (shared by all four configs). Real ε = 1
+/// with volumetric σ = 2.0 keeps the pencil well-conditioned *and* keeps the
+/// matrix-free ingredient available (the matrix-free path takes real ε only;
+/// σ is folded into the damping term `iωC(σ)`).
+fn build_fixture(n: usize) -> Fixture {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+    let n_tets = mesh.n_tets();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let n_interior = mask.iter().filter(|&&k| k).count();
+
+    let eps: Vec<c64> = vec![c64::new(1.0, 0.0); n_tets];
+    let sigma_tet = vec![2.0_f64; n_tets];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let source = CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; n_tets],
+    };
+
+    let op = DrivenOperator::assemble::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &source,
+        &device(),
+    )
+    .expect("operator assembly");
+
+    Fixture {
+        op,
+        n_edges,
+        n_interior,
+        n_tets,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Timing helpers
+// ---------------------------------------------------------------------------
+
+/// Median of a slice of `f64` (small n; sort-and-pick).
+fn median(xs: &[f64]) -> f64 {
+    let mut v = xs.to_vec();
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let m = v.len() / 2;
+    if v.len() % 2 == 1 {
+        v[m]
+    } else {
+        0.5 * (v[m - 1] + v[m])
+    }
+}
+
+/// Full-field relative L2 error of `sol` vs the Direct-f64 reference `refs`
+/// (both `[n_edges]` complex edge-DOF vectors).
+fn rel_l2(refs: &[c64], sol: &[c64]) -> f64 {
+    let mut num = 0.0_f64;
+    let mut den = 0.0_f64;
+    for (r, s) in refs.iter().zip(sol.iter()) {
+        let d = *r - *s;
+        num += d.re * d.re + d.im * d.im;
+        den += r.re * r.re + r.im * r.im;
+    }
+    (num / den.max(1e-300)).sqrt()
+}
+
+/// Best-effort extraction of the stagnated relative residual from a COCG
+/// non-convergence error message ("... relative residual X > tol Y").
+fn residual_from_error(msg: &str) -> f64 {
+    msg.split("relative residual ")
+        .nth(1)
+        .and_then(|s| s.split_whitespace().next())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(f64::NAN)
+}
+
+/// One measured cell: solve-only + end-to-end timings, iteration count,
+/// residual, and the full-field solution for the accuracy column.
+struct Cell {
+    /// Solve-only wall clock in seconds (prepare_at + solve; excludes
+    /// assembly). Median over the *successful* reps; NaN if none succeeded.
+    solve_s: f64,
+    /// Successful solve-only repetitions (out of `reps`).
+    solve_reps_ok: usize,
+    /// End-to-end wall clock in seconds (assemble + prepare_at + solve).
+    /// Median over the *successful* reps; NaN if none succeeded.
+    end_to_end_s: f64,
+    /// Successful end-to-end repetitions (out of `reps`).
+    e2e_reps_ok: usize,
+    /// Requested repetitions per timing loop.
+    reps: usize,
+    /// COCG iterations (0 for the direct path), from the warm-up solve.
+    iters: usize,
+    /// Post-solve relative residual `‖Ax − b‖ / ‖b‖` (recomputed, not the
+    /// recurrence estimate), from the warm-up solve.
+    residual_rel: f64,
+    /// Full-field solution (for the accuracy column), from the warm-up solve.
+    e_edges: Vec<c64>,
+}
+
+/// Outcome of one (size × config) measurement: either a converged [`Cell`],
+/// or a **DNF** (did not finish — COCG hit `max_iters` above tolerance).
+enum Outcome {
+    Converged(Cell),
+    Dnf {
+        /// Wall clock of the failed solve attempt (time-to-stagnation).
+        attempt_s: f64,
+        /// Stagnated relative residual parsed from the error (NaN if the
+        /// message shape is unexpected).
+        stagnated_residual: f64,
+        /// The full error message (echoed as a TOML comment).
+        message: String,
+    },
+}
+
+/// Time one solver config on the shared fixture at a single ω.
+///
+/// `solve-only` times `prepare_at(ω, mode) + solve()`. `end-to-end` rebuilds
+/// the operator too (`build_fixture(n) + prepare_at + solve`) so the
+/// assembly cost is included honestly. A warm-up run precedes the timed reps
+/// and is excluded from the reported median. If the warm-up solve does not
+/// converge, the config is recorded as a DNF outcome. Individual timed reps
+/// are fallible too (GPU-f32 convergence is nondeterministic near the f32
+/// floor — see module docs): medians are taken over the successful reps and
+/// per-loop success counts are reported.
+fn time_config(n: usize, fix: &Fixture, mode: SolverMode, reps: usize) -> Outcome {
+    // Warm-up (excluded from stats): also captures the returned solution +
+    // report used for the accuracy / iteration / residual columns, and
+    // detects hard non-convergence before committing to timed reps.
+    let t_warm = Instant::now();
+    let solver = fix
+        .op
+        .prepare_at::<B>(OMEGA_SINGLE, mode, &device())
+        .expect("prepare_at");
+    let (sol, report) = match solver.solve() {
+        Ok(ok) => ok,
+        Err(e) => {
+            let message = format!("{e}");
+            return Outcome::Dnf {
+                attempt_s: t_warm.elapsed().as_secs_f64(),
+                stagnated_residual: residual_from_error(&message),
+                message,
+            };
+        }
+    };
+    let e_edges = sol.e_edges.clone();
+    let iters = report.iters;
+    let residual_rel = report.residual_rel;
+
+    // Timed solve-only reps (fallible; failures logged and skipped).
+    let mut solve_times = Vec::with_capacity(reps);
+    for k in 0..reps {
+        let t0 = Instant::now();
+        let solver = fix
+            .op
+            .prepare_at::<B>(OMEGA_SINGLE, mode, &device())
+            .expect("prepare_at (timed)");
+        match solver.solve() {
+            Ok(_) => solve_times.push(t0.elapsed().as_secs_f64()),
+            Err(e) => eprintln!("  [n={n}] solve-only rep {k} did not converge: {e}"),
+        }
+    }
+
+    // Timed end-to-end reps (assemble + prepare_at + solve; fallible).
+    let mut e2e_times = Vec::with_capacity(reps);
+    for k in 0..reps {
+        let t0 = Instant::now();
+        let f = build_fixture(n);
+        let solver =
+            f.op.prepare_at::<B>(OMEGA_SINGLE, mode, &device())
+                .expect("prepare_at (e2e)");
+        match solver.solve() {
+            Ok(_) => e2e_times.push(t0.elapsed().as_secs_f64()),
+            Err(e) => eprintln!("  [n={n}] end-to-end rep {k} did not converge: {e}"),
+        }
+    }
+
+    Outcome::Converged(Cell {
+        solve_s: if solve_times.is_empty() {
+            f64::NAN
+        } else {
+            median(&solve_times)
+        },
+        solve_reps_ok: solve_times.len(),
+        end_to_end_s: if e2e_times.is_empty() {
+            f64::NAN
+        } else {
+            median(&e2e_times)
+        },
+        e2e_reps_ok: e2e_times.len(),
+        reps,
+        iters,
+        residual_rel,
+        e_edges,
+    })
+}
+
+/// Time one solver config across the 5-point ω sweep (solve-only, summed over
+/// the 5 frequencies; one timed pass after a warm-up). Returns
+/// `Some((sum_solve_s, total_iters))`, or `None` if any frequency failed to
+/// converge in either pass (the sweep cell is then reported as DNF).
+fn time_sweep(fix: &Fixture, mode: SolverMode) -> Option<(f64, usize)> {
+    // Warm-up.
+    for &w in OMEGAS_SWEEP {
+        let solver = fix.op.prepare_at::<B>(w, mode, &device()).expect("prepare");
+        if solver.solve().is_err() {
+            return None;
+        }
+    }
+    let t0 = Instant::now();
+    let mut total_iters = 0usize;
+    for &w in OMEGAS_SWEEP {
+        let solver = fix
+            .op
+            .prepare_at::<B>(w, mode, &device())
+            .expect("prepare (sweep)");
+        match solver.solve() {
+            Ok((_, report)) => total_iters += report.iters,
+            Err(_) => return None,
+        }
+    }
+    Some((t0.elapsed().as_secs_f64(), total_iters))
+}
+
+// ---------------------------------------------------------------------------
+// Backend / provenance labels
+// ---------------------------------------------------------------------------
+
+/// The backend + dtype label for the matrix-free config (#3/#4), derived from
+/// the active feature flags so the emitted TOML self-documents which backend
+/// produced it (`ndarray`-f64 vs `Cuda`-f32).
+fn matrix_free_label() -> (&'static str, &'static str) {
+    #[cfg(feature = "cuda")]
+    {
+        ("Cuda", "f32")
+    }
+    #[cfg(not(feature = "cuda"))]
+    {
+        ("ndarray", "f64")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The benchmark
+// ---------------------------------------------------------------------------
+
+/// `#[ignore]`d wall-clock scaling benchmark. Prints a TOML fragment to
+/// stdout with one `[[cell]]` table per (size × config) plus the sweep
+/// variant. CI never runs this (`--ignored`), and never runs the cuda leg.
+#[test]
+#[ignore = "wall-clock benchmark; run explicitly with --ignored --nocapture"]
+fn gpu_driven_scaling_benchmark() {
+    let (mf_backend, mf_dtype) = matrix_free_label();
+    let mf_tol = if mf_dtype == "f32" {
+        ITER_TOL_F32
+    } else {
+        ITER_TOL_F64
+    };
+
+    println!("# ---- gpu_driven_scaling TOML fragment (issue #501) ----");
+    println!("# matrix-free backend/dtype for this run: {mf_backend} / {mf_dtype}");
+    println!(
+        "# configs: 1=Direct(faer LU, CPU f64)  2=Iterative(assembled COCG+Jacobi, CPU f64)  \
+         3=IterativeMatrixFree({mf_backend} {mf_dtype})"
+    );
+    println!("# single-ω = {OMEGA_SINGLE}; sweep ω = {OMEGAS_SWEEP:?}");
+    println!(
+        "# iter tol: f64 configs = {ITER_TOL_F64:e}, matrix-free ({mf_dtype}) = {mf_tol:e}; \
+         iter max = {ITER_MAX}"
+    );
+    println!();
+
+    for &n in SIZES {
+        let reps = if MEDIAN_SIZES.contains(&n) {
+            N_REPS_MEDIAN
+        } else {
+            1
+        };
+        let fix = build_fixture(n);
+        eprintln!(
+            "[size n={n}] edges={} interior={} tets={} reps={reps}",
+            fix.n_edges, fix.n_interior, fix.n_tets
+        );
+
+        let iset_f64 = IterativeSettings::new(ITER_TOL_F64, ITER_MAX);
+        let iset_mf = IterativeSettings::new(mf_tol, ITER_MAX);
+
+        // Config 1: Direct (faer sparse LU), CPU f64. This is the accuracy
+        // reference for every other config at this size.
+        let c_direct = match time_config(n, &fix, SolverMode::Direct, reps) {
+            Outcome::Converged(c) => c,
+            Outcome::Dnf { message, .. } => panic!("direct LU failed at n={n}: {message}"),
+        };
+        let sw_direct = time_sweep(&fix, SolverMode::Direct).expect("direct sweep");
+        let acc_direct = 0.0; // reference vs itself
+        emit_cell(
+            n,
+            fix.n_edges,
+            fix.n_interior,
+            "1_direct",
+            "faer_lu",
+            "cpu",
+            "f64",
+            f64::NAN, // no iterative tolerance on the direct path
+            &c_direct,
+            acc_direct,
+            Some(sw_direct),
+        );
+
+        // Config 2: assembled iterative COCG + Jacobi, CPU f64.
+        let c_iter = match time_config(n, &fix, SolverMode::Iterative(iset_f64), reps) {
+            Outcome::Converged(c) => c,
+            Outcome::Dnf { message, .. } => {
+                panic!("assembled COCG (f64) failed at n={n}: {message}")
+            }
+        };
+        let sw_iter =
+            time_sweep(&fix, SolverMode::Iterative(iset_f64)).expect("assembled COCG sweep");
+        let acc_iter = rel_l2(&c_direct.e_edges, &c_iter.e_edges);
+        emit_cell(
+            n,
+            fix.n_edges,
+            fix.n_interior,
+            "2_iterative_csr",
+            "cocg_jacobi",
+            "cpu",
+            "f64",
+            ITER_TOL_F64,
+            &c_iter,
+            acc_iter,
+            Some(sw_iter),
+        );
+
+        // Config 3/4: matrix-free (ndarray-f64 on CI, Cuda-f32 on the box).
+        // f32 non-convergence at large sizes is an expected, *reported*
+        // outcome (DNF cell / partial reps), not a benchmark crash.
+        let o_mf = time_config(n, &fix, SolverMode::IterativeMatrixFree(iset_mf), reps);
+        // Skip the matrix-free sweep entirely when the single-ω cell already
+        // DNF'd (it would burn max_iters × 5 frequencies × 2 passes).
+        let sw_mf = match &o_mf {
+            Outcome::Converged(_) => time_sweep(&fix, SolverMode::IterativeMatrixFree(iset_mf)),
+            Outcome::Dnf { .. } => None,
+        };
+        let mf_device = if mf_backend == "Cuda" { "gpu" } else { "cpu" };
+        match &o_mf {
+            Outcome::Converged(c_mf) => {
+                let acc_mf = rel_l2(&c_direct.e_edges, &c_mf.e_edges);
+                emit_cell(
+                    n,
+                    fix.n_edges,
+                    fix.n_interior,
+                    "3_matrix_free",
+                    "burn_cocg",
+                    mf_device,
+                    mf_dtype,
+                    mf_tol,
+                    c_mf,
+                    acc_mf,
+                    sw_mf,
+                );
+                // Accuracy envelope: f64 matrix-free tracks the assembled
+                // path (~1e-8); f32 floors at the f32 residual ceiling
+                // (observed ~1e-4-class on this fixture; 5e-2 is the
+                // fail-loudly rail, not the expectation).
+                let mf_acc_tol = if mf_dtype == "f32" { 5e-2 } else { 1e-5 };
+                assert!(
+                    acc_mf < mf_acc_tol,
+                    "config 3 (matrix-free {mf_backend} {mf_dtype}) rel-L2 vs Direct = \
+                     {acc_mf} exceeds {mf_acc_tol} at n={n}"
+                );
+            }
+            Outcome::Dnf {
+                attempt_s,
+                stagnated_residual,
+                message,
+            } => {
+                // The f64 (CI) leg must never DNF — that would be a real
+                // convergence regression, not an f32 precision ceiling.
+                assert!(
+                    mf_dtype == "f32",
+                    "matrix-free {mf_backend} {mf_dtype} DNF at n={n}: {message}"
+                );
+                emit_dnf_cell(
+                    n,
+                    fix.n_edges,
+                    fix.n_interior,
+                    "3_matrix_free",
+                    "burn_cocg",
+                    mf_device,
+                    mf_dtype,
+                    mf_tol,
+                    *attempt_s,
+                    *stagnated_residual,
+                    message,
+                );
+            }
+        }
+
+        // Sanity rails for the CPU f64 configs (always enforced).
+        assert!(
+            c_iter.residual_rel < 1e-5,
+            "config 2 (iterative) did not converge at n={n}: residual={}",
+            c_iter.residual_rel
+        );
+        assert!(
+            acc_iter < 1e-5,
+            "config 2 (iterative) rel-L2 vs Direct = {acc_iter} exceeds 1e-5 at n={n}"
+        );
+    }
+
+    println!("# ---- end fragment ----");
+}
+
+/// Emit one `[[cell]]` TOML table for a converged (size × config)
+/// measurement.
+#[allow(clippy::too_many_arguments)]
+fn emit_cell(
+    n: usize,
+    n_edges: usize,
+    n_interior: usize,
+    config: &str,
+    method: &str,
+    device_kind: &str,
+    dtype: &str,
+    tol: f64,
+    cell: &Cell,
+    accuracy_rel_l2_vs_direct: f64,
+    sweep: Option<(f64, usize)>,
+) {
+    let flaky = cell.solve_reps_ok < cell.reps || cell.e2e_reps_ok < cell.reps;
+    println!("[[cell]]");
+    println!("size_n = {n}");
+    println!("n_edges = {n_edges}");
+    println!("n_interior = {n_interior}");
+    println!("config = \"{config}\"");
+    println!("method = \"{method}\"");
+    println!("device = \"{device_kind}\"");
+    println!("dtype = \"{dtype}\"");
+    println!("tol = {}", toml_f64(tol));
+    println!("converged = true");
+    println!("flaky = {flaky}");
+    println!("reps = {}", cell.reps);
+    println!("solve_reps_ok = {}", cell.solve_reps_ok);
+    println!("e2e_reps_ok = {}", cell.e2e_reps_ok);
+    println!("solve_only_s = {}", toml_f64_fixed(cell.solve_s));
+    println!("end_to_end_s = {}", toml_f64_fixed(cell.end_to_end_s));
+    println!("iterations = {}", cell.iters);
+    println!("residual_rel = {:.3e}", cell.residual_rel);
+    println!(
+        "accuracy_rel_l2_vs_direct = {:.3e}",
+        accuracy_rel_l2_vs_direct
+    );
+    match sweep {
+        Some((s, it)) => {
+            println!("sweep5_converged = true");
+            println!("sweep5_solve_only_s = {s:.6}");
+            println!("sweep5_total_iters = {it}");
+        }
+        None => {
+            println!("sweep5_converged = false");
+        }
+    }
+    println!();
+}
+
+/// Emit one `[[cell]]` TOML table for a non-converged (DNF) measurement —
+/// the wall time is the time-to-stagnation of the single failed attempt.
+#[allow(clippy::too_many_arguments)]
+fn emit_dnf_cell(
+    n: usize,
+    n_edges: usize,
+    n_interior: usize,
+    config: &str,
+    method: &str,
+    device_kind: &str,
+    dtype: &str,
+    tol: f64,
+    attempt_s: f64,
+    stagnated_residual: f64,
+    message: &str,
+) {
+    println!("[[cell]]");
+    println!("size_n = {n}");
+    println!("n_edges = {n_edges}");
+    println!("n_interior = {n_interior}");
+    println!("config = \"{config}\"");
+    println!("method = \"{method}\"");
+    println!("device = \"{device_kind}\"");
+    println!("dtype = \"{dtype}\"");
+    println!("tol = {}", toml_f64(tol));
+    println!("converged = false");
+    println!("reps = 1");
+    println!("dnf_attempt_s = {attempt_s:.6}");
+    println!("iterations = {ITER_MAX}");
+    println!("residual_rel = {}", toml_f64_sci(stagnated_residual));
+    println!("accuracy_rel_l2_vs_direct = nan");
+    println!("sweep5_converged = false");
+    println!("# dnf: {message}");
+    println!();
+}
+
+/// Format an `f64` for TOML output, mapping NaN to the TOML `nan` literal.
+fn toml_f64(x: f64) -> String {
+    if x.is_nan() {
+        "nan".to_string()
+    } else {
+        format!("{x:e}")
+    }
+}
+
+/// Like [`toml_f64`] but with fixed scientific formatting for finite values.
+fn toml_f64_sci(x: f64) -> String {
+    if x.is_nan() {
+        "nan".to_string()
+    } else {
+        format!("{x:.3e}")
+    }
+}
+
+/// Like [`toml_f64`] but with fixed decimal formatting for finite values
+/// (seconds columns).
+fn toml_f64_fixed(x: f64) -> String {
+    if x.is_nan() {
+        "nan".to_string()
+    } else {
+        format!("{x:.6}")
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `#[ignore]`d release bench-test `gpu_driven_scaling` (issue #501, Epic #476 Phase D) — the *measurable* GPU cell of the transmon epic — and commits `benchmarks/gpu_driven_scaling/results.toml` with all four configs × four sizes measured on the **same host** (rented g6e.xlarge: NVIDIA L40S 46 GB, driver 595.71.05, CUDA 13.2, AMD EPYC 7R13 4 vCPU, Ubuntu 22.04.5, rustc 1.97.0).

One physical fixture (σ-lossy parallel-plate cube, single lumped port — the `tests/iterative_sweep.rs` family), scaled via `cube_tet_mesh(n)`, n ∈ {6, 9, 12, 15} = 1 854 → 25 695 edges. Solve-only AND end-to-end wall clock, medians of 3 (warm-up excluded), iterations, true recomputed residual, full-field rel-L2 accuracy vs Direct-f64, plus a 5-point ω-sweep variant per cell.

## Results (single ω = 0.1, solve-only medians, seconds, g6e.xlarge)

| n | edges | 1 Direct LU (CPU f64) | 2 CSR COCG (CPU f64) | 3 MF ndarray (CPU f64) | 4 MF Cuda (GPU f32) |
|---|-------|------|------|------|------|
| 6 | 1 854 | 0.024 | 0.032 | 1.65 | 4.39 |
| 9 | 5 859 | 0.203 | 0.198 | 8.88 | 13.35 |
| 12 | 13 428 | 1.540 | 0.709 | 30.23 | 34.38 |
| 15 | 25 695 | 6.036 | 1.865 | 82.06 | 81.76 |

Iterations (COCG): CSR-f64 800/1463/2187/2940 @ tol 1e-8; GPU-f32 770/1398/2016/2919 @ tol 1e-6 (1e-8 is below the f32 recurrence floor). Accuracy (rel-L2 vs Direct-f64): both f64 iterative configs 6e-9…2e-8; **GPU-f32 degrades with size: 1.26e-4 → 2.93e-4 → 4.60e-4 → 1.20e-3**, with true residuals flooring at 6.2e-4…5.4e-3 despite the recurrence "converging".

## Honest read

- **GPU-f32 loses to every CPU config at every measured size**: assembled CSR COCG is 136× faster at n=6 and still 44× faster at n=15; even Direct LU is 13× faster at n=15. Per-iteration GPU cost is kernel-launch dominated (~28 ms/iter at n=15 vs ~0.63 ms/iter CSR-CPU) — 26k edges is far too small to fill an L40S.
- **Only crossover in range**: GPU-f32 vs the *same* matrix-free algorithm on CPU falls monotonically from 2.7× slower (n=6) to **parity at n=15 (~26k edges)** — but the crossover is moot in f32: n=15 already sits at the f32 convergence ceiling. Convergence there is **nondeterministic** (CUDA reduction order varies run-to-run; one run stagnated an e2e rep at 3.3e-2, the committed run converged all 7 single-ω attempts but the 5-point sweep DNF'd). The test records DNF/flaky cells instead of crashing.
- Practical: assembled-CSR COCG (config 2) is the best iterative option in this range (beats LU from n≥9, 3.2× at n=15); scaling the GPU path needs f64-on-device (L40S f64 is 1/64 rate) or mixed precision, and >26k edges.
- **No conflation with the eigensolve headline**: this is the driven-solve cell only; the eigensolver has no GPU path (#302-future). Stated in the TOML header.

## Changes

- `crates/geode-core/tests/gpu_driven_scaling.rs` — new `#[ignore]`d bench-test; ndarray leg runs in CI-style (`--ignored` only), cuda leg via `--features cuda` on a GPU host. Configs 3/4 are the same source path on different Burn backends. Dtype-aware tolerance (f64 1e-8 / f32 1e-6), fallible timed reps with `solve_reps_ok`/`e2e_reps_ok`/`flaky` reporting, DNF cells for hard stagnation.
- `benchmarks/gpu_driven_scaling/results.toml` — 16 cells, provenance header (host/GPU/driver/CUDA/rustc, 4-vCPU caveat, warm-up-excluded medians-of-3, no-m6i-comparison, no-eigensolve-conflation), honest-read paragraph.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Bench runs green on ndarray locally (CI never runs the cuda leg) | ✅ | Final revision: `test result: ok` locally (1792 s) and on the box (2271 s); test is `#[ignore]`d so CI never executes it |
| CUDA leg executed on the rented box; results.toml committed with all four configs × sizes | ✅ | Cuda leg green on the box (2212 s); 16/16 cells in results.toml, all same-host |
| Accuracy deltas reported per cell; no conflation with eigensolve headline | ✅ | `accuracy_rel_l2_vs_direct` in every cell; explicit no-conflation note in TOML header |
| Honest read paragraph: where GPU wins/loses vs size (crossover if any) | ✅ | HONEST READ section in TOML + this PR body: GPU loses everywhere; parity-at-26k-edges vs CPU matrix-free only; f32 ceiling blocks scaling |

## Test Plan

- `cargo fmt --all -- --check` ✅
- `cargo clippy --tests -p geode-core --features arpack -- -D warnings` ✅ and default-features clippy ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` (± arpack) ✅
- `cargo test -p geode-core --release --tests` — 75 binaries, 0 failures ✅
- Benchmark itself: 3 full box runs during development (first exposed the f32 non-convergence panic, second exposed run-to-run nondeterminism at n=15, final run green on both legs with the DNF/flaky machinery)

Closes #501