### PR TITLE
docs(eigen,driven): document faer sparse-LU COLAMD ordering + Phase-1 fill-reduction negative

### DIFF
--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -1503,6 +1503,12 @@ impl DrivenOperator {
         let a_int = self.assemble_a_at(omega)?;
 
         // --- Factor once (same machinery as complex Lanczos) ----------------
+        // Fill-reducing ordering: faer 0.24's `sp_lu` hardcodes COLAMD with no
+        // hook for a user/METIS permutation (issue #527 Phase 1 — negative;
+        // see the full analysis at the eigensolve `sp_lu` in
+        // `crate::eigen::lanczos`). The driven direct path is affected
+        // identically; a stronger ordering needs a faer upstream change or the
+        // Phase-2 compressed-factorization follow-on.
         let lu = a_int
             .as_ref()
             .sp_lu()

--- a/crates/geode-core/src/eigen/lanczos.rs
+++ b/crates/geode-core/src/eigen/lanczos.rs
@@ -656,6 +656,44 @@ impl SparseShiftInvertLanczos {
                 let a = shifted_pencil(k, m, self.sigma)?;
                 let lu = {
                     let _par = ParallelismGuard::rayon(n_threads);
+                    // Fill-reducing ordering (issue #527, Phase 1). faer 0.24's
+                    // `sp_lu` uses a **COLAMD** (column approximate minimum
+                    // degree) fill-reducing column permutation. It is hardcoded:
+                    // `SymbolicLu::try_new` → `factorize_symbolic_lu` calls
+                    // `colamd::order` unconditionally, and `LuSymbolicParams`
+                    // exposes only `colamd::Control` — there is NO `Ordering`
+                    // enum and NO hook to supply a precomputed permutation.
+                    // (Contrast faer's *Cholesky* path, whose
+                    // `SymmetricOrdering` DOES offer `Amd`/`Identity`/`Custom`;
+                    // but the shifted pencil `A = K − σM` is symmetric-INDEFINITE,
+                    // so this direct path must use unsymmetric LU, not Cholesky.)
+                    //
+                    // Phase 1 goal was to plumb a stronger ordering (METIS
+                    // nested dissection) into this symbolic step to cut LU
+                    // fill-in. Outcome: NEGATIVE. faer 0.24's public sparse-LU
+                    // API accepts no user/alternative ordering, and the
+                    // `SymbolicLu` permutation fields are private, so a METIS
+                    // permutation cannot be injected without patching faer.
+                    // Pre-permuting the input does not help either: COLAMD is
+                    // invariant under column relabeling and simply re-derives
+                    // its own ordering, discarding any nested-dissection
+                    // structure. Adding a `metis` crate (a C-toolchain
+                    // dependency) would be dead weight with no integration
+                    // point. A stronger ordering therefore requires either a
+                    // faer upstream change (add an LU `Custom`-ordering hook,
+                    // mirroring Cholesky) or the compressed-factorization track
+                    // captured as Phase 2 below.
+                    //
+                    // Phase 2 (OUT OF SCOPE here, follow-on): the memory win at
+                    // ~1M DOF is the O(N^{4/3}) LU fill itself, addressable by a
+                    // compressed/low-rank (BLR / HSS / H-matrix) factorization.
+                    // The practical route is an FFI to a mature solver
+                    // (STRUMPACK or MUMPS-BLR) versus a scoped Rust
+                    // implementation; BLR is approximate, so it must be gated
+                    // within the existing ≤1% Palace bar and a tight tolerance
+                    // vs this exact-LU path. The complementary asymptotic fix is
+                    // the matrix-free inner solve (`InnerSolver::MatrixFree`,
+                    // issues #524/#526) already wired above.
                     a.as_ref()
                         .sp_lu()
                         .map_err(|e| EigenError::FaerGevd(format!("sparse LU: {e:?}")))?

--- a/crates/geode-core/tests/transmon_eigenmode.rs
+++ b/crates/geode-core/tests/transmon_eigenmode.rs
@@ -959,6 +959,16 @@ const PALACE_BAR_PCT: f64 = 1.0;
 /// cargo test -p geode-core --release --test transmon_eigenmode \
 ///     -- --ignored real_transmon_eigenmodes_release --nocapture
 /// ```
+///
+/// **Direct-path memory baseline (issue #527 Phase 1).** This same run,
+/// measured under `/usr/bin/time -l` (macOS, 133_108 interior DOFs, pencil
+/// nnz = 2_561_711, 12 modes), peaks at **maximum-resident-set ≈ 2.89 GiB**
+/// (3_101_294_592 bytes) — dominated by the COLAMD-ordered faer `sp_lu` L/U
+/// fill. faer 0.24's sparse LU offers no user/METIS ordering hook, so Phase 1
+/// is a documented negative (see the `sp_lu` comment in
+/// `crate::eigen::lanczos`); this figure is the fixed baseline the Phase-2
+/// compressed-factorization follow-on must beat. The 1M-DOF OOM retry is an
+/// operator/AWS task, not run in CI.
 #[test]
 #[ignore = "157k-DOF sparse shift-invert eigensolve — release benchmark only"]
 fn real_transmon_eigenmodes_release() {


### PR DESCRIPTION
## Summary

Issue #527 Phase 1 asked whether a stronger fill-reducing ordering (e.g. METIS nested dissection) could be plumbed into geode's direct sparse-LU eigensolve/driven paths to cut LU fill-in memory. The investigation — the crux of the issue — resolves to an **honest NEGATIVE**, which the issue explicitly names as an acceptable outcome ("do NOT fabricate an improvement").

**What faer 0.24's `sp_lu` ordering is: COLAMD** (column approximate minimum degree). `sp_lu` → `SymbolicLu::try_new` → `factorize_symbolic_lu`, which calls `linalg_sp::colamd::order(...)` **unconditionally**. The only tunable exposed is `LuSymbolicParams.colamd_params: colamd::Control` — there is **no `Ordering` enum, no hook to supply a precomputed permutation**, and the `SymbolicLu` `col_perm_fwd/inv` fields are private.

Notably, faer's **Cholesky** path *does* offer `SymmetricOrdering::{Amd, Identity, Custom(perm)}` — but the shifted pencil `A = K − σM` is symmetric-**indefinite** (and the driven system is complex-symmetric), so every direct path here must use unsymmetric LU, not Cholesky. That `Custom` hook is unavailable to LU.

**Why no better ordering could be wired:** faer 0.24's public sparse-LU API accepts no user/alternative ordering. Injecting a METIS permutation would require patching faer or reaching private fields. Pre-permuting the input does not help either — COLAMD is invariant under column relabeling and simply re-derives its own ordering, discarding any nested-dissection structure. Adding a `metis` crate (a C-toolchain dependency the issue flagged) would be dead weight with no integration point. So the change is deferred to a faer upstream feature (add an LU `Custom`-ordering hook mirroring Cholesky) or the Phase-2 compressed-factorization track.

## Changes

- `crates/geode-core/src/eigen/lanczos.rs`: full analysis comment at the `Direct` inner-solver `sp_lu` site — faer's COLAMD ordering, the Cholesky-vs-LU contrast, why a stronger ordering can't be injected, and the Phase-2 recommendation (BLR/HSS via STRUMPACK/MUMPS FFI vs scoped Rust, gated within the ≤1% Palace bar).
- `crates/geode-core/src/driven/solve.rs`: cross-reference comment at the driven direct-path `sp_lu` (`factor_at`) noting it is affected identically.
- `crates/geode-core/tests/transmon_eigenmode.rs`: records the measured 133k-DOF peak-RSS baseline on the release-tier `real_transmon_eigenmodes_release` benchmark.

No numeric path changed — comments/docs only.

## Measurement (133k DOF, the committed transmon fixture)

`/usr/bin/time -l` around `real_transmon_eigenmodes_release` (release, macOS):
- 22,684 nodes / 133,314 tets → **133,108 interior DOFs**, pencil nnz = 2,561,711, 12 modes.
- **Peak RSS (maximum resident set size): 3,101,294,592 bytes ≈ 2.89 GiB** — dominated by the COLAMD-ordered `sp_lu` L/U fill.
- Since Phase 1 is a documented negative (no ordering change is possible via faer's public API), there is no "after"; this is the fixed baseline the Phase-2 follow-on must beat. The 1M-DOF OOM retry is an operator/AWS task, not run in CI.

faer's public `Lu` exposes no nnz(L+U) accessor (numeric factors are private), so fill is reported via peak-RSS — the operationally meaningful metric, and the one that actually OOMs at 1M DOF.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| faer's current ordering identified and documented in a code comment / PR body | ✅ | COLAMD; documented in `lanczos.rs` + `solve.rs` comments and above |
| A stronger fill-reducing ordering wired in, OR a documented NEGATIVE with evidence | ✅ | Documented negative — faer 0.24's public sparse-LU API accepts no user/alternative ordering; evidence traced through `factorize_symbolic_lu`/`LuSymbolicParams` |
| Peak-RSS / fill reduction measured at 133k and reported | ✅ | ≈2.89 GiB peak RSS at 133,108 DOF; 1M retry noted as operator/AWS follow-up |
| Eigenvalues bit-stable / within existing tolerance | ✅ | No numeric path changed; release run: all 6 Palace modes within 0.029% of the ≤1% bar; `eigen::` lib tests pass |
| Phase 2 (BLR/HSS) captured as documented follow-on with STRUMPACK-FFI-vs-Rust tradeoff | ✅ | Recorded in the `lanczos.rs` comment |

Phase 2 (BLR/HSS/STRUMPACK FFI) is explicitly OUT OF SCOPE and was not attempted.

## Test Plan

- `cargo fmt --check` — clean.
- `cargo clippy -p geode-core --all-targets` — no warnings.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geode-core --no-deps` — clean (intra-doc link to public `crate::eigen::lanczos` resolves).
- `cargo test -p geode-core --lib eigen::` — 47 passed.
- `real_transmon_eigenmodes_release` (release, `--ignored`) — passed; worst-case Palace Δ = 0.0289%.

Closes #527