### PR TITLE
test(eigen): drop architecture-dependent wall-clock assertion in coarse-solve report

### DIFF
--- a/crates/geode-core/src/eigen/ams.rs
+++ b/crates/geode-core/src/eigen/ams.rs
@@ -2106,9 +2106,15 @@ mod tests {
     /// indefinite pencil where inner-CG cannot run — the deferred 1c point). What
     /// this test pins locally is the structural win: the SGS apply is markedly
     /// cheaper per call and needs no global factor, and the outer CG still
-    /// converges. The honest numbers are printed for the PR body.
+    /// converges. The honest per-apply timings are printed for the PR body, but
+    /// they are **informational only** — the per-apply wall-clock is *not*
+    /// asserted, because which of the two comparably-`O(n)` kernels wins on this
+    /// near-tridiagonal chain is a constant-factor, architecture-dependent
+    /// outcome (on Apple Silicon the cached LU triangular solve is ~1.7× faster
+    /// than 2 SGS sweeps; on the Linux CI runner the reverse). The load-bearing
+    /// gate is the convergence assertion below. See issue #567.
     #[test]
-    fn coarse_solve_cost_and_iteration_report() {
+    fn coarse_solve_iteration_report() {
         let n = 600;
         let (k, m) = laplacian(n);
         let g = chain_gradient(n);
@@ -2172,11 +2178,6 @@ mod tests {
         assert!(
             it_sgs > 0 && it_sgs < max_it,
             "SGS-preconditioned PCG failed to converge: it = {it_sgs} (max {max_it})"
-        );
-        assert!(
-            us_sgs < us_direct,
-            "SGS coarse apply was not cheaper than the direct factor: \
-             SGS = {us_sgs:.3} µs, direct = {us_direct:.3} µs"
         );
     }
 


### PR DESCRIPTION
## Summary
`eigen::ams::tests::coarse_solve_cost_and_iteration_report` (from #551) asserted the few-sweep SGS coarse apply is cheaper *per call* than the cached direct sparse-LU triangular solve. On the near-tridiagonal `n=600` chain fixture both kernels are comparably `O(n)`, so which one wins is a constant-factor, architecture-dependent outcome — on Apple Silicon faer's LU triangular solve is ~1.7× faster than 2 SGS sweeps and the assertion *reproducibly* fails, while the Linux CI runner passes it. This PR removes that hardware-timing hard gate (Option A from the issue) while preserving every property the test was designed to guarantee.

## Changes
- Removed the wall-clock `assert!(us_sgs < us_direct, ...)` block.
- Kept the `eprintln!` that reports both per-apply timings and the ratio under `--nocapture` (measurement preserved for PR-body reporting).
- Kept the two convergence assertions (`it_direct > 0`, `it_sgs > 0 && it_sgs < max_it`) as the load-bearing correctness gate — **not** weakened.
- Renamed the test `coarse_solve_cost_and_iteration_report` → `coarse_solve_iteration_report` (no longer implies a performance gate).
- Updated the test doc comment to state the timings are informational only and explain the architecture-dependence, referencing #567.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Test no longer contains a `wall-clock A < wall-clock B` hard assertion | ✅ | `grep -rn "us_sgs < us_direct"` returns nothing |
| Still asserts `it_direct > 0` and `it_sgs > 0 && it_sgs < max_it` | ✅ | Both assertions retained unchanged |
| Per-apply timings still emitted via `eprintln!` under `--nocapture` | ✅ | Report line prints direct LU µs, SGS µs, ratio |
| Passes reliably on Apple Silicon (arm64) | ✅ | Ran 4× on this arm64 machine, all green |
| No other test asserts a bare wall-clock `<` between solver variants | ✅ | Confirmed via tree-wide grep |
| Doc comment updated | ✅ | Closing wording now notes timings are informational only |

## Test Plan
- `cargo test -p geode-core --lib coarse_solve_iteration_report -- --nocapture` — passes, timings still print.
- Re-ran the test 4× consecutively on Apple Silicon — always green (no timing sensitivity remains).
- `cargo test -p geode-core --lib eigen` — 68 passed, 0 failed (no sibling regressions).

Closes #567