### PR TITLE
feat(mesh): spade 2-D CDT wave-port cross-section meshing spike (#582)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 596
-# Branch: feature/issue-596
+# Issue: 582
+# Branch: feature/issue-582
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde_json",
+ "spade",
  "thiserror 2.0.18",
  "toml 0.8.23",
 ]
@@ -6024,6 +6025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,6 +6502,18 @@ dependencies = [
  "geode-core",
  "geode-util",
  "serde",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ criterion = "0.5"
 # does not by itself parallelize any hot loop that regresses under rayon.
 faer = { version = "0.24", default-features = false, features = ["std", "linalg", "rayon"] }
 mshio = "0.4"
+# In-process 2-D constrained Delaunay triangulation + Ruppert/Chew quality
+# refinement for arbitrary wave-port cross-sections (issue #582). Optional,
+# pulled in by geode-core only under the `spade-mesh` feature. Dual
+# MIT/Apache-2.0 with a fully permissive transitive tree (hashbrown, num-traits,
+# robust, smallvec, allocator-api2, equivalent, foldhash, autocfg) — no GPL
+# exposure. 2-D only: this does NOT replace offline Gmsh for 3-D tet meshing.
+spade = "2.15"
 # Direct rayon dependency for host-side assembly parallelism (issue #522).
 # faer pulls rayon in transitively for its factorization, but the FEM
 # assembler's serial host loops (`NedelecScatterMap::new`,

--- a/crates/geode-core/Cargo.toml
+++ b/crates/geode-core/Cargo.toml
@@ -24,6 +24,11 @@ bunsen = { workspace = true }
 faer = { workspace = true, features = ["sparse-linalg"] }
 mshio = { workspace = true }
 thiserror = { workspace = true }
+# Optional: in-process 2-D CDT + Ruppert/Chew refinement for arbitrary
+# wave-port cross-sections (issue #582). Gated behind the `spade-mesh` feature
+# so the default dependency graph is unchanged (mirrors the `arpack` opt-in
+# pattern). 2-D only — not a Gmsh 3-D-tet replacement.
+spade = { workspace = true, optional = true }
 # Host-side assembly parallelism (issue #522). Optional and enabled by the
 # `faer-parallel` feature so `--no-default-features` builds a strictly
 # single-threaded assembler alongside the single-threaded faer factorization.
@@ -92,6 +97,12 @@ autodiff = ["burn/autodiff"]
 # so no C headers or Fortran toolchain are needed at build time. See
 # README §System dependencies.
 arpack = ["dep:pkg-config"]
+
+# In-process 2-D constrained Delaunay meshing for arbitrary wave-port
+# cross-sections (issue #582). Off by default; pulls in the optional `spade`
+# dependency and compiles `analytic::spade_mesh`. Enable with
+# `--features spade-mesh`. 2-D only — does not affect 3-D tet meshing.
+spade-mesh = ["dep:spade"]
 
 testing = ["dep:regex"]
 

--- a/crates/geode-core/src/analytic/mod.rs
+++ b/crates/geode-core/src/analytic/mod.rs
@@ -21,6 +21,10 @@
 //!   ε-coupling term the reduced transverse-E_t modal pencil drops (Epic #339).
 //! - [`mixed_pencil`] — the full-vector mixed E_t–E_z Nédélec–Lagrange
 //!   dielectric modal pencil that restores that coupling (Epic #339, #473).
+//! - [`spade_mesh`] (feature `spade-mesh`) — in-process 2-D constrained
+//!   Delaunay + Ruppert/Chew meshing of arbitrary wave-port cross-sections
+//!   from a polygon boundary, with a topological PEC boundary-edge mask
+//!   (issue #582).
 
 pub mod dispersion;
 pub mod fiber;
@@ -29,5 +33,7 @@ pub mod mie;
 pub mod mixed_pencil;
 pub mod patch;
 pub mod slotless_pm;
+#[cfg(feature = "spade-mesh")]
+pub mod spade_mesh;
 pub mod spiral;
 pub mod waveguide;

--- a/crates/geode-core/src/analytic/mod.rs
+++ b/crates/geode-core/src/analytic/mod.rs
@@ -21,7 +21,7 @@
 //!   ε-coupling term the reduced transverse-E_t modal pencil drops (Epic #339).
 //! - [`mixed_pencil`] — the full-vector mixed E_t–E_z Nédélec–Lagrange
 //!   dielectric modal pencil that restores that coupling (Epic #339, #473).
-//! - [`spade_mesh`] (feature `spade-mesh`) — in-process 2-D constrained
+//! - `spade_mesh` (feature `spade-mesh`) — in-process 2-D constrained
 //!   Delaunay + Ruppert/Chew meshing of arbitrary wave-port cross-sections
 //!   from a polygon boundary, with a topological PEC boundary-edge mask
 //!   (issue #582).

--- a/crates/geode-core/src/analytic/spade_mesh.rs
+++ b/crates/geode-core/src/analytic/spade_mesh.rs
@@ -1,0 +1,301 @@
+//! In-process 2-D constrained-Delaunay meshing of arbitrary wave-port
+//! cross-sections (issue #582).
+//!
+//! GEODE's general-cross-section transverse modal eigensolver
+//! ([`crate::analytic::waveguide::solve_waveguide_modes`], issue #265)
+//! already accepts an arbitrary [`TriMesh`] plus a per-edge PEC mask — the
+//! only missing piece for a *new* port shape is mesh **generation**. Today
+//! every non-rectangular cross-section fixture in the crate (the disk fan
+//! in `tests/circular_waveguide_modes.rs`, etc.) is a bespoke, hand-rolled
+//! triangulator written per shape. This module closes that gap for the 2-D
+//! case: given an ordered simple-polygon boundary it produces a quality
+//! [`TriMesh`] via [`spade`]'s constrained Delaunay triangulation +
+//! Ruppert/Chew refinement, and derives the PEC boundary-edge mask purely
+//! topologically (an edge is a wall edge iff exactly one triangle owns it).
+//!
+//! # Scope
+//!
+//! This is **2-D only** and does not replace GEODE's offline Gmsh 3-D
+//! tetrahedral meshing. It is gated behind the off-by-default `spade-mesh`
+//! Cargo feature so the default dependency graph is unchanged. Interior
+//! holes / conductor cutouts and production `WavePort` wiring are
+//! intentionally out of scope for this spike (follow-on work); only simple
+//! (hole-free) polygon boundaries are supported here.
+//!
+//! # Orientation contract
+//!
+//! [`TriMesh`]'s Nédélec assembler asserts strictly positive (CCW) signed
+//! area per triangle. `spade` returns each face's vertices in CCW order, and
+//! the walk below additionally enforces positive signed area defensively, so
+//! the produced mesh always satisfies that contract.
+
+use std::collections::{HashMap, HashSet};
+
+use spade::{
+    AngleLimit, ConstrainedDelaunayTriangulation, Point2, RefinementParameters, Triangulation,
+};
+
+use crate::analytic::waveguide::TriMesh;
+
+/// Local-edge vertex pairs of a triangle in the canonical order used by
+/// [`TriMesh::edges`] (`(v0,v1)`, `(v0,v2)`, `(v1,v2)`).
+const TRI_LOCAL_EDGES: [(usize, usize); 3] = [(0, 1), (0, 2), (1, 2)];
+
+/// Quality knobs forwarded to `spade`'s Ruppert/Chew refinement.
+///
+/// The two load-bearing knobs are [`min_angle_deg`](Self::min_angle_deg)
+/// (drives the circumradius-to-shortest-edge angle limit) and
+/// [`max_area`](Self::max_area) (a uniform upper bound on triangle area that
+/// sets the mesh density). [`min_area`](Self::min_area) is an optional
+/// over-refinement guard, and [`max_additional_vertices`](Self::max_additional_vertices)
+/// bounds the Steiner-point budget so refinement is guaranteed to terminate.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PortMeshParams {
+    /// Minimum interior angle (degrees) the refinement tries to guarantee.
+    /// Values above ~30° may not terminate without a vertex budget; `spade`
+    /// defaults to 30°. A typical safe choice is 25°.
+    pub min_angle_deg: f64,
+    /// Uniform upper bound on triangle area — the primary density control.
+    /// Smaller → finer mesh.
+    pub max_area: f64,
+    /// Optional lower bound on triangle area (over-refinement guard): faces
+    /// smaller than this are never split further.
+    pub min_area: Option<f64>,
+    /// Optional cap on the number of Steiner vertices refinement may insert
+    /// (hard termination guarantee).
+    pub max_additional_vertices: Option<usize>,
+}
+
+impl PortMeshParams {
+    /// Convenience constructor from the two primary knobs (25° angle limit is
+    /// applied unless overridden via the struct fields).
+    #[must_use]
+    pub fn new(max_area: f64) -> Self {
+        Self {
+            min_angle_deg: 25.0,
+            max_area,
+            min_area: None,
+            max_additional_vertices: None,
+        }
+    }
+}
+
+/// Failure modes of [`triangulate_polygon`].
+#[derive(Debug, thiserror::Error)]
+pub enum SpadeMeshError {
+    /// The supplied boundary had fewer than 3 distinct vertices.
+    #[error("polygon boundary must have at least 3 vertices, got {0}")]
+    DegenerateBoundary(usize),
+    /// `spade` could not construct the constrained triangulation (e.g. a
+    /// self-intersecting boundary or coincident vertices).
+    #[error("spade CDT construction failed: {0}")]
+    Insertion(String),
+    /// Refinement excluded every face, leaving no interior region — usually a
+    /// sign the boundary winding or `exclude_outer_faces` flood-fill trimmed
+    /// the whole domain.
+    #[error("refinement produced an empty interior triangulation")]
+    EmptyMesh,
+}
+
+/// Signed area (`z`-component of the edge cross product, halved) of a triangle
+/// given as three node indices into `nodes`. Positive for CCW vertex order.
+fn signed_area(nodes: &[[f64; 2]], tri: &[u32; 3]) -> f64 {
+    let a = nodes[tri[0] as usize];
+    let b = nodes[tri[1] as usize];
+    let c = nodes[tri[2] as usize];
+    0.5 * ((b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]))
+}
+
+/// Triangulate a simple (hole-free) polygon boundary into a quality
+/// [`TriMesh`] suitable for [`crate::analytic::waveguide::solve_waveguide_modes`].
+///
+/// `boundary` is an ordered list of `[x, y]` vertices tracing the polygon
+/// outline (CCW recommended; the resulting mesh is oriented CCW regardless,
+/// since `spade` returns CCW faces and the walk enforces positive signed
+/// area). Consecutive vertices — including the wrap-around from the last back
+/// to the first — become constraint edges, so the polygon outline is a
+/// hard-embedded boundary of the triangulation.
+///
+/// The mesh is refined with the Ruppert/Chew algorithm under `params`, and
+/// `exclude_outer_faces(true)` is applied so only the interior region is
+/// returned (for a convex boundary there are no outer faces, but this keeps
+/// the path correct for the general case). Vertex indices are compacted so the
+/// returned mesh has no orphan nodes.
+///
+/// # Errors
+///
+/// Returns [`SpadeMeshError::DegenerateBoundary`] if fewer than 3 vertices are
+/// supplied, [`SpadeMeshError::Insertion`] if `spade` rejects the boundary
+/// (e.g. self-intersection), or [`SpadeMeshError::EmptyMesh`] if refinement
+/// leaves no interior faces.
+pub fn triangulate_polygon(
+    boundary: &[[f64; 2]],
+    params: &PortMeshParams,
+) -> Result<TriMesh, SpadeMeshError> {
+    let n = boundary.len();
+    if n < 3 {
+        return Err(SpadeMeshError::DegenerateBoundary(n));
+    }
+
+    let vertices: Vec<Point2<f64>> = boundary.iter().map(|p| Point2::new(p[0], p[1])).collect();
+    // Cyclic constraint edges tracing the polygon outline.
+    let constraint_edges: Vec<[usize; 2]> = (0..n).map(|i| [i, (i + 1) % n]).collect();
+
+    let mut cdt: ConstrainedDelaunayTriangulation<Point2<f64>> =
+        ConstrainedDelaunayTriangulation::bulk_load_cdt(vertices, constraint_edges)
+            .map_err(|e| SpadeMeshError::Insertion(format!("{e:?}")))?;
+
+    let mut refine_params = RefinementParameters::<f64>::new()
+        .exclude_outer_faces(true)
+        .with_angle_limit(AngleLimit::from_deg(params.min_angle_deg))
+        .with_max_allowed_area(params.max_area);
+    if let Some(min_area) = params.min_area {
+        refine_params = refine_params.with_min_required_area(min_area);
+    }
+    if let Some(max_add) = params.max_additional_vertices {
+        refine_params = refine_params.with_max_additional_vertices(max_add);
+    }
+
+    let result = cdt.refine(refine_params);
+    let excluded: HashSet<_> = result.excluded_faces.into_iter().collect();
+
+    // Walk the included inner faces, compacting spade's vertex indices into a
+    // dense 0-based node list (no orphan nodes in the output).
+    let mut remap: HashMap<usize, u32> = HashMap::new();
+    let mut nodes: Vec<[f64; 2]> = Vec::new();
+    let mut tris: Vec<[u32; 3]> = Vec::new();
+
+    for face in cdt.inner_faces() {
+        if excluded.contains(&face.fix()) {
+            continue;
+        }
+        let verts = face.vertices(); // CCW order (spade guarantee)
+        let mut tri = [0u32; 3];
+        for (slot, v) in tri.iter_mut().zip(verts.iter()) {
+            let old = v.fix().index();
+            let new = *remap.entry(old).or_insert_with(|| {
+                let p = v.position();
+                nodes.push([p.x, p.y]);
+                (nodes.len() - 1) as u32
+            });
+            *slot = new;
+        }
+        // Defensive orientation guard: enforce positive signed area so the
+        // downstream Nédélec assembler's CCW assertion always holds.
+        if signed_area(&nodes, &tri) < 0.0 {
+            tri.swap(1, 2);
+        }
+        tris.push(tri);
+    }
+
+    if tris.is_empty() {
+        return Err(SpadeMeshError::EmptyMesh);
+    }
+
+    Ok(TriMesh { nodes, tris })
+}
+
+/// Compute the PEC boundary-edge mask of `mesh` purely **topologically**: an
+/// edge is a boundary (PEC) edge iff exactly one triangle is incident to it,
+/// and an interior DOF otherwise.
+///
+/// Returns `(edges, interior_edge_mask)` aligned with [`TriMesh::edges`], in
+/// the exact shape [`crate::analytic::waveguide::solve_waveguide_modes`]
+/// expects: `interior_edge_mask[i] == true` keeps edge `i` as an interior DOF;
+/// `false` marks it a PEC wall edge to be eliminated.
+///
+/// Unlike the per-shape helpers (`rect_pec_interior_edges`,
+/// `disk_pec_interior_edges`), this needs no geometric wall test and works for
+/// any simply-connected polygon mesh.
+#[must_use]
+pub fn boundary_edge_mask(mesh: &TriMesh) -> (Vec<[u32; 2]>, Vec<bool>) {
+    let edges = mesh.edges();
+    let mut lookup: HashMap<(u32, u32), usize> = HashMap::with_capacity(edges.len());
+    for (idx, e) in edges.iter().enumerate() {
+        lookup.insert((e[0], e[1]), idx);
+    }
+
+    let mut incident = vec![0usize; edges.len()];
+    for tri in &mesh.tris {
+        for &(la, lb) in TRI_LOCAL_EDGES.iter() {
+            let a = tri[la];
+            let b = tri[lb];
+            let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+            let idx = *lookup
+                .get(&(lo, hi))
+                .expect("edge derived from triangle must appear in TriMesh::edges");
+            incident[idx] += 1;
+        }
+    }
+
+    // Interior edge: shared by two triangles (count == 2). Boundary/PEC edge:
+    // owned by exactly one triangle (count == 1).
+    let mask: Vec<bool> = incident.iter().map(|&c| c != 1).collect();
+    (edges, mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A CCW unit-square boundary meshed at moderate density yields a
+    /// non-empty, orientation-correct triangulation whose every triangle has
+    /// strictly positive signed area (the Nédélec assembler contract).
+    #[test]
+    fn unit_square_mesh_is_ccw_and_nonempty() {
+        let boundary = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+        let mesh = triangulate_polygon(&boundary, &PortMeshParams::new(0.02))
+            .expect("unit square should triangulate");
+        assert!(mesh.n_tris() > 0, "expected a non-empty mesh");
+        for t in &mesh.tris {
+            assert!(
+                signed_area(&mesh.nodes, t) > 0.0,
+                "triangle {t:?} is not CCW (signed area ≤ 0)"
+            );
+        }
+    }
+
+    /// The topological boundary mask marks exactly the edges owned by a single
+    /// triangle as PEC (mask `false`) and interior-shared edges as DOFs
+    /// (mask `true`). On a closed simple polygon the boundary-edge subset must
+    /// itself form a single closed loop, so its count equals the number of
+    /// boundary nodes.
+    #[test]
+    fn boundary_mask_counts_match_topology() {
+        let boundary = [[0.0, 0.0], [2.0, 0.0], [2.0, 1.0], [0.0, 1.0]];
+        let mesh = triangulate_polygon(&boundary, &PortMeshParams::new(0.05))
+            .expect("rectangle should triangulate");
+        let (edges, mask) = boundary_edge_mask(&mesh);
+        assert_eq!(edges.len(), mask.len());
+
+        let n_boundary = mask.iter().filter(|&&keep| !keep).count();
+        let n_interior = mask.iter().filter(|&&keep| keep).count();
+        assert!(n_boundary >= 4, "at least the 4 corners bound the domain");
+        assert!(n_interior > 0, "a refined rectangle has interior edges");
+
+        // Euler check for a triangulated disk topology: on a simply-connected
+        // triangulation, (# boundary edges) == (# boundary vertices).
+        use std::collections::BTreeSet;
+        let mut boundary_nodes: BTreeSet<u32> = BTreeSet::new();
+        for (e, keep) in edges.iter().zip(mask.iter()) {
+            if !keep {
+                boundary_nodes.insert(e[0]);
+                boundary_nodes.insert(e[1]);
+            }
+        }
+        assert_eq!(
+            n_boundary,
+            boundary_nodes.len(),
+            "boundary edges should form a single closed loop"
+        );
+    }
+
+    /// Fewer than three boundary vertices is a degenerate boundary.
+    #[test]
+    fn degenerate_boundary_rejected() {
+        let boundary = [[0.0, 0.0], [1.0, 0.0]];
+        let err = triangulate_polygon(&boundary, &PortMeshParams::new(0.1))
+            .expect_err("2-vertex boundary must be rejected");
+        assert!(matches!(err, SpadeMeshError::DegenerateBoundary(2)));
+    }
+}

--- a/crates/geode-core/tests/spade_port_mesh.rs
+++ b/crates/geode-core/tests/spade_port_mesh.rs
@@ -1,0 +1,182 @@
+//! `spade`-generated wave-port cross-section meshing spike (issue #582).
+//!
+//! Validates that the in-process 2-D constrained-Delaunay mesher
+//! ([`geode_core::analytic::spade_mesh::triangulate_polygon`]) produces
+//! FEM-equivalent meshes to the existing hand-rolled generators on two
+//! known-good waveguide cross-sections, driving the general-cross-section
+//! modal eigensolver ([`solve_waveguide_modes`], issue #265) end to end:
+//!
+//! 1. **Rectangle regression** — mesh a rectangular boundary via `spade`,
+//!    solve, and compare the lowest cutoff against the analytic
+//!    [`rect_waveguide_cutoff`] oracle (the same oracle the structured
+//!    `rect_tri_mesh` tests use in `tests/rect_waveguide_modes.rs`). This
+//!    proves the `spade` mesh is FEM-equivalent to the structured mesh on a
+//!    case with a closed-form answer. It also cross-checks the two PEC-mask
+//!    construction strategies — the new topological
+//!    [`boundary_edge_mask`] versus the geometric
+//!    [`rect_pec_interior_edges`] — on the *same* `spade` mesh.
+//!
+//! 2. **Circular non-rectangular proof point** — approximate a disk boundary
+//!    with a regular polygon, mesh it via `spade`, solve, and compare the
+//!    lowest cutoff against the Bessel-zero oracle already used in
+//!    `tests/circular_waveguide_modes.rs`. This is the load-bearing evidence
+//!    that `spade` handles a genuinely non-rectangular shape the same way the
+//!    bespoke `disk_tri_mesh` fan generator does — the core claim of the
+//!    proposal.
+//!
+//! # Running
+//!
+//! ```sh
+//! cargo test -p geode-core --features spade-mesh --test spade_port_mesh
+//! ```
+#![cfg(feature = "spade-mesh")]
+
+use geode_core::analytic::spade_mesh::{PortMeshParams, boundary_edge_mask, triangulate_polygon};
+use geode_core::analytic::waveguide::{
+    rect_pec_interior_edges, rect_waveguide_cutoff, solve_waveguide_modes,
+};
+
+/// Bessel-zero table for the circular-waveguide analytic oracle (identical to
+/// the one in `tests/circular_waveguide_modes.rs`). TE_{m,n} cutoffs are zeros
+/// of `J'_m`; the dominant mode TE_{1,1} has `j'_{1,1} ≈ 1.84118`.
+const JP_M_ZEROS: &[(u32, u32, f64)] = &[(0, 1, 3.83171), (1, 1, 1.84118), (2, 1, 3.05424)];
+
+/// Regular `n`-gon inscribed in a circle of radius `r`, centered at the
+/// origin, listed CCW. Used as the polygonal approximation of a disk boundary.
+fn regular_polygon(r: f64, n: usize) -> Vec<[f64; 2]> {
+    use std::f64::consts::TAU;
+    (0..n)
+        .map(|k| {
+            let theta = TAU * (k as f64) / (n as f64);
+            [r * theta.cos(), r * theta.sin()]
+        })
+        .collect()
+}
+
+/// **Rectangle regression (issue #582 acceptance)**: a `spade`-meshed
+/// rectangular cross-section recovers the analytic TE₁₀ cutoff `π/a` through
+/// the general-cross-section solver, to within the few-percent band the
+/// structured-mesh tests use. The `spade` mesh is unstructured, so this is a
+/// genuine FEM-equivalence check, not a re-run of the structured fixture.
+#[test]
+fn spade_rectangle_recovers_te10() {
+    let (a, b) = (2.0_f64, 1.0_f64);
+    let boundary = [[0.0, 0.0], [a, 0.0], [a, b], [0.0, b]];
+    // Target ~a·b / max_area ≈ 250 triangles — comparable resolution to the
+    // structured 16×8 rect_tri_mesh fixture.
+    let mesh = triangulate_polygon(&boundary, &PortMeshParams::new(0.008))
+        .expect("spade should mesh the rectangle");
+    eprintln!(
+        "spade rectangle {a}x{b}: {} nodes, {} tris",
+        mesh.n_nodes(),
+        mesh.n_tris()
+    );
+
+    let (edges, mask) = boundary_edge_mask(&mesh);
+    let modes =
+        solve_waveguide_modes(&mesh, &edges, &mask, 2).expect("modal solve on spade rectangle");
+    assert_eq!(modes.len(), 2);
+
+    let kc_te10 = rect_waveguide_cutoff(1, 0, a, b);
+    let rel_err = (modes[0].k_c - kc_te10).abs() / kc_te10;
+    eprintln!(
+        "spade rect TE10: fem k_c = {:.5}, analytic = {:.5} ({:+.2}%)",
+        modes[0].k_c,
+        kc_te10,
+        100.0 * rel_err
+    );
+    assert!(
+        rel_err < 0.05,
+        "spade-meshed rectangle TE10: rel err {:.3}% too large",
+        100.0 * rel_err
+    );
+    for (i, m) in modes.iter().enumerate() {
+        assert!(
+            m.lambda > 1e-6,
+            "mode[{i}]: λ = {} — too close to the gradient cluster",
+            m.lambda
+        );
+    }
+}
+
+/// **PEC-mask cross-check (issue #582 Test Plan)**: on the *same*
+/// `spade`-generated rectangle mesh, the new topological
+/// [`boundary_edge_mask`] must agree edge-for-edge with the geometric
+/// [`rect_pec_interior_edges`] wall test. This pins that the purely
+/// topological "an edge is PEC iff exactly one triangle owns it" rule
+/// reproduces the shape-specific wall-membership logic without any geometry.
+#[test]
+fn topological_mask_matches_geometric_on_spade_rect() {
+    let (a, b) = (2.0_f64, 1.0_f64);
+    let boundary = [[0.0, 0.0], [a, 0.0], [a, b], [0.0, b]];
+    let mesh = triangulate_polygon(&boundary, &PortMeshParams::new(0.02))
+        .expect("spade should mesh the rectangle");
+
+    let (topo_edges, topo_mask) = boundary_edge_mask(&mesh);
+    let (geo_edges, geo_mask) = rect_pec_interior_edges(&mesh, a, b);
+
+    assert_eq!(
+        topo_edges, geo_edges,
+        "both helpers derive the same edge list from the same mesh"
+    );
+    assert_eq!(
+        topo_mask, geo_mask,
+        "topological boundary mask disagrees with the geometric wall test"
+    );
+}
+
+/// **Circular non-rectangular proof point (issue #582 acceptance)**: a
+/// `spade`-meshed polygonal disk recovers the analytic TE₁₁ circular-waveguide
+/// cutoff `j'_{1,1}/R ≈ 1.84118/R` to within a few percent — the same
+/// acceptance band and oracle as the hand-rolled `disk_tri_mesh` test in
+/// `tests/circular_waveguide_modes.rs`. TE₁₁ is doubly degenerate (azimuthal
+/// sin/cos), so either of the two lowest FEM eigenvalues is an acceptable
+/// match.
+#[test]
+fn spade_circle_recovers_te11() {
+    let r = 1.0_f64;
+    // 64-gon: the inscribed-polygon perimeter/area error is well below the
+    // few-percent modal-accuracy band.
+    let boundary = regular_polygon(r, 64);
+    // ~π·r² / max_area ≈ 520 triangles — comparable to the 8×24 disk fan.
+    let mesh = triangulate_polygon(&boundary, &PortMeshParams::new(0.006))
+        .expect("spade should mesh the polygonal disk");
+    eprintln!(
+        "spade disk R={r} (64-gon): {} nodes, {} tris",
+        mesh.n_nodes(),
+        mesh.n_tris()
+    );
+
+    let (edges, mask) = boundary_edge_mask(&mesh);
+    let n_modes = 3;
+    let modes = solve_waveguide_modes(&mesh, &edges, &mask, n_modes)
+        .expect("modal solve on spade polygonal disk");
+    assert_eq!(modes.len(), n_modes);
+
+    let kc_te11 = JP_M_ZEROS
+        .iter()
+        .find(|&&(m, n, _)| m == 1 && n == 1)
+        .map(|&(_, _, jp)| jp / r)
+        .unwrap();
+
+    for (i, m) in modes.iter().enumerate() {
+        let rel = (m.k_c - kc_te11).abs() / kc_te11;
+        eprintln!(
+            "  mode[{i}]: fem k_c = {:.5}  (|Δ| vs TE11 {:.5} = {:+.2}%)",
+            m.k_c,
+            kc_te11,
+            100.0 * rel
+        );
+    }
+
+    let best_match = modes
+        .iter()
+        .map(|m| (m.k_c - kc_te11).abs() / kc_te11)
+        .fold(f64::INFINITY, f64::min);
+    assert!(
+        best_match < 0.05,
+        "spade circular waveguide TE_{{1,1}}: no FEM mode within 5% of \
+         analytic k_c = {kc_te11:.4} (best rel err {:.2}%)",
+        100.0 * best_match
+    );
+}


### PR DESCRIPTION
## Summary

Adoption spike for `spade` (MIT/Apache-2.0, 2-D constrained Delaunay triangulation + Ruppert/Chew refinement) as the in-process mesher for arbitrary wave-port cross-sections, per the curated scope of #582. Everything is gated behind a new off-by-default `spade-mesh` Cargo feature, so the default build and dependency graph are unchanged.

**New module `crates/geode-core/src/analytic/spade_mesh.rs`:**
- `triangulate_polygon(boundary, params)` — builds a `TriMesh` from an ordered simple-polygon boundary via `ConstrainedDelaunayTriangulation::bulk_load_cdt` (cyclic constraint edges) + `refine()` with `exclude_outer_faces(true)`. `PortMeshParams` exposes the angle-limit / max-area / min-area / Steiner-vertex-budget knobs. Vertex indices are compacted (no orphan nodes) and a defensive orientation guard enforces positive signed area, so `assemble_2d_nedelec`'s CCW assertion always holds.
- `boundary_edge_mask(mesh)` — purely topological PEC mask: an edge is a wall edge iff exactly one triangle owns it. Generalizes the per-shape `rect_pec_interior_edges` / `disk_pec_interior_edges` pattern to any simply-connected polygon with zero geometric wall tests.

**Cargo wiring:** `spade = "2.15"` in `[workspace.dependencies]`; optional dep + `spade-mesh = ["dep:spade"]` feature in geode-core (mirrors the `arpack` opt-in pattern). Verified `cargo tree -p geode-core | grep -c spade` → 0 on default features.

## Validation (tests/spade_port_mesh.rs, feature-gated)

| Test | Oracle | Result |
|---|---|---|
| `spade_rectangle_recovers_te10` | `rect_waveguide_cutoff(1,0,2,1)` | TE10 k_c = 1.57097 vs 1.57080 (**+0.01%**, band 5%) |
| `topological_mask_matches_geometric_on_spade_rect` | `rect_pec_interior_edges` on the same spade mesh | edge lists and masks agree **exactly** |
| `spade_circle_recovers_te11` | Bessel-zero table (same as `circular_waveguide_modes.rs`) | TE11 degenerate pair **+0.11% / +0.12%**; mode[2] = 3.05805 lands on TE21 (j'_{2,1}=3.05424, +0.12%) |

Plus 3 module unit tests (CCW invariant, boundary-loop Euler check, degenerate-boundary rejection).

## Test results

- `cargo test -p geode-core --features spade-mesh`: lib (419 tests incl. 3 new) + doc tests + **80 of 81** integration-test binaries pass, 0 failures. The one exception: `sphere_pec_eigenmode` (pre-existing dense-QZ test, documented in its own header as "debug-*safe*, not debug-fast") was not run to completion locally — it exceeded 50 CPU-minutes on a heavily loaded box and was skipped. It is untouched by this diff (feature-gated 2-D module + optional dep only), passes on main, and is not a CI gate.
- `cargo build -p geode-core` (default features): clean, `spade` absent from the graph.
- `cargo clippy -p geode-core --features spade-mesh --tests`: clean.
- `cargo fmt --check`: clean.

## Explicitly deferred (per issue scope)

- `WavePort` production wiring (`solve_wave_port_sweep_with_mode`).
- Interior holes / conductor cutouts in the port face.
- Any 3-D meshing / the fTetWild thread (separate proposal).

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)