### PR TITLE
fix(docs): repair geode-validation rustdoc lints + widen doc-lint gate to workspace

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -31,11 +31,15 @@ env:
 
 jobs:
   doc:
-    name: cargo doc -p geode-core (-D warnings)
+    name: cargo doc --workspace (-D warnings)
     runs-on: ubuntu-latest
-    # Doc build of a single crate (twice, with/without arpack). A 10-min
-    # cap bounds queue-wait while leaving room for a cold dependency
-    # build (issue #354).
+    # Doc build of the whole workspace (default features), plus a second
+    # geode-core-only build with arpack. The workspace build was
+    # previously scoped to `-p geode-core`, which let geode-validation
+    # drift to broken intra-doc links unnoticed (the exact silent-drift
+    # this gate exists to prevent) — so the default build now covers all
+    # crates. A 10-min cap bounds queue-wait while leaving room for a
+    # cold dependency build (issue #354).
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -57,10 +61,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build docs (CPU backend)
+      - name: Build docs (workspace, CPU backend)
         run: |
-          cargo doc -p geode-core --no-deps
+          cargo doc --workspace --no-deps
 
-      - name: Build docs (--features arpack, CPU backend)
+      - name: Build docs (geode-core --features arpack, CPU backend)
         run: |
           cargo doc -p geode-core --no-deps --features arpack

--- a/crates/geode-validation/src/fixture.rs
+++ b/crates/geode-validation/src/fixture.rs
@@ -7,12 +7,12 @@
 //! sites unchanged.
 //!
 //! What stays in `geode-validation` is the *diff artifact* — the
-//! [`ComparisonReport`](crate::ComparisonReport) producing comparison entry
+//! [`ComparisonReport`] producing comparison entry
 //! points. Because [`Fixture`] is now a foreign type, the orphan rule
 //! forbids keeping `compare_against` / `compare_complex_against` as inherent
 //! methods on it; they live here as free functions ([`compare_against`],
-//! [`compare_complex_against`]) wrapping [`crate::diff::compare`] /
-//! [`crate::diff::compare_complex`].
+//! [`compare_complex_against`]) wrapping the crate-internal `diff::compare` /
+//! `diff::compare_complex`.
 
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
The `doc-lint` CI gate only ran `cargo doc -p geode-core`, so **`geode-validation` accumulated three rustdoc warnings-as-errors** that never failed a PR — precisely the silent drift the gate's own header comment says it exists to prevent.

## Doc fixes (`crates/geode-validation/src/fixture.rs`)
- Module doc linked to **private** `crate::diff::compare` / `crate::diff::compare_complex` (`rustdoc::private_intra_doc_links`) → demoted to plain code spans.
- `` [`ComparisonReport`](crate::ComparisonReport) `` had a **redundant explicit target** (`rustdoc::redundant_explicit_links`) → dropped the explicit target.

## Root-cause fix (`.github/workflows/doc-lint.yml`)
- Default doc build widened from `-p geode-core` to **`--workspace`**, so any crate's doc-lint regression now fails the PR. The arpack build stays `geode-core`-scoped (arpack is a geode-core feature).
- Job renamed `cargo doc --workspace (-D warnings)` (branch is unprotected — no required-check name to break).

## Verification
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` → clean, exit 0 (was: `error: could not document geode-validation`).