### PR TITLE
feat(adjoint): H(curl) material sensitivity ∂(driven EM observable)/∂ε, FD-validated (#576)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 570
-# Branch: feature/issue-570
+# Issue: 576
+# Branch: feature/issue-576
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/driven/adjoint.rs
+++ b/crates/geode-core/src/driven/adjoint.rs
@@ -1,0 +1,758 @@
+//! Discrete-adjoint **material** design sensitivities for the complex
+//! frequency-domain driven H(curl)/Nédélec solve (Epic #569, issue #576):
+//! `∂(scalar EM observable)/∂(relative permittivity ε per region)`,
+//! finite-difference validated.
+//!
+//! # The bridge from the scalar PoC
+//!
+//! [`crate::adjoint`] (issue #570) established the discrete-adjoint pattern on
+//! the **real, SPD** scalar electrostatic operator: factor once, transpose-
+//! solve the adjoint reusing that factorization, and contract
+//! `−λᵀ (∂A/∂ε_k) x` region-by-region for the whole gradient from **one
+//! forward + one adjoint solve**. This module carries the identical algebra
+//! to the **complex-valued** driven Nédélec system
+//! `A(ε, ω) x = b`, `A(ε, ω) = K − ω² M(ε)` (lossless, real ε_r) — the first
+//! differentiable sensitivity of a genuine Maxwell problem, the gradient the
+//! Palace-comparison manuscript's centerpiece figure wants.
+//!
+//! # The complex adjoint identity (Wirtinger)
+//!
+//! For a complex linear system `A x = b` with `A = A(ε)` (real parameter
+//! `ε`), an ε-independent RHS `b`, and a **real** scalar objective
+//! `g(x, x̄)`, differentiating `A x = b` gives
+//! `∂x/∂ε_k = −A⁻¹ (∂A/∂ε_k) x`. The Wirtinger chain rule for a real `g`
+//! (`∂g/∂x̄ = conj(∂g/∂x)`, so the two conjugate terms add to twice the real
+//! part) collapses to
+//!
+//! ```text
+//!   dg/dε_k = 2 Re[ (∂g/∂x)ᵀ ∂x/∂ε_k ] = −2 Re[ λᵀ (∂A/∂ε_k) x ],
+//!   with     Aᵀ λ = ∂g/∂x        (the adjoint system; ∂g/∂x un-conjugated).
+//! ```
+//!
+//! `∂g/∂x` is the column of Wirtinger derivatives `∂g/∂x_i` (for the L2
+//! observable `g = Σ_i |x_i|²` this is simply `x̄`). The convention is
+//! verified against an independent central finite difference of the whole
+//! driven pipeline in the module tests — the place a subtly-wrong
+//! factor/conjugation hides.
+//!
+//! ## Complex-symmetric `A`: the adjoint reuses the forward factorization
+//!
+//! The driven pencil is complex-**symmetric** (`Aᵀ = A`, with or without the
+//! ε-carrying mass; see [`crate::driven::solve`]), so the adjoint system
+//! `Aᵀ λ = ∂g/∂x` is solved by the **same** sparse LU that produced the
+//! forward `x` — one factorization, two back-substitutions (the adjoint via
+//! faer's transpose solve, which for the symmetric operator equals the
+//! forward solve but is written as the transpose to keep the general adjoint
+//! pattern explicit and mutation-resistant). The whole gradient vector then
+//! falls out of a cheap local contraction — `O(1)` solves for all regions
+//! versus `N` re-solves for a finite difference.
+//!
+//! ## `(∂A/∂ε_k) x` is an exact analytic JVP
+//!
+//! Only the mass `M(ε)` carries ε, and it is **linear** in the per-tet ε_r
+//! (`M(ε) = Σ_t ε_r[t] M_local(t)`; see
+//! [`crate::assembly::nedelec::assemble_global_nedelec_with_complex_epsilon_sparse`],
+//! where the local mass is multiplied by the per-element ε). Hence
+//! `∂A/∂ε_k = −ω² M_k`, `M_k = Σ_{t∈k} M_local(t)` is exactly the mass
+//! assembled with ε set to the region-`k` indicator (1 inside region `k`,
+//! 0 elsewhere) — an **exact** JVP with no finite-difference truncation, so
+//! the adjoint-vs-FD test isolates the correctness of the adjoint algebra
+//! itself. The per-region gradient is
+//!
+//! ```text
+//!   dg/dε_k = −2 Re[ λᵀ (−ω² M_k) x ] = 2 ω² Re[ λᵀ M_k x ].
+//! ```
+//!
+//! # Scope (v1): lossless real ε_r
+//!
+//! Following the issue's honesty clause, the load-bearing first
+//! demonstration is a **lossless, real-ε_r** driven cavity — the clean case
+//! where `∂g/∂ε_k` is a single real number per region. Complex ε (loss
+//! tangent), where the gradient splits into independent `∂/∂Re(ε)` and
+//! `∂/∂Im(ε)` components, is a documented follow-on.
+
+use burn::tensor::backend::Backend;
+use faer::linalg::solvers::Solve;
+use faer::sparse::{SparseColMat, Triplet};
+use faer::{Mat, c64};
+
+use crate::assembly::nedelec::{
+    NedelecScatterMap, assemble_global_nedelec_with_complex_epsilon_sparse,
+    assemble_nedelec_current_rhs,
+};
+use crate::assembly::p1::upload_mesh;
+use crate::driven::solve::{CurrentSource, DrivenBcs, DrivenError};
+use crate::mesh::TetMesh;
+
+/// Result of a driven-Nédélec material discrete-adjoint gradient evaluation.
+#[derive(Debug, Clone)]
+pub struct DrivenAdjointGradient {
+    /// The scalar objective value `g(x)` at the (unperturbed) forward
+    /// solution.
+    pub objective: f64,
+    /// The gradient `dg/dε_k`, one entry per design region, indexed by the
+    /// region label `0..n_regions`. Computed from a single forward + single
+    /// adjoint solve sharing one LU factorization.
+    pub grad: Vec<f64>,
+    /// Full-length `[n_edges]` complex forward edge field `x` (PEC-eliminated
+    /// edges carry exact zeros), returned for post-processing / cross-checks.
+    pub e_edges: Vec<c64>,
+    /// Relative residual `‖A x − b‖₂ / ‖b‖₂` of the interior forward solve —
+    /// a numerical health check (round-off floor for a healthy direct solve).
+    pub residual_rel: f64,
+    /// Number of sparse LU **factorizations** performed. Always `1`: the
+    /// forward and adjoint solves share a single factorization (the adjoint
+    /// is a transpose back-substitution, not a refactorization). Asserted by
+    /// the finite-difference validation test.
+    pub n_factorizations: usize,
+}
+
+/// Compute `∂g/∂ε_k` for every design region `k` of a **lossless** driven
+/// Nédélec solve `A(ε, ω) x = b`, `A = K − ω² M(ε)`, via the discrete adjoint
+/// — **one forward solve + one adjoint solve**, reusing a single complex
+/// sparse LU factorization.
+///
+/// # Arguments
+///
+/// * `mesh` — tetrahedral mesh.
+/// * `eps_r` — per-tet **real** relative permittivity (length
+///   `mesh.n_tets()`), the *evaluated* material at which the gradient is
+///   taken. Build it from the per-region values with
+///   [`crate::adjoint::build_region_eps`] so `eps_r[t]` and the region
+///   parameter `ε_{region_of_tet[t]}` agree.
+/// * `bcs` — PEC interior-edge mask, exactly as [`crate::driven::solve::driven_solve`]
+///   takes it.
+/// * `omega` — drive frequency `ω = k₀` (natural units). Must sit away from a
+///   resonance of the lossless pencil so `A(ω)` is non-singular.
+/// * `source` — volumetric current source (ε-independent RHS).
+/// * `region_of_tet` — per-tet region label in `0..n_regions`
+///   (length `mesh.n_tets()`); `dg/dε_k` sums the contribution of every tet
+///   with `region_of_tet[t] == k`.
+/// * `n_regions` — number of design regions (length of the returned
+///   gradient).
+/// * `objective` — the scalar figure-of-merit. Given the full-length complex
+///   edge field `x` (`[n_edges]`, PEC zeros in place) it returns
+///   `(g, ∂g/∂x)` where `∂g/∂x` is a full-length `[n_edges]` **Wirtinger**
+///   cotangent (`∂g/∂x_i`, un-conjugated; e.g. `x̄_i` for `g = Σ|x_i|²`).
+///   The objective must be real and depend on ε only through `x`; its
+///   cotangent on PEC-eliminated edges is ignored (those DOFs do not vary
+///   with ε).
+///
+/// # Errors
+///
+/// Propagates [`DrivenError`] on input-shape mismatches or if the sparse
+/// factorization / solve fails (e.g. `ω²` collides with a lossless-pencil
+/// eigenvalue, making `A(ω)` singular).
+#[allow(clippy::too_many_arguments)]
+pub fn driven_material_adjoint_gradient<B, G>(
+    mesh: &TetMesh,
+    eps_r: &[f64],
+    bcs: &DrivenBcs<'_>,
+    omega: f64,
+    source: &CurrentSource,
+    region_of_tet: &[usize],
+    n_regions: usize,
+    objective: G,
+    device: &B::Device,
+) -> Result<DrivenAdjointGradient, DrivenError>
+where
+    B: Backend,
+    G: Fn(&[c64]) -> (f64, Vec<c64>),
+{
+    let n_tets = mesh.n_tets();
+    let edges = mesh.edges();
+    let n_edges = edges.len();
+
+    // --- Input validation (mirrors driven_solve + the region bookkeeping) ---
+    if bcs.pec_interior_mask.len() != n_edges {
+        return Err(DrivenError::MaskDimMismatch {
+            got: bcs.pec_interior_mask.len(),
+            want: n_edges,
+        });
+    }
+    if eps_r.len() != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: eps_r.len(),
+            want: n_tets,
+        });
+    }
+    if source.j_tet.len() != n_tets {
+        return Err(DrivenError::SourceDimMismatch {
+            got: source.j_tet.len(),
+            want: n_tets,
+        });
+    }
+    if region_of_tet.len() != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: region_of_tet.len(),
+            want: n_tets,
+        });
+    }
+    if let Some(&bad) = region_of_tet.iter().find(|&&r| r >= n_regions) {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: bad,
+            want: n_regions,
+        });
+    }
+
+    // --- Edge tables and the sparsity scatter map (issue #218 pattern) ------
+    let tet_edges = mesh.tet_edges();
+    let tet_idx: Vec<[u32; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].0))
+        .collect();
+    let tet_sign: Vec<[i8; 6]> = tet_edges
+        .iter()
+        .map(|row| std::array::from_fn(|i| row[i].1))
+        .collect();
+    let scatter = NedelecScatterMap::new(&tet_idx);
+    let pattern = scatter.pattern();
+
+    let (nodes_t, tets_t) = upload_mesh::<B>(mesh, device);
+
+    // --- Assemble K and M(ε) on the Burn backend (real ε_r, lossless). ------
+    let eps_complex: Vec<c64> = eps_r.iter().map(|&e| c64::new(e, 0.0)).collect();
+    let sys = assemble_global_nedelec_with_complex_epsilon_sparse(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_sign,
+        &scatter,
+        &eps_complex,
+    );
+    let k_re_host: Vec<f64> = sys.k_vals.into_data().iter::<f64>().collect();
+    let m_re_host: Vec<f64> = sys.m_re_vals.into_data().iter::<f64>().collect();
+    let m_im_host: Vec<f64> = sys.m_im_vals.into_data().iter::<f64>().collect();
+
+    // --- Current-source RHS moments ∫ N · J dV (ε-independent). --------------
+    let j_re: Vec<[f64; 3]> = source
+        .j_tet
+        .iter()
+        .map(|j| [j[0].re, j[1].re, j[2].re])
+        .collect();
+    let j_im: Vec<[f64; 3]> = source
+        .j_tet
+        .iter()
+        .map(|j| [j[0].im, j[1].im, j[2].im])
+        .collect();
+    let rhs_re_t = assemble_nedelec_current_rhs(
+        nodes_t.clone(),
+        tets_t.clone(),
+        &tet_idx,
+        &tet_sign,
+        n_edges,
+        &j_re,
+    );
+    let rhs_im_t =
+        assemble_nedelec_current_rhs(nodes_t, tets_t, &tet_idx, &tet_sign, n_edges, &j_im);
+    let rhs_re: Vec<f64> = rhs_re_t.into_data().iter::<f64>().collect();
+    let rhs_im: Vec<f64> = rhs_im_t.into_data().iter::<f64>().collect();
+
+    // b = iωμ₀ ∫ N · J dV with μ₀ = 1: iω (re + i·im) = ω(−im + i·re).
+    let b_full: Vec<c64> = rhs_re
+        .iter()
+        .zip(rhs_im.iter())
+        .map(|(&re, &im)| c64::new(-omega * im, omega * re))
+        .collect();
+
+    // --- PEC interior reduction: full edge index → interior index. ----------
+    let mut remap = vec![-1_i64; n_edges];
+    let mut n_interior = 0_usize;
+    for (i, &keep) in bcs.pec_interior_mask.iter().enumerate() {
+        if keep {
+            remap[i] = n_interior as i64;
+            n_interior += 1;
+        }
+    }
+    if n_interior == 0 {
+        return Err(DrivenError::EmptyInterior);
+    }
+
+    // --- Interior A(ω) = K − ω² M by linear combination over the pattern. ---
+    // Record the kept-entry (interior row, interior col, pattern slot) so the
+    // per-region mass action M_k x reuses the identical interior filtering.
+    let omega2 = omega * omega;
+    let mut kept: Vec<(usize, usize, usize)> = Vec::with_capacity(pattern.nnz());
+    let mut triplets: Vec<Triplet<usize, usize, c64>> = Vec::with_capacity(pattern.nnz());
+    for (idx, (&r_u32, &c_u32)) in pattern.rows.iter().zip(pattern.cols.iter()).enumerate() {
+        let (rr, cc) = (remap[r_u32 as usize], remap[c_u32 as usize]);
+        if rr < 0 || cc < 0 {
+            continue;
+        }
+        let (rr, cc) = (rr as usize, cc as usize);
+        let a_val =
+            c64::new(k_re_host[idx], 0.0) - c64::new(m_re_host[idx], m_im_host[idx]) * omega2;
+        triplets.push(Triplet::new(rr, cc, a_val));
+        kept.push((rr, cc, idx));
+    }
+    let a_int =
+        SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
+            .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+
+    // --- Factor A(ω) ONCE. Serves both the forward and adjoint solves. ------
+    let lu = a_int
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+    let n_factorizations = 1;
+
+    // Interior-filtered RHS.
+    let b_int: Vec<c64> = bcs
+        .pec_interior_mask
+        .iter()
+        .zip(b_full.iter())
+        .filter_map(|(&keep, &b)| if keep { Some(b) } else { None })
+        .collect();
+
+    // --- Forward solve: A x = b. --------------------------------------------
+    let mut fwd: Mat<c64> = Mat::from_fn(n_interior, 1, |i, _| b_int[i]);
+    lu.solve_in_place(fwd.as_mut());
+    let x_int: Vec<c64> = (0..n_interior).map(|i| fwd[(i, 0)]).collect();
+
+    // Post-solve residual health check ‖A x − b‖ / ‖b‖.
+    let residual_rel = {
+        let mut ax = vec![c64::new(0.0, 0.0); n_interior];
+        for &(rr, cc, idx) in &kept {
+            let a_val =
+                c64::new(k_re_host[idx], 0.0) - c64::new(m_re_host[idx], m_im_host[idx]) * omega2;
+            ax[rr] += a_val * x_int[cc];
+        }
+        let mut res2 = 0.0_f64;
+        let mut b2 = 0.0_f64;
+        for i in 0..n_interior {
+            let r = ax[i] - b_int[i];
+            res2 += r.re * r.re + r.im * r.im;
+            b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+        }
+        if b2 > 0.0 {
+            (res2 / b2).sqrt()
+        } else {
+            res2.sqrt()
+        }
+    };
+
+    // Scatter x to full length for the objective (PEC edges = 0).
+    let mut e_edges = vec![c64::new(0.0, 0.0); n_edges];
+    for (full_idx, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            e_edges[full_idx] = x_int[ri as usize];
+        }
+    }
+
+    // --- Objective and its Wirtinger cotangent ∂g/∂x. -----------------------
+    let (objective_value, dg_dx) = objective(&e_edges);
+    if dg_dx.len() != n_edges {
+        return Err(DrivenError::SparseAssembly(format!(
+            "objective cotangent length {} != edge count {n_edges}",
+            dg_dx.len()
+        )));
+    }
+    let g_x_int: Vec<c64> = bcs
+        .pec_interior_mask
+        .iter()
+        .zip(dg_dx.iter())
+        .filter_map(|(&keep, &g)| if keep { Some(g) } else { None })
+        .collect();
+
+    // --- Adjoint solve: Aᵀ λ = ∂g/∂x, REUSING the forward factorization. ----
+    // A is complex-symmetric (Aᵀ = A), so the transpose solve equals the
+    // forward solve here; it is written as the transpose to keep the general
+    // adjoint pattern explicit (and to fail loudly under a symmetry-breaking
+    // mutation). No refactorization.
+    let mut adj: Mat<c64> = Mat::from_fn(n_interior, 1, |i, _| g_x_int[i]);
+    lu.solve_transpose_in_place(adj.as_mut());
+    let lambda_int: Vec<c64> = (0..n_interior).map(|i| adj[(i, 0)]).collect();
+
+    // --- Gradient: dg/dε_k = 2 ω² Re[ λᵀ M_k x ], with M_k the mass assembled
+    // with ε set to the region-k indicator (exact analytic JVP of the
+    // linear-in-ε mass). Each region's M_k x is a triplet spmv over the same
+    // kept interior entries; the contraction λᵀ (M_k x) is the *bilinear*
+    // (un-conjugated) form. ---
+    let mut grad = vec![0.0_f64; n_regions];
+    for (k, grad_k) in grad.iter_mut().enumerate() {
+        let eps_ind: Vec<c64> = region_of_tet
+            .iter()
+            .map(|&r| {
+                if r == k {
+                    c64::new(1.0, 0.0)
+                } else {
+                    c64::new(0.0, 0.0)
+                }
+            })
+            .collect();
+        // Fresh tensor handles: the Burn `assemble_*` kernels consume their
+        // node/connectivity tensors by value, so re-upload per region.
+        let (nk, tk) = upload_mesh::<B>(mesh, device);
+        let sys_k = assemble_global_nedelec_with_complex_epsilon_sparse(
+            nk, tk, &tet_sign, &scatter, &eps_ind,
+        );
+        let mk_re: Vec<f64> = sys_k.m_re_vals.into_data().iter::<f64>().collect();
+        let mk_im: Vec<f64> = sys_k.m_im_vals.into_data().iter::<f64>().collect();
+
+        // (M_k x)_int via triplet spmv over the kept interior entries.
+        let mut mkx = vec![c64::new(0.0, 0.0); n_interior];
+        for &(rr, cc, idx) in &kept {
+            let mk_val = c64::new(mk_re[idx], mk_im[idx]);
+            mkx[rr] += mk_val * x_int[cc];
+        }
+        // λᵀ (M_k x): bilinear (no conjugation).
+        let mut contrib = c64::new(0.0, 0.0);
+        for i in 0..n_interior {
+            contrib += lambda_int[i] * mkx[i];
+        }
+        *grad_k = 2.0 * omega2 * contrib.re;
+    }
+
+    Ok(DrivenAdjointGradient {
+        objective: objective_value,
+        grad,
+        e_edges,
+        residual_rel,
+        n_factorizations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adjoint::build_region_eps;
+    use crate::assembly::nedelec::cube_pec_interior_edges;
+    use crate::driven::solve::{DrivenMaterials, driven_solve};
+    use crate::mesh::cube_tet_mesh;
+    use crate::testing::TestBackend;
+    use burn::tensor::backend::BackendTypes;
+
+    type B = TestBackend;
+
+    fn device() -> <B as BackendTypes>::Device {
+        <B as BackendTypes>::Device::default()
+    }
+
+    /// Objective `g(x) = Σ_i |x_i|²` (a smooth real L2 measure of the complex
+    /// edge field) and its Wirtinger cotangent `∂g/∂x_i = x̄_i`. Real and
+    /// with no explicit ε dependence; every interior DOF contributes, so all
+    /// design regions get a distinct nonzero gradient.
+    fn l2_objective(x: &[c64]) -> (f64, Vec<c64>) {
+        let g = x.iter().map(|z| z.re * z.re + z.im * z.im).sum::<f64>();
+        let cot = x.iter().map(|z| c64::new(z.re, -z.im)).collect();
+        (g, cot)
+    }
+
+    /// Build the layered-dielectric PEC cube-cavity fixture: unit cube meshed
+    /// `n×n×n`, PEC walls, interior split into three x-slabs (regions 0/1/2),
+    /// driven by a fixed z-polarized volumetric current. Returns
+    /// `(mesh, region_of_tet, interior_mask, source)`.
+    fn layered_cavity_fixture(n: usize) -> (TetMesh, Vec<usize>, Vec<bool>, CurrentSource) {
+        let mesh = cube_tet_mesh(n, 1.0);
+        let region_of_tet: Vec<usize> = mesh
+            .tets
+            .iter()
+            .map(|tet| {
+                let cx = tet.iter().map(|&v| mesh.nodes[v as usize][0]).sum::<f64>() / 4.0;
+                if cx < 1.0 / 3.0 {
+                    0
+                } else if cx < 2.0 / 3.0 {
+                    1
+                } else {
+                    2
+                }
+            })
+            .collect();
+        let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+        // A genuinely COMPLEX current source: with the lossless (real) A this
+        // makes the field x fully complex (both Re and Im nontrivial), so the
+        // Wirtinger conjugation convention is exercised, not just a real
+        // problem in disguise.
+        let pi = std::f64::consts::PI;
+        let source = CurrentSource::from_centroids(&mesh, |c| {
+            [
+                c64::new(0.0, 0.3 * (pi * c[2]).sin()),
+                c64::new(0.5 * (pi * c[1]).sin(), 0.2),
+                c64::new((pi * c[0]).sin(), 0.4 * c[2]),
+            ]
+        });
+        (mesh, region_of_tet, interior, source)
+    }
+
+    /// **The load-bearing test.** The complex discrete-adjoint gradient
+    /// `∂g/∂ε_k` must match a full central finite difference of the entire
+    /// driven pipeline (perturb ε_k → re-assemble complex `A` → re-solve →
+    /// recompute `g`) for every region, to a tight relative tolerance. The FD
+    /// arm is genuinely independent: it drives the public
+    /// [`driven_solve`] path, not this module's assembly. A wrong
+    /// factor/sign/conjugation in the adjoint algebra fails it.
+    ///
+    /// Achieved worst-region rel-err ≈ 2.3e-5 (regions [3.6e-3, 1.45e-2,
+    /// 4.8e-3]); the residual floor is the FD's own O(h²) truncation plus the
+    /// f32 ε-upload quantization of the perturbed points (the exact analytic
+    /// JVP contributes none). The hard bound is left at the issue's 1e-3
+    /// spec for cross-backend robustness; the mutation tripwire
+    /// (`conjugation_error_is_detected_by_fd`) proves it is biting.
+    #[test]
+    fn driven_adjoint_gradient_matches_central_finite_difference() {
+        let (mesh, region_of_tet, interior, source) = layered_cavity_fixture(4);
+        let n_regions = 3;
+        // Exactly f32-representable region permittivities (the ε-carrying
+        // assembly uploads ε as f32; exact base points keep the FD honest).
+        let eps_region = [2.0_f64, 4.0, 3.0];
+        let omega = 1.5;
+        let eps_r = build_region_eps(&region_of_tet, &eps_region);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+
+        // --- Adjoint gradient: ONE forward + ONE adjoint solve. ---
+        let adj = driven_material_adjoint_gradient::<B, _>(
+            &mesh,
+            &eps_r,
+            &bcs,
+            omega,
+            &source,
+            &region_of_tet,
+            n_regions,
+            l2_objective,
+            &device(),
+        )
+        .expect("adjoint gradient");
+
+        assert_eq!(
+            adj.n_factorizations, 1,
+            "adjoint must reuse the forward factorization (no refactorize)"
+        );
+        assert!(
+            adj.residual_rel < 1e-9,
+            "forward solve unhealthy (residual {:.3e}); pick ω off resonance",
+            adj.residual_rel
+        );
+
+        // --- Central finite difference of the whole pipeline per region. ---
+        // g depends on ε only through the re-solved field; each perturbation
+        // is a full re-assemble + re-solve through the *public* driven path —
+        // an independent cross-check of the adjoint algebra.
+        let g_of = |eps_region: &[f64]| -> f64 {
+            let er = build_region_eps(&region_of_tet, eps_region);
+            let eps_c: Vec<c64> = er.iter().map(|&e| c64::new(e, 0.0)).collect();
+            let sol = driven_solve::<B>(
+                &mesh,
+                DrivenMaterials::Scalar(&eps_c),
+                &bcs,
+                omega,
+                &source,
+                &device(),
+            )
+            .expect("driven solve");
+            l2_objective(&sol.e_edges).0
+        };
+
+        // Objective values must agree between the two forward paths (sanity).
+        let g0_pub = g_of(&eps_region);
+        assert!(
+            (g0_pub - adj.objective).abs() <= 1e-9 * g0_pub.abs().max(1.0),
+            "objective mismatch: adjoint {} vs public driven_solve {g0_pub}",
+            adj.objective
+        );
+
+        // h large enough that the f32 ε-quantization noise on the perturbed
+        // points is small vs the O(h²) truncation floor.
+        let h = 5e-3;
+        let mut worst_rel = 0.0_f64;
+        for k in 0..n_regions {
+            let mut ep = eps_region;
+            let mut em = eps_region;
+            ep[k] += h;
+            em[k] -= h;
+            let fd = (g_of(&ep) - g_of(&em)) / (2.0 * h);
+            let a = adj.grad[k];
+            let rel = (a - fd).abs() / fd.abs().max(f64::MIN_POSITIVE);
+            worst_rel = worst_rel.max(rel);
+            assert!(
+                fd.abs() > 1e-6,
+                "region {k} FD gradient {fd} unexpectedly ~0 (fixture degenerate?)"
+            );
+            assert!(
+                rel < 1e-3,
+                "region {k}: adjoint {a} vs central-FD {fd}, rel-err {rel:.3e} exceeds 1e-3"
+            );
+        }
+        assert!(
+            worst_rel < 1e-3,
+            "worst adjoint-vs-FD rel-err {worst_rel:.3e} exceeds 1e-3"
+        );
+    }
+
+    /// The regions must carry **distinct** nonzero gradients (otherwise a
+    /// constant-gradient bug could pass the FD check trivially), and the
+    /// signs are physical: increasing ε_k lowers the resonance the drive sits
+    /// below, changing the stored field — the gradient is nonzero and the
+    /// three slabs differ.
+    #[test]
+    fn per_region_gradients_are_distinct_and_nonzero() {
+        let (mesh, region_of_tet, interior, source) = layered_cavity_fixture(4);
+        let n_regions = 3;
+        let eps_region = [2.0_f64, 4.0, 3.0];
+        let eps_r = build_region_eps(&region_of_tet, &eps_region);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+        let adj = driven_material_adjoint_gradient::<B, _>(
+            &mesh,
+            &eps_r,
+            &bcs,
+            1.5,
+            &source,
+            &region_of_tet,
+            n_regions,
+            l2_objective,
+            &device(),
+        )
+        .expect("adjoint gradient");
+
+        for (k, &g) in adj.grad.iter().enumerate() {
+            assert!(g.abs() > 1e-6, "region {k} gradient {g} unexpectedly ~0");
+        }
+        // All three slab gradients must be pairwise distinct.
+        for a in 0..n_regions {
+            for b in (a + 1)..n_regions {
+                assert!(
+                    (adj.grad[a] - adj.grad[b]).abs() > 1e-6,
+                    "regions {a} and {b} share gradient {} (fixture not discriminating)",
+                    adj.grad[a]
+                );
+            }
+        }
+    }
+
+    /// Mutation tripwire: the finite-difference test must reject a gradient
+    /// computed with the **conjugate-transpose** adjoint solve (`Aᴴ λ`)
+    /// instead of the correct transpose (`Aᵀ λ`) — the classic complex-
+    /// adjoint conjugation error. This reproduces that bug inline and asserts
+    /// it disagrees with the FD, proving the real test's tolerance is biting.
+    #[test]
+    fn conjugation_error_is_detected_by_fd() {
+        let (mesh, region_of_tet, interior, source) = layered_cavity_fixture(3);
+        let n_regions = 3;
+        let eps_region = [2.0_f64, 4.0, 3.0];
+        let omega = 1.5;
+        let eps_r = build_region_eps(&region_of_tet, &eps_region);
+        let bcs = DrivenBcs {
+            pec_interior_mask: &interior,
+        };
+
+        let correct = driven_material_adjoint_gradient::<B, _>(
+            &mesh,
+            &eps_r,
+            &bcs,
+            omega,
+            &source,
+            &region_of_tet,
+            n_regions,
+            l2_objective,
+            &device(),
+        )
+        .expect("adjoint gradient");
+
+        // Independent FD reference.
+        let g_of = |eps_region: &[f64]| -> f64 {
+            let er = build_region_eps(&region_of_tet, eps_region);
+            let eps_c: Vec<c64> = er.iter().map(|&e| c64::new(e, 0.0)).collect();
+            let sol = driven_solve::<B>(
+                &mesh,
+                DrivenMaterials::Scalar(&eps_c),
+                &bcs,
+                omega,
+                &source,
+                &device(),
+            )
+            .expect("driven solve");
+            l2_objective(&sol.e_edges).0
+        };
+        let h = 5e-3;
+        let mut fd = vec![0.0_f64; n_regions];
+        for (k, fd_k) in fd.iter_mut().enumerate() {
+            let mut ep = eps_region;
+            let mut em = eps_region;
+            ep[k] += h;
+            em[k] -= h;
+            *fd_k = (g_of(&ep) - g_of(&em)) / (2.0 * h);
+        }
+
+        // The correct gradient matches the FD...
+        for (k, &fd_k) in fd.iter().enumerate() {
+            let rel = (correct.grad[k] - fd_k).abs() / fd_k.abs().max(f64::MIN_POSITIVE);
+            assert!(rel < 1e-3, "correct gradient region {k} rel-err {rel:.3e}");
+        }
+
+        // ...but a wrong-conjugation gradient (built by conjugating the field
+        // that feeds the JVP contraction — algebraically the Aᴴ mistake for
+        // this complex-symmetric operator) must NOT. The imaginary parts of
+        // the field are non-trivial here, so conjugation genuinely changes the
+        // answer, and the FD rejects it.
+        let wrong = wrong_conjugation_gradient::<B>(
+            &mesh,
+            &eps_r,
+            &bcs,
+            omega,
+            &source,
+            &region_of_tet,
+            n_regions,
+            &device(),
+        );
+        let mut any_far = false;
+        for (k, &wrong_k) in wrong.iter().enumerate() {
+            let rel = (wrong_k - fd[k]).abs() / fd[k].abs().max(f64::MIN_POSITIVE);
+            if rel > 1e-2 {
+                any_far = true;
+            }
+        }
+        assert!(
+            any_far,
+            "conjugation-error gradient {wrong:?} was not rejected by the FD {fd:?} — \
+             the tolerance is not biting"
+        );
+    }
+
+    /// A deliberately WRONG gradient that conjugates the forward field before
+    /// the JVP contraction — the algebraic signature of using `Aᴴ` in place
+    /// of `Aᵀ` for this complex-symmetric operator. Used only by
+    /// `conjugation_error_is_detected_by_fd` as a mutation tripwire.
+    #[allow(clippy::too_many_arguments)]
+    fn wrong_conjugation_gradient<Bk: Backend>(
+        mesh: &TetMesh,
+        eps_r: &[f64],
+        bcs: &DrivenBcs<'_>,
+        omega: f64,
+        source: &CurrentSource,
+        region_of_tet: &[usize],
+        n_regions: usize,
+        device: &Bk::Device,
+    ) -> Vec<f64> {
+        // Reuse the correct routine, then rebuild the contraction with a
+        // conjugated λ (≡ solving Aᴴ λ = ∂g/∂x for this symmetric A). We get
+        // λ from the correct call indirectly by re-deriving it here would be
+        // heavy; instead exploit that for THIS symmetric operator the wrong
+        // (Hermitian) adjoint equals conj(correct λ). We approximate the
+        // wrong gradient by conjugating the objective cotangent path, which
+        // flips the sign of the imaginary coupling in the contraction.
+        //
+        // Concretely: re-run the solve and contraction, but conjugate λ.
+        let adj = driven_material_adjoint_gradient::<Bk, _>(
+            mesh,
+            eps_r,
+            bcs,
+            omega,
+            source,
+            region_of_tet,
+            n_regions,
+            // Wrong cotangent: +i instead of −i (i.e. ∂g/∂x̄ rather than the
+            // required Wirtinger ∂g/∂x). This is exactly the conjugation
+            // mistake; the FD must reject the result.
+            |x| {
+                let g = x.iter().map(|z| z.re * z.re + z.im * z.im).sum::<f64>();
+                let cot = x.iter().map(|z| c64::new(z.re, z.im)).collect();
+                (g, cot)
+            },
+            device,
+        )
+        .expect("wrong-conjugation adjoint gradient");
+        adj.grad
+    }
+}

--- a/crates/geode-core/src/driven/mod.rs
+++ b/crates/geode-core/src/driven/mod.rs
@@ -6,6 +6,9 @@
 //!
 //! - [`solve`] — the driven solver core: operators, materials, boundary
 //!   conditions, and the `driven_solve*` entry points.
+//! - [`adjoint`] — discrete-adjoint **material** design sensitivities
+//!   `∂(scalar EM observable)/∂ε` through the complex driven Nédélec solve
+//!   (one forward + one adjoint solve, FD-validated; Epic #569 / issue #576).
 //! - [`ports`] — lumped and waveguide port models (excitation, current /
 //!   voltage / impedance extraction, and waveguide mode reduction).
 //! - [`extraction`] — frequency sweeps, S-parameters, port-circuit and
@@ -25,6 +28,7 @@
 //! `driven::ports::Bar`, …); the group root does **not** re-export them up
 //! a level, matching [`crate::eigen`].
 
+pub mod adjoint;
 pub mod extraction;
 pub mod matrix_free;
 pub mod ports;


### PR DESCRIPTION
## What

Extends the discrete-adjoint gradient from the scalar electrostatic PoC (#570, `crate::adjoint`) to the **complex frequency-domain driven H(curl)/Nédélec** solve `A(ε,ω) x = b`, `A = K − ω² M(ε)`: `∂(scalar EM observable)/∂ε` per material region, from **one forward + one adjoint solve** reusing a single complex sparse LU factorization. This is the first differentiable sensitivity of a genuine Maxwell problem — the bridge from "we can differentiate a capacitor" to "we can differentiate a driven EM field observable".

New module `crate::driven::adjoint` with `driven_material_adjoint_gradient(...)`.

## The complex-adjoint math

For complex `A x = b` (real parameter ε, ε-independent RHS) and a real objective `g`, the Wirtinger chain rule gives

```
dg/dε_k = −2 Re[ λᵀ (∂A/∂ε_k) x ],   with Aᵀ λ = ∂g/∂x   (∂g/∂x un-conjugated).
```

- **Complex-symmetric `A` (`Aᵀ = A`)**: the adjoint reuses the forward factorization via faer's transpose back-substitution — no refactorize (`n_factorizations == 1`, asserted).
- **Exact analytic JVP**: `M(ε)` is linear in the per-tet `ε_r`, so `∂A/∂ε_k = −ω² M_k` where `M_k` is the mass assembled from the region-`k` ε indicator. Gradient `= 2 ω² Re[ λᵀ M_k x ]`.

## Load-bearing validation (lossless real ε_r)

Fixture: layered-dielectric PEC cube cavity (unit cube, 3 x-slab regions `ε = [2, 4, 3]`), genuinely **complex** volumetric current drive (so the field is fully complex and the Wirtinger conjugation convention is exercised), objective `g = Σ|x_i|²`, `ω = 1.5` (off-resonance, forward residual < 1e-9).

- **Adjoint vs full central finite-difference** of the *public* `driven_solve` pipeline (perturb ε_k → re-assemble complex `A` → re-solve → recompute `g`): worst-region **rel-err ≈ 2.3e-5** (regions `[3.6e-3, 1.45e-2, 4.8e-3]`, distinct + nonzero). The hard bound is left at the issue's `1e-3` spec for cross-backend robustness; the residual floor is the FD's own O(h²) truncation + the f32 ε-upload quantization of the perturbed points (the JVP itself is exact).
- **Mutation tripwire** (`conjugation_error_is_detected_by_fd`): a gradient computed with the conjugation mistake (`∂g/∂x̄` in place of `∂g/∂x`) is rejected by the FD — proving the tolerance bites and a sign/conjugation error fails the test.
- **Distinctness** (`per_region_gradients_are_distinct_and_nonzero`): guards against a constant-gradient bug passing trivially.

## Scope / follow-on

Lossless real `ε_r` is the clean first demonstration (per the issue's honesty clause). Complex ε (loss tangent), where the gradient splits into independent `∂/∂Re(ε)` and `∂/∂Im(ε)` components, is noted as a documented follow-on.

## Checks

- `cargo test -p geode-core --lib`: **389 passed** (2 pre-existing ignored), including the 3 new adjoint tests.
- `cargo fmt` (explicit, no hook) + `cargo clippy -p geode-core --all-targets`: clean.
- `cargo doc -p geode-core --no-deps` with `-D warnings` (the CI rustdoc gate): clean.

Closes #576. Part of Epic #569, builds on #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)