### PR TITLE
test(driven): add CUDA f32 runtime smoke for the matrix-free driven path

### DIFF
--- a/crates/geode-core/tests/driven_matrix_free_equivalence.rs
+++ b/crates/geode-core/tests/driven_matrix_free_equivalence.rs
@@ -529,3 +529,119 @@ fn matrix_free_rejects_wave_port_sweep() {
         "expected UnsupportedMatrixFree for wave-port matrix-free, got {res:?}"
     );
 }
+
+// ===========================================================================
+// 6. CUDA f32 smoke test — rented-EC2-box only, NEVER runs in CI.
+// ===========================================================================
+//
+// `burn-cuda 0.21` disables f64 (cubecl asserts !supports_dtype(F64)), so the
+// tight f64 driven-equivalence gates above cannot run on CUDA. This f32 leg is
+// the fast *correctness* companion to the multi-size wall-clock scaling bench
+// in `gpu_driven_scaling.rs` (issue #501 / PR #516, `#[ignore]` release bench,
+// `n ∈ {6, 9, 12, 15}`): where that bench measures how the driven solve scales,
+// this smoke is a single-fixture / single-ω gate that runs in the same
+// few-seconds-to-15s ballpark as the sibling smokes `matrix_free_cuda_f32_smoke`
+// (#483, 15.0s) and `cocg_burn_cuda_f32_smoke` (#487, 3.3s).
+//
+// It (a) drives one σ-lossy cube lumped-port solve through
+// `SolverMode::IterativeMatrixFree` on the `Cuda` backend at f32 and asserts it
+// *converges* (records iterations), and (b) compares the port impedance `Z(ω)`
+// back to the f64 `Direct` (faer sparse-LU) reference computed on the ndarray
+// `TestBackend`. The tolerance is sized from the measured f32 reality on PR
+// #516's GPU run — at this small size the f32 matrix-free path lands ~1e-4 of
+// Direct — so the gate is `rel-Z < 1e-3` (a loose f32-appropriate band, NOT the
+// tight `1e-6` f64 gate in `driven_frequency_sweep_matrix_free_matches_direct`
+// above).
+//
+// Both `cuda`-feature-gated and `#[ignore]`d so `cargo test` (default features,
+// no ignored tests) skips it in CI; run explicitly on the box with
+// `cargo test -p geode-core --features cuda --test driven_matrix_free_equivalence \
+//    -- --ignored driven_matrix_free_cuda_f32_smoke`.
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "CUDA f32 smoke — rented EC2 box only, not CI (burn-cuda 0.21 has no f64)"]
+fn driven_matrix_free_cuda_f32_smoke() {
+    use burn::backend::Cuda;
+
+    // Same σ-lossy parallel-plate cube lumped-port fixture as
+    // `driven_frequency_sweep_matrix_free_matches_direct`, kept small: grid=4,
+    // single lumped port, single ω (no sweep) — a fast correctness gate.
+    let mesh = cube_tet_mesh(4, 1.0);
+    let edges = mesh.edges();
+    let port_faces = plane_faces(&mesh, 2, 0.0);
+    let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0)]);
+    let eps = vacuum(&mesh);
+    let sigma_tet = vec![2.0_f64; mesh.n_tets()];
+    let port = LumpedPort {
+        faces: &port_faces,
+        e_hat: [0.0, 1.0, 0.0],
+        resistance: 1.0,
+        width: 1.0,
+        length: 1.0,
+        v_inc: c64::new(1.0, 0.0),
+    };
+    let omegas = [0.10_f64];
+
+    // f64 Direct reference (faer sparse LU) on the ndarray `TestBackend`.
+    let direct = driven_frequency_sweep::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        &device(),
+    )
+    .expect("direct sweep (f64 reference)");
+
+    // CUDA-f32 matrix-free driven solve. A loose f32 COCG stopping tolerance is
+    // appropriate — f32 cannot reach the 1e-10 the f64 gates request.
+    type Cu = Cuda;
+    let dev_cu = <Cu as BackendTypes>::Device::default();
+    let settings = IterativeSettings::new(1e-6, 5_000);
+    let matrix_free = driven_frequency_sweep_with_mode::<Cu>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        Some(&sigma_tet),
+        &DrivenBcs {
+            pec_interior_mask: &mask,
+        },
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&mesh),
+        SolverMode::IterativeMatrixFree(settings),
+        &dev_cu,
+    )
+    .expect("matrix-free sweep (CUDA f32)");
+
+    assert_eq!(direct.len(), matrix_free.len());
+    let pt_d = &direct[0];
+    let pt_m = &matrix_free[0];
+
+    // (a) It converges — records a positive iteration count.
+    let iters = pt_m.iters_per_rhs[0];
+    assert!(
+        iters > 0,
+        "CUDA f32 smoke: matrix-free path must record iterations"
+    );
+
+    // (b) Port Z(ω) agrees with the f64 Direct reference at an f32-loose band.
+    let z_d = pt_d.ports[0].z;
+    let z_m = pt_m.ports[0].z;
+    let rel_diff = (z_d - z_m).norm() / z_d.norm().max(1e-30);
+    eprintln!(
+        "[#499 / driven CUDA f32 smoke] ω = {:.3}: Z_direct = {z_d}, \
+         Z_cuda_f32 = {z_m}, rel_diff = {:.3e}, BurnCOCG iters = {iters}, \
+         residual_rel = {:.3e}",
+        pt_d.omega, rel_diff, pt_m.residual_rel,
+    );
+    assert!(
+        rel_diff < 1e-3,
+        "CUDA f32 smoke: Z agreement |Z_d − Z_mf| / |Z_d| = {rel_diff} (f32 tol 1e-3)"
+    );
+}


### PR DESCRIPTION
## Summary

PR #495's driven `SolverMode::IterativeMatrixFree` wiring shipped compile-gated CUDA structure but **no runtime smoke** — `cargo test --features cuda --test driven_matrix_free_equivalence -- --ignored` matched zero tests. This adds `driven_matrix_free_cuda_f32_smoke`, closing that gap by mirroring the house pattern of the two existing sibling smokes.

It is the fast **correctness gate** companion to the multi-size wall-clock **scaling bench** in `gpu_driven_scaling.rs` (#501 / PR #516, now on `main`): one small fixture, one ω, seconds-to-15s — distinct in purpose from the bench's `n ∈ {6, 9, 12, 15}` sweep. The doc comment cross-references the bench.

## Changes

- Add `driven_matrix_free_cuda_f32_smoke` to `crates/geode-core/tests/driven_matrix_free_equivalence.rs` (additive; +116 lines, no existing code touched).
  - `#[cfg(feature = "cuda")] #[ignore = "CUDA f32 smoke — rented EC2 box only, not CI (burn-cuda 0.21 has no f64)"]` — exact gating of the siblings `matrix_free_cuda_f32_smoke` (#483) and `cocg_burn_cuda_f32_smoke` (#487).
  - Fixture: the existing σ-lossy cube lumped-port setup lifted verbatim from `driven_frequency_sweep_matrix_free_matches_direct` — `cube_tet_mesh(4, 1.0)`, single `LumpedPort`, single ω (0.10), no sweep.
  - Computes the f64 `Direct` (faer sparse-LU) port `Z(ω)` reference on the ndarray `TestBackend`, then runs the same solve through `SolverMode::IterativeMatrixFree` on the `Cuda` backend at f32.
  - Asserts (a) convergence (`iters > 0`) and (b) `rel-Z < 1e-3`.

### Tolerance rationale (f32-realistic, per issue guidance)

Sized from the **measured f32 reality** on PR #516's GPU run, not the f64 gates: at this small size the f32 matrix-free path lands ~`1e-4` of Direct, so the gate is a loose `rel-Z < 1e-3` — NOT the tight `1e-6` f64 gate directly above it in the same file. The f32 COCG stopping tolerance is `1e-6` (f32 cannot reach the `1e-10` the f64 gates request).

## Acceptance Criteria Verification

| Criterion (from issue) | Status | Verification |
|-----|-----|-----|
| One `#[cfg(feature="cuda")] #[ignore]` smoke, mirroring #483/#487 | ✅ | Same attributes + ignore string; matches sibling shape |
| Small ported driven solve, cube lumped-port fixture, `IterativeMatrixFree` on `Cuda` f32 | ✅ | `cube_tet_mesh(4,1.0)` + single `LumpedPort`, `driven_frequency_sweep_with_mode::<Cuda>` |
| Asserts convergence + agreement with f64 `Direct` at an f32-appropriate tolerance | ✅ | `iters > 0` and `rel-Z < 1e-3` vs `driven_frequency_sweep::<TestBackend>` Direct reference |
| Rented-box-only, never CI | ✅ | `#[cfg(feature="cuda")]` + `#[ignore]`; skipped by default `cargo test` |
| Distinct from #501/#516 scaling bench | ✅ | Single fixture/ω correctness gate; doc comment references the bench |

## Test Plan / Gates

Run in the worktree on `feature/issue-499`:

- `cargo fmt --check -p geode-core` — clean
- `cargo clippy -p geode-core --tests --release` (default features) — clean
- `cargo clippy -p geode-core --tests --release --features cuda` — **clean** (burn-cuda compiles as a lib dep on macOS; this compile- and lint-verifies the `#[cfg(feature="cuda")]` smoke body)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean
- `cargo test -p geode-core --release --test driven_matrix_free_equivalence` — the file's 7 ndarray tests still green (7 passed)
- `cargo test -p geode-core --release --tests` — full suite green (0 failed)
- `cargo test -p geode-core --release --features cuda --test driven_matrix_free_equivalence -- --list` — confirms `driven_matrix_free_cuda_f32_smoke` is discoverable under the cuda feature

### GPU box run — deferred (AWS capacity)

The instructed box run could not be executed: `aws ec2 start-instances` for `i-04405081a5ba458a1` (g6e.xlarge L40S, us-west-2) returned `InsufficientInstanceCapacity` on **five** consecutive attempts with backoff. The instance never left `stopped`, so no cost was incurred (verified via `describe-instances` → `stopped`).

Per the issue's own contingency ("If the box won't start/SSH, land the test compile-verified with the run deferred honestly"), the CUDA leg here is **compile- and clippy-verified under `--features cuda`** and confirmed discoverable via `--list`; only the runtime execution + measured `rel-Z`/`iters` numbers are deferred until L40S capacity returns. The smoke is `#[ignore]`d so this does not affect CI or the default suite. A follow-up box run can capture the numbers when capacity frees up (expected ~1e-4 rel-Z, per PR #516's data).

Closes #499