### PR TITLE
chore(tooling): commit Repo Skills v0.1.0 install

### DIFF
--- a/.claude/commands/repo/audit.md
+++ b/.claude/commands/repo/audit.md
@@ -1,0 +1,82 @@
+---
+name: "audit"
+description: "Full repo health scan — READMEs, orphans, links, gitignore, branches"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:audit — Full Health Sweep
+
+Run a full health sweep of the repository (or a specific subtree). Reports
+findings grouped by category and severity. Does not make changes — presents
+findings for discussion.
+
+## Usage
+
+```
+/repo:audit                    # Full repo
+/repo:audit packages/core      # Scope to one subtree
+```
+
+## What It Checks
+
+Run each of the following checks and compile results into a single report:
+
+### 1. README Accuracy (see [[readme]])
+- Directories with >5 files that lack a README
+- READMEs whose file/folder listings don't match actual contents
+- Stale "gitignored" or "TODO" annotations that are no longer true
+
+### 2. Orphaned Files (see [[orphans]])
+- Scripts not referenced by any other file, Makefile, or CI config
+- Data files (.yaml, .json, .csv) not imported or referenced anywhere
+- Generated outputs (PDFs, binaries) without a corresponding source
+
+### 3. Broken Links (see [[links]])
+- Markdown links (`[text](path)`) pointing to nonexistent files
+- CLAUDE.md paths that don't resolve
+- Skill/command cross-references to missing files
+
+### 4. Gitignore Issues (see [[gitignore]])
+- Files that are ignored but probably shouldn't be
+- Build artifacts that aren't ignored but should be
+- Redundant or stale gitignore rules
+
+### 5. Branch & Worktree Hygiene (see [[branches]])
+- Local branches whose PRs are merged
+- Orphaned or stale worktrees
+
+## Output Format
+
+Present findings as a table grouped by category:
+
+```
+## Repo Audit — packages/core
+
+### README Issues (2 findings)
+| Severity | Path | Issue |
+|----------|------|-------|
+| warn | docs/analysis/ | No README, 8 files |
+| info | README.md | Lists `sim/` but dir doesn't exist |
+
+### Orphaned Files (1 finding)
+...
+
+### Summary
+- 2 README issues (0 critical, 1 warn, 1 info)
+- 1 orphan (0 critical, 0 warn, 1 info)
+- 0 broken links
+- 0 gitignore issues
+- 3 stale branches
+```
+
+After presenting, ask: "Want me to fix any of these?"
+
+## Severity Levels
+
+- **critical**: Something is actively misleading or broken (dead link in
+  CLAUDE.md, gitignore rule hiding important files)
+- **warn**: Should be fixed but isn't causing immediate harm (stale README,
+  orphaned script)
+- **info**: Nice to fix, low priority (missing README in a small directory)

--- a/.claude/commands/repo/branches.md
+++ b/.claude/commands/repo/branches.md
@@ -1,0 +1,156 @@
+---
+name: "branches"
+description: "Audit local branches and worktrees — find merged PRs, orphaned worktree branches, and stale worktrees"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:branches — Branch & Worktree Hygiene
+
+Find stale local branches and worktrees that can be safely removed. Reports
+findings and waits for confirmation before deleting anything.
+
+## Usage
+
+```
+/repo:branches                   # Full audit
+/repo:branches --prune           # Delete confirmed-safe branches after reporting
+```
+
+## Steps
+
+### 1. Inventory
+
+Gather current state:
+
+```bash
+# Default branch
+git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|origin/||'
+
+# Count local branches
+git branch --list | wc -l
+
+# List worktrees
+git worktree list
+
+# Identify active worktree branches (these are PROTECTED)
+git worktree list --porcelain | grep '^branch ' | sed 's|branch refs/heads/||'
+```
+
+### 2. Categorize branches
+
+For every local branch, classify it into one of these buckets:
+
+#### PROTECTED (never delete)
+- The default branch (`main`/`master`) and the currently checked-out branch
+- Any branch currently checked out by a worktree
+- Any branch with an **open** PR (`gh pr list --head <branch> --state open`)
+- Long-lived branches the repo's own docs (CLAUDE.md, CONTRIBUTING.md) name as
+  release/project branches — if such a list exists, honor it
+
+#### MERGED PR BRANCHES
+- Branches matching common PR patterns: `feature/*`, `fix/*`, `feat/*`, `pr-*`
+- Check if a PR exists and is merged:
+  `gh pr list --head <branch> --state merged --json number --jq length`
+- If the PR is merged, the branch is safe to delete
+- Also safe: any branch fully merged into the default branch
+  (`git branch --merged <default>`)
+
+#### CLOSED ISSUE BRANCHES
+- Branches whose names embed an issue number (e.g. `feature/issue-123`,
+  `loom/issue-123`)
+- Check the linked issue: `gh issue view <number> --json state --jq .state`
+- If the issue is CLOSED and no open PR exists for the branch, it's safe to delete
+
+#### ORPHANED AUTOMATION BRANCHES
+- Ephemeral branches created by tooling and abandoned — e.g. `worktree-agent-*`,
+  `sync/*`, `wt/*` (Loom and similar orchestrators create these)
+- Safe to delete when no active worktree uses them
+
+#### UNKNOWN
+- Any branch that doesn't match the above patterns
+- Report these for manual review, do NOT auto-delete
+
+### 3. Check worktrees for active automation
+
+If the repo uses Loom (a `.loom/` directory exists), check each worktree's
+linked issue for active labels before treating it as stale:
+
+```bash
+issue=$(echo "$branch" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+gh issue view "$issue" --json state,labels --jq '[.state, (.labels[].name)] | join(",")'
+```
+
+Active labels (`loom:building`, `loom:review-requested`,
+`loom:changes-requested`) mean a builder is mid-work — do NOT remove.
+
+### 4. Present findings
+
+```
+BRANCH AUDIT
+============
+
+Local branches: 53
+Worktrees: 4
+
+SAFE TO DELETE (32 branches):
+  Merged PR branches: 15
+    fix/123-parser-crash (PR #150, merged 2026-06-28)
+    ...
+  Closed issue branches: 3
+  Orphaned automation branches: 14
+
+PROTECTED (10 branches):
+  main
+  feature/issue-462 (worktree active)
+  ...
+
+UNKNOWN (11 branches):
+  experiment-quantizer — no PR found, no issue linked
+  ...
+
+STALE WORKTREES (0):
+  (none)
+```
+
+### 5. If `--prune` flag is set
+
+After presenting the report, delete branches in the SAFE TO DELETE category:
+
+```bash
+git branch -D <branch_name>
+```
+
+For stale worktrees:
+```bash
+git worktree unlock <path> 2>/dev/null
+git worktree remove --force <path>
+```
+
+Report what was deleted and what remains.
+
+### 6. If no `--prune` flag
+
+End with:
+```
+To delete safe branches, run: /repo:branches --prune
+To investigate unknown branches: git log --oneline -5 <branch>
+```
+
+## Safety Rules
+
+1. **NEVER delete a branch that has an active worktree** — `git worktree remove` first
+2. **NEVER delete branches with open PRs** — even if the issue is closed
+3. **NEVER delete branches named as long-lived by the repo's own docs**
+4. **Always report before deleting** — the user must see the full list before `--prune` acts
+5. **When in doubt, classify as UNKNOWN** — let the user decide
+
+## Notes
+
+- PR/issue lookups need the `gh` CLI and GitHub auth; without them, fall back
+  to `git branch --merged` analysis only and say so in the report
+- Rate limiting: if there are hundreds of branches, batch `gh` calls
+- Remote branch pruning is NOT done by this command; to prune stale remote
+  tracking refs: `git fetch --prune` (safe, only removes local refs to deleted
+  remote branches)

--- a/.claude/commands/repo/gitignore.md
+++ b/.claude/commands/repo/gitignore.md
@@ -1,0 +1,72 @@
+---
+name: "gitignore"
+description: "Audit gitignore rules — find over-ignored files and under-ignored build artifacts"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:gitignore — Gitignore Audit
+
+Check that gitignore rules are appropriate for this repository. Catches files
+that shouldn't be ignored and build artifacts that should be.
+
+## Usage
+
+```
+/repo:gitignore                  # Full repo
+/repo:gitignore data/            # Check one subtree
+```
+
+## Context First
+
+Determine whether the repo is public or private before judging rules
+(`gh repo view --json isPrivate --jq .isPrivate`, or ask the user if there is
+no GitHub remote). The right answer differs:
+- **Private repos** often want data files, docs, and notes *tracked* — flag
+  rules that hide them.
+- **Public repos** often want those same files *ignored* — flag tracked files
+  that look like they leaked in (credentials, dumps, personal notes are
+  critical findings either way).
+
+## What It Checks
+
+### 1. Over-Ignored Files
+Flag gitignore rules that exclude things that look like real content:
+- Data files (.yaml, .json, .csv) that aren't build output
+- Documentation or notes
+- Configuration that isn't secrets
+
+**Always keep ignored, in any repo:**
+- `.env` files and anything credential-like
+- `node_modules/`, `.venv/`, `__pycache__/`
+- Build output (`dist/`, `build/`, `target/`, `*.pyc`)
+- IDE files (`.vscode/`, `.idea/`)
+- OS files (`.DS_Store`)
+
+### 2. Under-Ignored Files
+Find tracked files that are probably build artifacts:
+- `*.pyc`, `__pycache__/`
+- `dist/`, `build/`, coverage output
+- Large binaries that look generated (`.o`, `.so`, `.whl`)
+
+### 3. Gitignore Hygiene
+- Redundant rules (already covered by a parent `.gitignore`)
+- Rules that match zero files (stale after cleanup)
+- Scattered `.gitignore` files that could be consolidated
+
+### 4. Large Untracked Files
+Find untracked files >1 MB that might need a decision:
+- Should they be tracked? (data files, docs)
+- Should they be gitignored? (build output, caches)
+- Should they live outside the repo? (measurement data, large datasets —
+  object storage, LFS, or a NAS)
+
+## Interaction
+
+For each `.gitignore` file, show:
+- Current rules and what they match
+- Suggested additions or removals
+- Files affected by changes
+
+Ask before modifying any gitignore.

--- a/.claude/commands/repo/help.md
+++ b/.claude/commands/repo/help.md
@@ -1,0 +1,91 @@
+---
+name: "help"
+description: "Explain the installed /repo:* commands — what each does, how to use them, where to start"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:help — How to Use Repo Skills
+
+Explain the repo skills installed in **this** repository. Introspect the
+actual install rather than assuming — installs can be filtered to a subset of
+commands.
+
+## Usage
+
+```
+/repo:help                     # Overview of all installed commands
+/repo:help reset               # Detailed help for one command
+```
+
+## Steps — no argument (overview)
+
+### 1. Read the actual install
+
+```bash
+ls .claude/commands/repo/*.md
+cat .claude/skills/repo/install-metadata.json
+```
+
+Build the command list from the files present. For each, pull the one-line
+`description:` from its frontmatter. Do not list commands that are not
+installed here.
+
+### 2. Present the overview
+
+Structure it like this:
+
+```
+## Repo Skills v<version> (installed <date>)
+
+General repository hygiene and environment tools. Everything is
+**report-first**: commands show findings and wait for your direction
+before changing anything.
+
+### Everyday
+| Command | When to reach for it |
+|---------|----------------------|
+| /repo:reset | Done with a task — get back on main, synced, stale state reviewed |
+| /repo:tidy  | Working tree cluttered with build artifacts and temp files |
+| /repo:remote | Need a cloud dev box (GCP/AWS) with this repo ready to go |
+
+### Periodic maintenance
+| /repo:audit | Monthly sweep, or after a big refactor/import |
+| /repo:update-tools | Keep Loom/Anvil/Repo Skills installs current |
+
+### Focused checks (audit runs all of these)
+| /repo:branches | ... |
+| /repo:gitignore | ... |
+| /repo:links | ... |
+| /repo:orphans | ... |
+| /repo:readme | ... |
+```
+
+Group whatever is actually installed into those three buckets (everyday /
+periodic / focused); put unrecognized commands in a fourth "Other" group with
+their frontmatter descriptions.
+
+### 3. Close with orientation
+
+- Where to start: `/repo:audit` for a first look at repo health, `/repo:reset`
+  at the end of a work session
+- Most commands take an optional path to limit scope, and a flag to apply
+  fixes (`--prune`, `--apply`) — without it they only report
+- Full details per command: `/repo:help <command>` or the files in
+  `.claude/commands/repo/`
+- Updating: `/repo:update-tools` (source: https://github.com/rjwalters/repo)
+
+## Steps — with a command argument
+
+Read `.claude/commands/repo/<name>.md` and summarize it for a user (not a
+reimplementation): what it does, the usage lines, what it will and won't do
+without confirmation, and one concrete example invocation. If the file isn't
+installed, say so and list what is.
+
+## Notes
+
+- This is a read-only command: it never runs the other commands, only
+  describes them
+- Keep the overview short enough to read in one screen — the point is
+  orientation, not documentation

--- a/.claude/commands/repo/links.md
+++ b/.claude/commands/repo/links.md
@@ -1,0 +1,66 @@
+---
+name: "links"
+description: "Validate internal cross-references — markdown links, CLAUDE.md paths, skill graph edges"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:links — Link Checker
+
+Validate that internal cross-references across the repo actually resolve.
+Catches broken links from reorganization, renames, and deletions.
+
+## Usage
+
+```
+/repo:links                    # Full repo
+/repo:links CLAUDE.md          # Check one file
+/repo:links .claude/           # Check skill/command files
+```
+
+## What It Checks
+
+### 1. Markdown Links
+Scan all `.md` files for `[text](path)` links where `path` is a relative file
+path (not a URL). Verify the target exists on disk.
+
+Skip:
+- External URLs (http://, https://)
+- Anchor-only links (#section)
+- Image URLs from external services
+
+### 2. CLAUDE.md File References
+CLAUDE.md files typically list key file paths (reference tables, "see X"
+pointers). Verify every path mentioned resolves. This is **critical**
+severity — these are the primary navigation paths for agents.
+
+### 3. Skill/Command Cross-References
+If the repo has `.claude/skills/` and `.claude/commands/`:
+- Every `[[wikilink]]` in a SKILL.md has a corresponding command `.md` file
+  in the same domain
+- If a `.claude/skill-graph.json` exists: every node references a file that
+  exists, and every edge connects two valid nodes
+
+### 4. Nested CLAUDE.md References
+Subdirectory CLAUDE.md files often list key files relative to their own
+directory. Verify those paths resolve relative to that directory.
+
+## Interaction
+
+Group findings by source file:
+
+```
+## CLAUDE.md — 2 broken links
+
+| Line | Target | Status |
+|------|--------|--------|
+| 42 | docs/setup.md | MISSING (removed?) |
+| 87 | legacy/MIGRATION.md | MISSING (renamed?) |
+
+## packages/core/CLAUDE.md — 1 broken link
+...
+```
+
+For each broken link, suggest the most likely correct target (fuzzy match on
+filename) if one exists. Ask before fixing.

--- a/.claude/commands/repo/orphans.md
+++ b/.claude/commands/repo/orphans.md
@@ -1,0 +1,58 @@
+---
+name: "orphans"
+description: "Find unreferenced files — dead scripts, stale data, outputs without sources"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:orphans — Orphan Finder
+
+Find files that appear to have no consumers — scripts nobody calls, data files
+nothing reads, build outputs without sources.
+
+## Usage
+
+```
+/repo:orphans                    # Full repo
+/repo:orphans tools/             # Scope to subtree
+/repo:orphans --type scripts     # Only check scripts
+```
+
+## What It Checks
+
+### 1. Orphaned Scripts
+Python/shell scripts in `scripts/`, `tools/`, or `bin/` directories that are
+not referenced by:
+- Any other script, Makefile, package.json script, or CI config
+- Any README or documentation
+- Any skill/command file
+
+Search for the script's basename across the repo. If zero references exist
+outside the file itself, it's likely orphaned.
+
+### 2. Orphaned Data Files
+YAML, JSON, CSV files that are not:
+- Imported or read by any code
+- Referenced in any README or documentation
+- A recognized tool config (`.eslintrc`, `pyproject.toml`, CI workflows, etc. —
+  many configs are consumed by convention, not by reference)
+
+### 3. Source/Output Mismatches
+- Generated outputs (`.pdf`, `.html`, compiled binaries) without a
+  corresponding source (`.tex`, `.md`, `.py`, …)
+- Sources whose expected output is missing (may indicate a broken build)
+- `.example` / `.sample` files where the real file now exists
+
+### 4. Empty Directories
+Directories that contain no files (only subdirs or nothing at all).
+
+## Interaction
+
+Present findings grouped by type. For each orphan, show:
+- The file path and size
+- What was searched for (e.g., "grepped for `extract.py` — 0 references")
+- Suggested action: delete, move, or add a reference
+
+Ask before taking any action. Some "orphans" are legitimate standalone files —
+the user knows which.

--- a/.claude/commands/repo/readme.md
+++ b/.claude/commands/repo/readme.md
@@ -1,0 +1,51 @@
+---
+name: "readme"
+description: "Check README accuracy against actual directory contents and offer to update"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:readme — README Check
+
+Validate that READMEs accurately describe the directories they live in. Catches
+stale file trees, incorrect descriptions, and missing READMEs in significant
+directories.
+
+## Usage
+
+```
+/repo:readme                    # Scan all READMEs in repo
+/repo:readme packages/core      # Scope to one subtree
+/repo:readme docs/README.md     # Check a specific README
+```
+
+## What It Checks
+
+### 1. File Tree Accuracy
+If a README contains an ASCII file tree (```...``` block with `├──` or `└──`),
+compare it against the actual directory listing:
+- Files/dirs listed in README but missing on disk
+- Files/dirs on disk but not listed in README
+- Descriptions that are factually wrong (e.g., "gitignored" when it's tracked)
+
+### 2. Missing READMEs
+Flag directories that probably need one:
+- Any directory with >5 files and no README
+- Any top-level package/project directory without a README
+- Skip: `node_modules/`, `.git/`, `__pycache__/`, virtualenvs, build output dirs
+
+### 3. Stale Content
+- References to removed files or directories
+- "TODO" or "WIP" markers older than 30 days (check git blame)
+- References to tools or workflows that no longer exist in the repo
+
+## Interaction
+
+For each finding, show the specific discrepancy and ask whether to:
+1. **Update the README** to match reality (add/remove entries)
+2. **Skip** this finding
+3. **Show me the README** so I can decide
+
+When updating, preserve the README's existing style and voice — just fix the
+factual inaccuracies.

--- a/.claude/commands/repo/remote.md
+++ b/.claude/commands/repo/remote.md
@@ -1,0 +1,168 @@
+---
+name: "remote"
+description: "Launch a cloud dev session on GCP or AWS with this repo ready to go, then open an SSH session"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:remote — Remote Dev Session
+
+Stand up (or reuse) a cloud VM with this repository cloned and synced, then
+hand the user a live SSH session in a new terminal window.
+
+## Usage
+
+```
+/repo:remote                   # Interactive: pick provider, instance, size
+/repo:remote gcp               # Skip the provider question
+/repo:remote aws
+/repo:remote --status          # List instances created by this command
+/repo:remote --down            # Stop instances created by this command
+/repo:remote --down --delete   # Terminate/delete them
+```
+
+## Configuration (optional)
+
+If the consumer repo has `.claude/remote.json`, read defaults from it. All
+fields are optional:
+
+```json
+{
+  "provider": "gcp",
+  "gcp": { "project": "my-project", "zone": "us-west1-a", "machineType": "e2-standard-8" },
+  "aws": { "region": "us-west-2", "instanceType": "m5.2xlarge", "keyName": "my-key" },
+  "diskGb": 100,
+  "image": "ubuntu-2404-lts",
+  "idleShutdownMinutes": 120,
+  "setup": "make setup"
+}
+```
+
+Built-in defaults when the file is absent: GCP `e2-standard-4` / AWS
+`m5.xlarge`, 50 GB disk, latest Ubuntu LTS, 120-minute idle shutdown.
+
+## Steps
+
+### 1. Detect providers
+
+```bash
+gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null
+aws sts get-caller-identity --query Account --output text 2>/dev/null
+```
+
+- Both authenticated → ask the user which to use (mention the default machine
+  type and rough hourly price for each)
+- One authenticated → use it, say so
+- Neither → help the user authenticate. Do **not** run `gcloud auth login` or
+  `aws sso login` yourself — these need a browser; tell the user to run them
+  in their own terminal (or with a `!` prefix in this session) and wait.
+
+### 2. Look for an existing instance
+
+Instances created by this command carry a label/tag `repo-remote=<repo-name>`
+(repo name = basename of the git root). If one exists:
+- RUNNING → offer to reuse it (skip to step 4)
+- STOPPED → offer to start it (much faster and cheaper than creating)
+
+```bash
+gcloud compute instances list --filter="labels.repo-remote=<name>" \
+  --format="table(name,zone,status,machineType)"
+aws ec2 describe-instances \
+  --filters "Name=tag:repo-remote,Values=<name>" "Name=instance-state-name,Values=running,stopped"
+```
+
+### 3. Create the instance (with confirmation)
+
+**Before creating anything**, show the user the exact command, the machine
+spec, and the estimated hourly cost, and get an explicit yes.
+
+Requirements for the created instance:
+- Label/tag it `repo-remote=<repo-name>` so `--status`/`--down` only ever
+  touch instances this command created
+- Ubuntu LTS image, disk size from config
+- Install an idle-shutdown guard (cron that checks SSH sessions + CPU and
+  runs `shutdown -h` after the configured idle window) so a forgotten VM
+  doesn't burn money
+- GCP: prefer OS Login / IAP; AWS: use the configured key pair and a security
+  group that allows SSH from the user's IP only
+
+If the zone/region is stocked out, offer the nearest alternative zone or the
+next machine type down rather than failing.
+
+### 4. Get the repo onto the instance
+
+Pick based on what exists:
+
+- **Repo has an `origin` remote** and the user's forge auth can be used
+  non-interactively (e.g. `gh auth token` for GitHub over HTTPS): clone it on
+  the VM, check out the current branch.
+- **Then sync uncommitted work** (or when there is no usable remote, sync the
+  whole tree): rsync the working tree over SSH, excluding gitignored content:
+
+```bash
+# Respect .gitignore; include untracked-but-not-ignored files
+rsync -az --delete \
+  --filter=':- .gitignore' --exclude '.git/' \
+  ./ <host>:~/​<repo-name>/
+```
+
+Never copy `.env` files, keys, or anything credential-like unless the user
+explicitly asks; call out anything skipped for this reason.
+
+### 5. Bootstrap
+
+- Install baseline tooling on first boot: git, build-essential, and whatever
+  the repo obviously needs (detect from `pyproject.toml`, `package.json`,
+  `Cargo.toml`, …)
+- If config has a `setup` command, offer to run it
+- Write/refresh a local SSH config entry so the connection is one word:
+
+```
+Host repo-remote-<name>
+    HostName <ip-or-iap-alias>
+    User <user>
+    # GCP+IAP: use a ProxyCommand via `gcloud compute start-iap-tunnel`
+```
+
+### 6. Open the SSH view
+
+Verify reachability first:
+
+```bash
+ssh -o ConnectTimeout=30 repo-remote-<name> 'echo "SSH OK: $(hostname)"'
+```
+
+Then open a new terminal window with the session. Claude Code cannot host an
+interactive SSH session itself, so hand it to the OS:
+
+- **macOS**: `osascript -e 'tell app "Terminal" to do script "ssh repo-remote-<name>"' -e 'tell app "Terminal" to activate'`
+  (if the user runs iTerm2, use the equivalent iTerm AppleScript)
+- **Linux**: try `x-terminal-emulator -e ssh repo-remote-<name>` or the
+  desktop's terminal
+- **Fallback / SSH-only session**: print the command and tell the user to run
+  `ssh repo-remote-<name>` in a separate terminal
+
+### 7. Report
+
+End with a compact status block: instance name, zone, machine type, hourly
+cost estimate, idle-shutdown window, the SSH alias, and the teardown command
+(`/repo:remote --down`).
+
+## `--status` and `--down`
+
+- `--status`: list all instances labeled `repo-remote=<repo-name>` with state
+  and uptime; estimate accumulated cost
+- `--down`: stop them (confirm first, listing exactly what will stop);
+  `--down --delete` terminates/deletes instead — confirm with the instance
+  names spelled out, since disks go with them
+
+## Safety Rules
+
+1. **Never create, stop, or delete cloud resources without showing the exact
+   plan and getting a yes** — including estimated cost for creation
+2. **Only ever touch instances carrying this repo's `repo-remote` label** —
+   never enumerate-and-guess
+3. **Never copy credentials to the VM** unless explicitly asked
+4. **Always install the idle-shutdown guard** — a VM that outlives the session
+   should turn itself off

--- a/.claude/commands/repo/reset.md
+++ b/.claude/commands/repo/reset.md
@@ -1,0 +1,92 @@
+---
+name: "reset"
+description: "Return the repo to a clean baseline — review stale worktrees/branches/stashes, sync with remote, land back on the default branch"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:reset — Back to Baseline
+
+The end-of-task ritual: review and prune stale git state, sync with the
+remote, and land back on the default branch with a clean working tree.
+Report-first — nothing is deleted or dropped without appearing in the report
+and getting a yes.
+
+## Usage
+
+```
+/repo:reset                    # Interactive: review everything, act on approval
+/repo:reset --prune            # Also delete confirmed-safe branches/worktrees without per-item prompts
+```
+
+## Steps
+
+### 1. Working tree safety check
+
+```bash
+git status --porcelain
+```
+
+If the tree is dirty, stop and resolve it **first** — everything after this
+step assumes no work can be lost. Show the changes and ask:
+- **Commit** them (offer to draft the commit)
+- **Stash** them with a descriptive message (`git stash push -m "..."`)
+- **Abort** the reset and leave everything as is
+
+NEVER discard changes. `git checkout --`, `git reset --hard`, and `git clean`
+on tracked modifications are off the table unless the user explicitly asks.
+
+### 2. Stash review
+
+```bash
+git stash list --format='%gd %cr %gs'
+```
+
+For each stash, show what's in it (`git stash show --stat <ref>`) and its age.
+Ask per stash: **apply**, **drop**, or **keep**. Old stashes (>30 days) are
+usually droppable but the user decides — never auto-drop.
+
+### 3. Branch & worktree review
+
+Run the full [[branches]] classification (PROTECTED / merged-PR / closed-issue
+/ orphaned-automation / UNKNOWN, plus stale worktrees). With `--prune`, delete
+the SAFE TO DELETE category after presenting it; otherwise ask.
+
+### 4. Sync with remote
+
+```bash
+git fetch --all --prune
+```
+
+Then return to the default branch and fast-forward it:
+
+```bash
+default=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|origin/||')
+git checkout "$default"
+git pull --ff-only
+```
+
+If `--ff-only` fails, the local default branch has diverged from the remote —
+report the divergence (`git log --oneline @{u}..HEAD` and `HEAD..@{u}`) and
+ask how to proceed. Do not rebase or force anything on your own.
+
+### 5. Final state report
+
+```
+RESET COMPLETE
+==============
+Branch:    main (up to date with origin/main)
+Tree:      clean
+Stashes:   1 kept (stash@{0}: "wip: quantizer experiment", 3 days old)
+Branches:  4 deleted, 2 UNKNOWN kept (experiment-a, spike/cache)
+Worktrees: 1 removed (../repo-wt-fix123)
+```
+
+List anything intentionally left behind so nothing is silently forgotten.
+
+## Related
+
+- Filesystem clutter (build artifacts, caches, temp files) is [[tidy]]'s job —
+  offer to run it after the reset if the inventory looked messy
+- Deep branch analysis and its safety rules live in [[branches]]

--- a/.claude/commands/repo/tidy.md
+++ b/.claude/commands/repo/tidy.md
@@ -1,0 +1,103 @@
+---
+name: "tidy"
+description: "Tidy up the repository — build artifacts, caches, temp files, empty dirs"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:tidy — Tidy Up
+
+Sweep the working tree for clutter and clean it up. Report-first: inventory
+everything, categorize by confidence, then delete only what the user approves
+(or only the SAFE category with `--apply`).
+
+## Usage
+
+```
+/repo:tidy                    # Inventory + report, then discuss
+/repo:tidy --apply            # Report, then delete the SAFE category without asking per-item
+/repo:tidy packages/core      # Scope to one subtree
+```
+
+## Steps
+
+### 1. Inventory
+
+Gather candidates without deleting anything:
+
+```bash
+# Ignored files that exist on disk (usually build output/caches)
+git clean -ndX
+
+# Untracked files (may include work-in-progress — treat carefully)
+git clean -nd
+
+# Empty directories
+find . -type d -empty -not -path './.git/*'
+
+# Large files in the working tree (>10 MB, tracked or not)
+find . -type f -size +10M -not -path './.git/*' -not -path './node_modules/*'
+
+# Stale worktrees
+git worktree list
+```
+
+Also look for junk by pattern, wherever it lives:
+- OS/editor droppings: `.DS_Store`, `Thumbs.db`, `*~`, `*.swp`, `.#*`
+- Python: `__pycache__/`, `*.pyc`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`
+- JS: `node_modules/` outside package roots, stale `dist/`, `.turbo/`, coverage output
+- Logs and temp files: `*.log`, `*.tmp`, `tmp/` contents older than a week
+- Merge/patch leftovers: `*.orig`, `*.rej`, `*.BACKUP.*`
+
+### 2. Categorize
+
+- **SAFE** — regenerable with certainty: gitignored build output and caches,
+  OS/editor droppings, `__pycache__`, empty directories. Nothing in this
+  category may be tracked by git or match a source-code extension.
+- **ASK** — probably junk but needs a human call: untracked files that aren't
+  gitignored (could be unsaved work!), large files, stale-looking logs, old
+  `tmp/` contents. Stale worktrees, branches, and stashes are [[reset]]'s
+  job — point there instead of handling them here.
+- **KEEP** — flagged only as information: tracked files that look like they
+  don't belong (build output that got committed — point to [[gitignore]]).
+
+### 3. Report
+
+```
+## Repo Clean — inventory
+
+SAFE (would free 412 MB):
+  .DS_Store × 14
+  __pycache__/ × 22 dirs
+  dist/ (gitignored, 380 MB)
+  6 empty directories
+
+ASK:
+  notes-scratch.md         untracked, 3 KB, modified today  ← might be real work
+  sim-output-old/          untracked, 1.2 GB, untouched 60 days
+  worktree: ../repo-wt-fix123 (branch merged)
+
+KEEP (informational):
+  assets/build.min.js      tracked but looks generated — see /repo:gitignore
+```
+
+### 4. Apply
+
+- Without `--apply`: walk through categories with the user; delete what they
+  approve.
+- With `--apply`: delete the SAFE category immediately, then present ASK items
+  as usual. Never auto-delete anything in ASK, no matter the flags.
+
+Use `git clean -fdX -- <paths>` for gitignored artifacts and plain `rm` only
+for pattern-matched junk you listed in the report. After deleting, re-run the
+inventory to confirm and report bytes freed.
+
+## Safety Rules
+
+1. **Never delete tracked files** — that's a git operation the user does deliberately
+2. **Never touch `.git/`** internals
+3. **Untracked ≠ junk** — an untracked file modified recently is presumed to be
+   unsaved work and always lands in ASK
+4. **Everything deleted must have appeared in the report first**
+5. When scoped to a subtree, do not delete anything outside it

--- a/.claude/commands/repo/update-tools.md
+++ b/.claude/commands/repo/update-tools.md
@@ -1,0 +1,104 @@
+---
+name: "update-tools"
+description: "Check installed tool packages (Loom, Anvil, Repo Skills, …) against their source repos and offer to update"
+domain: repo
+type: command
+user-invocable: true
+---
+
+# /repo:update-tools — Tool Package Updates
+
+Find every tool package installed into this repo by an Anvil/Loom-style
+installer, compare each against the latest version of its source, and offer
+to update the stale ones.
+
+## Usage
+
+```
+/repo:update-tools             # Report, then offer updates
+/repo:update-tools --check     # Report only
+/repo:update-tools loom        # Only check/update one tool
+```
+
+## Steps
+
+### 1. Discover installed tools
+
+Tools in this family record their install in a metadata file. Look for:
+
+```bash
+ls .loom/install-metadata.json .anvil/install-metadata.json 2>/dev/null
+ls .claude/skills/*/install-metadata.json 2>/dev/null
+```
+
+Key names vary by tool (`version` vs `loom_version` / `anvil_version`, `source`
+vs `loom_source` / `anvil_source`) — read whichever variant is present. Each
+file gives: installed version, installed commit, install date, and the path of
+the local source clone it was installed from.
+
+Known family members: Loom (`.loom/`), Anvil (`.anvil/`), Repo Skills
+(`.claude/skills/repo/`), kicad-tools, and anything else that follows the same
+metadata pattern. Report any metadata file found even if the tool is
+unrecognized.
+
+### 2. Determine the latest version of each
+
+For each tool, prefer the local source clone recorded in the metadata:
+
+```bash
+git -C <source> fetch origin --quiet
+git -C <source> log --oneline HEAD..origin/HEAD | wc -l    # source clone itself behind?
+# Version at origin: VERSION file, package.json, or pyproject.toml on origin/HEAD
+git -C <source> show origin/HEAD:VERSION 2>/dev/null
+```
+
+If the source clone no longer exists, fall back to GitHub:
+`gh api repos/<owner>/<repo>/tags --jq '.[0].name'` or the latest release.
+If neither works, mark the tool UNKNOWN rather than guessing.
+
+### 3. Report
+
+```
+TOOL PACKAGES
+=============
+| Tool        | Installed        | Latest  | Status      |
+|-------------|------------------|---------|-------------|
+| loom        | 0.9.1 (Jun 4)    | 0.10.6  | STALE       |
+| anvil       | 0.9.0 (Jul 1)    | 0.9.0   | current     |
+| repo-skills | 0.1.0 (Jul 14)   | 0.1.0   | current     |
+| kicad-tools | 2.3.0 (May 20)   | ?       | source repo missing — clone it? |
+```
+
+Where a changelog exists in the source repo, summarize what changed between
+the installed and latest versions.
+
+### 4. Update (with confirmation)
+
+For each stale tool the user approves, update the source clone first, then
+re-run that tool's own installer — never hand-copy files:
+
+```bash
+git -C <source> pull --ff-only
+# Loom:        <source>/install.sh --quick -y <this-repo>
+# Anvil:       <source>/scripts/install-anvil.sh <this-repo>
+# Repo Skills: <source>/install.sh -y <this-repo>
+# kicad-tools: <source>/scripts/install-kct.sh <this-repo>
+# Unknown tools: look for install.sh / scripts/install-*.sh in the source repo
+```
+
+If the source clone has local modifications or `--ff-only` fails, report it
+and skip that tool rather than resolving on your own.
+
+After updating, re-read each metadata file to confirm the new version, and
+show a summary of what changed in the repo (`git status --short`) so the user
+can review and commit the update.
+
+## Safety Rules
+
+1. **Never update without confirmation** — show installed → latest per tool first
+2. **Always use the tool's own installer** — it owns its write footprint and
+   marker blocks; hand-copying breaks reinstall idempotency
+3. **Never resolve source-repo git problems silently** (diverged clone, dirty
+   tree) — report and skip
+4. **The update touches the working tree** — leave the changes uncommitted for
+   the user to review

--- a/.claude/skills/repo/SKILL.md
+++ b/.claude/skills/repo/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: "Repo Skills"
+description: "General repository hygiene and environment tools — audits, cleanup, branch/worktree pruning, link checking, and cloud dev sessions"
+domain: repo
+type: skill
+user-invocable: false
+---
+
+# Repo Skills
+
+General-purpose tools for keeping a git repository healthy and productive. The
+hygiene commands are **interactive** — they report findings and discuss fixes
+with the user before making changes. The environment commands (`remote`) stand
+up infrastructure only after showing exactly what they will create and what it
+costs.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| [[help]] | Explain the installed `/repo:*` commands — what each does, where to start |
+| [[audit]] | Full sweep — runs all hygiene checks, produces a summary report |
+| [[reset]] | Back to baseline — review stale worktrees/branches/stashes, sync with remote, return to the default branch |
+| [[tidy]] | Tidy up — build artifacts, caches, temp files, empty dirs |
+| [[remote]] | Launch a cloud dev session (GCP or AWS) with this repo ready to go, then open SSH |
+| [[update-tools]] | Check installed tool packages (Loom, Anvil, …) against their sources and offer updates |
+| [[branches]] | Branch & worktree hygiene — merged PRs, orphaned branches, stale worktrees |
+| [[gitignore]] | Gitignore hygiene — over-ignored files, under-ignored build artifacts |
+| [[links]] | Internal cross-references — markdown links, CLAUDE.md paths, skill graph |
+| [[orphans]] | Files with no references — dead scripts, stale data, outputs without sources |
+| [[readme]] | README accuracy vs actual directory contents |
+
+## When to Use
+
+- After finishing a task, to get back to a known-good state (`reset`)
+- After a large refactor, consolidation, or import (`audit`, `links`, `readme`)
+- When the working tree feels messy (`tidy`, `orphans`)
+- When `git branch` output has grown unmanageable (`branches`)
+- When local hardware isn't enough or you need a clean Linux box (`remote`)
+- Periodically, to keep installed tool packages current (`update-tools`)
+- Periodically (monthly) as general hygiene (`audit`)
+- Before a demo, handoff, or onboarding (clean up before they arrive)
+
+## Principles
+
+1. **Report first, fix second.** Never silently change files or create
+   infrastructure. Show findings (or the exact provisioning plan), discuss,
+   then act on what the user approves.
+2. **Scope matters.** Most hygiene commands accept an optional path argument to
+   limit scope (e.g., `/repo:readme docs/`). Without it, they scan the full repo.
+3. **General by design.** These commands make no assumptions about org,
+   project structure, or infrastructure. Anything repo-specific is read from
+   the consumer repo's own files (CLAUDE.md conventions, `.claude/remote.json`),
+   never hardcoded.
+4. **Don't be noisy.** Only flag things that are actually wrong or confusing.
+   A missing README in a tiny utility directory isn't worth flagging.

--- a/.claude/skills/repo/install-metadata.json
+++ b/.claude/skills/repo/install-metadata.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.1.0",
+  "commit": "7a412e5",
+  "installed_at": "2026-07-15T05:19:46Z",
+  "source": "/Users/rwalters/GitHub/repo",
+  "commands": ["audit","branches","gitignore","help","links","orphans","readme","remote","reset","tidy","update-tools"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,11 @@ This repository uses [Loom](https://github.com/rjwalters/loom) for AI-powered de
 <!-- BEGIN ANVIL -->
 This repository uses [Anvil](https://github.com/rjwalters/anvil) for AI-powered artifact creation. See `.anvil/CLAUDE.md` for the full guide (skills, rubric, state machine). To upgrade Anvil, re-run `install-anvil.sh .` from the anvil checkout without `--skills=` to pick up newly-shipped skills; pass `--skills=...` only to install a strict subset.
 <!-- END ANVIL -->
+
+<!-- BEGIN REPO-SKILLS -->
+This repository has [Repo Skills](https://github.com/rjwalters/repo) v0.1.0 installed —
+general repository hygiene and environment commands invoked as `/repo:<command>`. Run
+`/repo:help` for the command list, or see `.claude/skills/repo/SKILL.md` for the full
+guide. Hygiene commands are report-first: they present findings and wait before changing
+anything. Managed by `install.sh` — edit outside the markers only.
+<!-- END REPO-SKILLS -->


### PR DESCRIPTION
Brings the out-of-band Repo Skills v0.1.0 install under version control, matching how Loom and Anvil are already tracked in this repo.

- `CLAUDE.md`: marker-managed `<!-- BEGIN/END REPO-SKILLS -->` section.
- `.claude/commands/repo/` + `.claude/skills/repo/`: the `/repo:*` hygiene commands + skill definition (`install-metadata.json` records v0.1.0).

Tooling-only; no source or build changes. Managed by the upstream `install.sh` (edit outside the markers only).