### PR TITLE
feat(eigen): enable faer rayon parallelism for the sparse-LU factorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1569,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1605,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2701,7 +2733,9 @@ dependencies = [
  "num-traits",
  "private-gemm-x86",
  "pulp",
+ "rayon",
  "reborrow",
+ "spindle",
 ]
 
 [[package]]
@@ -3110,6 +3144,21 @@ name = "generativity"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "generic-array"
@@ -4138,6 +4187,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -5300,10 +5362,14 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
 dependencies = [
+ "crossbeam",
  "defer",
  "interpol",
  "num_cpus",
  "raw-cpuid",
+ "rayon",
+ "spindle",
+ "sysctl",
 ]
 
 [[package]]
@@ -6136,6 +6202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6432,6 +6504,19 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
  "portable-atomic",
+]
+
+[[package]]
+name = "spindle"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
+dependencies = [
+ "atomic-wait",
+ "crossbeam",
+ "equator 0.4.2",
+ "loom",
+ "rayon",
 ]
 
 [[package]]
@@ -8138,6 +8223,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8207,6 +8307,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8219,6 +8325,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8228,6 +8340,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8255,6 +8373,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8264,6 +8388,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8279,6 +8409,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8288,6 +8424,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,15 @@ clap = { version = "4", features = ["derive"] }
 criterion = "0.5"
 # Base faer feature set shared by every consumer; geode-core additionally
 # enables `sparse-linalg` on its own reference.
-faer = { version = "0.24", default-features = false, features = ["std", "linalg"] }
+#
+# `rayon` enables faer's multi-threaded factorization path (issue #518). It is
+# required so `Par::rayon(n)` / `Par::Rayon` exist and so the sparse LU that
+# fronts the shift-invert Lanczos eigensolve can use more than one core. The
+# eigensolve scopes parallelism to the factorization via a panic-safe RAII
+# guard (`crate::eigen::parallel::ParallelismGuard`) and reverts to serial for
+# the latency-bound single-RHS triangular-solve loop, so enabling the feature
+# does not by itself parallelize any hot loop that regresses under rayon.
+faer = { version = "0.24", default-features = false, features = ["std", "linalg", "rayon"] }
 mshio = "0.4"
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
 pkg-config = "0.3"

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -45,7 +45,16 @@ toml = { workspace = true }
 pkg-config = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["faer-parallel"]
+
+# Multi-threaded faer factorization for the sparse shift-invert Lanczos
+# eigensolve (issue #518). Enables faer's `rayon` feature (so `Par::rayon(n)`
+# / `Par::Rayon` exist) and gates the parallel arm of the RAII parallelism
+# guard in `src/eigen/parallel.rs`. On by default; disable with
+# `--no-default-features` to build a strictly single-threaded faer (the guard
+# then compiles to a no-op and the eigensolve runs serial regardless of
+# `GEODE_NUM_THREADS`).
+faer-parallel = ["faer/rayon"]
 
 wgpu = ["burn/wgpu"]
 cuda = ["burn/cuda"]

--- a/crates/geode-core/src/eigen/complex/lanczos.rs
+++ b/crates/geode-core/src/eigen/complex/lanczos.rs
@@ -68,6 +68,7 @@ use faer::sparse::{SparseColMat, SparseColMatRef};
 use faer::{Mat, MatMut, c64};
 
 use crate::eigen::dense::EigenError;
+use crate::eigen::parallel::{ParallelismGuard, resolve_num_threads};
 
 /// Sparse generalized complex-symmetric eigensolver via shift-and-invert
 /// Lanczos.
@@ -306,6 +307,26 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
         m: SparseColMatRef<'_, usize, c64>,
         n_modes: usize,
     ) -> Result<Vec<c64>, EigenError> {
+        self.smallest_complex_pencil_eigenvalues_with_threads(k, m, n_modes, resolve_num_threads())
+    }
+}
+
+impl SparseComplexShiftInvertLanczos {
+    /// [`SparseComplexEigenSolver::smallest_complex_pencil_eigenvalues`] with
+    /// an explicit factorization thread count, bypassing the
+    /// `GEODE_NUM_THREADS` lookup.
+    ///
+    /// See
+    /// [`crate::eigen::lanczos::SparseShiftInvertLanczos::smallest_eigenvalues_with_threads`]
+    /// for why the cross-thread tests use an explicit count rather than
+    /// mutating the process environment.
+    pub fn smallest_complex_pencil_eigenvalues_with_threads(
+        &self,
+        k: SparseColMatRef<'_, usize, c64>,
+        m: SparseColMatRef<'_, usize, c64>,
+        n_modes: usize,
+        n_threads: usize,
+    ) -> Result<Vec<c64>, EigenError> {
         let n = k.nrows();
         assert_eq!(k.ncols(), n, "K must be square");
         assert_eq!(m.nrows(), n, "M and K must agree in size");
@@ -314,12 +335,18 @@ impl SparseComplexEigenSolver for SparseComplexShiftInvertLanczos {
             return Ok(Vec::new());
         }
 
-        // 1. Build A = K - σM and factor it once.
+        // 1. Build A = K - σM and factor it once. Scope faer's global
+        //    parallelism to this factorization only (issue #518): rayon
+        //    speeds up the complex sparse LU but regresses the latency-bound
+        //    single-RHS triangular solves in the Lanczos loop, and the guard
+        //    restores serial parallelism on drop.
         let a = shifted_pencil_complex(k, m, self.sigma)?;
-        let lu = a
-            .as_ref()
-            .sp_lu()
-            .map_err(|e| EigenError::FaerGevd(format!("complex sparse LU: {e:?}")))?;
+        let lu = {
+            let _par = ParallelismGuard::rayon(n_threads);
+            a.as_ref()
+                .sp_lu()
+                .map_err(|e| EigenError::FaerGevd(format!("complex sparse LU: {e:?}")))?
+        };
 
         // 2. Lanczos in the bilinear M-inner product. The tridiagonal
         //    `T_k` is complex symmetric (not Hermitian) and its
@@ -513,12 +540,16 @@ impl SparseComplexShiftInvertLanczos {
             return Ok(Vec::new());
         }
 
-        // 1. Build A = K - σM and factor it once.
+        // 1. Build A = K - σM and factor it once. Parallelism scoped to the
+        //    factorization only (issue #518); see the eigenvalues-only
+        //    sibling above for the rayon-regresses-the-solves rationale.
         let a = shifted_pencil_complex(k, m, self.sigma)?;
-        let lu = a
-            .as_ref()
-            .sp_lu()
-            .map_err(|e| EigenError::FaerGevd(format!("complex sparse LU: {e:?}")))?;
+        let lu = {
+            let _par = ParallelismGuard::rayon(resolve_num_threads());
+            a.as_ref()
+                .sp_lu()
+                .map_err(|e| EigenError::FaerGevd(format!("complex sparse LU: {e:?}")))?
+        };
 
         // 2. Lanczos in the bilinear M-inner product, retaining the full
         //    basis V_k for Ritz-vector recovery. Always run to the
@@ -903,6 +934,71 @@ mod tests {
                     p.lambda
                 );
             }
+        }
+    }
+
+    /// CORRECTNESS GATE (issue #518), complex path: the computed spectrum
+    /// must be identical whether the complex sparse-LU factorization runs
+    /// single-threaded or multi-threaded. Uses a non-diagonal
+    /// complex-symmetric tridiagonal pencil so the LU has real fill.
+    ///
+    /// Drives the thread count through the `_with_threads` entry point (the
+    /// same path `GEODE_NUM_THREADS` feeds) to avoid mutating a
+    /// process-global env var (this crate denies `unsafe_code`). Holds the
+    /// shared parallelism lock so the transient global-parallelism change
+    /// during factorization does not race the guard RAII test in
+    /// `eigen::parallel`.
+    #[test]
+    fn complex_eigenvalues_agree_across_thread_counts() {
+        let _lock = crate::eigen::parallel::PARALLELISM_TEST_LOCK
+            .lock()
+            .unwrap();
+
+        // Complex-symmetric tridiagonal K = tridiag(-1, 2 + 0.1i, -1),
+        // M = identity. Off-diagonal fill exercises the multi-threaded LU.
+        let n = 40usize;
+        let mut tk: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(3 * n);
+        let mut tm: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(n);
+        for i in 0..n {
+            tk.push(Triplet::new(i, i, c64::new(2.0, 0.1)));
+            if i + 1 < n {
+                tk.push(Triplet::new(i, i + 1, c64::new(-1.0, 0.0)));
+                tk.push(Triplet::new(i + 1, i, c64::new(-1.0, 0.0)));
+            }
+            tm.push(Triplet::new(i, i, c64::new(1.0, 0.0)));
+        }
+        let k = SparseColMat::try_new_from_triplets(n, n, &tk).unwrap();
+        let m = SparseColMat::try_new_from_triplets(n, n, &tm).unwrap();
+
+        let solver = SparseComplexShiftInvertLanczos {
+            sigma: 0.0,
+            max_iters: 64,
+            tol: 1e-11,
+        };
+
+        let serial = solver
+            .smallest_complex_pencil_eigenvalues_with_threads(k.as_ref(), m.as_ref(), 4, 1)
+            .unwrap();
+        let parallel = solver
+            .smallest_complex_pencil_eigenvalues_with_threads(k.as_ref(), m.as_ref(), 4, 4)
+            .unwrap();
+
+        assert_eq!(
+            serial.len(),
+            parallel.len(),
+            "thread count changed the number of converged modes"
+        );
+        for (i, (s, p)) in serial.iter().zip(parallel.iter()).enumerate() {
+            assert_eq!(
+                s.re.to_bits(),
+                p.re.to_bits(),
+                "eigenvalue[{i}] Re differs across thread counts: {s} vs {p}"
+            );
+            assert_eq!(
+                s.im.to_bits(),
+                p.im.to_bits(),
+                "eigenvalue[{i}] Im differs across thread counts: {s} vs {p}"
+            );
         }
     }
 }

--- a/crates/geode-core/src/eigen/lanczos.rs
+++ b/crates/geode-core/src/eigen/lanczos.rs
@@ -33,20 +33,22 @@
 //! to ~0.8 s — a 1.64x end-to-end wall-time reduction on that test
 //! (34.9 s → 21.3 s). See issue #506 for the full profile.
 //!
-//! **Deferred (issue #506 Phase 0, faer-parallelism half):** the sparse LU
-//! factorization phase (`sp_lu`, ~33% of the solve) could be sped up ~1.75x
-//! by compiling faer with its `rayon` feature. That is *not* landed here.
-//! In faer 0.24 parallelism is a process-global `AtomicUsize`
-//! (`set_global_parallelism` / `get_global_parallelism`, no per-call `Par`
-//! argument), so "phase-scoped" factorization parallelism can only be a
-//! bare global toggle that (a) races other threads in the same test process
-//! — the driven/assembly paths also call `sp_lu`/`solve_in_place` — and
-//! (b) must be reverted to serial before the single-RHS triangular-solve
-//! loop, where rayon is measurably *slower* (latency-bound). The safe
-//! landing is an opt-in toggle defaulting to today's serial behavior; the
-//! M·V cache above is the dominant, risk-free win and ships alone. The
-//! parallelism knob (faer `rayon` feature + a panic-safe RAII guard around
-//! the factorization + an opt-in solver flag) is tracked for a follow-on.
+//! **faer-parallelism (issue #518, was deferred from #506 Phase 0):** the
+//! sparse LU factorization phase (`sp_lu`, ~33% of the solve) is sped up by
+//! compiling faer with its `rayon` feature. faer 0.24 parallelism is a
+//! process-global `AtomicUsize` (`set_global_parallelism` /
+//! `get_global_parallelism`, no per-call `Par` argument), so it (a) races
+//! other threads in the same process — the driven/assembly paths also call
+//! `sp_lu`/`solve_in_place` — and (b) must be reverted to serial before the
+//! single-RHS triangular-solve loop, where rayon is measurably *slower*
+//! (latency-bound). Both concerns are handled by scoping the parallelism to
+//! exactly the `sp_lu` call via [`crate::eigen::parallel::ParallelismGuard`],
+//! a panic-safe RAII guard that sets `Par::rayon(n)` for the factorization
+//! and restores the prior global parallelism on drop (including on panic).
+//! The thread count comes from `GEODE_NUM_THREADS` (falling back to the
+//! physical core count). The factorization is deterministic, so eigenvalues
+//! are identical within tolerance across thread counts — see the
+//! `*_agree_across_thread_counts` regression tests below.
 //!
 //! Convergence is declared when the residual norm
 //! `‖K x - λ M x‖_2 / ‖λ M x‖_2 < tol` for **every** requested mode.
@@ -69,6 +71,7 @@ use faer::sparse::{SparseColMat, SparseColMatRef};
 use faer::{Mat, MatMut};
 
 use crate::eigen::dense::{EigenError, EigenPair};
+use crate::eigen::parallel::{ParallelismGuard, resolve_num_threads};
 
 /// Sparse generalized-symmetric eigensolver via shift-and-invert Lanczos.
 ///
@@ -290,6 +293,24 @@ impl SparseShiftInvertLanczos {
         m: SparseColMatRef<'_, usize, f64>,
         n_modes: usize,
     ) -> Result<Vec<EigenPair>, EigenError> {
+        self.smallest_eigenpairs_with_threads(k, m, n_modes, resolve_num_threads())
+    }
+
+    /// [`Self::smallest_eigenpairs`] with an explicit factorization thread
+    /// count, bypassing the `GEODE_NUM_THREADS` lookup.
+    ///
+    /// The public entry point resolves the thread count from the environment;
+    /// this variant takes it directly so the cross-thread agreement tests can
+    /// drive `n_threads = 1` vs `n_threads = N` without mutating a
+    /// process-global env var (this crate denies `unsafe_code`, and
+    /// edition-2024 `env::set_var` is `unsafe`).
+    pub fn smallest_eigenpairs_with_threads(
+        &self,
+        k: SparseColMatRef<'_, usize, f64>,
+        m: SparseColMatRef<'_, usize, f64>,
+        n_modes: usize,
+        n_threads: usize,
+    ) -> Result<Vec<EigenPair>, EigenError> {
         let n = k.nrows();
         assert_eq!(k.ncols(), n, "K must be square");
         assert_eq!(m.nrows(), n, "M and K must agree in size");
@@ -298,12 +319,20 @@ impl SparseShiftInvertLanczos {
             return Ok(Vec::new());
         }
 
-        // 1. Build A = K - σM and factor it once.
+        // 1. Build A = K - σM and factor it once. Scope faer's global
+        //    parallelism to the factorization: rayon speeds up sparse LU but
+        //    is measurably slower on the latency-bound single-RHS triangular
+        //    solves below, so the guard restores serial parallelism the
+        //    moment `sp_lu` returns (issue #518). The eigenvalues are
+        //    independent of the thread count — the correctness gate is the
+        //    `eigenpairs_agree_across_thread_counts` test.
         let a = shifted_pencil(k, m, self.sigma)?;
-        let lu = a
-            .as_ref()
-            .sp_lu()
-            .map_err(|e| EigenError::FaerGevd(format!("sparse LU: {e:?}")))?;
+        let lu = {
+            let _par = ParallelismGuard::rayon(n_threads);
+            a.as_ref()
+                .sp_lu()
+                .map_err(|e| EigenError::FaerGevd(format!("sparse LU: {e:?}")))?
+        };
 
         // 2. Run Lanczos to convergence, retaining the full M-orthonormal
         //    basis V_k. Unlike the eigenvalue-only path we always run to
@@ -464,14 +493,18 @@ impl SparseShiftInvertLanczos {
         }
         Ok(out)
     }
-}
 
-impl SparseEigenSolver for SparseShiftInvertLanczos {
-    fn smallest_eigenvalues(
+    /// [`SparseEigenSolver::smallest_eigenvalues`] with an explicit
+    /// factorization thread count, bypassing the `GEODE_NUM_THREADS` lookup.
+    ///
+    /// See [`Self::smallest_eigenpairs_with_threads`] for why the tests use
+    /// an explicit count instead of mutating the environment.
+    pub fn smallest_eigenvalues_with_threads(
         &self,
         k: SparseColMatRef<'_, usize, f64>,
         m: SparseColMatRef<'_, usize, f64>,
         n_modes: usize,
+        n_threads: usize,
     ) -> Result<Vec<f64>, EigenError> {
         let n = k.nrows();
         assert_eq!(k.ncols(), n, "K must be square");
@@ -481,12 +514,17 @@ impl SparseEigenSolver for SparseShiftInvertLanczos {
             return Ok(Vec::new());
         }
 
-        // 1. Build A = K - σM and factor it once.
+        // 1. Build A = K - σM and factor it once. Parallelism is scoped to
+        //    the factorization only (rayon regresses the single-RHS
+        //    triangular solves that follow); see issue #518 and the
+        //    `smallest_eigenpairs` sibling above.
         let a = shifted_pencil(k, m, self.sigma)?;
-        let lu = a
-            .as_ref()
-            .sp_lu()
-            .map_err(|e| EigenError::FaerGevd(format!("sparse LU: {e:?}")))?;
+        let lu = {
+            let _par = ParallelismGuard::rayon(n_threads);
+            a.as_ref()
+                .sp_lu()
+                .map_err(|e| EigenError::FaerGevd(format!("sparse LU: {e:?}")))?
+        };
 
         // 2. Lanczos in the M-inner product.
         //
@@ -652,6 +690,17 @@ impl SparseEigenSolver for SparseShiftInvertLanczos {
     }
 }
 
+impl SparseEigenSolver for SparseShiftInvertLanczos {
+    fn smallest_eigenvalues(
+        &self,
+        k: SparseColMatRef<'_, usize, f64>,
+        m: SparseColMatRef<'_, usize, f64>,
+        n_modes: usize,
+    ) -> Result<Vec<f64>, EigenError> {
+        self.smallest_eigenvalues_with_threads(k, m, n_modes, resolve_num_threads())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -734,6 +783,127 @@ mod tests {
                 (max_val - 1.0).abs() < 1e-6,
                 "eigenvector[{i}] not localized: max = {max_val}"
             );
+        }
+    }
+
+    /// Build a larger, non-diagonal SPD tridiagonal pencil so the faer
+    /// sparse LU has enough fill for the multi-threaded factorization path
+    /// to be meaningfully exercised (a diagonal pencil factors trivially).
+    ///
+    /// `K` is the 1-D Laplacian stencil `tridiag(-1, 2, -1)` (SPD after the
+    /// implicit Dirichlet ends) and `M` is the identity, so the eigenvalues
+    /// are the known `2 - 2 cos(π i / (n+1))`, a smoothly separated spectrum.
+    fn laplacian_pencil(n: usize) -> (SparseColMat<usize, f64>, SparseColMat<usize, f64>) {
+        let mut tk: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(3 * n);
+        let mut tm: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(n);
+        for i in 0..n {
+            tk.push(Triplet::new(i, i, 2.0));
+            if i + 1 < n {
+                tk.push(Triplet::new(i, i + 1, -1.0));
+                tk.push(Triplet::new(i + 1, i, -1.0));
+            }
+            tm.push(Triplet::new(i, i, 1.0));
+        }
+        let k = SparseColMat::try_new_from_triplets(n, n, &tk).unwrap();
+        let m = SparseColMat::try_new_from_triplets(n, n, &tm).unwrap();
+        (k, m)
+    }
+
+    /// CORRECTNESS GATE (issue #518): the computed spectrum must be identical
+    /// whether the faer sparse-LU factorization runs single-threaded or
+    /// multi-threaded. The factorization is deterministic, so we assert
+    /// *bit-for-bit* equality (not merely "within tolerance") across thread
+    /// counts — any drift would signal a nondeterministic parallel LU, which
+    /// would be a correctness bug rather than acceptable rounding.
+    ///
+    /// This test drives the thread count through the `_with_threads` entry
+    /// point (the same code path the `GEODE_NUM_THREADS` knob feeds), which
+    /// avoids mutating a process-global env var — this crate denies
+    /// `unsafe_code` and edition-2024 `env::set_var` is `unsafe`.
+    #[test]
+    fn eigenvalues_agree_across_thread_counts() {
+        // Hold the shared parallelism lock: the solves transiently set faer's
+        // process-global parallelism during factorization, which would
+        // otherwise race the guard RAII test in `eigen::parallel`.
+        let _lock = crate::eigen::parallel::PARALLELISM_TEST_LOCK
+            .lock()
+            .unwrap();
+
+        let (k, m) = laplacian_pencil(64);
+        let solver = SparseShiftInvertLanczos {
+            sigma: 0.0,
+            max_iters: 64,
+            tol: 1e-11,
+        };
+
+        let serial = solver
+            .smallest_eigenvalues_with_threads(k.as_ref(), m.as_ref(), 5, 1)
+            .unwrap();
+        let parallel = solver
+            .smallest_eigenvalues_with_threads(k.as_ref(), m.as_ref(), 5, 4)
+            .unwrap();
+
+        assert_eq!(
+            serial.len(),
+            parallel.len(),
+            "thread count changed the number of converged modes"
+        );
+        for (i, (s, p)) in serial.iter().zip(parallel.iter()).enumerate() {
+            assert_eq!(
+                s.to_bits(),
+                p.to_bits(),
+                "eigenvalue[{i}] differs across thread counts: serial={s}, parallel={p}"
+            );
+        }
+    }
+
+    /// Companion to the agreement test: confirm the eigenpair path (vectors,
+    /// not just eigenvalues) is also thread-count invariant within the
+    /// solver's tolerance. Vectors carry an arbitrary global sign, so compare
+    /// eigenvalues bit-for-bit and vectors up to sign.
+    #[test]
+    fn eigenpairs_agree_across_thread_counts() {
+        let _lock = crate::eigen::parallel::PARALLELISM_TEST_LOCK
+            .lock()
+            .unwrap();
+
+        let (k, m) = laplacian_pencil(48);
+        let solver = SparseShiftInvertLanczos {
+            sigma: 0.0,
+            max_iters: 64,
+            tol: 1e-11,
+        };
+
+        let serial = solver
+            .smallest_eigenpairs_with_threads(k.as_ref(), m.as_ref(), 4, 1)
+            .unwrap();
+        let parallel = solver
+            .smallest_eigenpairs_with_threads(k.as_ref(), m.as_ref(), 4, 4)
+            .unwrap();
+
+        assert_eq!(serial.len(), parallel.len());
+        for (i, (s, p)) in serial.iter().zip(parallel.iter()).enumerate() {
+            assert_eq!(
+                s.lambda.to_bits(),
+                p.lambda.to_bits(),
+                "eigenpair λ[{i}] differs across thread counts"
+            );
+            // Vectors may differ by a global sign; align on the dominant
+            // entry, then compare component-wise within tolerance.
+            let pivot = s
+                .vector
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.abs().partial_cmp(&b.1.abs()).unwrap())
+                .map(|(idx, _)| idx)
+                .unwrap();
+            let sign = (s.vector[pivot] * p.vector[pivot]).signum();
+            for (a, b) in s.vector.iter().zip(p.vector.iter()) {
+                assert!(
+                    (a - sign * b).abs() < 1e-9,
+                    "eigenvector[{i}] differs beyond tolerance across thread counts"
+                );
+            }
         }
     }
 }

--- a/crates/geode-core/src/eigen/mod.rs
+++ b/crates/geode-core/src/eigen/mod.rs
@@ -8,6 +8,9 @@
 //!   [`dense::EigenError`] / [`dense::EigenPair`] types and the
 //!   Burn→faer / Dirichlet-BC helpers.
 //! - [`lanczos`] — sparse real shift-and-invert Lanczos.
+//! - [`parallel`] — process-global faer parallelism control (a panic-safe
+//!   RAII guard + `GEODE_NUM_THREADS` knob) scoped to the sparse LU
+//!   factorization that fronts the shift-invert eigensolves (issue #518).
 //! - [`complex`] — complex (non-Hermitian) dense and sparse solvers for
 //!   the Silver-Müller and Mie pencils.
 //! - `arpack` — optional ARPACK-backed sparse solver (behind the
@@ -29,6 +32,7 @@ pub mod complex;
 pub mod dense;
 pub mod gauge;
 pub mod lanczos;
+pub mod parallel;
 pub mod projection;
 pub mod self_consistent;
 pub mod transmon;

--- a/crates/geode-core/src/eigen/parallel.rs
+++ b/crates/geode-core/src/eigen/parallel.rs
@@ -40,7 +40,7 @@
 //! whose result is independent of the thread count. The eigenvalues are
 //! therefore identical (within the existing tolerance) whether run at 1 or N
 //! threads; see the cross-thread agreement tests in [`crate::eigen::lanczos`]
-//! and [`crate::eigen::complex::lanczos`].
+//! and [`crate::eigen::complex::SparseComplexShiftInvertLanczos`].
 //!
 //! # When faer is built without `rayon`
 //!

--- a/crates/geode-core/src/eigen/parallel.rs
+++ b/crates/geode-core/src/eigen/parallel.rs
@@ -1,0 +1,262 @@
+//! Process-global faer parallelism control for the sparse eigensolves.
+//!
+//! # Why this module exists
+//!
+//! The default sparse path factors `A = K - σ M` once via faer's sparse LU
+//! (`sp_lu`) before running shift-and-invert Lanczos. On the 133k-DOF
+//! transmon eigensolve that factorization is ~33% of the wall time, and it
+//! is the phase faer can parallelize with rayon (see the design notes at
+//! the top of [`crate::eigen::lanczos`] and issue #518). Compiling faer with
+//! its `rayon` feature and setting the global parallelism to `Par::rayon(n)`
+//! for the factorization is the fair core-for-core comparison against
+//! Palace's MPI ranks.
+//!
+//! # faer 0.24's process-global parallelism
+//!
+//! faer 0.24 exposes parallelism as a **process-global `AtomicUsize`**:
+//! [`faer::set_global_parallelism`] / [`faer::get_global_parallelism`], with
+//! **no** per-call `Par` argument on `sp_lu`. That has two consequences the
+//! design notes call out:
+//!
+//! 1. The setting is global, so it races other threads in the same process
+//!    that also call faer routines. In this crate the eigensolve owns the
+//!    factorization scope, so we set the global exactly around `sp_lu` and
+//!    restore it immediately afterward.
+//! 2. It must be reverted to serial before the single-RHS triangular-solve
+//!    loop, where rayon is measurably *slower* (the per-solve work is
+//!    latency-bound). Scoping the guard tightly around the factorization
+//!    (not the whole Lanczos loop) achieves exactly this.
+//!
+//! # RAII, panic-safety, and the correctness gate
+//!
+//! [`ParallelismGuard`] records the prior global parallelism on construction,
+//! sets `Par::rayon(n)`, and restores the prior value on `Drop`. Because
+//! `Drop` runs during stack unwinding, the prior value is restored **even if
+//! the factorization panics** — the process is never left in a globally
+//! parallel state by accident.
+//!
+//! The number of threads is fixed for a given factorization but does **not**
+//! change the arithmetic: faer's sparse LU is a deterministic factorization
+//! whose result is independent of the thread count. The eigenvalues are
+//! therefore identical (within the existing tolerance) whether run at 1 or N
+//! threads; see the cross-thread agreement tests in [`crate::eigen::lanczos`]
+//! and [`crate::eigen::complex::lanczos`].
+//!
+//! # When faer is built without `rayon`
+//!
+//! `Par::Rayon` only exists when faer is compiled with its `rayon` feature.
+//! This module compiles either way: without `rayon` the guard is a no-op that
+//! leaves the (already serial) global parallelism untouched, so callers do
+//! not need to feature-gate their use of it.
+
+use std::env;
+
+use faer::{Par, get_global_parallelism, set_global_parallelism};
+
+/// The environment variable that overrides the eigensolve thread count.
+///
+/// When unset (or unparseable), the eigensolve falls back to the physical
+/// core count via [`std::thread::available_parallelism`].
+pub const NUM_THREADS_ENV: &str = "GEODE_NUM_THREADS";
+
+/// Serialization lock for tests that touch faer's **process-global**
+/// parallelism (via [`ParallelismGuard`] or a factorization that sets it).
+///
+/// `cargo test` runs test functions on multiple threads by default, and
+/// faer's global parallelism is a single shared `AtomicUsize`. A test that
+/// asserts "the global equals X" can therefore race another test that
+/// concurrently sets it to Y. Any test in the crate that observes or mutates
+/// the global parallelism must hold this lock for the duration of the
+/// observation so those tests run one at a time.
+#[cfg(test)]
+pub(crate) static PARALLELISM_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Resolve the number of threads faer should use for the factorization.
+///
+/// Precedence:
+/// 1. `GEODE_NUM_THREADS`, if set to a parseable positive integer.
+/// 2. [`std::thread::available_parallelism`] (physical/logical core count).
+/// 3. `1` as a last resort if the platform cannot report a core count.
+///
+/// A value of `0` or an unparseable value falls through to the core-count
+/// default rather than being treated as "serial" — request one thread
+/// explicitly (`GEODE_NUM_THREADS=1`) for the single-threaded path.
+pub fn resolve_num_threads() -> usize {
+    match parse_num_threads(env::var(NUM_THREADS_ENV).ok().as_deref()) {
+        Some(n) => n,
+        None => std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
+    }
+}
+
+/// Pure parse of the `GEODE_NUM_THREADS` value, split out so it can be
+/// unit-tested without mutating the process environment (this crate denies
+/// `unsafe_code`, and edition-2024 `env::set_var` is `unsafe`).
+///
+/// Returns `Some(n)` for a positive integer, and `None` (meaning "fall back
+/// to the core count") for an unset, empty, zero, or unparseable value.
+fn parse_num_threads(raw: Option<&str>) -> Option<usize> {
+    raw?.trim().parse::<usize>().ok().filter(|&n| n > 0)
+}
+
+/// Panic-safe RAII guard that sets faer's process-global parallelism to
+/// `Par::rayon(n)` for its lifetime and restores the prior value on drop.
+///
+/// Construct one immediately before a faer factorization and let it drop at
+/// the end of the factorization scope:
+///
+/// ```ignore
+/// let lu = {
+///     let _par = ParallelismGuard::rayon(resolve_num_threads());
+///     a.as_ref().sp_lu()?
+/// }; // prior global parallelism restored here, even on panic
+/// ```
+///
+/// The guard is a no-op when `n <= 1`, or when faer is compiled without its
+/// `rayon` feature (in which case `Par::Rayon` does not exist and the global
+/// is left at its serial default).
+#[derive(Debug)]
+#[must_use = "the guard restores parallelism on drop; binding it to `_` drops it immediately"]
+pub struct ParallelismGuard {
+    prior: Par,
+    /// Whether we actually changed the global parallelism. If we did not
+    /// (n <= 1, or faer built without `rayon`), `Drop` skips the restore to
+    /// avoid a spurious `set_global_parallelism` call.
+    changed: bool,
+}
+
+impl ParallelismGuard {
+    /// Record the current global parallelism, then set `Par::rayon(n)`.
+    ///
+    /// `n` is the number of threads. `n <= 1` leaves the global untouched
+    /// (the serial default), so a caller can pass `resolve_num_threads()`
+    /// unconditionally and get single-threaded behavior for
+    /// `GEODE_NUM_THREADS=1`.
+    pub fn rayon(n: usize) -> Self {
+        let prior = get_global_parallelism();
+        let changed = Self::try_set_rayon(n);
+        Self { prior, changed }
+    }
+
+    /// Set the global parallelism to `Par::rayon(n)` and report whether the
+    /// global was actually changed.
+    ///
+    /// Returns `false` (leaving the global untouched) when `n <= 1` or when
+    /// faer was built without its `rayon` feature.
+    fn try_set_rayon(n: usize) -> bool {
+        if n <= 1 {
+            return false;
+        }
+        // `Par::rayon` and `Par::Rayon` only exist when faer is compiled with
+        // its `rayon` feature. This crate's `faer-parallel` feature (on by
+        // default) turns that feature on and gates the parallel arm below.
+        set_rayon_parallelism(n)
+    }
+}
+
+impl Drop for ParallelismGuard {
+    fn drop(&mut self) {
+        if self.changed {
+            // Runs during normal scope exit *and* during panic unwinding, so
+            // the global parallelism is always restored to its prior value.
+            set_global_parallelism(self.prior);
+        }
+    }
+}
+
+/// Set faer's global parallelism to `Par::rayon(n)` when faer's `rayon`
+/// feature is enabled; otherwise a no-op that reports `false`.
+///
+/// faer re-exports the `Par::Rayon` variant only under its own `rayon`
+/// feature. We cannot name `Par::rayon` unconditionally, so the two arms
+/// below are selected by this crate's `faer-parallel` feature, which turns
+/// faer's `rayon` feature on. `faer-parallel` is a default feature, so the
+/// parallel arm is the one that compiles in normal builds.
+#[cfg(feature = "faer-parallel")]
+fn set_rayon_parallelism(n: usize) -> bool {
+    set_global_parallelism(Par::rayon(n));
+    true
+}
+
+#[cfg(not(feature = "faer-parallel"))]
+fn set_rayon_parallelism(_n: usize) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RAII behavior of [`ParallelismGuard`]: restore-on-normal-drop,
+    /// restore-on-panic, and single-thread-is-a-no-op.
+    ///
+    /// These three assertions all observe/mutate faer's process-global
+    /// parallelism, so they are combined into one `#[test]` that holds
+    /// [`PARALLELISM_TEST_LOCK`] for its whole body — otherwise a concurrent
+    /// parallelism-touching test could change the global between the set and
+    /// the assert. (`cargo test` runs test functions on multiple threads.)
+    #[test]
+    fn guard_raii_restores_global_parallelism() {
+        let _lock = PARALLELISM_TEST_LOCK.lock().unwrap();
+
+        // 1. Restore on normal scope exit.
+        let before = get_global_parallelism();
+        {
+            let _g = ParallelismGuard::rayon(4);
+            // (the global may or may not have changed, depending on faer's
+            // rayon feature — but it must be back to `before` after the scope)
+        }
+        assert_eq!(
+            get_global_parallelism(),
+            before,
+            "global parallelism not restored after guard drop"
+        );
+
+        // 2. Restore even when the scope panics (Drop runs during unwind).
+        let result = std::panic::catch_unwind(|| {
+            let _g = ParallelismGuard::rayon(4);
+            panic!("boom inside the factorization scope");
+        });
+        assert!(result.is_err(), "expected the inner closure to panic");
+        assert_eq!(
+            get_global_parallelism(),
+            before,
+            "global parallelism not restored after a panicking scope"
+        );
+
+        // 3. Requesting a single thread must not change the global at all.
+        {
+            let _g = ParallelismGuard::rayon(1);
+            assert_eq!(
+                get_global_parallelism(),
+                before,
+                "requesting 1 thread should leave global parallelism unchanged"
+            );
+        }
+        assert_eq!(get_global_parallelism(), before);
+    }
+
+    /// The `GEODE_NUM_THREADS` parse honors a positive integer and falls
+    /// through (to the core-count default) on unset/empty/zero/garbage.
+    ///
+    /// Tested via the pure [`parse_num_threads`] helper so no `unsafe`
+    /// `env::set_var` is needed (this crate denies `unsafe_code`).
+    #[test]
+    fn parse_num_threads_precedence() {
+        assert_eq!(parse_num_threads(Some("3")), Some(3));
+        assert_eq!(parse_num_threads(Some("  8 ")), Some(8));
+        assert_eq!(parse_num_threads(Some("0")), None);
+        assert_eq!(parse_num_threads(Some("")), None);
+        assert_eq!(parse_num_threads(Some("not-a-number")), None);
+        assert_eq!(parse_num_threads(Some("-4")), None);
+        assert_eq!(parse_num_threads(None), None);
+    }
+
+    /// `resolve_num_threads` always reports a positive count: with the env
+    /// var unset (the CI/default case) it falls back to the core count.
+    #[test]
+    fn resolve_num_threads_is_positive() {
+        assert!(resolve_num_threads() >= 1);
+    }
+}


### PR DESCRIPTION
## Summary

The sparse shift-invert Lanczos eigensolve fronts every solve with a faer
sparse-LU factorization (~33% of the transmon wall time), but the workspace
built faer with `default-features = false, features = ["std", "linalg"]` —
the `rayon` feature was **off**, so the factorization ran single-threaded.
That is the reason the CPU head-to-head shows Palace ahead in wall clock even
though geode is far more efficient per core. This PR turns on faer's rayon
factorization and scopes it safely to the factorization phase, honoring a
`GEODE_NUM_THREADS` knob.

This is the **code** half of #518 (rayon feature + RAII guard + thread knob +
correctness tests). The AWS benchmark re-run (`transmon_bench_cpu` at 1/2/4/8
threads on m6i, strong-scaling column in `results.toml`) is a follow-up
operator step and is intentionally **not** part of this PR — no benchmark
numbers are produced here.

## Changes

- **faer `rayon` feature on** (workspace `Cargo.toml` + `crates/geode-core/Cargo.toml`),
  gated behind a new on-by-default `faer-parallel` geode-core feature so
  `--no-default-features` still yields a strictly serial faer.
- **New module `crates/geode-core/src/eigen/parallel.rs`:**
  - `ParallelismGuard` — a panic-safe RAII guard. On construction it records
    the prior faer process-global parallelism (`get_global_parallelism`) and
    sets `Par::rayon(n)`; on `Drop` (including during panic unwinding) it
    restores the prior value. No-op at `n <= 1` and when faer is built without
    rayon.
  - `resolve_num_threads()` reads `GEODE_NUM_THREADS`, falling back to
    `std::thread::available_parallelism()` (physical/logical cores).
- **Guard scoped to exactly the `sp_lu` call** in both the real
  (`eigen/lanczos.rs`) and complex (`eigen/complex/lanczos.rs`) shift-invert
  paths — rayon is reverted to serial before the latency-bound single-RHS
  triangular-solve loop, where the prior author's design notes measured it as
  *slower*.
- **`*_with_threads` entry points** on both solvers so tests can drive an
  explicit thread count without mutating the process environment (this crate
  is `#![deny(unsafe_code)]` and edition-2024 `env::set_var` is `unsafe`). The
  public methods delegate with `resolve_num_threads()`.
- Updated the deferred-work design note at the top of `eigen/lanczos.rs` to
  reflect that the faer-parallelism half of #506 has now landed.

## Acceptance Criteria Verification

| Criterion (issue #518) | Status | Verification |
|---|---|---|
| faer built with `rayon` | ✅ | Workspace + geode-core faer lines add `rayon`; `Cargo.lock` gains the rayon/crossbeam graph; both default and `--no-default-features` builds compile. |
| Panic-safe RAII parallelism guard, unit-tested (restores on panic) | ✅ | `ParallelismGuard`; `guard_raii_restores_global_parallelism` asserts restore-on-drop, restore-on-`catch_unwind`-panic, and single-thread no-op. |
| Thread-count knob wired through the eigensolve entry point | ✅ | `GEODE_NUM_THREADS` → `resolve_num_threads()`, consumed at both real and complex `sp_lu` scopes; `parse_num_threads_precedence` + `resolve_num_threads_is_positive` cover the parse/fallback logic. |
| Eigenvalue agreement unchanged (≤ tolerance) at all thread counts | ✅ | `eigenvalues_agree_across_thread_counts`, `eigenpairs_agree_across_thread_counts` (real), `complex_eigenvalues_agree_across_thread_counts` — all assert **bit-for-bit** equality (`f64::to_bits`) at 1 vs 4 threads; existing transmon and cube tolerances untouched. |
| Benchmark re-run at 1/2/4/8 threads | ⏭️ Deferred | Operator/GPU-box step per the issue; out of scope for this code PR (noted above). |

## Test Plan

- `cargo test -p geode-core --lib` → **354 passed, 0 failed** (incl. the three
  cross-thread agreement tests, the guard RAII test, and all transmon tests).
- `cargo test -p geode-core --lib --no-default-features --features testing eigen::`
  → **41 passed** (confirms the guard-no-op arm compiles and agrees).
- `cargo clippy -p geode-core --all-targets` → clean.
- `cargo fmt --check` → clean.
- `cargo build --workspace` → all crates + examples build.

Closes #518