### PR TITLE
chore(bench): commit 1.16M mesh regen recipe + recovered at-scale run log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ Cargo.lock.bak
 
 # Build artifacts
 *.log
+# Committed benchmark evidence log (recovered at-scale run; see issue #556)
+!benchmarks/transmon_bench_cpu/geode_runs_1p16M_2026-07-15.log
 .loom-in-use
 .loom-checkpoint
 .loom/.daemon.pid

--- a/benchmarks/transmon_bench_cpu/geode_runs_1p16M_2026-07-15.log
+++ b/benchmarks/transmon_bench_cpu/geode_runs_1p16M_2026-07-15.log
@@ -1,0 +1,73 @@
+===== DIRECT (COLAMD) @ 1.16M  Wed Jul 15 15:34:15 UTC 2026 =====
+loading external mesh: /home/ubuntu/transmon_refine1.msh (47354117 bytes)
+fixture: 179547 nodes, 1066512 tets
+inner solver = Direct, target = 4.5 GHz, n_modes = 6
+PEC reduction: 1249522 edges -> 1157564 interior DOFs
+assembling sparse real pencil (nnz = 20467522)...
+setup (mesh+assembly) done in 35.78 s; shift sigma = 8.8949e-9
+computed modes (sorted by lambda):
+  mode[0]: f = 0.6215 GHz (lambda = 1.6969e-10), participation p = 0.0000
+  mode[1]: f = 0.7479 GHz (lambda = 2.4570e-10), participation p = 0.0000
+  mode[2]: f = 0.8627 GHz (lambda = 3.2689e-10), participation p = 0.0000
+  mode[3]: f = 2.4890 GHz (lambda = 2.7213e-9), participation p = 0.0000
+  mode[4]: f = 3.8938 GHz (lambda = 6.6598e-9), participation p = 0.9637
+  mode[5]: f = 5.4136 GHz (lambda = 1.2873e-8), participation p = 0.0011
+---
+SETUP_S = 35.784
+SOLVE_S = 529.747
+TOTAL_S = 565.531  (inner=Direct, n_interior_dofs=1157564, n_modes=6, target=4.5GHz)
+	Command being timed: "./target/release/examples/transmon_bench /home/ubuntu/transmon_refine1.msh"
+	User time (seconds): 2807.74
+	System time (seconds): 315.44
+	Percent of CPU this job got: 551%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 9:26.65
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 92166884
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 0
+	Minor (reclaiming a frame) page faults: 28325319
+	Voluntary context switches: 21248769
+	Involuntary context switches: 1754434
+	Swaps: 0
+	File system inputs: 0
+	File system outputs: 16
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+===== AMD (DirectCustomOrder) @ 1.16M  Wed Jul 15 15:43:41 UTC 2026 =====
+loading external mesh: /home/ubuntu/transmon_refine1.msh (47354117 bytes)
+fixture: 179547 nodes, 1066512 tets
+inner solver = DirectCustomOrder, target = 4.5 GHz, n_modes = 6
+PEC reduction: 1249522 edges -> 1157564 interior DOFs
+assembling sparse real pencil (nnz = 20467522)...
+setup (mesh+assembly) done in 30.04 s; shift sigma = 8.8949e-9
+Command terminated by signal 9
+	Command being timed: "./target/release/examples/transmon_bench /home/ubuntu/transmon_refine1.msh"
+	User time (seconds): 649.97
+	System time (seconds): 76.54
+	Percent of CPU this job got: 290%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 4:10.49
+	Average shared text size (kbytes): 0
+	Average unshared data size (kbytes): 0
+	Average stack size (kbytes): 0
+	Average total size (kbytes): 0
+	Maximum resident set size (kbytes): 128565428
+	Average resident set size (kbytes): 0
+	Major (requiring I/O) page faults: 1
+	Minor (reclaiming a frame) page faults: 39971896
+	Voluntary context switches: 1822941
+	Involuntary context switches: 51844
+	Swaps: 0
+	File system inputs: 256
+	File system outputs: 8
+	Socket messages sent: 0
+	Socket messages received: 0
+	Signals delivered: 0
+	Page size (bytes): 4096
+	Exit status: 0
+===== ALL_RUNS_DONE  Wed Jul 15 15:47:52 UTC 2026 =====

--- a/crates/geode-core/tests/fixtures/.gitignore
+++ b/crates/geode-core/tests/fixtures/.gitignore
@@ -1,0 +1,5 @@
+# The 1.16M-DOF at-scale mesh is DERIVED and intentionally NOT committed
+# (47 MB blob). Regenerate in ~1.3 s from transmon_smoke.msh per the recipe in
+# transmon_refine1.provenance.txt. This rule prevents accidental commits of the
+# regenerated file. See issue #556.
+transmon_refine1.msh

--- a/crates/geode-core/tests/fixtures/transmon_refine1.provenance.txt
+++ b/crates/geode-core/tests/fixtures/transmon_refine1.provenance.txt
@@ -1,0 +1,33 @@
+fixture:        transmon_refine1.msh  (the 1.16M-DOF at-scale benchmark mesh)
+kind:           DERIVED — one uniform Gmsh refinement of transmon_smoke.msh
+NOT COMMITTED:  the 47 MB .msh blob is intentionally NOT in the repo. It is
+                regenerable in ~1.3 s from the committed base fixture with the
+                one-line recipe below, so it never needs to live as a single
+                copy on a remote box (see the 2026-07-15 recovery incident).
+
+recipe (deterministic; Gmsh 4.15.2):
+    gmsh crates/geode-core/tests/fixtures/transmon_smoke.msh \
+         -refine -format msh41 -o transmon_refine1.msh
+
+base fixture:   transmon_smoke.msh  (see transmon_smoke.provenance.txt —
+                DeviceLayout.jl v1.15.0 SingleTransmon, Tet4, MSH 4.1 ASCII)
+refinement:     one uniform 3-D subdivision (each tet -> 8 children)
+
+counts (base -> refined):
+    nodes:      22684    -> 179547
+    tets:       133314   -> 1066512   (8x)
+    elements:   (total)  -> 1125824   ($Elements header, tets + surface tris)
+
+solver-relevant (from the geode transmon pipeline at 4.5 GHz, 6 modes):
+    interior DOFs after PEC reduction: 1157564   (1249522 edges -> 1157564)
+    real-pencil nnz:                   20467522
+
+use:            the at-scale gate for epic #547 / #531 sub-phase 1c. Run via the
+                committed harness:
+                  GEODE_INNER=minres GEODE_SIGMA_GHZ=4.5 GEODE_NMODES=6 \
+                    ./target/release/examples/transmon_bench transmon_refine1.msh
+                (matrixfree/plain-CG is invalid at sigma=4.5 — the ungauged
+                 pencil is indefinite; use the minres/MatrixFreeIndefinite path.)
+
+recovered-copy: /Users/rwalters/geode-recovery-2026-07-15/transmon_refine1.msh
+                (convenience cache only; the recipe above is the source of truth)


### PR DESCRIPTION
## Summary
Makes the 1.16M-DOF transmon benchmark artifacts durable in-repo so they never again live only on an ephemeral EC2 box (2026-07-15 we ran a volume-snapshot rescue to recover them). Two small tracked files; the 47 MB `.msh` blob is intentionally **not** committed — it regenerates in ~1.3 s from the already-committed `transmon_smoke.msh`.

## Changes
- **`crates/geode-core/tests/fixtures/transmon_refine1.provenance.txt`** (new) — deterministic Gmsh recipe that regenerates the at-scale mesh (verified: 179547 nodes / 1125824 elements) from the committed base fixture, plus solver-relevant counts.
- **`benchmarks/transmon_bench_cpu/geode_runs_1p16M_2026-07-15.log`** (new) — recovered primary evidence behind the memory-abundance finding (r6i.4xlarge, 128 GB, us-east-1): DIRECT completes at 565.5 s / 92.2 GB (RSS 92166884 kB); AMD `DirectCustomOrder` OOM-kills (signal 9) at 128.5 GB (RSS 128565428 kB).
- **`crates/geode-core/tests/fixtures/.gitignore`** (new) — ignores `transmon_refine1.msh` so the regenerated blob can never be accidentally committed.
- **`.gitignore`** — negation rule so the committed evidence log survives the global `*.log` ignore.

## Notes
- No `.msh` blob staged (`git check-ignore` confirms `transmon_refine1.msh` is ignored).
- File contents copied byte-for-byte from issue #556 (diffed IDENTICAL against the fenced blocks).
- `benchmarks/transmon_bench_cpu/` has no README/index, so no pointer added.
- Docs/data-only; `cargo build -p geode-core` still green.

Part of #547.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)