### PR TITLE
feat(eigen): Hellmann–Feynman eigenvalue sensitivities ∂λ/∂p (Phase A, #596)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 594
-# Branch: feature/issue-594
+# Issue: 596
+# Branch: feature/issue-596
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/driven/shape.rs
+++ b/crates/geode-core/src/driven/shape.rs
@@ -109,19 +109,25 @@ use crate::mesh::{TET_LOCAL_EDGES, TetMesh};
 /// evaluating [`nedelec_local_dual`] returns, in the `.du` fields of the
 /// resulting local matrices / RHS moments, the exact partial derivatives of
 /// those entries w.r.t. that coordinate.
+///
+/// `pub(crate)`: shared with [`crate::eigen::sensitivity`] (issue #596), which
+/// reuses the same exact element-kernel JVP for the Hellmann–Feynman
+/// eigenvalue-sensitivity contraction `xᵀ(∂K/∂X − λ ∂M/∂X)x`. Only the
+/// constructors [`Dual::cst`] / [`Dual::var`] and the `.re`/`.du` fields are
+/// needed there; the arithmetic methods remain private to this module.
 #[derive(Clone, Copy, Debug)]
-struct Dual {
-    re: f64,
-    du: f64,
+pub(crate) struct Dual {
+    pub(crate) re: f64,
+    pub(crate) du: f64,
 }
 
 impl Dual {
     #[inline]
-    fn cst(re: f64) -> Self {
+    pub(crate) fn cst(re: f64) -> Self {
         Self { re, du: 0.0 }
     }
     #[inline]
-    fn var(re: f64) -> Self {
+    pub(crate) fn var(re: f64) -> Self {
         Self { re, du: 1.0 }
     }
     #[inline]
@@ -213,8 +219,15 @@ fn ddot3(a: [Dual; 3], b: [Dual; 3]) -> Dual {
 ///          f_pq = 2 if p==q else 1
 ///   ∫N_i dV = sign(det)/24 · (g_b − g_a)
 /// ```
+///
+/// `pub(crate)`: reused by [`crate::eigen::sensitivity`] (issue #596) for the
+/// geometry half of the Hellmann–Feynman eigenvalue sensitivity — the same
+/// exact `∂K_local/∂X`, `∂M_local/∂X` element JVP, contracted `xᵀ(·)x` instead
+/// of the adjoint's `λᵀ(·)x`.
 #[allow(clippy::type_complexity)]
-fn nedelec_local_dual(coords: &[[Dual; 3]; 4]) -> ([[Dual; 6]; 6], [[Dual; 6]; 6], [[Dual; 3]; 6]) {
+pub(crate) fn nedelec_local_dual(
+    coords: &[[Dual; 3]; 4],
+) -> ([[Dual; 6]; 6], [[Dual; 6]; 6], [[Dual; 3]; 6]) {
     let v0 = coords[0];
     let e1 = dsub3(coords[1], v0);
     let e2 = dsub3(coords[2], v0);

--- a/crates/geode-core/src/eigen/mod.rs
+++ b/crates/geode-core/src/eigen/mod.rs
@@ -31,6 +31,10 @@
 //!   `M`-orthogonal deflation of the gradient subspace that removes the
 //!   spurious mode *without* shifting the physical spectrum (issue #509,
 //!   the spectrum-preserving alternative to the DOF-elimination `gauge`).
+//! - [`sensitivity`] — **Hellmann–Feynman eigenvalue sensitivities** `∂λ/∂p`
+//!   (material + geometry) on a converged simple eigenpair (issue #596,
+//!   Phase A of the differentiable-eigenmode roadmap; Nelson eigenvector
+//!   derivatives and the PHJD interior eigensolver are deferred follow-ons).
 
 pub mod ams;
 pub mod complex;
@@ -45,6 +49,7 @@ pub(crate) mod ordering;
 pub mod parallel;
 pub mod projection;
 pub mod self_consistent;
+pub mod sensitivity;
 pub mod transmon;
 
 #[cfg(feature = "arpack")]

--- a/crates/geode-core/src/eigen/sensitivity.rs
+++ b/crates/geode-core/src/eigen/sensitivity.rs
@@ -1,0 +1,445 @@
+//! **Hellmann–Feynman eigenvalue sensitivities** `∂λ/∂p` on a converged
+//! eigenpair of the real symmetric-definite transmon pencil `K x = λ M x`
+//! (Epic #569 eigen leg, issue #596 — **Phase A**).
+//!
+//! # Phase A / B / C boundary (scope fence)
+//!
+//! The differentiable-eigenmode roadmap (the paper's §10) has three phases of
+//! very different sizes. **This module is Phase A ONLY:**
+//!
+//! - **Phase A (here):** the eigen*value* sensitivity `∂λ/∂p`. For a **simple**
+//!   eigenvalue of a symmetric pencil, Hellmann–Feynman gives the gradient from
+//!   the *converged eigenpair alone* — **no adjoint solve, no new eigensolver.**
+//! - **Phase B (NOT here — follow-on issue):** Nelson eigen*vector* derivatives
+//!   → EPR / participation sensitivities. Needs one bordered solve per
+//!   eigenpair. **Do not implement it in this module.**
+//! - **Phase C (NOT here — follow-on issue):** the PHJD interior eigensolver.
+//!   A multi-PR numerical-methods build, unrelated to Phase A's math. **Do not
+//!   implement it in this module.**
+//!
+//! # The Hellmann–Feynman identity (why Phase A is adjoint-free)
+//!
+//! For a **simple** eigenvalue `λ` of the real symmetric-definite pencil
+//! `K x = λ M x` with eigenvector `x`,
+//!
+//! ```text
+//!   ∂λ/∂p = xᵀ (∂K/∂p − λ ∂M/∂p) x / (xᵀ M x).
+//! ```
+//!
+//! Unlike the material/shape *adjoints* ([`crate::adjoint`] #570,
+//! [`crate::shape`] #571, [`crate::driven::adjoint`] #576,
+//! [`crate::driven::shape`] #577), there is **no adjoint solve**: for a
+//! symmetric pencil the eigenvector is its own adjoint. The transmon
+//! eigensolvers ([`crate::eigen::dense`] / [`crate::eigen::lanczos`]) return
+//! **M-normalized** eigenvectors (`xᵀ M x = 1`), so the denominator is exactly
+//! `1` and drops out — the required precondition, documented on the input.
+//!
+//! ## Material: `∂λ/∂ε_k = −λ · xᵀ M_k x`
+//!
+//! `K` does not depend on the (isotropic real) permittivity; only the mass is
+//! ε-weighted and **linear** in the per-tet `ε_r`
+//! (`M(ε) = Σ_t ε_r[t] M_local(t)`, the same structure
+//! [`crate::driven::adjoint`] exploits). So `∂K/∂ε_k = 0` and
+//! `∂M/∂ε_k = M_k = Σ_{t ∈ region k} M_local(t)` (region-`k`-indicator mass),
+//! collapsing the identity to
+//!
+//! ```text
+//!   ∂λ/∂ε_k = −λ · xᵀ M_k x = −λ · Σ_{t ∈ k} x_locᵀ M_local(t) x_loc,
+//! ```
+//!
+//! an adjoint-free local element-loop contraction. (Sanity closed form: a
+//! **uniform** ε perturbation gives `∂λ/∂ε = −λ/ε`, since `M(ε) = ε M_vol` and
+//! `K x = λ ε M_vol x ⇒ λ ∝ 1/ε`.)
+//!
+//! ## Geometry: `∂λ/∂θ` via the shared exact element JVP + node-motion chain
+//!
+//! Both `K_local(X)` and `M_local(X)` depend on the node coordinates through
+//! the element Jacobian. We reuse [`crate::driven::shape`]'s exact forward-mode
+//! `Dual` element kernel `nedelec_local_dual` — the identical
+//! `∂K_local/∂X`, `∂M_local/∂X` used by the driven shape adjoint — but contract
+//! `xᵀ(·)x` (adjoint-free) instead of `λᵀ(·)x`:
+//!
+//! ```text
+//!   ∂λ/∂X_{n,d} = Σ_{t ∋ n} x_locᵀ (∂K_local/∂X_{n,d} − λ ε_t ∂M_local/∂X_{n,d}) x_loc,
+//! ```
+//!
+//! then chained through any analytic node-motion map with the
+//! geometry-kernel-agnostic [`crate::shape::chain_node_motion`]:
+//! `∂λ/∂θ = ⟨grad_node, ∂X/∂θ⟩`.
+//!
+//! # Scope fences (Phase A, v1)
+//!
+//! - **Simple eigenvalues only.** Hellmann–Feynman as stated holds only for a
+//!   *simple* eigenvalue; a numerically degenerate / near-degenerate pair needs
+//!   subspace perturbation theory (out of scope). Every entry point **checks a
+//!   minimum relative spectral gap** ([`EigenSensitivity::min_rel_gap`]) and
+//!   returns [`EigenSensitivityError::DegenerateEigenvalue`] rather than
+//!   silently producing a wrong gradient.
+//! - **Isotropic real `ε_r`.** Matching [`crate::driven::adjoint`] /
+//!   [`crate::driven::shape`] (#576/#577), the material is a per-tet isotropic
+//!   real scalar. The anisotropic-tensor / lossy-ε sensitivity is a follow-on.
+//! - **Volume curl-curl / mass terms.** The geometry gradient covers the
+//!   *volume* element kernels. A lumped-port surface term
+//!   ([`crate::eigen::transmon`]'s `S_Γ`) that *moves with the geometry* is not
+//!   modeled here; supply a node-motion map that leaves port-tagged nodes fixed
+//!   (the port `S_Γ` geometry derivative is a documented follow-on). Material
+//!   sensitivity is port-agnostic (the port mass depends on `C`, not `ε`).
+//! - **Lossless `R = 0`.** Inherited from [`crate::eigen::transmon`]'s v1 fence:
+//!   a resistive `R` makes the pencil complex (out of scope).
+
+use crate::driven::shape::{Dual, nedelec_local_dual};
+use crate::mesh::TetMesh;
+
+/// Error returned by the Hellmann–Feynman sensitivity entry points.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EigenSensitivityError {
+    /// The target eigenvalue is not (numerically) simple: its relative gap to
+    /// the nearest neighboring converged eigenvalue is below the required
+    /// [`EigenSensitivity::min_rel_gap`]. Hellmann–Feynman does not apply to a
+    /// degenerate pair, so no gradient is produced.
+    DegenerateEigenvalue {
+        /// Index of the target mode within the converged `lambdas`.
+        index: usize,
+        /// The target eigenvalue.
+        lambda: f64,
+        /// Measured relative gap `min_j |λ_i − λ_j| / max(|λ_i|, tiny)`.
+        rel_gap: f64,
+        /// The required minimum relative gap.
+        min_rel_gap: f64,
+    },
+    /// An input array length did not match the expected size.
+    DimMismatch {
+        /// Which array was wrong (for the message).
+        what: &'static str,
+        /// The provided length.
+        got: usize,
+        /// The expected length.
+        want: usize,
+    },
+    /// The interior mask keeps no DOFs (empty reduced pencil).
+    EmptyInterior,
+    /// `mode_index` is out of range for the provided `lambdas`.
+    ModeIndexOutOfRange {
+        /// The requested index.
+        index: usize,
+        /// Number of converged eigenvalues available.
+        n_modes: usize,
+    },
+}
+
+impl std::fmt::Display for EigenSensitivityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EigenSensitivityError::DegenerateEigenvalue {
+                index,
+                lambda,
+                rel_gap,
+                min_rel_gap,
+            } => write!(
+                f,
+                "eigenvalue {index} (λ = {lambda:.6e}) is not simple: relative gap \
+                 {rel_gap:.3e} < required {min_rel_gap:.3e} — Hellmann–Feynman does not \
+                 apply to a (near-)degenerate mode"
+            ),
+            EigenSensitivityError::DimMismatch { what, got, want } => {
+                write!(f, "{what} length {got} != expected {want}")
+            }
+            EigenSensitivityError::EmptyInterior => {
+                write!(f, "no interior DOFs after PEC reduction")
+            }
+            EigenSensitivityError::ModeIndexOutOfRange { index, n_modes } => {
+                write!(f, "mode index {index} out of range (have {n_modes} modes)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EigenSensitivityError {}
+
+/// The converged eigen-context for a Hellmann–Feynman sensitivity evaluation.
+///
+/// Bundles the mesh + material + PEC reduction with a **single simple**
+/// converged eigenpair (identified by `mode_index` into `lambdas`, with its
+/// reduced M-normalized `eigenvector`). All entry points enforce the
+/// simple-eigenvalue precondition against `min_rel_gap` before contracting.
+///
+/// The `eigenvector` is in the **reduced interior-DOF ordering** the transmon
+/// pencil uses (the ungauged PEC reduction of `interior_mask`, exactly as
+/// [`crate::eigen::transmon::solve_transmon_eigenmodes_full`] returns); this
+/// context recomputes the identical map to scatter it back to full edge length
+/// for the per-tet contraction.
+pub struct EigenSensitivity<'a> {
+    /// Tetrahedral mesh (fixed topology; geometry gradients are w.r.t. its node
+    /// positions).
+    pub mesh: &'a TetMesh,
+    /// Global edge table (`mesh.edges()`), the DOF set `K`/`M` index.
+    pub edges: &'a [[u32; 2]],
+    /// Interior-DOF mask over `edges` (`true` = kept interior edge, `false` =
+    /// PEC/Dirichlet). Defines the reduced ordering of `eigenvector`.
+    pub interior_mask: &'a [bool],
+    /// Per-tet **isotropic real** relative permittivity (length `n_tets`), the
+    /// evaluated material at which the gradient is taken.
+    pub eps_r: &'a [f64],
+    /// All converged eigenvalues (used for the simple-eigenvalue gap check).
+    pub lambdas: &'a [f64],
+    /// Index of the target mode within `lambdas`.
+    pub mode_index: usize,
+    /// The target mode's reduced interior-DOF eigenvector, **M-normalized**
+    /// (`xᵀ M x = 1`), length = interior dim.
+    pub eigenvector: &'a [f64],
+    /// Minimum relative spectral gap required to treat the target eigenvalue as
+    /// simple (e.g. `1e-3`). Below this the entry points refuse to produce a
+    /// gradient.
+    pub min_rel_gap: f64,
+}
+
+impl EigenSensitivity<'_> {
+    /// The target eigenvalue `λ = lambdas[mode_index]`.
+    fn lambda(&self) -> Result<f64, EigenSensitivityError> {
+        self.lambdas.get(self.mode_index).copied().ok_or(
+            EigenSensitivityError::ModeIndexOutOfRange {
+                index: self.mode_index,
+                n_modes: self.lambdas.len(),
+            },
+        )
+    }
+
+    /// Enforce the simple-eigenvalue precondition: the relative gap to the
+    /// nearest neighboring converged eigenvalue must meet `min_rel_gap`.
+    /// Returns the (verified-simple) target eigenvalue.
+    fn checked_simple_lambda(&self) -> Result<f64, EigenSensitivityError> {
+        let lambda = self.lambda()?;
+        let denom = lambda.abs().max(f64::MIN_POSITIVE);
+        let mut rel_gap = f64::INFINITY;
+        for (j, &lj) in self.lambdas.iter().enumerate() {
+            if j == self.mode_index {
+                continue;
+            }
+            rel_gap = rel_gap.min((lambda - lj).abs() / denom);
+        }
+        if rel_gap < self.min_rel_gap {
+            return Err(EigenSensitivityError::DegenerateEigenvalue {
+                index: self.mode_index,
+                lambda,
+                rel_gap,
+                min_rel_gap: self.min_rel_gap,
+            });
+        }
+        Ok(lambda)
+    }
+
+    /// Scatter the reduced M-normalized eigenvector back to full edge length
+    /// (length `edges.len()`), with exact zeros on PEC/eliminated edges — the
+    /// form the per-tet contraction consumes.
+    fn full_edge_vector(&self) -> Result<Vec<f64>, EigenSensitivityError> {
+        let n_edges = self.edges.len();
+        if self.interior_mask.len() != n_edges {
+            return Err(EigenSensitivityError::DimMismatch {
+                what: "interior_mask",
+                got: self.interior_mask.len(),
+                want: n_edges,
+            });
+        }
+        // Recompute the ungauged PEC-interior reindex (identical to the solver).
+        let mut interior_index = vec![None; n_edges];
+        let mut dim = 0usize;
+        for (e, &keep) in self.interior_mask.iter().enumerate() {
+            if keep {
+                interior_index[e] = Some(dim);
+                dim += 1;
+            }
+        }
+        if dim == 0 {
+            return Err(EigenSensitivityError::EmptyInterior);
+        }
+        if self.eigenvector.len() != dim {
+            return Err(EigenSensitivityError::DimMismatch {
+                what: "eigenvector",
+                got: self.eigenvector.len(),
+                want: dim,
+            });
+        }
+        let mut xf = vec![0.0_f64; n_edges];
+        for (e, &idx) in interior_index.iter().enumerate() {
+            if let Some(r) = idx {
+                xf[e] = self.eigenvector[r];
+            }
+        }
+        Ok(xf)
+    }
+
+    /// Per-tet global edge index + orientation-sign tables
+    /// (`TET_LOCAL_EDGES` order), matching the assembly convention.
+    fn tet_edge_tables(&self) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+        let te = self.mesh.tet_edges();
+        let idx = te
+            .iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect();
+        let sign = te
+            .iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect();
+        (idx, sign)
+    }
+
+    /// **Material** sensitivity `∂λ/∂ε_k` for every region `k ∈ 0..n_regions`.
+    ///
+    /// `region_of[t]` is the region label of tet `t` (length `n_tets`;
+    /// out-of-range labels are ignored). Adjoint-free Hellmann–Feynman:
+    /// `∂λ/∂ε_k = −λ · Σ_{t ∈ k} x_locᵀ M_local(t) x_loc`, with `M_local` the
+    /// ε = 1 Whitney mass (the same kernel the assembly and
+    /// [`crate::driven::shape`] use). A region with **no tets** yields exactly
+    /// `0.0` (not NaN).
+    ///
+    /// # Errors
+    ///
+    /// [`EigenSensitivityError::DegenerateEigenvalue`] if the target eigenvalue
+    /// fails the simple-mode gap check; [`EigenSensitivityError::DimMismatch`]
+    /// on a length mismatch.
+    pub fn deigenvalue_deps(
+        &self,
+        region_of: &[usize],
+        n_regions: usize,
+    ) -> Result<Vec<f64>, EigenSensitivityError> {
+        let lambda = self.checked_simple_lambda()?;
+        let n_tets = self.mesh.n_tets();
+        if region_of.len() != n_tets {
+            return Err(EigenSensitivityError::DimMismatch {
+                what: "region_of",
+                got: region_of.len(),
+                want: n_tets,
+            });
+        }
+        if self.eps_r.len() != n_tets {
+            return Err(EigenSensitivityError::DimMismatch {
+                what: "eps_r",
+                got: self.eps_r.len(),
+                want: n_tets,
+            });
+        }
+        let xf = self.full_edge_vector()?;
+        let (tet_idx, tet_sign) = self.tet_edge_tables();
+
+        let mut grad = vec![0.0_f64; n_regions];
+        for t in 0..n_tets {
+            let k = region_of[t];
+            if k >= n_regions {
+                continue;
+            }
+            let gidx = &tet_idx[t];
+            let gsign = &tet_sign[t];
+            let x_loc: [f64; 6] = std::array::from_fn(|i| xf[gidx[i] as usize] * (gsign[i] as f64));
+            if x_loc.iter().all(|&v| v == 0.0) {
+                continue;
+            }
+            // ε = 1 Whitney mass M_local from the shared element kernel (const
+            // coords → the `.re` fields reproduce the production kernel).
+            let m_local = self.local_mass(t);
+            let mut q = 0.0_f64;
+            for i in 0..6 {
+                for j in 0..6 {
+                    q += x_loc[i] * m_local[i][j] * x_loc[j];
+                }
+            }
+            grad[k] += -lambda * q;
+        }
+        Ok(grad)
+    }
+
+    /// The full **nodal-coordinate** geometry gradient `∂λ/∂X_{n,d}`, one
+    /// `[x,y,z]` triple per node. Chain it through a node-motion map with
+    /// [`deigenvalue_dtheta`](Self::deigenvalue_dtheta) /
+    /// [`crate::shape::chain_node_motion`].
+    ///
+    /// Adjoint-free Hellmann–Feynman per tet:
+    /// `Σ x_locᵀ (∂K_local/∂X − λ ε_t ∂M_local/∂X) x_loc`, via the exact
+    /// forward-mode `nedelec_local_dual` element JVP.
+    ///
+    /// # Errors
+    ///
+    /// As [`deigenvalue_deps`](Self::deigenvalue_deps).
+    pub fn deigenvalue_dx(&self) -> Result<Vec<[f64; 3]>, EigenSensitivityError> {
+        let lambda = self.checked_simple_lambda()?;
+        let n_tets = self.mesh.n_tets();
+        if self.eps_r.len() != n_tets {
+            return Err(EigenSensitivityError::DimMismatch {
+                what: "eps_r",
+                got: self.eps_r.len(),
+                want: n_tets,
+            });
+        }
+        let xf = self.full_edge_vector()?;
+        let (tet_idx, tet_sign) = self.tet_edge_tables();
+
+        let mut grad_node = vec![[0.0_f64; 3]; self.mesh.n_nodes()];
+        for (t, tet) in self.mesh.tets.iter().enumerate() {
+            let gidx = &tet_idx[t];
+            let gsign = &tet_sign[t];
+            let x_loc: [f64; 6] = std::array::from_fn(|i| xf[gidx[i] as usize] * (gsign[i] as f64));
+            if x_loc.iter().all(|&v| v == 0.0) {
+                continue;
+            }
+            let eps_t = self.eps_r[t];
+            let base = [
+                self.mesh.nodes[tet[0] as usize],
+                self.mesh.nodes[tet[1] as usize],
+                self.mesh.nodes[tet[2] as usize],
+                self.mesh.nodes[tet[3] as usize],
+            ];
+            for a in 0..4 {
+                let node = tet[a] as usize;
+                for c_axis in 0..3 {
+                    // Seed local vertex a, axis c_axis; all others constant.
+                    let mut dc = base.map(|v| v.map(Dual::cst));
+                    dc[a][c_axis] = Dual::var(base[a][c_axis]);
+                    let (dk, dm, _dnint) = nedelec_local_dual(&dc);
+
+                    // xᵀ (∂K/∂X − λ ε_t ∂M/∂X) x. K is ε-independent; the mass
+                    // carries the isotropic ε_t. Tangents are the `.du` fields.
+                    let mut d = 0.0_f64;
+                    for i in 0..6 {
+                        for j in 0..6 {
+                            let d_a = dk[i][j].du - lambda * eps_t * dm[i][j].du;
+                            d += x_loc[i] * x_loc[j] * d_a;
+                        }
+                    }
+                    grad_node[node][c_axis] += d;
+                }
+            }
+        }
+        Ok(grad_node)
+    }
+
+    /// **Geometry** sensitivity `∂λ/∂θ` for a node-motion map with velocity
+    /// field `dnode_dtheta[n] = ∂X_n/∂θ` (one `[x,y,z]` triple per node) —
+    /// [`deigenvalue_dx`](Self::deigenvalue_dx) chained through
+    /// [`crate::shape::chain_node_motion`].
+    ///
+    /// # Errors
+    ///
+    /// As [`deigenvalue_dx`](Self::deigenvalue_dx). Panics (via
+    /// `chain_node_motion`) if `dnode_dtheta.len() != mesh.n_nodes()`.
+    pub fn deigenvalue_dtheta(
+        &self,
+        dnode_dtheta: &[[f64; 3]],
+    ) -> Result<f64, EigenSensitivityError> {
+        let grad_node = self.deigenvalue_dx()?;
+        Ok(crate::shape::chain_node_motion(&grad_node, dnode_dtheta))
+    }
+
+    /// The ε = 1 Whitney element mass `M_local(t)` (`6×6`, sign-unaware) via the
+    /// shared `Dual` kernel evaluated on constant coordinates — the `.re`
+    /// fields reproduce the production Nédélec mass kernel bit-for-bit.
+    fn local_mass(&self, t: usize) -> [[f64; 6]; 6] {
+        let tet = &self.mesh.tets[t];
+        let coords: [[Dual; 3]; 4] = [
+            self.mesh.nodes[tet[0] as usize].map(Dual::cst),
+            self.mesh.nodes[tet[1] as usize].map(Dual::cst),
+            self.mesh.nodes[tet[2] as usize].map(Dual::cst),
+            self.mesh.nodes[tet[3] as usize].map(Dual::cst),
+        ];
+        let (_k, m, _n) = nedelec_local_dual(&coords);
+        std::array::from_fn(|i| std::array::from_fn(|j| m[i][j].re))
+    }
+}

--- a/crates/geode-core/src/eigen/transmon.rs
+++ b/crates/geode-core/src/eigen/transmon.rs
@@ -76,6 +76,8 @@ use faer::sparse::{SparseColMat, Triplet};
 use crate::assembly::nedelec::NedelecScatterMap;
 use crate::driven::ports::assemble_port_surface_mass;
 use crate::eigen::dense::EigenError;
+#[allow(unused_imports)] // referenced in doc links
+use crate::eigen::dense::EigenPair;
 use crate::eigen::gauge::TreeCotreeGauge;
 use crate::eigen::lanczos::{InnerSolver, SparseShiftInvertLanczos};
 use crate::mesh::TetMesh;
@@ -246,6 +248,24 @@ impl ModeReport {
     }
 }
 
+/// A converged transmon eigenmode: the [`ModeReport`] **plus** the reduced
+/// interior-DOF eigenvector.
+///
+/// The `vector` is the M-normalized ([`EigenPair`] convention, `xᵀ (M+M_port)
+/// x = 1`) eigenvector in the **same reduced DOF ordering** the pencil `K`/`M`
+/// use (the plain PEC-interior reduction of the ungauged path). It is what
+/// [`crate::eigen::sensitivity`] consumes for the Hellmann–Feynman `∂λ/∂p`
+/// gradient (issue #596) — the plain [`solve_transmon_eigenmodes`] entry point
+/// drops it, so [`solve_transmon_eigenmodes_full`] surfaces it.
+#[derive(Debug, Clone)]
+pub struct TransmonMode {
+    /// The mode's eigenvalue / frequency / junction participation.
+    pub report: ModeReport,
+    /// Reduced interior-DOF eigenvector, M-normalized (`xᵀ (M+M_port) x = 1`),
+    /// in the ungauged PEC-interior DOF ordering (length = interior dim).
+    pub vector: Vec<f64>,
+}
+
 /// Build a real faer [`SparseColMat`] from a `[nnz]` value slice aligned
 /// to the volume sparsity pattern of `scatter`, restricted to the
 /// interior DOFs, with **extra surface triplets** added on top.
@@ -377,14 +397,31 @@ pub fn solve_transmon_eigenmodes_with_inner(
     m_per_unit: f64,
     inner: InnerSolver,
 ) -> Result<Vec<ModeReport>, EigenError> {
+    Ok(
+        solve_transmon_eigenmodes_full(pencil, sigma, n_modes, m_per_unit, inner)?
+            .into_iter()
+            .map(|m| m.report)
+            .collect(),
+    )
+}
+
+/// Build the plain **ungauged** PEC-interior reindex (`Some(reduced) = kept
+/// interior edge`, `None = Dirichlet/PEC edge`) and the reduced dimension —
+/// the DOF ordering the ungauged transmon eigensolve and its eigenvectors use.
+///
+/// Shared by [`solve_transmon_eigenmodes_full`] and
+/// [`crate::eigen::sensitivity`] (which recomputes the identical map from the
+/// same `interior_mask` to scatter a reduced eigenvector back to full edge
+/// length for the per-tet Hellmann–Feynman contraction).
+fn ungauged_interior_reindex(
+    pencil: &TransmonPencil<'_>,
+) -> Result<(Vec<Option<usize>>, usize), EigenError> {
     let n_edges = pencil.edges.len();
     assert_eq!(
         pencil.interior_mask.len(),
         n_edges,
         "interior mask length must equal edge count"
     );
-
-    // Ungauged path: reindex is the plain PEC interior reduction.
     let mut interior_index = vec![None; n_edges];
     let mut dim = 0usize;
     for (e, &keep) in pencil.interior_mask.iter().enumerate() {
@@ -398,6 +435,30 @@ pub fn solve_transmon_eigenmodes_with_inner(
             "no interior DOFs after PEC reduction".into(),
         ));
     }
+    Ok((interior_index, dim))
+}
+
+/// [`solve_transmon_eigenmodes_with_inner`] returning the full
+/// [`TransmonMode`]s — the mode reports **and** the reduced M-normalized
+/// eigenvectors — through the ungauged PEC-interior reduction.
+///
+/// This is the entry point [`crate::eigen::sensitivity`] drives: it needs the
+/// converged eigenvector (in the reduced DOF ordering `K`/`M` use) for the
+/// Hellmann–Feynman `∂λ/∂p` gradient (issue #596), which the report-only
+/// [`solve_transmon_eigenmodes_with_inner`] discards. All numerics are
+/// identical to that function; only the eigenvector is additionally surfaced.
+///
+/// # Errors
+///
+/// Propagates [`EigenError`] from the reduced assembly or the Lanczos solve.
+pub fn solve_transmon_eigenmodes_full(
+    pencil: &TransmonPencil<'_>,
+    sigma: f64,
+    n_modes: usize,
+    m_per_unit: f64,
+    inner: InnerSolver,
+) -> Result<Vec<TransmonMode>, EigenError> {
+    let (interior_index, dim) = ungauged_interior_reindex(pencil)?;
     solve_transmon_eigenmodes_reindexed(
         pencil,
         &interior_index,
@@ -455,7 +516,7 @@ pub fn solve_transmon_eigenmodes_gauged(
             "no cotree DOFs after tree-cotree gauge".into(),
         ));
     }
-    solve_transmon_eigenmodes_reindexed(
+    Ok(solve_transmon_eigenmodes_reindexed(
         pencil,
         gauge.gauged_index_map(),
         dim,
@@ -463,7 +524,10 @@ pub fn solve_transmon_eigenmodes_gauged(
         n_modes,
         m_per_unit,
         InnerSolver::Direct,
-    )
+    )?
+    .into_iter()
+    .map(|m| m.report)
+    .collect())
 }
 
 /// Shared core: solve the reduced real pencil under an arbitrary
@@ -481,7 +545,7 @@ fn solve_transmon_eigenmodes_reindexed(
     n_modes: usize,
     m_per_unit: f64,
     inner: InnerSolver,
-) -> Result<Vec<ModeReport>, EigenError> {
+) -> Result<Vec<TransmonMode>, EigenError> {
     let pattern = pencil.scatter.pattern();
     assert_eq!(pencil.k_vals.len(), pattern.nnz(), "k_vals length mismatch");
     assert_eq!(pencil.m_vals.len(), pattern.nnz(), "m_vals length mismatch");
@@ -562,11 +626,14 @@ fn solve_transmon_eigenmodes_reindexed(
     };
 
     Ok(pairs
-        .iter()
-        .map(|pair| ModeReport {
-            lambda: pair.lambda,
-            frequency_hz: frequency_hz_from_lambda(pair.lambda, m_per_unit),
-            participation: junction_participation(&k_red, &k_port_red, &pair.vector),
+        .into_iter()
+        .map(|pair| TransmonMode {
+            report: ModeReport {
+                lambda: pair.lambda,
+                frequency_hz: frequency_hz_from_lambda(pair.lambda, m_per_unit),
+                participation: junction_participation(&k_red, &k_port_red, &pair.vector),
+            },
+            vector: pair.vector,
         })
         .collect())
 }

--- a/crates/geode-core/tests/transmon_eigen_sensitivity.rs
+++ b/crates/geode-core/tests/transmon_eigen_sensitivity.rs
@@ -1,0 +1,773 @@
+//! Hellmann–Feynman eigenvalue-sensitivity `∂λ/∂p` finite-difference
+//! validation (Epic #569 eigen leg, issue #596 — **Phase A**).
+//!
+//! For a **simple** eigenvalue of the real symmetric-definite transmon pencil
+//! `K x = λ M x`, [`geode_core::eigen::sensitivity`] computes `∂λ/∂ε` (material)
+//! and `∂λ/∂θ` (geometry) analytically from the *converged eigenpair alone* —
+//! no adjoint solve. These tests confirm the analytic gradients against a
+//! central finite difference that **re-solves the same `InnerSolver::Direct`
+//! eigensolver** for the same mode, exactly the pattern the material/shape
+//! sensitivity epic (#570/#571/#576/#577) used.
+//!
+//! - **CI-fast:** a small dielectric PEC-cavity fixture (bare cavity, no port),
+//!   both material and geometry, plus the simple-eigenvalue gap guard and the
+//!   zero-volume-region edge case.
+//! - **Release / `#[ignore]`:** the real 133k-tet DeviceLayout mesh, the
+//!   honesty/scale cross-check.
+
+use burn::tensor::Tensor;
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+
+use geode_core::assembly::nedelec::{
+    NedelecScatterMap, assemble_global_nedelec_with_full_tensors_sparse,
+};
+use geode_core::assembly::p1::upload_mesh;
+use geode_core::eigen::lanczos::InnerSolver;
+use geode_core::eigen::sensitivity::{EigenSensitivity, EigenSensitivityError};
+use geode_core::eigen::transmon::{
+    LumpedReactiveShunt, ReactiveElementNatural, TransmonMode, TransmonPencil,
+    solve_transmon_eigenmodes_full,
+};
+use geode_core::mesh::spiral::pec_interior_mask_from_triangles;
+use geode_core::mesh::{TetMesh, TransmonFixture, cube_tet_mesh, read_transmon_smoke_fixture};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+const M_PER_UNIT: f64 = 1e-6;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vals_to_host(t: Tensor<B, 1>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+    let te = mesh.tet_edges();
+    (
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect(),
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect(),
+    )
+}
+
+/// Assemble the REAL Nédélec pencil value vectors `(k_vals, m_vals)` for a
+/// per-tet **isotropic** real permittivity `eps_r` (μ_r = 1, lossless). The
+/// mass is `M = Σ_t ε_r[t] ∫ N·N` — the linear-in-ε structure the material
+/// sensitivity exploits.
+fn assemble_iso_pencil(
+    mesh: &TetMesh,
+    tet_sign: &[[i8; 6]],
+    scatter: &NedelecScatterMap,
+    eps_r: &[f64],
+) -> (Vec<f64>, Vec<f64>) {
+    let (nodes_t, tets_t) = upload_mesh::<B>(mesh, &device());
+    let identity: [[c64; 3]; 3] = std::array::from_fn(|i| {
+        std::array::from_fn(|j| c64::new(if i == j { 1.0 } else { 0.0 }, 0.0))
+    });
+    let nu_tensor = vec![identity; mesh.n_tets()];
+    let epsilon_tensor: Vec<[[c64; 3]; 3]> = eps_r
+        .iter()
+        .map(|&e| {
+            std::array::from_fn(|i| {
+                std::array::from_fn(|j| c64::new(if i == j { e } else { 0.0 }, 0.0))
+            })
+        })
+        .collect();
+
+    let sys = assemble_global_nedelec_with_full_tensors_sparse::<B>(
+        nodes_t,
+        tets_t,
+        tet_sign,
+        scatter,
+        &epsilon_tensor,
+        &nu_tensor,
+    );
+    (vals_to_host(sys.k_re_vals), vals_to_host(sys.m_re_vals))
+}
+
+/// A closed dielectric PEC-cavity fixture: an `n×n×n` unit cube, PEC on the
+/// entire outer boundary, uniform isotropic ε. NO junction port (a bare cavity)
+/// so the geometry gradient is purely the volume curl-curl/mass terms and the
+/// eigenvector is M-normalized w.r.t. the plain mass.
+struct CavityFixture {
+    mesh: TetMesh,
+    tet_edge_idx: Vec<[u32; 6]>,
+    tet_edge_sign: Vec<[i8; 6]>,
+    edges: Vec<[u32; 2]>,
+    interior_mask: Vec<bool>,
+}
+
+fn cavity_fixture(n: usize) -> CavityFixture {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let (tet_edge_idx, tet_edge_sign) = edge_tables(&mesh);
+
+    // PEC on every outer-boundary face (a fully closed cavity).
+    let metal: Vec<[u32; 3]> = mesh
+        .faces()
+        .into_iter()
+        .filter(|f| {
+            let on = |c: usize, val: f64| {
+                f.iter()
+                    .all(|&v| (mesh.nodes[v as usize][c] - val).abs() < 1e-12)
+            };
+            on(0, 0.0) || on(0, 1.0) || on(1, 0.0) || on(1, 1.0) || on(2, 0.0) || on(2, 1.0)
+        })
+        .collect();
+    let interior_mask = pec_interior_mask_from_triangles(&edges, &[metal.as_slice()]);
+
+    CavityFixture {
+        mesh,
+        tet_edge_idx,
+        tet_edge_sign,
+        edges,
+        interior_mask,
+    }
+}
+
+/// Bare-cavity shunt (no port): `L = ∞` (k_scale 0) and `C = 0` (m_scale 0),
+/// so no surface terms are added — the pencil is the pure volume `(K, M(ε))`.
+fn bare_shunt(faces: &[[u32; 3]]) -> LumpedReactiveShunt<'_> {
+    LumpedReactiveShunt {
+        faces,
+        length: 1.0,
+        width: 1.0,
+        element: ReactiveElementNatural {
+            l_natural: f64::INFINITY,
+            c_natural: 0.0,
+        },
+    }
+}
+
+/// Solve the bare cavity with per-tet isotropic `eps_r`, returning the full
+/// [`TransmonMode`]s (reports + reduced M-normalized eigenvectors) via the
+/// `Direct` eigensolver.
+fn solve_cavity(
+    fx: &CavityFixture,
+    eps_r: &[f64],
+    sigma: f64,
+    n_modes: usize,
+) -> Vec<TransmonMode> {
+    let scatter = NedelecScatterMap::new(&fx.tet_edge_idx);
+    let (k_vals, m_vals) = assemble_iso_pencil(&fx.mesh, &fx.tet_edge_sign, &scatter, eps_r);
+    let no_faces: Vec<[u32; 3]> = Vec::new();
+    let pencil = TransmonPencil {
+        scatter: &scatter,
+        k_vals: &k_vals,
+        m_vals: &m_vals,
+        edges: &fx.edges,
+        mesh: &fx.mesh,
+        shunt: bare_shunt(&no_faces),
+        interior_mask: &fx.interior_mask,
+    };
+    solve_transmon_eigenmodes_full(&pencil, sigma, n_modes, M_PER_UNIT, InnerSolver::Direct)
+        .expect("cavity eigensolve")
+}
+
+/// Pick the returned mode with the largest relative gap to its neighbors that
+/// is well above the nullspace — the safest "simple" mode for the HF test.
+/// Returns `(index_in_list, lambdas_vec, chosen_mode)`.
+fn pick_simple_mode(modes: &[TransmonMode]) -> (usize, Vec<f64>, TransmonMode) {
+    let lambdas: Vec<f64> = modes.iter().map(|m| m.report.lambda).collect();
+    let mut best = (0usize, f64::NEG_INFINITY);
+    for (i, &li) in lambdas.iter().enumerate() {
+        if li <= 1e-3 {
+            continue; // skip nullspace-adjacent modes
+        }
+        let denom = li.abs().max(f64::MIN_POSITIVE);
+        let mut gap = f64::INFINITY;
+        for (j, &lj) in lambdas.iter().enumerate() {
+            if i != j {
+                gap = gap.min((li - lj).abs() / denom);
+            }
+        }
+        if gap > best.1 {
+            best = (i, gap);
+        }
+    }
+    let idx = best.0;
+    (idx, lambdas, modes[idx].clone())
+}
+
+/// Central-difference the eigenvalue of the mode nearest `lambda_base` under a
+/// mesh + material perturbation, re-solving the same `Direct` eigensolver.
+#[allow(clippy::too_many_arguments)]
+fn fd_lambda(
+    fx_mesh: &TetMesh,
+    tet_edge_idx: &[[u32; 6]],
+    tet_edge_sign: &[[i8; 6]],
+    edges: &[[u32; 2]],
+    interior_mask: &[bool],
+    eps_r: &[f64],
+    sigma: f64,
+    n_modes: usize,
+    lambda_base: f64,
+) -> f64 {
+    let scatter = NedelecScatterMap::new(tet_edge_idx);
+    let (k_vals, m_vals) = assemble_iso_pencil(fx_mesh, tet_edge_sign, &scatter, eps_r);
+    let no_faces: Vec<[u32; 3]> = Vec::new();
+    let pencil = TransmonPencil {
+        scatter: &scatter,
+        k_vals: &k_vals,
+        m_vals: &m_vals,
+        edges,
+        mesh: fx_mesh,
+        shunt: bare_shunt(&no_faces),
+        interior_mask,
+    };
+    let modes =
+        solve_transmon_eigenmodes_full(&pencil, sigma, n_modes, M_PER_UNIT, InnerSolver::Direct)
+            .expect("FD eigensolve");
+    // Track the mode by nearest eigenvalue (small perturbation ⇒ continuous).
+    modes
+        .iter()
+        .map(|m| m.report.lambda)
+        .min_by(|a, b| {
+            (a - lambda_base)
+                .abs()
+                .partial_cmp(&(b - lambda_base).abs())
+                .unwrap()
+        })
+        .expect("no FD modes")
+}
+
+// -------------------------------------------------------------------------
+// CI-fast: material sensitivity ∂λ/∂ε.
+// -------------------------------------------------------------------------
+
+/// `∂λ/∂ε` (material) FD-validated on the synthetic cavity: the analytic
+/// Hellmann–Feynman gradient matches a central finite difference of the
+/// re-solved eigenvalue, and the uniform-ε closed form `∂λ/∂ε = −λ/ε`.
+#[test]
+fn material_sensitivity_matches_fd_and_closed_form() {
+    let fx = cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let n_tets = fx.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    let sigma = 5.0;
+    let n_modes = 6;
+
+    let modes = solve_cavity(&fx, &eps_r, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+    let lambda = mode.report.lambda;
+    assert!(lambda > 1e-3, "picked λ = {lambda} too close to nullspace");
+
+    let sens = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e-2,
+    };
+
+    // Uniform region (all tets → region 0): analytic HF gradient.
+    let region_of = vec![0usize; n_tets];
+    let grad = sens.deigenvalue_deps(&region_of, 1).expect("material grad");
+    let analytic = grad[0];
+
+    // Closed form for a uniform ε: ∂λ/∂ε = −λ/ε.
+    let closed_form = -lambda / eps0;
+    let rel_cf = (analytic - closed_form).abs() / closed_form.abs();
+    assert!(
+        rel_cf < 1e-6,
+        "uniform ∂λ/∂ε analytic {analytic:.6e} vs closed form −λ/ε {closed_form:.6e} \
+         (rel {rel_cf:.2e})"
+    );
+
+    // Central FD of the re-solved eigenvalue under a uniform ε perturbation.
+    let h = 1e-4 * eps0;
+    let eps_p: Vec<f64> = eps_r.iter().map(|&e| e + h).collect();
+    let eps_m: Vec<f64> = eps_r.iter().map(|&e| e - h).collect();
+    let lam_p = fd_lambda(
+        &fx.mesh,
+        &fx.tet_edge_idx,
+        &fx.tet_edge_sign,
+        &fx.edges,
+        &fx.interior_mask,
+        &eps_p,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let lam_m = fd_lambda(
+        &fx.mesh,
+        &fx.tet_edge_idx,
+        &fx.tet_edge_sign,
+        &fx.edges,
+        &fx.interior_mask,
+        &eps_m,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let fd = (lam_p - lam_m) / (2.0 * h);
+    let rel_fd = (analytic - fd).abs() / fd.abs().max(1e-30);
+    eprintln!(
+        "material: analytic {analytic:.6e}, FD {fd:.6e}, closed-form {closed_form:.6e} \
+         (rel_fd {rel_fd:.2e})"
+    );
+    assert!(
+        rel_fd < 1e-4,
+        "∂λ/∂ε analytic {analytic:.6e} vs FD {fd:.6e} (rel {rel_fd:.2e})"
+    );
+}
+
+/// Per-region `∂λ/∂ε_k`: split the cube into two regions by centroid `x`, FD
+/// each region independently, and verify the two region gradients sum to the
+/// uniform closed form `−λ/ε`. Also the zero-volume-region edge case → 0.
+#[test]
+fn per_region_material_sensitivity_matches_fd() {
+    let fx = cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let n_tets = fx.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    let sigma = 5.0;
+    let n_modes = 6;
+
+    // Region 0 = tets with centroid x < 0.5, region 1 otherwise.
+    let region_of: Vec<usize> = (0..n_tets)
+        .map(|t| {
+            let tet = &fx.mesh.tets[t];
+            let cx = (0..4)
+                .map(|k| fx.mesh.nodes[tet[k] as usize][0])
+                .sum::<f64>()
+                / 4.0;
+            if cx < 0.5 { 0 } else { 1 }
+        })
+        .collect();
+
+    let modes = solve_cavity(&fx, &eps_r, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+    let lambda = mode.report.lambda;
+
+    // Use 3 regions so region 2 has NO tets (zero-volume edge case).
+    let n_regions = 3;
+    let sens = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e-2,
+    };
+    let grad = sens
+        .deigenvalue_deps(&region_of, n_regions)
+        .expect("region grad");
+
+    // Zero-volume region → exactly 0 (not NaN).
+    assert_eq!(grad[2], 0.0, "empty region 2 must have zero sensitivity");
+    assert!(grad[2].is_finite());
+
+    // Sum of region gradients == uniform ∂λ/∂ε = −λ/ε.
+    let sum = grad[0] + grad[1];
+    let closed_form = -lambda / eps0;
+    assert!(
+        (sum - closed_form).abs() / closed_form.abs() < 1e-6,
+        "Σ region grads {sum:.6e} != uniform −λ/ε {closed_form:.6e}"
+    );
+
+    // FD each region separately (perturb only that region's ε).
+    #[allow(clippy::needless_range_loop)]
+    for k in 0..2 {
+        let h = 1e-4 * eps0;
+        let bump = |sign: f64| -> Vec<f64> {
+            (0..n_tets)
+                .map(|t| eps_r[t] + if region_of[t] == k { sign * h } else { 0.0 })
+                .collect()
+        };
+        let lam_p = fd_lambda(
+            &fx.mesh,
+            &fx.tet_edge_idx,
+            &fx.tet_edge_sign,
+            &fx.edges,
+            &fx.interior_mask,
+            &bump(1.0),
+            sigma,
+            n_modes,
+            lambda,
+        );
+        let lam_m = fd_lambda(
+            &fx.mesh,
+            &fx.tet_edge_idx,
+            &fx.tet_edge_sign,
+            &fx.edges,
+            &fx.interior_mask,
+            &bump(-1.0),
+            sigma,
+            n_modes,
+            lambda,
+        );
+        let fd = (lam_p - lam_m) / (2.0 * h);
+        let rel = (grad[k] - fd).abs() / fd.abs().max(1e-30);
+        eprintln!(
+            "region {k}: analytic {:.6e}, FD {fd:.6e} (rel {rel:.2e})",
+            grad[k]
+        );
+        assert!(
+            rel < 5e-4,
+            "region {k} ∂λ/∂ε_k analytic {:.6e} vs FD {fd:.6e} (rel {rel:.2e})",
+            grad[k]
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// CI-fast: geometry sensitivity ∂λ/∂θ.
+// -------------------------------------------------------------------------
+
+/// Move the mesh node whose position is nearest a given target.
+fn nearest_interior_node(mesh: &TetMesh, target: [f64; 3]) -> usize {
+    // Prefer a strictly-interior node (all coords in (eps, 1-eps)) so its
+    // adjacent tets never touch a boundary face.
+    let eps = 1e-9;
+    let mut best = (0usize, f64::INFINITY);
+    for (i, p) in mesh.nodes.iter().enumerate() {
+        let interior = p.iter().all(|&c| c > eps && c < 1.0 - eps);
+        if !interior {
+            continue;
+        }
+        let d = (0..3).map(|k| (p[k] - target[k]).powi(2)).sum::<f64>();
+        if d < best.1 {
+            best = (i, d);
+        }
+    }
+    assert!(best.1.is_finite(), "no strictly-interior node found");
+    best.0
+}
+
+/// `∂λ/∂θ` (geometry) FD-validated on the synthetic cavity: moving a single
+/// interior node along `x`, the analytic Hellmann–Feynman node-motion gradient
+/// matches a central finite difference of the re-solved eigenvalue.
+#[test]
+fn geometry_sensitivity_matches_fd() {
+    let fx = cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let n_tets = fx.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    let sigma = 5.0;
+    let n_modes = 6;
+
+    let modes = solve_cavity(&fx, &eps_r, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+    let lambda = mode.report.lambda;
+    assert!(lambda > 1e-3);
+
+    // Node-motion velocity: move one interior node along +x by θ.
+    let node = nearest_interior_node(&fx.mesh, [0.5, 0.5, 0.5]);
+    let mut vel = vec![[0.0_f64; 3]; fx.mesh.n_nodes()];
+    vel[node] = [1.0, 0.0, 0.0];
+
+    let sens = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e-2,
+    };
+    let analytic = sens.deigenvalue_dtheta(&vel).expect("geometry grad");
+
+    // Central FD: move the node ±h along the velocity, re-solve.
+    let h = 1e-5;
+    let moved = |sign: f64| -> TetMesh {
+        let mut m = fx.mesh.clone();
+        for (n, v) in vel.iter().enumerate() {
+            m.nodes[n][0] += sign * h * v[0];
+            m.nodes[n][1] += sign * h * v[1];
+            m.nodes[n][2] += sign * h * v[2];
+        }
+        m
+    };
+    let mesh_p = moved(1.0);
+    let mesh_m = moved(-1.0);
+    let lam_p = fd_lambda(
+        &mesh_p,
+        &fx.tet_edge_idx,
+        &fx.tet_edge_sign,
+        &fx.edges,
+        &fx.interior_mask,
+        &eps_r,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let lam_m = fd_lambda(
+        &mesh_m,
+        &fx.tet_edge_idx,
+        &fx.tet_edge_sign,
+        &fx.edges,
+        &fx.interior_mask,
+        &eps_r,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let fd = (lam_p - lam_m) / (2.0 * h);
+    let rel = (analytic - fd).abs() / fd.abs().max(1e-30);
+    eprintln!("geometry: analytic {analytic:.6e}, FD {fd:.6e} (rel {rel:.2e})");
+    assert!(
+        rel < 5e-3,
+        "∂λ/∂θ analytic {analytic:.6e} vs FD {fd:.6e} (rel {rel:.2e})"
+    );
+}
+
+// -------------------------------------------------------------------------
+// CI-fast: simple-eigenvalue guard.
+// -------------------------------------------------------------------------
+
+/// The simple-eigenvalue precondition trips rather than silently producing a
+/// wrong gradient: with an unreachable `min_rel_gap`, every entry point returns
+/// `DegenerateEigenvalue`; with a sane gap, the same mode succeeds.
+#[test]
+fn degenerate_gap_guard_trips() {
+    let fx = cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let n_tets = fx.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    let sigma = 5.0;
+    let n_modes = 6;
+
+    let modes = solve_cavity(&fx, &eps_r, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+
+    // Unreachable gap → guard trips on ALL entry points.
+    let strict = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e9,
+    };
+    let region_of = vec![0usize; n_tets];
+    assert!(matches!(
+        strict.deigenvalue_deps(&region_of, 1),
+        Err(EigenSensitivityError::DegenerateEigenvalue { .. })
+    ));
+    assert!(matches!(
+        strict.deigenvalue_dx(),
+        Err(EigenSensitivityError::DegenerateEigenvalue { .. })
+    ));
+    let vel = vec![[0.0_f64; 3]; fx.mesh.n_nodes()];
+    assert!(matches!(
+        strict.deigenvalue_dtheta(&vel),
+        Err(EigenSensitivityError::DegenerateEigenvalue { .. })
+    ));
+
+    // Sane gap → the picked (simple) mode succeeds.
+    let ok = EigenSensitivity {
+        min_rel_gap: 1e-2,
+        ..strict
+    };
+    assert!(ok.deigenvalue_deps(&region_of, 1).is_ok());
+}
+
+// -------------------------------------------------------------------------
+// Release / #[ignore]: real 133k-tet fixture scale cross-check.
+// -------------------------------------------------------------------------
+
+/// Assemble the real-mesh bare-cavity pencil (uniform isotropic ε) and solve
+/// `n_modes` near `sigma_f_hz` via `Direct`.
+#[allow(clippy::type_complexity)]
+fn solve_real_bare_cavity(
+    f: &TransmonFixture,
+    eps_r: &[f64],
+    sigma: f64,
+    n_modes: usize,
+) -> (
+    Vec<[u32; 2]>,
+    Vec<bool>,
+    Vec<[u32; 6]>,
+    Vec<[i8; 6]>,
+    Vec<TransmonMode>,
+) {
+    let edges = f.mesh.edges();
+    let (tet_edge_idx, tet_edge_sign) = edge_tables(&f.mesh);
+    let metal = f.metal_triangles();
+    let exterior = f.exterior_boundary_triangles();
+    let interior_mask =
+        pec_interior_mask_from_triangles(&edges, &[metal.as_slice(), exterior.as_slice()]);
+    let scatter = NedelecScatterMap::new(&tet_edge_idx);
+    let (k_vals, m_vals) = assemble_iso_pencil(&f.mesh, &tet_edge_sign, &scatter, eps_r);
+    let no_faces: Vec<[u32; 3]> = Vec::new();
+    let pencil = TransmonPencil {
+        scatter: &scatter,
+        k_vals: &k_vals,
+        m_vals: &m_vals,
+        edges: &edges,
+        mesh: &f.mesh,
+        shunt: bare_shunt(&no_faces),
+        interior_mask: &interior_mask,
+    };
+    let modes =
+        solve_transmon_eigenmodes_full(&pencil, sigma, n_modes, M_PER_UNIT, InnerSolver::Direct)
+            .expect("real bare-cavity eigensolve");
+    (edges, interior_mask, tet_edge_idx, tet_edge_sign, modes)
+}
+
+/// Release-tier honesty/scale cross-check: on the real 133k-tet DeviceLayout
+/// mesh (bare dielectric cavity, uniform isotropic ε), the analytic
+/// Hellmann–Feynman `∂λ/∂ε` and `∂λ/∂θ` match a central finite difference of
+/// the re-solved `Direct` eigensolver on a picked simple mode.
+///
+/// ```sh
+/// cargo test -p geode-core --release --test transmon_eigen_sensitivity \
+///     -- --ignored real_eigen_sensitivity_release --nocapture
+/// ```
+#[test]
+#[ignore = "two+ 133k-DOF sparse shift-invert eigensolves (FD) — release benchmark only"]
+fn real_eigen_sensitivity_release() {
+    let f: TransmonFixture = read_transmon_smoke_fixture().expect("real transmon fixture");
+    eprintln!(
+        "fixture: {} nodes, {} tets",
+        f.mesh.n_nodes(),
+        f.mesh.n_tets()
+    );
+    let eps0 = 10.0_f64; // isotropic dielectric (scale cross-check, not sapphire)
+    let n_tets = f.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    // Target a low physical band on the μm mesh; request several modes to find
+    // a well-separated simple one above the gradient nullspace.
+    let sigma = geode_core::eigen::transmon::lambda_shift_for_frequency_hz(5.0e9, M_PER_UNIT);
+    let n_modes = 8;
+
+    let (edges, interior_mask, tet_edge_idx, tet_edge_sign, modes) =
+        solve_real_bare_cavity(&f, &eps_r, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+    let lambda = mode.report.lambda;
+    eprintln!(
+        "picked mode {idx}: λ = {lambda:.6e}, f = {:.4} GHz",
+        mode.report.frequency_ghz()
+    );
+    assert!(lambda > 0.0);
+
+    let sens = EigenSensitivity {
+        mesh: &f.mesh,
+        edges: &edges,
+        interior_mask: &interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e-3,
+    };
+
+    // --- Material: uniform ∂λ/∂ε vs FD and closed form −λ/ε. ---
+    let region_of = vec![0usize; n_tets];
+    let grad = sens.deigenvalue_deps(&region_of, 1).expect("material grad");
+    let analytic_m = grad[0];
+    let closed_form = -lambda / eps0;
+    let h = 1e-4 * eps0;
+    let lam_p = {
+        let eps: Vec<f64> = eps_r.iter().map(|&e| e + h).collect();
+        fd_lambda(
+            &f.mesh,
+            &tet_edge_idx,
+            &tet_edge_sign,
+            &edges,
+            &interior_mask,
+            &eps,
+            sigma,
+            n_modes,
+            lambda,
+        )
+    };
+    let lam_m = {
+        let eps: Vec<f64> = eps_r.iter().map(|&e| e - h).collect();
+        fd_lambda(
+            &f.mesh,
+            &tet_edge_idx,
+            &tet_edge_sign,
+            &edges,
+            &interior_mask,
+            &eps,
+            sigma,
+            n_modes,
+            lambda,
+        )
+    };
+    let fd_m = (lam_p - lam_m) / (2.0 * h);
+    eprintln!("material: analytic {analytic_m:.6e}, FD {fd_m:.6e}, closed-form {closed_form:.6e}");
+    assert!(
+        (analytic_m - closed_form).abs() / closed_form.abs() < 1e-6,
+        "uniform ∂λ/∂ε vs −λ/ε mismatch"
+    );
+    assert!(
+        (analytic_m - fd_m).abs() / fd_m.abs() < 1e-3,
+        "material ∂λ/∂ε analytic {analytic_m:.6e} vs FD {fd_m:.6e}"
+    );
+
+    // --- Geometry: move one interior node along +x, ∂λ/∂θ vs FD. ---
+    let node = nearest_interior_node(&f.mesh, {
+        // centroid of the mesh bounding box
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for p in &f.mesh.nodes {
+            for k in 0..3 {
+                lo[k] = lo[k].min(p[k]);
+                hi[k] = hi[k].max(p[k]);
+            }
+        }
+        [
+            0.5 * (lo[0] + hi[0]),
+            0.5 * (lo[1] + hi[1]),
+            0.5 * (lo[2] + hi[2]),
+        ]
+    });
+    let mut vel = vec![[0.0_f64; 3]; f.mesh.n_nodes()];
+    vel[node] = [1.0, 0.0, 0.0];
+    let analytic_g = sens.deigenvalue_dtheta(&vel).expect("geometry grad");
+    let hg = 1e-3; // μm-unit mesh: a small absolute node motion
+    let moved = |sign: f64| -> TetMesh {
+        let mut m = f.mesh.clone();
+        m.nodes[node][0] += sign * hg;
+        m
+    };
+    let mesh_p = moved(1.0);
+    let mesh_m = moved(-1.0);
+    let lam_gp = fd_lambda(
+        &mesh_p,
+        &tet_edge_idx,
+        &tet_edge_sign,
+        &edges,
+        &interior_mask,
+        &eps_r,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let lam_gm = fd_lambda(
+        &mesh_m,
+        &tet_edge_idx,
+        &tet_edge_sign,
+        &edges,
+        &interior_mask,
+        &eps_r,
+        sigma,
+        n_modes,
+        lambda,
+    );
+    let fd_g = (lam_gp - lam_gm) / (2.0 * hg);
+    let rel_g = (analytic_g - fd_g).abs() / fd_g.abs().max(1e-30);
+    eprintln!("geometry: analytic {analytic_g:.6e}, FD {fd_g:.6e} (rel {rel_g:.2e})");
+    assert!(
+        rel_g < 1e-2,
+        "geometry ∂λ/∂θ analytic {analytic_g:.6e} vs FD {fd_g:.6e} (rel {rel_g:.2e})"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **Phase A** of issue #596 — Hellmann–Feynman eigenvalue
sensitivities `∂λ/∂p` on the existing converged eigenpairs of the real
symmetric-definite transmon pencil `K x = λ M x`. This is the **eigenvalue**
leg of the differentiable-eigenmode roadmap (Epic #569, the paper's §10),
and it is strictly cheaper than the prior material/shape adjoints
(#570/#571/#576/#577): for a **simple** eigenvalue the eigenvector is its own
adjoint, so there is **no adjoint solve and no new eigensolver**.

New module `crate::eigen::sensitivity`:

- **Material** `∂λ/∂ε_k = −λ · xᵀ M_k x`, per region — `K` is ε-independent
  and the mass is linear in the per-tet isotropic `ε_r`, so the formula
  collapses to a region-indicator mass contraction (adjoint-free).
- **Geometry** `∂λ/∂θ` via the exact forward-mode `nedelec_local_dual`
  element JVP reused from `crate::driven::shape` (widened `fn` → `pub(crate)
  fn`), contracting `xᵀ(∂K/∂X − λ ∂M/∂X)x` per tet and chaining through
  `crate::shape::chain_node_motion` (unchanged).
- **Simple-eigenvalue guard**: every entry point enforces a minimum relative
  spectral gap and returns `EigenSensitivityError::DegenerateEigenvalue`
  rather than silently producing a wrong gradient on a (near-)degenerate mode.

To make the converged eigenvector available (the report-only
`solve_transmon_eigenmodes` dropped it), added `TransmonMode` and
`solve_transmon_eigenmodes_full` to `crate::eigen::transmon` — additive; the
existing report-returning entry points are unchanged (mapped from the new
full result), and all existing transmon eigen tests still pass.

## Scope fence (per the Curator enhancement)

Phase A **only**. Out of scope, deferred to follow-on issues: Nelson
eigenvector derivatives / EPR participation sensitivities (Phase B) and the
PHJD interior eigensolver (Phase C). Also inherits the isotropic-real-`ε_r`,
lossless-`R=0`, volume-term scope of #576/#577; no changes to `InnerSolver`,
`eigen::ams`, or the matrix-free path.

## Tests

CI-fast FD-vs-analytic validation on the synthetic PEC dielectric cavity
(`tests/transmon_eigen_sensitivity.rs`):

- `material_sensitivity_matches_fd_and_closed_form` — analytic `−1.1519e0`
  vs FD `−1.1519e0` (rel `1e-8`) and the `−λ/ε` closed form (rel `1e-8`).
- `per_region_material_sensitivity_matches_fd` — two-region FD (rel `~1e-9`),
  region-sum invariant, and the zero-volume-region → exactly `0.0` edge case.
- `geometry_sensitivity_matches_fd` — analytic `3.2190e-1` vs FD (rel
  `5.6e-10`).
- `degenerate_gap_guard_trips` — all three entry points return
  `DegenerateEigenvalue` under an unreachable gap; succeed under a sane one.

Release-tier `#[ignore]` cross-check on the real 133k-tet DeviceLayout
fixture (`real_eigen_sensitivity_release`).

Results: **4 passed, 1 ignored** (sensitivity file); library **408 passed**;
`transmon_eigenmode` **14 passed, 10 ignored**. `cargo fmt`, `cargo clippy
--tests`, and `cargo doc -D warnings` (public) all clean.

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)