### PR TITLE
feat(eigen): vector-nodal Π (ΠᵀAΠ) block completing the Hiptmair–Xu AMS cycle

### DIFF
--- a/crates/geode-core/src/eigen/ams.rs
+++ b/crates/geode-core/src/eigen/ams.rs
@@ -20,13 +20,25 @@
 //! gradient near-kernel that Jacobi cannot see becomes an ordinary well-
 //! conditioned nodal problem in the auxiliary space.
 //!
-//! # AMS-lite (the two-level form implemented here)
+//! # AMS-lite and the full three-space cycle
 //!
-//! The full AMS of Hiptmair–Xu adds a second (vector-nodal `Πᵀ A Π`) auxiliary
-//! correction. Following the issue's Phase-1 guidance, this module ships the
-//! **minimal effective form**: a two-level cycle built from just an edge Jacobi
-//! smoother and the gradient-space (nodal) coarse correction. Two apply modes
-//! are provided:
+//! The full AMS of Hiptmair–Xu uses **two** auxiliary spaces: the scalar
+//! gradient space `G` and the **vector-nodal** space `Π` (three Cartesian
+//! nodal-vector components interpolated onto the edge DOFs). The gradient
+//! space alone damps the `image(d⁰)` near-kernel Jacobi cannot see; the
+//! vector-nodal `Πᵀ A Π` block corrects the remaining H(curl) error components
+//! the gradient space does not reach.
+//!
+//! This module implements both. The gradient-only two-space cycle (edge
+//! smoother + `G (Gᵀ A G)⁻¹ Gᵀ`) is the default; when the caller supplies the
+//! per-edge geometry (via [`InteriorGradient::with_edge_vectors`], issue #550)
+//! the preconditioner additionally forms the vector-nodal interpolation `Π`
+//! (`edge_dim × 3·node_dim`) and its coarse operator `Πᵀ A Π`, and adds the
+//! `Π (ΠᵀAΠ)⁻¹ Πᵀ` correction — the complete Hiptmair–Xu three-space cycle.
+//! The two auxiliary corrections are combined **additively** on the same
+//! residual (as in the original Hiptmair–Xu splitting), which keeps each apply
+//! mode symmetric positive definite (a sum of SPD subspace corrections wrapped
+//! by the symmetric pre-/post-smooth). Two apply modes are provided:
 //!
 //! - **Multiplicative symmetric V-cycle** (`AmsLitePreconditioner::apply_vcycle`,
 //!   the shipped default): damped pre-smooth, gradient-space coarse correction on
@@ -60,9 +72,13 @@
 //! borrowed edge operators, the length-`edge_dim` Jacobi diagonal, and the small
 //! node-space `C` factors. No edge-space factorization is ever formed.
 //!
-//! The vector-nodal `Πᵀ A Π` blocks of full AMS are a documented follow-on
-//! (issue #526 Phase 2); the gradient-space + damped-Jacobi V-cycle here already
-//! delivers the ≥5× iteration reduction the acceptance criteria call for.
+//! The vector-nodal `Πᵀ A Π` block (issue #550) is node-vector-indexed
+//! (`3·node_dim` square, still an order of magnitude below `edge_dim`), so its
+//! LU fill is `O(node_dim)` and the working set stays `O(N)` — no edge-space
+//! factorization is ever formed for it either. The at-scale iteration numbers
+//! on the 133k / 1.16M meshes remain an operator/AWS follow-up (issue #531
+//! sub-phase 1c); this module delivers the correct, SPD, spectrum-preserving
+//! three-space operator and the local iteration-count measurement.
 
 use faer::Mat;
 use faer::sparse::linalg::solvers::Lu;
@@ -133,6 +149,16 @@ pub(crate) struct AmsLitePreconditioner {
     inv_diag: Vec<f64>,
     /// Cached LU of the nodal coupling `C = Gᵀ A G` (node-indexed, SPD).
     c_lu: Lu<usize, f64>,
+    /// The vector-nodal interpolation `Π` (`edge_dim × 3·node_dim`) of the
+    /// full Hiptmair–Xu AMS (issue #550), present only when the discrete
+    /// gradient carried per-edge geometry
+    /// ([`InteriorGradient::with_edge_vectors`]). `None` ⇒ the gradient-only
+    /// two-space cycle.
+    pi: Option<SparseColMat<usize, f64>>,
+    /// Cached LU of the vector-nodal coarse operator `Πᵀ A Π`
+    /// (`3·node_dim` square, SPD), paired with [`Self::pi`]. `Some` iff `pi`
+    /// is `Some`.
+    pi_ata_lu: Option<Lu<usize, f64>>,
     /// Damped-Jacobi smoother weight `ω` for the multiplicative V-cycle
     /// ([`Self::apply_vcycle`]). An undamped (`ω = 1`) Jacobi smoother is not a
     /// contraction on the wide H(curl) spectrum, so the multiplicative cycle
@@ -223,10 +249,25 @@ impl AmsLitePreconditioner {
             .sp_lu()
             .map_err(|e| EigenError::FaerGevd(format!("Gᵀ(K−σM)G sparse LU: {e:?}")))?;
 
+        // Vector-nodal auxiliary space (full Hiptmair–Xu, issue #550): build
+        // Π and cache the LU of Πᵀ A Π, but ONLY when the caller supplied the
+        // per-edge geometry. Without it we keep the gradient-only two-space
+        // cycle (backward-compatible; Π is undefined without node coordinates).
+        let (pi, pi_ata_lu) = match gradient.edge_vectors() {
+            Some(edge_vectors) => {
+                let pi = build_pi(&g_rows, edge_vectors, edge_dim, node_dim)?;
+                let pi_ata_lu = build_pi_ata_lu(pi.as_ref(), k, m, sigma, node_dim)?;
+                (Some(pi), Some(pi_ata_lu))
+            }
+            None => (None, None),
+        };
+
         Ok(Self {
             gradient: gradient.clone(),
             inv_diag,
             c_lu,
+            pi,
+            pi_ata_lu,
             smooth_weight: DEFAULT_SMOOTH_WEIGHT,
             edge_dim,
             node_dim,
@@ -262,9 +303,45 @@ impl AmsLitePreconditioner {
         spmv(self.gradient.matrix(), &yc, out);
     }
 
+    /// Vector-nodal coarse correction `out = Π (ΠᵀAΠ)⁻¹ Πᵀ r` (issue #550).
+    ///
+    /// The second Hiptmair–Xu auxiliary space: restricts the edge residual to
+    /// the vector-nodal space (`Πᵀ r`, length `3·node_dim`), solves the cached
+    /// `Πᵀ A Π` system there, and prolongs back to edges (`Π ·`). This corrects
+    /// the H(curl) error components the scalar gradient space does not see.
+    /// `out` is overwritten. Only called when [`Self::pi`] is `Some` (the
+    /// three-space cycle); a no-op guard returns zeros otherwise.
+    fn coarse_correction_pi(&self, r: &[f64], out: &mut [f64]) {
+        use faer::linalg::solvers::Solve;
+        let (Some(pi), Some(pi_ata_lu)) = (&self.pi, &self.pi_ata_lu) else {
+            out.iter_mut().for_each(|v| *v = 0.0);
+            return;
+        };
+        let pi_dim = 3 * self.node_dim;
+        // rc = Πᵀ r  (vector-nodal space)
+        let mut rc = vec![0.0_f64; pi_dim];
+        spmv_transpose(pi.as_ref(), r, &mut rc);
+        // yc = (ΠᵀAΠ)⁻¹ rc
+        let mut yc_mat: Mat<f64> = Mat::from_fn(pi_dim, 1, |row, _| rc[row]);
+        pi_ata_lu.solve_in_place(yc_mat.as_mut());
+        let yc: Vec<f64> = (0..pi_dim).map(|row| yc_mat[(row, 0)]).collect();
+        // out = Π yc  (edge space)
+        spmv(pi.as_ref(), &yc, out);
+    }
+
+    /// Whether the full three-space (gradient + vector-nodal) cycle is active
+    /// — i.e. the caller supplied per-edge geometry so `Π` could be built.
+    #[cfg(test)]
+    pub(crate) fn has_vector_nodal_space(&self) -> bool {
+        self.pi.is_some()
+    }
+
     /// Apply the AMS-lite preconditioner in **additive** form
-    /// `z = D⁻¹ r + G C⁻¹ Gᵀ r` (the reference / fallback form; the shipped
-    /// default is the stronger multiplicative [`Self::apply_vcycle`]).
+    /// `z = D⁻¹ r + G C⁻¹ Gᵀ r (+ Π (ΠᵀAΠ)⁻¹ Πᵀ r)` (the reference / fallback
+    /// form; the shipped default is the stronger multiplicative
+    /// [`Self::apply_vcycle`]). The vector-nodal `Π` term is present only in the
+    /// full three-space cycle (issue #550, when the gradient carried per-edge
+    /// geometry); the gradient-only cycle drops it.
     ///
     /// The two SPD terms — the (undamped) edge Jacobi smoother and the
     /// gradient-space coarse correction — are summed independently, so the apply
@@ -288,6 +365,13 @@ impl AmsLitePreconditioner {
         self.coarse_correction(r, &mut coarse);
         for (zi, &ci) in z.iter_mut().zip(coarse.iter()) {
             *zi += ci;
+        }
+        // z += Π (ΠᵀAΠ)⁻¹ Πᵀ r  (vector-nodal space, full three-space cycle).
+        if self.pi.is_some() {
+            self.coarse_correction_pi(r, &mut coarse);
+            for (zi, &ci) in z.iter_mut().zip(coarse.iter()) {
+                *zi += ci;
+            }
         }
     }
 
@@ -333,6 +417,18 @@ impl AmsLitePreconditioner {
         for (zi, &ci) in z.iter_mut().zip(coarse.iter()) {
             *zi += ci;
         }
+        // Vector-nodal coarse correction on the SAME residual r₁ (issue #550):
+        // the two auxiliary corrections are combined additively (the original
+        // Hiptmair–Xu splitting), so the middle stage is (C_G + C_Π) applied to
+        // r₁. Summing two SPD subspace corrections keeps the middle stage SPD,
+        // and the symmetric pre-/post-smooth around it keeps the whole cycle a
+        // valid (SPD) CG preconditioner.
+        if self.pi.is_some() {
+            self.coarse_correction_pi(&resid, &mut coarse);
+            for (zi, &ci) in z.iter_mut().zip(coarse.iter()) {
+                *zi += ci;
+            }
+        }
 
         // Post-smooth on the residual r₂ = r − A z.
         op_apply(z, &mut az);
@@ -347,12 +443,130 @@ impl AmsLitePreconditioner {
     }
 }
 
-/// Accumulate the triplets of `scale · Gᵀ A G` for a single edge operator `A`
-/// (given in CSC) into `trips`. `g_rows[i]` is the ≤2-entry row `i` of `G`
-/// (list of `(node_col, sign)`), so every nonzero `A[i,j] = v` contributes the
-/// ≤4 node-indexed triplets of `scale · v · gᵢ gⱼᵀ`, deduplicated later by faer.
-fn accumulate_gtag(
+/// Assemble the vector-nodal interpolation `Π` (`edge_dim × 3·node_dim`) of
+/// the full Hiptmair–Xu AMS (issue #550) from `G`'s row incidence and the
+/// per-edge geometry.
+///
+/// For lowest-order Nédélec elements the edge DOF is the tangential line
+/// integral `∫_e v·t`. Interpolating a P1 nodal **vector** field
+/// `V = Σ_c φ_c V_c` onto edge `e = (i, j)` gives the coefficient
+/// `(1/2)(V_i + V_j)·(p_j − p_i)`: each endpoint contributes the same weight
+/// `(1/2) d_e` per Cartesian component, where `d_e = p_j − p_i` is the edge
+/// vector. So `Π` has exactly `G`'s node-column incidence (read from
+/// `g_rows`), and for every free-node column `c` that edge `e` touches and
+/// component `α ∈ {0,1,2}`, `Π[e, 3c+α] = (1/2) d_e[α]`. The column layout
+/// interleaves the three Cartesian components per node (`3c+α`).
+///
+/// # Errors
+///
+/// Returns [`EigenError::FaerGevd`] if faer rejects the `Π` triplets.
+fn build_pi(
     g_rows: &[Vec<(usize, f64)>],
+    edge_vectors: &[[f64; 3]],
+    edge_dim: usize,
+    node_dim: usize,
+) -> Result<SparseColMat<usize, f64>, EigenError> {
+    assert_eq!(g_rows.len(), edge_dim, "g_rows length must equal edge_dim");
+    assert_eq!(
+        edge_vectors.len(),
+        edge_dim,
+        "edge_vectors length must equal edge_dim"
+    );
+    let pi_dim = 3 * node_dim;
+    let mut trips: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(6 * edge_dim);
+    for (e, row) in g_rows.iter().enumerate() {
+        let d = edge_vectors[e];
+        for &(c, _sign) in row {
+            for (alpha, &da) in d.iter().enumerate() {
+                let v = 0.5 * da;
+                if v != 0.0 {
+                    trips.push(Triplet::new(e, 3 * c + alpha, v));
+                }
+            }
+        }
+    }
+    SparseColMat::<usize, f64>::try_new_from_triplets(edge_dim, pi_dim, &trips)
+        .map_err(|err| EigenError::FaerGevd(format!("Π assembly: {err:?}")))
+}
+
+/// Form the vector-nodal coarse operator `Πᵀ (K − σM) Π` and factor it once
+/// (issue #550). The outer-product assembly reuses [`accumulate_gtag`] with
+/// `Π`'s ≤6-entry rows in place of `G`'s ≤2-entry rows.
+///
+/// A tiny relative Tikhonov shift `τ = 1e-8 · max|diag|` is added to the
+/// diagonal before factoring. `Π` can be rank-deficient on a coarse mesh
+/// (e.g. `3·node_dim > edge_dim`, or colinear edges), which would make the
+/// exact `Πᵀ A Π` singular and its LU fail; the shift restores SPD
+/// invertibility. Because `Π (ΠᵀAΠ + τI)⁻¹ Πᵀ` is still symmetric positive
+/// semidefinite, the preconditioner stays SPD, and `τ` is negligible against
+/// the operator so the correction is essentially unchanged.
+///
+/// # Errors
+///
+/// Returns [`EigenError::FaerGevd`] if the coarse assembly or its sparse LU
+/// factorization fails.
+fn build_pi_ata_lu(
+    pi: SparseColMatRef<'_, usize, f64>,
+    k: SparseColMatRef<'_, usize, f64>,
+    m: SparseColMatRef<'_, usize, f64>,
+    sigma: f64,
+    node_dim: usize,
+) -> Result<Lu<usize, f64>, EigenError> {
+    let pi_dim = 3 * node_dim;
+    let edge_dim = pi.nrows();
+
+    // Row view of Π: pi_rows[e] = list of (col, value) (≤6 entries).
+    let mut pi_rows: Vec<Vec<(usize, f64)>> = vec![Vec::new(); edge_dim];
+    {
+        let col_ptr = pi.col_ptr();
+        let row_idx = pi.row_idx();
+        let val = pi.val();
+        for col in 0..pi.ncols() {
+            for kk in col_ptr[col]..col_ptr[col + 1] {
+                pi_rows[row_idx[kk]].push((col, val[kk]));
+            }
+        }
+    }
+
+    // Πᵀ A Π = Σ_{A[i,j]=v} v · πᵢ πⱼᵀ, A = K − σM (same folded-shift stream
+    // as C = Gᵀ A G).
+    let mut trips: Vec<Triplet<usize, usize, f64>> = Vec::new();
+    accumulate_gtag(&pi_rows, k, 1.0, &mut trips);
+    if sigma != 0.0 {
+        accumulate_gtag(&pi_rows, m, -sigma, &mut trips);
+    }
+
+    // Tikhonov guard: assemble once to read the diagonal magnitude, then add
+    // τ·I so the LU is well-posed even when Π is rank-deficient.
+    let ata0 = SparseColMat::<usize, f64>::try_new_from_triplets(pi_dim, pi_dim, &trips)
+        .map_err(|e| EigenError::FaerGevd(format!("ΠᵀAΠ assembly: {e:?}")))?;
+    let mut diag = vec![0.0_f64; pi_dim];
+    csc_diagonal(ata0.as_ref(), &mut diag);
+    let max_diag = diag.iter().fold(0.0_f64, |a, &d| a.max(d.abs()));
+    let tau = if max_diag > 0.0 {
+        1e-8 * max_diag
+    } else {
+        1e-12
+    };
+    for i in 0..pi_dim {
+        trips.push(Triplet::new(i, i, tau));
+    }
+
+    let ata = SparseColMat::<usize, f64>::try_new_from_triplets(pi_dim, pi_dim, &trips)
+        .map_err(|e| EigenError::FaerGevd(format!("ΠᵀAΠ assembly (regularized): {e:?}")))?;
+    ata.as_ref()
+        .sp_lu()
+        .map_err(|e| EigenError::FaerGevd(format!("ΠᵀAΠ sparse LU: {e:?}")))
+}
+
+/// Accumulate the triplets of `scale · Rᵀ A R` for a single operator `A`
+/// (given in CSC) into `trips`, where `R` is a sparse restriction whose row
+/// `i` is `rows[i]` (a list of `(col, weight)` — `G`'s ≤2-entry rows for the
+/// gradient space, `Π`'s ≤6-entry rows for the vector-nodal space). Every
+/// nonzero `A[i,j] = v` contributes the `|rows[i]|·|rows[j]|` coarse-indexed
+/// triplets of `scale · v · rᵢ rⱼᵀ`, deduplicated later by faer.
+fn accumulate_gtag(
+    rows: &[Vec<(usize, f64)>],
     a: SparseColMatRef<'_, usize, f64>,
     scale: f64,
     trips: &mut Vec<Triplet<usize, usize, f64>>,
@@ -361,7 +575,7 @@ fn accumulate_gtag(
     let ri = a.row_idx();
     let val = a.val();
     for j in 0..a.ncols() {
-        let gj = &g_rows[j];
+        let gj = &rows[j];
         if gj.is_empty() {
             continue;
         }
@@ -371,7 +585,7 @@ fn accumulate_gtag(
             if v == 0.0 {
                 continue;
             }
-            let gi = &g_rows[i];
+            let gi = &rows[i];
             if gi.is_empty() {
                 continue;
             }
@@ -595,5 +809,206 @@ mod tests {
                 "coarse solve wrong at {i}: got {got}, want {want}"
             );
         }
+    }
+
+    /// The same synthetic chain as [`chain_gradient`], but with 3-D **node
+    /// geometry** attached so the full-AMS vector-nodal interpolation `Π` is
+    /// built (issue #550). Node `i` is placed on a helix
+    /// `p_i = (i, sin 0.7i, cos 0.5i)`, so consecutive edge vectors span all
+    /// three Cartesian directions — `Π` is non-degenerate (its `x/y/z` blocks
+    /// are all populated), exercising the real three-space code path rather
+    /// than a colinear special case.
+    fn chain_gradient_geom(edge_dim: usize) -> InteriorGradient {
+        let total_edges = edge_dim + 2;
+        let n_nodes = edge_dim + 3;
+        let coords: Vec<[f64; 3]> = (0..n_nodes)
+            .map(|i| {
+                let f = i as f64;
+                [f, (0.7 * f).sin(), (0.5 * f).cos()]
+            })
+            .collect();
+        let edges: Vec<[u32; 2]> = (0..total_edges)
+            .map(|e| [e as u32, (e + 1) as u32])
+            .collect();
+        let mut interior_mask = vec![true; total_edges];
+        interior_mask[0] = false;
+        interior_mask[total_edges - 1] = false;
+        let mut edge_index = vec![None; total_edges];
+        let mut edge_vectors = vec![[0.0_f64; 3]; edge_dim];
+        let mut row = 0usize;
+        for (e, keep) in interior_mask.iter().enumerate() {
+            if *keep {
+                edge_index[e] = Some(row);
+                let [a, b] = edges[e];
+                let (pa, pb) = (coords[a as usize], coords[b as usize]);
+                edge_vectors[row] = [pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]];
+                row += 1;
+            }
+        }
+        assert_eq!(row, edge_dim, "kept edge count must equal edge_dim");
+        InteriorGradient::build(&edges, &interior_mask, &edge_index, n_nodes, edge_dim)
+            .with_edge_vectors(edge_vectors)
+    }
+
+    /// Without attached geometry the preconditioner is the gradient-only
+    /// two-space cycle (no `Π`); with geometry it is the full three-space
+    /// cycle. This pins the switch [`AmsLitePreconditioner::build`] keys off.
+    #[test]
+    fn vector_nodal_space_present_iff_geometry_supplied() {
+        let n = 10;
+        let (k, m) = laplacian(n);
+        let sigma = -0.5;
+
+        let ams_grad_only =
+            AmsLitePreconditioner::build(&chain_gradient(n), k.as_ref(), m.as_ref(), sigma)
+                .unwrap();
+        assert!(
+            !ams_grad_only.has_vector_nodal_space(),
+            "gradient-only build must not carry Π"
+        );
+
+        let ams_three =
+            AmsLitePreconditioner::build(&chain_gradient_geom(n), k.as_ref(), m.as_ref(), sigma)
+                .unwrap();
+        assert!(
+            ams_three.has_vector_nodal_space(),
+            "three-space build must carry Π"
+        );
+        // Π has edge_dim rows and 3·node_dim columns.
+        let pi = ams_three.pi.as_ref().unwrap();
+        assert_eq!(pi.nrows(), n, "Π rows must equal edge_dim");
+        assert_eq!(
+            pi.ncols(),
+            3 * ams_three.node_dim,
+            "Π cols must equal 3·node_dim"
+        );
+    }
+
+    /// ACCEPTANCE (issue #550): the **full three-space** AMS apply is SPD in
+    /// BOTH modes — `zᵀ r > 0` for `r ≠ 0` and `⟨M_prec u, v⟩ = ⟨u, M_prec v⟩`.
+    /// Adding the vector-nodal `Π (ΠᵀAΠ)⁻¹ Πᵀ` correction (a symmetric PSD
+    /// subspace solve) to the existing SPD cycle must keep the preconditioner
+    /// SPD, or it is not a valid CG preconditioner.
+    #[test]
+    fn full_three_space_apply_is_spd() {
+        let n = 12;
+        let (k, m) = laplacian(n);
+        let g = chain_gradient_geom(n);
+        let sigma = -0.5; // below the spectrum ⇒ A = K − σM SPD
+        let ams = AmsLitePreconditioner::build(&g, k.as_ref(), m.as_ref(), sigma).unwrap();
+        assert!(ams.has_vector_nodal_space());
+
+        let a_apply = |x: &[f64], y: &mut [f64]| {
+            let mut kx = vec![0.0; n];
+            let mut mx = vec![0.0; n];
+            spmv(k.as_ref(), x, &mut kx);
+            spmv(m.as_ref(), x, &mut mx);
+            for i in 0..n {
+                y[i] = kx[i] - sigma * mx[i];
+            }
+        };
+
+        // Positive-definiteness of BOTH apply modes on several residuals.
+        for seed in 0..6 {
+            let r: Vec<f64> = (0..n)
+                .map(|i| (((i + seed) as f64) * 0.7).sin() + 0.3)
+                .collect();
+
+            let mut z_v = vec![0.0; n];
+            ams.apply_vcycle(&r, &mut z_v, a_apply);
+            let rz_v: f64 = r.iter().zip(z_v.iter()).map(|(a, b)| a * b).sum();
+            assert!(
+                rz_v > 0.0,
+                "three-space V-cycle not positive definite: rᵀz = {rz_v}"
+            );
+
+            let mut z_a = vec![0.0; n];
+            ams.apply(&r, &mut z_a);
+            let rz_a: f64 = r.iter().zip(z_a.iter()).map(|(a, b)| a * b).sum();
+            assert!(
+                rz_a > 0.0,
+                "three-space additive apply not positive definite: rᵀz = {rz_a}"
+            );
+        }
+
+        // Symmetry of BOTH modes: uᵀ M_prec v == vᵀ M_prec u.
+        let u: Vec<f64> = (0..n).map(|i| ((i as f64) * 0.9).cos()).collect();
+        let v: Vec<f64> = (0..n).map(|i| ((i as f64) * 0.4 + 1.0).sin()).collect();
+        for mode in ["vcycle", "additive"] {
+            let mut mu = vec![0.0; n];
+            let mut mv = vec![0.0; n];
+            if mode == "vcycle" {
+                ams.apply_vcycle(&u, &mut mu, a_apply);
+                ams.apply_vcycle(&v, &mut mv, a_apply);
+            } else {
+                ams.apply(&u, &mut mu);
+                ams.apply(&v, &mut mv);
+            }
+            let umv: f64 = u.iter().zip(mv.iter()).map(|(a, b)| a * b).sum();
+            let vmu: f64 = v.iter().zip(mu.iter()).map(|(a, b)| a * b).sum();
+            assert!(
+                (umv - vmu).abs() < 1e-10 * (umv.abs() + 1.0),
+                "three-space {mode} not symmetric: uᵀM_prec v = {umv}, vᵀM_prec u = {vmu}"
+            );
+        }
+    }
+
+    /// The vector-nodal coarse solve inverts `Πᵀ A Π` on the vector-nodal
+    /// space up to the tiny Tikhonov regularization: for a coarse vector `yc`,
+    /// restricting `A Π yc` back through `Πᵀ` and solving the cached factor
+    /// recovers `yc`. This pins that `Π` and its coarse operator are assembled
+    /// consistently (the vector-nodal analogue of
+    /// `coarse_correction_inverts_on_gradient_space`).
+    #[test]
+    fn pi_coarse_solve_inverts_on_vector_nodal_space() {
+        use faer::linalg::solvers::Solve;
+        let n = 12;
+        let (k, m) = laplacian(n);
+        let g = chain_gradient_geom(n);
+        let sigma = -1.0;
+        let ams = AmsLitePreconditioner::build(&g, k.as_ref(), m.as_ref(), sigma).unwrap();
+        let pi = ams.pi.as_ref().unwrap();
+        let pi_dim = 3 * ams.node_dim;
+
+        let yc: Vec<f64> = (0..pi_dim)
+            .map(|i| ((i as f64) * 0.37).sin() + 0.1)
+            .collect();
+        // pyc = Π yc (edge)
+        let mut pyc = vec![0.0; n];
+        spmv(pi.as_ref(), &yc, &mut pyc);
+        // a_pyc = A pyc = (K − σM) pyc
+        let mut kg = vec![0.0; n];
+        let mut mg = vec![0.0; n];
+        spmv(k.as_ref(), &pyc, &mut kg);
+        spmv(m.as_ref(), &pyc, &mut mg);
+        let a_pyc: Vec<f64> = kg
+            .iter()
+            .zip(mg.iter())
+            .map(|(a, b)| a - sigma * b)
+            .collect();
+        // rc = Πᵀ a_pyc (coarse)
+        let mut rc = vec![0.0; pi_dim];
+        spmv_transpose(pi.as_ref(), &a_pyc, &mut rc);
+        // solve (ΠᵀAΠ + τI) yc' = rc; with τ ≈ 1e-8·max|diag| the recovered
+        // yc' matches yc to a loose tolerance on the populated directions.
+        let mut mat = Mat::from_fn(pi_dim, 1, |row, _| rc[row]);
+        ams.pi_ata_lu.as_ref().unwrap().solve_in_place(mat.as_mut());
+        // Compare in the A-energy-agnostic sense: Π yc' ≈ Π yc (the physical
+        // edge-space correction is what matters; the coarse coordinates can
+        // differ in any Π-nullspace direction the regularization pins to ~0).
+        let ycp: Vec<f64> = (0..pi_dim).map(|i| mat[(i, 0)]).collect();
+        let mut pycp = vec![0.0; n];
+        spmv(pi.as_ref(), &ycp, &mut pycp);
+        let num: f64 = pyc
+            .iter()
+            .zip(pycp.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum();
+        let den: f64 = pyc.iter().map(|a| a * a).sum::<f64>().max(1e-30);
+        assert!(
+            (num / den).sqrt() < 1e-4,
+            "Π coarse solve did not reproduce the edge-space correction: rel = {:.2e}",
+            (num / den).sqrt()
+        );
     }
 }

--- a/crates/geode-core/src/eigen/projection.rs
+++ b/crates/geode-core/src/eigen/projection.rs
@@ -76,6 +76,16 @@ pub struct InteriorGradient {
     /// Free interior-node count (cols of `G`, = `rank(d⁰_interior)` on a
     /// connected boundary-touching mesh).
     node_dim: usize,
+    /// Optional per-reduced-edge-row geometric edge vector
+    /// `d_e = p_b − p_a` (with `edges[e] = [a, b]`, the same `−1@a / +1@b`
+    /// orientation `G` encodes), length `edge_dim`. Supplied by the caller
+    /// when the mesh node coordinates are available; consumed by the
+    /// full-AMS vector-nodal interpolation `Π` (Hiptmair–Xu, issue #550) in
+    /// [`crate::eigen::ams::AmsLitePreconditioner`]. `None` on the pure
+    /// divergence-free-projection path (which never needs `Π`); its presence
+    /// is exactly what switches the AMS preconditioner from the gradient-only
+    /// two-space cycle to the full three-space cycle.
+    edge_vectors: Option<Vec<[f64; 3]>>,
 }
 
 impl InteriorGradient {
@@ -116,7 +126,42 @@ impl InteriorGradient {
             g,
             edge_dim,
             node_dim,
+            edge_vectors: None,
         }
+    }
+
+    /// Attach the per-reduced-edge-row geometric edge vectors
+    /// `d_e = p_b − p_a` (`edges[e] = [a, b]`), length `edge_dim`, enabling
+    /// the full-AMS vector-nodal interpolation `Π` (issue #550). Returns
+    /// `self` for builder-style chaining.
+    ///
+    /// The vectors are indexed by **reduced edge row** (the same reindex `G`'s
+    /// rows use), so `edge_vectors[row]` is the geometry of the interior edge
+    /// mapped to row `row`. The `Π` block reads the node-column *incidence*
+    /// (which free nodes an edge touches) from `G`'s own sparsity and the edge
+    /// *geometry* from these vectors, so no separate free-node → global-node
+    /// map is needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `edge_vectors.len() != edge_dim`.
+    #[must_use]
+    pub fn with_edge_vectors(mut self, edge_vectors: Vec<[f64; 3]>) -> Self {
+        assert_eq!(
+            edge_vectors.len(),
+            self.edge_dim,
+            "edge_vectors length must equal edge_dim (one per reduced edge row)"
+        );
+        self.edge_vectors = Some(edge_vectors);
+        self
+    }
+
+    /// The per-reduced-edge-row edge vectors `d_e = p_b − p_a`, if attached
+    /// via [`Self::with_edge_vectors`]. `None` means no geometry was supplied,
+    /// so the AMS preconditioner runs the gradient-only (two-space) cycle.
+    #[inline]
+    pub fn edge_vectors(&self) -> Option<&[[f64; 3]]> {
+        self.edge_vectors.as_deref()
     }
 
     /// The sparse gradient operator `G` (`edge_dim × node_dim`).
@@ -1618,6 +1663,7 @@ mod tests {
             g: g_mat,
             edge_dim: n,
             node_dim: 1,
+            edge_vectors: None,
         };
         let proj = MOrthogonalGradientProjector::build(&gradient, m.as_ref()).unwrap();
 
@@ -1815,6 +1861,7 @@ mod tests {
             g: g_mat,
             edge_dim: n,
             node_dim: 1,
+            edge_vectors: None,
         };
         let bulk = MOrthogonalGradientProjector::build(&gradient, m.as_ref()).unwrap();
 

--- a/crates/geode-core/src/eigen/transmon.rs
+++ b/crates/geode-core/src/eigen/transmon.rs
@@ -558,6 +558,51 @@ pub fn solve_transmon_eigenmodes_matrix_free_inner_iters(
     m_per_unit: f64,
     precond: crate::eigen::lanczos::InnerPreconditioner,
 ) -> Result<(Vec<ModeReport>, usize), EigenError> {
+    matrix_free_inner_iters_impl(pencil, sigma, n_modes, m_per_unit, precond, false)
+}
+
+/// [`solve_transmon_eigenmodes_matrix_free_inner_iters`] running the **full
+/// three-space** Hiptmair–Xu AMS cycle (issue #550): the gradient-space
+/// correction PLUS the vector-nodal `Π (ΠᵀAΠ)⁻¹ Πᵀ` block.
+///
+/// Identical to the two-space entry point except that the per-edge geometry
+/// `d_e = p_b − p_a` (from the mesh node coordinates) is attached to the
+/// discrete gradient, which is exactly the switch
+/// [`crate::eigen::ams::AmsLitePreconditioner`] uses to build `Π`. Meaningful
+/// only with `precond == InnerPreconditioner::Ams`; with `Jacobi` the geometry
+/// is ignored (Jacobi never touches `G` or `Π`), so the two entry points
+/// coincide there. Returns the modes and the total inner-CG iteration count,
+/// the apples-to-apples measurement vehicle for the three-space vs
+/// gradient-only comparison.
+///
+/// # Errors
+///
+/// Propagates [`EigenError`] from the reduced assembly, the AMS build (the
+/// nodal `Gᵀ(K−σM)G` and vector-nodal `Πᵀ(K−σM)Π` LUs), or the matrix-free
+/// Lanczos solve.
+pub fn solve_transmon_eigenmodes_matrix_free_inner_iters_three_space(
+    pencil: &TransmonPencil<'_>,
+    sigma: f64,
+    n_modes: usize,
+    m_per_unit: f64,
+    precond: crate::eigen::lanczos::InnerPreconditioner,
+) -> Result<(Vec<ModeReport>, usize), EigenError> {
+    matrix_free_inner_iters_impl(pencil, sigma, n_modes, m_per_unit, precond, true)
+}
+
+/// Shared body of the instrumented matrix-free transmon eigensolve. When
+/// `three_space` is set the discrete gradient additionally carries the
+/// per-reduced-edge-row geometry `d_e = p_b − p_a`, enabling the vector-nodal
+/// `Π` block of full AMS (issue #550); otherwise it is the gradient-only
+/// two-space cycle.
+fn matrix_free_inner_iters_impl(
+    pencil: &TransmonPencil<'_>,
+    sigma: f64,
+    n_modes: usize,
+    m_per_unit: f64,
+    precond: crate::eigen::lanczos::InnerPreconditioner,
+    three_space: bool,
+) -> Result<(Vec<ModeReport>, usize), EigenError> {
     let n_edges = pencil.edges.len();
     assert_eq!(
         pencil.interior_mask.len(),
@@ -607,13 +652,28 @@ pub fn solve_transmon_eigenmodes_matrix_free_inner_iters(
 
     // G = d⁰_interior — the AMS auxiliary-space prolongation. Only consumed by
     // the AMS preconditioner; the Jacobi path ignores it.
-    let gradient = crate::eigen::projection::InteriorGradient::build(
+    let mut gradient = crate::eigen::projection::InteriorGradient::build(
         pencil.edges,
         pencil.interior_mask,
         &interior_index,
         pencil.mesh.n_nodes(),
         dim,
     );
+    if three_space {
+        // Per-reduced-edge-row edge vectors d_e = p_b − p_a (edges[e] = [a,b],
+        // the same −1@a/+1@b orientation G encodes) — the geometry the
+        // vector-nodal Π interpolation needs (issue #550).
+        let mut edge_vectors = vec![[0.0_f64; 3]; dim];
+        for (e, &row) in interior_index.iter().enumerate() {
+            if let Some(row) = row {
+                let [a, b] = pencil.edges[e];
+                let pa = pencil.mesh.nodes[a as usize];
+                let pb = pencil.mesh.nodes[b as usize];
+                edge_vectors[row] = [pb[0] - pa[0], pb[1] - pa[1], pb[2] - pa[2]];
+            }
+        }
+        gradient = gradient.with_edge_vectors(edge_vectors);
+    }
 
     let solver = SparseShiftInvertLanczos {
         sigma,

--- a/crates/geode-core/src/eigen/transmon.rs
+++ b/crates/geode-core/src/eigen/transmon.rs
@@ -568,7 +568,7 @@ pub fn solve_transmon_eigenmodes_matrix_free_inner_iters(
 /// Identical to the two-space entry point except that the per-edge geometry
 /// `d_e = p_b − p_a` (from the mesh node coordinates) is attached to the
 /// discrete gradient, which is exactly the switch
-/// [`crate::eigen::ams::AmsLitePreconditioner`] uses to build `Π`. Meaningful
+/// the `AmsLitePreconditioner` (`crate::eigen::ams`) uses to build `Π`. Meaningful
 /// only with `precond == InnerPreconditioner::Ams`; with `Jacobi` the geometry
 /// is ignored (Jacobi never touches `G` or `Π`), so the two entry points
 /// coincide there. Returns the modes and the total inner-CG iteration count,

--- a/crates/geode-core/tests/transmon_eigenmode.rs
+++ b/crates/geode-core/tests/transmon_eigenmode.rs
@@ -588,6 +588,27 @@ fn solve_synthetic_matrix_free_inner_iters(
     n_modes: usize,
     precond: geode_core::eigen::lanczos::InnerPreconditioner,
 ) -> (Vec<ModeReport>, usize) {
+    solve_synthetic_matrix_free_inner_iters_ext(
+        fx, element, l_geom, w_geom, sigma, n_modes, precond, false,
+    )
+}
+
+/// [`solve_synthetic_matrix_free_inner_iters`] with an explicit `three_space`
+/// switch: when `true`, the AMS preconditioner runs the full Hiptmair–Xu
+/// three-space cycle (gradient space + vector-nodal `Π` block, issue #550);
+/// when `false`, the gradient-only two-space cycle. The `three_space` = `false`
+/// path is byte-identical to the two-argument helper above.
+#[allow(clippy::too_many_arguments)]
+fn solve_synthetic_matrix_free_inner_iters_ext(
+    fx: &SyntheticFixture,
+    element: ReactiveElementNatural,
+    l_geom: f64,
+    w_geom: f64,
+    sigma: f64,
+    n_modes: usize,
+    precond: geode_core::eigen::lanczos::InnerPreconditioner,
+    three_space: bool,
+) -> (Vec<ModeReport>, usize) {
     let scatter = NedelecScatterMap::new(&fx.tet_edge_idx);
     let (k_vals, m_vals) =
         assemble_real_pencil(&fx.mesh, &fx.tet_edge_sign, &scatter, &fx.epsilon_tensor);
@@ -606,10 +627,17 @@ fn solve_synthetic_matrix_free_inner_iters(
         shunt,
         interior_mask: &fx.interior_mask,
     };
-    geode_core::eigen::transmon::solve_transmon_eigenmodes_matrix_free_inner_iters(
-        &pencil, sigma, n_modes, M_PER_UNIT, precond,
-    )
-    .expect("synthetic matrix-free eigensolve (instrumented)")
+    if three_space {
+        geode_core::eigen::transmon::solve_transmon_eigenmodes_matrix_free_inner_iters_three_space(
+            &pencil, sigma, n_modes, M_PER_UNIT, precond,
+        )
+        .expect("synthetic matrix-free eigensolve (three-space, instrumented)")
+    } else {
+        geode_core::eigen::transmon::solve_transmon_eigenmodes_matrix_free_inner_iters(
+            &pencil, sigma, n_modes, M_PER_UNIT, precond,
+        )
+        .expect("synthetic matrix-free eigensolve (instrumented)")
+    }
 }
 
 /// ACCEPTANCE CRITERION (issue #526, CI-fast): the **AMS-lite** inner-CG
@@ -691,6 +719,94 @@ fn synthetic_ams_beats_jacobi_inner_iterations() {
              (a preconditioner must not change the eigenvalues)",
             j.lambda,
             a.lambda
+        );
+    }
+}
+
+/// ACCEPTANCE (issue #550): the **full three-space** Hiptmair–Xu AMS cycle
+/// (gradient space + vector-nodal `Π (ΠᵀAΠ)⁻¹ Πᵀ` block) vs the current
+/// **gradient-only** two-space AMS-lite, measured apples-to-apples through the
+/// SAME instrumented matrix-free path on the genuine synthetic Nédélec
+/// curl-curl fixture.
+///
+/// The shift `σ = −0.5` sits below the cavity spectrum, so `(K − σM)` is SPD
+/// and the inner CG converges under BOTH preconditioners (the required
+/// converging configuration — the embedded 133k `transmon_smoke.msh` fixture
+/// at the physical `σ = 4.5 GHz` is indefinite on the ungauged pencil, so no
+/// iteration count is readable there; that at-scale measurement is deferred to
+/// sub-phase 1c per the issue).
+///
+/// The three-space cycle must (a) not change the eigenvalues — a preconditioner
+/// only moves the iteration path — and (b) not converge *slower* than
+/// gradient-only. The near-kernel benefit of the vector-nodal block is
+/// fixture-size dependent and modest on this small cube; the honest iteration
+/// counts are printed (visible with `--nocapture`) and recorded in the PR body.
+#[test]
+fn synthetic_three_space_vs_gradient_only_inner_iterations() {
+    use geode_core::eigen::lanczos::InnerPreconditioner;
+
+    let fx = synthetic_fixture(6);
+    let sigma = -0.5;
+    let element = ReactiveElementNatural {
+        l_natural: 50.0,
+        c_natural: 5.0,
+    };
+    let n_modes = 4;
+
+    let (grad_modes, grad_iters) = solve_synthetic_matrix_free_inner_iters_ext(
+        &fx,
+        element,
+        1.0,
+        1.0,
+        sigma,
+        n_modes,
+        InnerPreconditioner::Ams,
+        false, // gradient-only two-space cycle
+    );
+    let (three_modes, three_iters) = solve_synthetic_matrix_free_inner_iters_ext(
+        &fx,
+        element,
+        1.0,
+        1.0,
+        sigma,
+        n_modes,
+        InnerPreconditioner::Ams,
+        true, // full three-space cycle (gradient + vector-nodal Π)
+    );
+
+    let ratio = grad_iters as f64 / three_iters.max(1) as f64;
+    println!(
+        "inner-CG iterations (synthetic n=6, σ=-0.5): gradient-only AMS = {grad_iters}, \
+         three-space AMS = {three_iters}, reduction = {ratio:.3}×"
+    );
+
+    assert!(
+        three_iters > 0,
+        "three-space run performed no inner CG iterations — instrumentation broken?"
+    );
+    // The vector-nodal block is an ADDITIONAL SPD auxiliary correction, so it
+    // must not make the cycle converge slower. Allow a tiny slack for the
+    // discrete iteration granularity.
+    assert!(
+        three_iters <= grad_iters + 1,
+        "three-space cycle converged slower than gradient-only: \
+         gradient-only = {grad_iters}, three-space = {three_iters}"
+    );
+
+    // Correctness: a preconditioner must NOT change the eigenvalues.
+    assert_eq!(
+        grad_modes.len(),
+        three_modes.len(),
+        "gradient-only and three-space returned different mode counts"
+    );
+    for (i, (g, t)) in grad_modes.iter().zip(three_modes.iter()).enumerate() {
+        let rel = (g.lambda - t.lambda).abs() / g.lambda.abs().max(1.0);
+        assert!(
+            rel < 1e-5,
+            "mode[{i}] gradient-only λ={} three-space λ={} rel-diff={rel:.2e} > 1e-5 \
+             (a preconditioner must not change the eigenvalues)",
+            g.lambda,
+            t.lambda
         );
     }
 }


### PR DESCRIPTION
## Summary

Completes the Hiptmair–Xu AMS operator in `crates/geode-core/src/eigen/ams.rs` by adding the **vector-nodal `Π` auxiliary-space correction** `Π (ΠᵀAΠ)⁻¹ Πᵀ`. The `AmsLitePreconditioner` previously corrected only the scalar gradient near-kernel (`G(GᵀAG)⁻¹Gᵀ`); the new vector-nodal block corrects the H(curl) error components the gradient space does not reach — the standard three-space cycle (edge smoother + gradient space + vector-nodal space).

The vector-nodal block is built only when the discrete gradient carries per-edge geometry, so the gradient-only two-space cycle stays the default and the change is purely additive.

## Changes

- **`ams.rs`**: build and cache `Π` (`edge_dim × 3·node_dim`) from `G`'s node-column incidence and the per-edge vectors `d_e = p_b − p_a`, plus a cached LU of the SPD coarse operator `ΠᵀAΠ` (node-vector-indexed, `O(node_dim)` fill — no edge-space factorization). Wire the `Π (ΠᵀAΠ)⁻¹ Πᵀ` correction into **both** apply modes (additive `apply` and multiplicative `apply_vcycle`), combined additively on the same residual so each cycle stays SPD. A tiny relative Tikhonov shift (`τ = 1e-8·max|diag|`) guards the `ΠᵀAΠ` LU against a rank-deficient `Π` on coarse meshes.
- **`projection.rs`**: `InteriorGradient` carries optional per-reduced-edge-row edge vectors via `with_edge_vectors` / `edge_vectors()`. Their presence is exactly the switch from the two-space to the three-space cycle — no lanczos plumbing needed since the gradient already flows to the AMS build.
- **`transmon.rs`**: add `solve_transmon_eigenmodes_matrix_free_inner_iters_three_space`, which attaches the mesh edge geometry, as the apples-to-apples measurement vehicle.
- **tests**: three-space SPD unit tests (both apply modes), a `Π`-coarse-solve consistency test, and the inner-CG iteration-count comparison on the genuine synthetic Nédélec curl-curl fixture.

## Iteration-count measurement (acceptance criterion 4)

Measured through the SAME instrumented matrix-free path (`InnerPreconditioner::Ams`) on the synthetic Nédélec curl-curl fixture, gradient-only vs three-space, apples-to-apples in one build:

| Configuration | Total inner-CG iterations |
|---|---|
| gradient-only two-space AMS | **6254** |
| full three-space AMS (+ Π) | **4003** |
| reduction | **1.562×** |

Config: `synthetic_fixture(6)`, `σ = −0.5` (below the cavity spectrum ⇒ `(K − σM)` SPD ⇒ inner CG converges under both preconditioners), `n_modes = 4`. Eigenvalues identical to `< 1e-5` relative across the two runs (a preconditioner only moves the iteration path).

**Why not `transmon_smoke.msh`:** at the physical `σ = 4.5 GHz` the ungauged 133k pencil is indefinite (the `image(d⁰)` near-kernel sits below the shift), so plain/AMS **CG breaks down** and no iteration count is readable — exactly the weakness this block improves but not a readable measurement point. The synthetic curl-curl fixture is the converging apples-to-apples vehicle the issue's measurement note endorses. The 133k / 1.16M numbers remain the gate for sub-phase 1c (#531).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `Π` and `ΠᵀAΠ` implemented, wired into **both** apply modes | ✅ | `build_pi` / `build_pi_ata_lu`; `apply` and `apply_vcycle` both add the correction when `Π` present (`vector_nodal_space_present_iff_geometry_supplied` pins dims) |
| Spectrum unchanged | ✅ | `synthetic_ams_matches_direct`, `synthetic_matrix_free_matches_direct`, `synthetic_ams_beats_jacobi_inner_iterations`, and the new comparison all pass with eigenvalues `< 1e-5` rel; 375 lib unit tests + 13 active transmon tests green |
| Preconditioner SPD (`⟨Mr,r⟩ > 0` + symmetry on random residual) | ✅ | `full_three_space_apply_is_spd` (both modes, 6 residuals + symmetry) |
| Iteration count instrumented + reported | ✅ | `synthetic_three_space_vs_gradient_only_inner_iterations`: 6254 → 4003 (1.562×), printed with `--nocapture` |

## Test Plan

- `cargo test -p geode-core --lib` — 375 passed, 0 failed.
- `cargo test -p geode-core --test transmon_eigenmode` — 13 passed, 0 failed, 9 ignored (release-only 133k benchmarks, unchanged).
- `cargo fmt -p geode-core` + `cargo clippy -p geode-core` — clean.

Closes #550