### PR TITLE
feat(elements): P2 Lagrange tet elements on the electrostatic path — higher-order capacitance with the adjoint retained

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 582
-# Branch: feature/issue-582
+# Issue: 602
+# Branch: feature/issue-602
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/adjoint.rs
+++ b/crates/geode-core/src/adjoint.rs
@@ -71,10 +71,13 @@
 
 use faer::Mat;
 use faer::linalg::solvers::Solve;
+use faer::sparse::SparseColMat;
 
 use crate::assembly::electrostatic::{
-    EPS_0, Electrode, ElectrostaticError, assemble_electrostatic, tet_p1_local,
+    EPS_0, Electrode, ElectrostaticError, assemble_electrostatic, assemble_electrostatic_p2,
+    tet_p1_local,
 };
+use crate::elements::p2::{TET_P2_DOFS, tet_p2_local};
 use crate::mesh::TetMesh;
 
 /// Result of an electrostatic discrete-adjoint gradient evaluation.
@@ -251,6 +254,329 @@ where
         phi,
         n_factorizations,
     })
+}
+
+/// Compute `∂g/∂ε_k` for every region `k` of a **quadratic (P2)** scalar
+/// electrostatic solve via the discrete adjoint — the P2 twin of
+/// [`electrostatic_adjoint_gradient`] (issue #602: the FD-validated ∂/∂ε
+/// adjoint survives the order lift, it is not deferred).
+///
+/// Identical contract, with the P2 DOF layout: the objective receives (and
+/// returns a cotangent of) the full-length `[n_dof]` quadratic potential
+/// (`n_dof = n_nodes + n_edges`; vertex values then edge-midpoint values),
+/// and the returned [`AdjointGradient::phi`] has length `n_dof`. The
+/// element-level JVP reuses the P2 assembler's own kernel
+/// ([`tet_p2_local`]) — exact, as in the P1 path. A dedicated twin is
+/// deliberately chosen over generalizing the P1 signature (the P1 function
+/// hard-codes the `[n_nodes]` layout; keeping it untouched keeps the
+/// merged #570/#571 sensitivity results bit-for-bit).
+///
+/// # Errors
+///
+/// As [`electrostatic_adjoint_gradient`], with the cotangent length checked
+/// against `n_dof` instead of `n_nodes`.
+#[allow(clippy::too_many_arguments)]
+pub fn electrostatic_adjoint_gradient_p2<G>(
+    mesh: &TetMesh,
+    eps_r: &[f64],
+    rho: &[f64],
+    electrodes: &[Electrode],
+    ground: &[u32],
+    region_of_tet: &[usize],
+    n_regions: usize,
+    objective: G,
+) -> Result<AdjointGradient, ElectrostaticError>
+where
+    G: Fn(&[f64]) -> (f64, Vec<f64>),
+{
+    let n_tets = mesh.n_tets();
+    if region_of_tet.len() != n_tets {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "region_of_tet length {} != tet count {n_tets}",
+            region_of_tet.len()
+        )));
+    }
+    if let Some(&bad) = region_of_tet.iter().find(|&&r| r >= n_regions) {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "region label {bad} out of range for n_regions {n_regions}"
+        )));
+    }
+
+    // --- Assemble the SPD P2 system (full + reduced K, RHS). ---
+    let sys = assemble_electrostatic_p2(mesh, eps_r, rho, electrodes, ground)?;
+    let n_dof = sys.n_dof;
+
+    // --- Factor the reduced stiffness ONCE (forward + adjoint). ---
+    let lu = sys
+        .k
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| ElectrostaticError::Factorization(format!("{e:?}")))?;
+    let n_factorizations = 1;
+
+    // --- Forward solve: K_ff u_free = b_free. ---
+    let mut fwd: Mat<f64> = Mat::from_fn(sys.n_free, 1, |i, _| sys.b[i]);
+    lu.solve_in_place(fwd.as_mut());
+
+    let mut u = sys.dirichlet_value.clone();
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            u[g] = fwd[(*fi, 0)];
+        }
+    }
+
+    // --- Objective and its cotangent ∂g/∂u. ---
+    let (objective_value, dg_du) = objective(&u);
+    if dg_du.len() != n_dof {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "objective cotangent length {} != P2 DOF count {n_dof}",
+            dg_du.len()
+        )));
+    }
+
+    // --- Adjoint solve: K_ffᵀ λ_free = (∂g/∂u)_free, reusing the LU. ---
+    let mut adj: Mat<f64> = Mat::from_fn(sys.n_free, 1, |_, _| 0.0);
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            adj[(*fi, 0)] = dg_du[g];
+        }
+    }
+    lu.solve_transpose_in_place(adj.as_mut());
+
+    let mut lambda_full = vec![0.0_f64; n_dof];
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            lambda_full[g] = adj[(*fi, 0)];
+        }
+    }
+
+    // --- Gradient: dg/dε_k = −λᵀ (∂A/∂ε_k) u, region-by-region, reusing
+    // the P2 element kernel (exact analytic JVP of the linear-in-ε
+    // assembly). Local→global DOF mapping matches the assembler (edge sign
+    // discarded — midpoint value DOFs are orientation-independent). ---
+    let tet_edges = mesh.tet_edges();
+    let n_nodes = mesh.n_nodes();
+    let mut grad = vec![0.0_f64; n_regions];
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords = [
+            mesh.nodes[tet[0] as usize],
+            mesh.nodes[tet[1] as usize],
+            mesh.nodes[tet[2] as usize],
+            mesh.nodes[tet[3] as usize],
+        ];
+        let (k_local, _load, _vol) = tet_p2_local(&coords);
+        let te = &tet_edges[t];
+        let gdof = |l: usize| -> usize {
+            if l < 4 {
+                tet[l] as usize
+            } else {
+                n_nodes + te[l - 4].0 as usize
+            }
+        };
+        let r = region_of_tet[t];
+        let mut contrib = 0.0_f64;
+        for p in 0..TET_P2_DOFS {
+            let lp = lambda_full[gdof(p)];
+            if lp == 0.0 {
+                continue;
+            }
+            let mut ku_p = 0.0_f64;
+            for q in 0..TET_P2_DOFS {
+                ku_p += k_local[p][q] * u[gdof(q)];
+            }
+            contrib += lp * EPS_0 * ku_p;
+        }
+        grad[r] -= contrib;
+    }
+
+    Ok(AdjointGradient {
+        objective: objective_value,
+        grad,
+        phi: u,
+        n_factorizations,
+    })
+}
+
+/// Result of a P2 capacitance ε-sensitivity evaluation: the two-terminal
+/// capacitance and its exact discrete gradient with respect to the
+/// per-region relative permittivity.
+#[derive(Debug, Clone)]
+pub struct CapacitanceGradient {
+    /// The two-terminal capacitance `C = 2W/V²` (F) at the evaluated ε.
+    pub capacitance: f64,
+    /// `dC/dε_k`, one entry per region.
+    pub grad: Vec<f64>,
+    /// Number of sparse LU factorizations performed (always `1`; the
+    /// adjoint reuses the forward factorization).
+    pub n_factorizations: usize,
+}
+
+/// Two-terminal capacitance `C = 2W/V²` and its per-region `∂C/∂ε_k` at
+/// **P2**, via the discrete adjoint (issue #602's headline deliverable:
+/// higher-order capacitance **with the adjoint retained**).
+///
+/// Unlike [`electrostatic_adjoint_gradient_p2`]'s generic objective, the
+/// energy objective `C(ε) = u(ε)ᵀ K(ε) u(ε) / V²` depends on ε **both**
+/// explicitly (through `K`) and implicitly (through the solved `u`), so the
+/// total derivative carries two terms:
+///
+/// ```text
+///   dC/dε_k = (1/V²) uᵀ (∂K/∂ε_k) u  −  λᵀ (∂K/∂ε_k) u ,
+///   with  K_ffᵀ λ = (2/V²) (K u)|_free      (λ = 0 on pinned DOFs).
+/// ```
+///
+/// For a source-free voltage-driven solve the residual `(K u)|_free` is
+/// zero to solver precision (the classic stationarity of the energy at the
+/// solution), so the adjoint term is numerically negligible — but it is
+/// computed, not assumed, and the finite-difference validation covers the
+/// total. One factorization serves both solves.
+///
+/// # Arguments
+///
+/// `electrodes` must contain **exactly one** electrode (the driven
+/// terminal, at its `voltage` `V ≠ 0`); `ground` is the return conductor.
+/// Multi-conductor Maxwell-matrix sensitivities are out of scope here.
+///
+/// # Errors
+///
+/// [`ElectrostaticError::ShapeMismatch`] if `region_of_tet` is the wrong
+/// length, a region label is out of range, `electrodes.len() != 1`, or the
+/// electrode voltage is zero; otherwise propagates assembly/factorization
+/// errors.
+pub fn capacitance_adjoint_gradient_p2(
+    mesh: &TetMesh,
+    eps_r: &[f64],
+    electrodes: &[Electrode],
+    ground: &[u32],
+    region_of_tet: &[usize],
+    n_regions: usize,
+) -> Result<CapacitanceGradient, ElectrostaticError> {
+    let n_tets = mesh.n_tets();
+    if region_of_tet.len() != n_tets {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "region_of_tet length {} != tet count {n_tets}",
+            region_of_tet.len()
+        )));
+    }
+    if let Some(&bad) = region_of_tet.iter().find(|&&r| r >= n_regions) {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "region label {bad} out of range for n_regions {n_regions}"
+        )));
+    }
+    if electrodes.len() != 1 {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "capacitance gradient needs exactly one driven electrode, got {}",
+            electrodes.len()
+        )));
+    }
+    let v_drive = electrodes[0].voltage;
+    if v_drive == 0.0 {
+        return Err(ElectrostaticError::ShapeMismatch(
+            "driven electrode voltage must be non-zero".into(),
+        ));
+    }
+
+    let rho = vec![0.0_f64; n_tets];
+    let sys = assemble_electrostatic_p2(mesh, eps_r, &rho, electrodes, ground)?;
+    let n_dof = sys.n_dof;
+
+    // Factor ONCE; forward + adjoint share it.
+    let lu = sys
+        .k
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| ElectrostaticError::Factorization(format!("{e:?}")))?;
+    let n_factorizations = 1;
+
+    // Forward solve.
+    let mut fwd: Mat<f64> = Mat::from_fn(sys.n_free, 1, |i, _| sys.b[i]);
+    lu.solve_in_place(fwd.as_mut());
+    let mut u = sys.dirichlet_value.clone();
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            u[g] = fwd[(*fi, 0)];
+        }
+    }
+
+    // C = uᵀ K u / V² (= 2W/V²).
+    let ku = sparse_matvec(&sys.k_full, &u);
+    let utku: f64 = u.iter().zip(ku.iter()).map(|(a, b)| a * b).sum();
+    let inv_v2 = 1.0 / (v_drive * v_drive);
+    let capacitance = utku * inv_v2;
+
+    // Adjoint solve: K_ffᵀ λ = (2/V²)(K u)|_free.
+    let mut adj: Mat<f64> = Mat::from_fn(sys.n_free, 1, |_, _| 0.0);
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            adj[(*fi, 0)] = 2.0 * inv_v2 * ku[g];
+        }
+    }
+    lu.solve_transpose_in_place(adj.as_mut());
+    let mut lambda_full = vec![0.0_f64; n_dof];
+    for (g, slot) in sys.free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            lambda_full[g] = adj[(*fi, 0)];
+        }
+    }
+
+    // Per-region accumulation of both terms in one tet pass.
+    let tet_edges = mesh.tet_edges();
+    let n_nodes = mesh.n_nodes();
+    let mut grad = vec![0.0_f64; n_regions];
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords = [
+            mesh.nodes[tet[0] as usize],
+            mesh.nodes[tet[1] as usize],
+            mesh.nodes[tet[2] as usize],
+            mesh.nodes[tet[3] as usize],
+        ];
+        let (k_local, _load, _vol) = tet_p2_local(&coords);
+        let te = &tet_edges[t];
+        let gdof = |l: usize| -> usize {
+            if l < 4 {
+                tet[l] as usize
+            } else {
+                n_nodes + te[l - 4].0 as usize
+            }
+        };
+        let r = region_of_tet[t];
+        let mut explicit = 0.0_f64; // uᵀ (ε₀ K_local) u
+        let mut adjoint = 0.0_f64; //  λᵀ (ε₀ K_local) u
+        for (p, k_row) in k_local.iter().enumerate() {
+            let gp = gdof(p);
+            let mut ku_p = 0.0_f64;
+            for (q, &kpq) in k_row.iter().enumerate() {
+                ku_p += kpq * u[gdof(q)];
+            }
+            explicit += u[gp] * EPS_0 * ku_p;
+            adjoint += lambda_full[gp] * EPS_0 * ku_p;
+        }
+        grad[r] += explicit * inv_v2 - adjoint;
+    }
+
+    Ok(CapacitanceGradient {
+        capacitance,
+        grad,
+        n_factorizations,
+    })
+}
+
+/// Full-length sparse matrix-vector product `K · u` (column-walk).
+fn sparse_matvec(k: &SparseColMat<usize, f64>, u: &[f64]) -> Vec<f64> {
+    let k_ref = k.as_ref();
+    let cp = k_ref.col_ptr();
+    let row_idx = k_ref.row_idx();
+    let vals = k_ref.val();
+    let mut out = vec![0.0_f64; k_ref.nrows()];
+    for (j, &uj) in u.iter().enumerate().take(k_ref.ncols()) {
+        if uj == 0.0 {
+            continue;
+        }
+        for k in cp[j]..cp[j + 1] {
+            out[row_idx[k]] += vals[k] * uj;
+        }
+    }
+    out
 }
 
 /// Expand a per-region relative-permittivity table into the per-tet `ε_r`
@@ -474,6 +800,125 @@ mod tests {
                 rel < 1e-4,
                 "region {k}: adjoint {} vs FD {fd}, rel-err {rel:.3e}",
                 adj.grad[k]
+            );
+        }
+    }
+
+    /// **P2 twin of the load-bearing test** (issue #602): the P2
+    /// discrete-adjoint gradient must match a full central finite
+    /// difference of the entire P2 pipeline (perturb ε_k → re-assemble →
+    /// re-solve → recompute g) for every region, at the same rel < 1e-4
+    /// bar, with exactly one factorization.
+    #[test]
+    fn adjoint_gradient_p2_matches_central_finite_difference() {
+        use crate::assembly::electrostatic::assemble_electrostatic_p2;
+
+        let (mesh, region_of_tet, electrodes, ground) = layered_capacitor_fixture(4);
+        let n_regions = 3;
+        let eps_region = [2.0_f64, 5.0, 3.0];
+        let rho = vec![0.0; mesh.n_tets()];
+        let eps_r = build_region_eps(&region_of_tet, &eps_region);
+
+        let adj = electrostatic_adjoint_gradient_p2(
+            &mesh,
+            &eps_r,
+            &rho,
+            &electrodes,
+            &ground,
+            &region_of_tet,
+            n_regions,
+            quadratic_objective,
+        )
+        .unwrap();
+        assert_eq!(adj.n_factorizations, 1);
+
+        let g_of = |eps_region: &[f64]| -> f64 {
+            let er = build_region_eps(&region_of_tet, eps_region);
+            let sys = assemble_electrostatic_p2(&mesh, &er, &rho, &electrodes, &ground).unwrap();
+            let u = sys.solve().unwrap();
+            quadratic_objective(&u).0
+        };
+
+        let h = 1e-5;
+        for k in 0..n_regions {
+            let mut ep = eps_region;
+            let mut em = eps_region;
+            ep[k] += h;
+            em[k] -= h;
+            let fd = (g_of(&ep) - g_of(&em)) / (2.0 * h);
+            let a = adj.grad[k];
+            let rel = (a - fd).abs() / fd.abs().max(f64::MIN_POSITIVE);
+            assert!(
+                fd.abs() > 1e-6,
+                "region {k} FD gradient {fd} unexpectedly ~0 (fixture degenerate?)"
+            );
+            assert!(
+                rel < 1e-4,
+                "region {k}: P2 adjoint {a} vs central-FD {fd}, rel-err {rel:.3e} exceeds 1e-4"
+            );
+        }
+    }
+
+    /// **∂C/∂ε FD-validated at P2** (issue #602 acceptance criterion). The
+    /// layered capacitor with slab-aligned elements (n divisible by 3) has
+    /// a piecewise-linear exact solution, so the P2 capacitance equals the
+    /// analytic series capacitance to rounding — checked as a bonus — and
+    /// the adjoint dC/dε_k must match the central FD of the full
+    /// (re-assemble → re-solve → C = 2W/V²) pipeline at rel < 1e-4.
+    #[test]
+    fn p2_capacitance_gradient_matches_central_finite_difference() {
+        use crate::assembly::electrostatic::assemble_electrostatic_p2;
+
+        // n = 6 aligns the region interfaces (x = 1/3, 2/3) with element
+        // faces, making the exact solution piecewise linear.
+        let (mesh, region_of_tet, electrodes, ground) = layered_capacitor_fixture(6);
+        let n_regions = 3;
+        let eps_region = [2.0_f64, 5.0, 3.0];
+        let eps_r = build_region_eps(&region_of_tet, &eps_region);
+
+        let res = capacitance_adjoint_gradient_p2(
+            &mesh,
+            &eps_r,
+            &electrodes,
+            &ground,
+            &region_of_tet,
+            n_regions,
+        )
+        .unwrap();
+        assert_eq!(res.n_factorizations, 1);
+
+        // Bonus exactness check: series capacitance of three equal slabs,
+        // C = ε₀ A / (Σ d_i/ε_i) with A = 1, d_i = 1/3.
+        let c_series = EPS_0 / ((1.0 / 3.0) * (1.0 / 2.0 + 1.0 / 5.0 + 1.0 / 3.0));
+        let rel_c = (res.capacitance - c_series).abs() / c_series;
+        assert!(
+            rel_c < 1e-9,
+            "P2 layered C {} vs series {c_series}, rel {rel_c}",
+            res.capacitance
+        );
+
+        let c_of = |eps_region: &[f64]| -> f64 {
+            let er = build_region_eps(&region_of_tet, eps_region);
+            let rho = vec![0.0; mesh.n_tets()];
+            let sys = assemble_electrostatic_p2(&mesh, &er, &rho, &electrodes, &ground).unwrap();
+            let u = sys.solve().unwrap();
+            let v = electrodes[0].voltage;
+            2.0 * sys.field_energy(&u) / (v * v)
+        };
+
+        let h = 1e-5;
+        for k in 0..n_regions {
+            let mut ep = eps_region;
+            let mut em = eps_region;
+            ep[k] += h;
+            em[k] -= h;
+            let fd = (c_of(&ep) - c_of(&em)) / (2.0 * h);
+            let a = res.grad[k];
+            let rel = (a - fd).abs() / fd.abs().max(f64::MIN_POSITIVE);
+            assert!(fd.abs() > 1e-20, "region {k} FD dC/dε {fd} unexpectedly ~0");
+            assert!(
+                rel < 1e-4,
+                "region {k}: adjoint dC/dε {a} vs central-FD {fd}, rel-err {rel:.3e} exceeds 1e-4"
             );
         }
     }

--- a/crates/geode-core/src/assembly/electrostatic.rs
+++ b/crates/geode-core/src/assembly/electrostatic.rs
@@ -1,5 +1,8 @@
 //! Host-side **scalar electrostatic** assembly and multi-conductor
-//! capacitance-matrix extraction on a 3-D tetrahedral mesh (P1).
+//! capacitance-matrix extraction on a 3-D tetrahedral mesh (P1 by
+//! default; an opt-in quadratic P2 path — [`assemble_electrostatic_p2`] /
+//! [`extract_capacitance_p2`] — was added by issue #602 and leaves the P1
+//! path untouched).
 //!
 //! Palace's `Electrostatic` problem type solves
 //!
@@ -71,6 +74,7 @@ use faer::Mat;
 use faer::sparse::{SparseColMat, Triplet};
 
 pub use crate::assembly::p1::SparsityPattern;
+use crate::elements::p2::{TET_P2_DOFS, tet_p2_local};
 use crate::mesh::TetMesh;
 
 /// Vacuum permittivity `ε₀` (F/m, CODATA). The electrostatic operator is
@@ -907,6 +911,434 @@ fn sparsity_from_tets(tets: &[[u32; 4]]) -> SparsityPattern {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Quadratic (P2) electrostatic path (Epic #475, issue #602). Fully additive
+// alongside the P1 path above — the P1 functions are untouched, and P2 is
+// opt-in via these `_p2` entry points. DOF numbering follows the 2-D P2
+// magnetostatic precedent (#472): vertex DOFs keep their node index, and
+// the edge-midpoint DOF of global edge `k` (from `TetMesh::edges`) sits at
+// `n_nodes + k`. The element kernel lives in `crate::elements::p2`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Global P2 DOF count for a tet mesh: `n_nodes + n_edges` (see
+/// [`TetMesh::edges`]). The size of the potential vector
+/// [`ElectrostaticP2System::solve`] returns.
+#[inline]
+pub fn p2_dof_count(mesh: &TetMesh) -> usize {
+    mesh.n_nodes() + mesh.edges().len()
+}
+
+/// P2 DOF bookkeeping for a tet mesh: the global edge table plus the
+/// **boundary-face** table needed to pin edge-midpoint DOFs on electrodes.
+///
+/// # Electrode edge-DOF classification (the issue-#602 pitfall)
+///
+/// [`Electrode`] carries only **node** indices. A P2 edge-midpoint DOF is
+/// pinned to electrode *k* iff its edge lies on a **boundary face** (a tet
+/// face owned by exactly one tet) whose three vertices are all in
+/// electrode *k*'s node set. The tempting "both endpoints on the
+/// electrode" vertex-AND shortcut is wrong in general: it mis-tags edges
+/// that span **between two electrodes** or cut through the dielectric
+/// between two points of the same conductor surface — such edges' midpoint
+/// potentials are unknowns, not boundary data. See
+/// `p2_pitfall_cross_plate_edges_stay_free` for the concrete failure the
+/// facet rule prevents.
+#[derive(Debug, Clone)]
+pub struct P2DofMap {
+    /// Node count of the source mesh (edge DOFs start at this offset).
+    pub n_nodes: usize,
+    /// The sorted-unique global edge table ([`TetMesh::edges`]).
+    pub edges: Vec<[u32; 2]>,
+    /// Canonical `(lo, hi)` node pair → global edge index.
+    edge_index: std::collections::HashMap<(u32, u32), u32>,
+    /// Boundary faces (sorted node triples owned by exactly one tet).
+    boundary_faces: Vec<[u32; 3]>,
+}
+
+impl P2DofMap {
+    /// Build the P2 DOF map (edge table + boundary-face table) for a mesh.
+    pub fn new(mesh: &TetMesh) -> Self {
+        use std::collections::HashMap;
+        let edges = mesh.edges();
+        let mut edge_index: HashMap<(u32, u32), u32> = HashMap::with_capacity(edges.len());
+        for (i, e) in edges.iter().enumerate() {
+            edge_index.insert((e[0], e[1]), i as u32);
+        }
+        // Boundary faces: sorted triples that appear in exactly one tet.
+        const FACES: [[usize; 3]; 4] = [[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]];
+        let mut count: HashMap<[u32; 3], u32> = HashMap::new();
+        for tet in &mesh.tets {
+            for f in FACES.iter() {
+                let key = sorted3([tet[f[0]], tet[f[1]], tet[f[2]]]);
+                *count.entry(key).or_insert(0) += 1;
+            }
+        }
+        let boundary_faces: Vec<[u32; 3]> = count
+            .into_iter()
+            .filter(|&(_, c)| c == 1)
+            .map(|(k, _)| k)
+            .collect();
+        Self {
+            n_nodes: mesh.n_nodes(),
+            edges,
+            edge_index,
+            boundary_faces,
+        }
+    }
+
+    /// Total P2 DOF count (`n_nodes + n_edges`).
+    #[inline]
+    pub fn n_dof(&self) -> usize {
+        self.n_nodes + self.edges.len()
+    }
+
+    /// The full pinned P2 DOF set of an electrode given its node set:
+    /// the vertex DOFs (the nodes themselves) plus the edge-midpoint DOFs
+    /// of every edge of a **boundary face fully contained in the node set**
+    /// (the facet rule — see the type-level docs). Sorted, deduplicated.
+    pub fn electrode_dofs(&self, nodes: &[u32]) -> Vec<usize> {
+        use std::collections::HashSet;
+        let set: HashSet<u32> = nodes.iter().copied().collect();
+        let mut dofs: Vec<usize> = nodes.iter().map(|&n| n as usize).collect();
+        for f in &self.boundary_faces {
+            if f.iter().all(|v| set.contains(v)) {
+                // Face triples are sorted, so each pair is canonical (lo, hi).
+                for &(a, b) in &[(f[0], f[1]), (f[0], f[2]), (f[1], f[2])] {
+                    let idx = *self
+                        .edge_index
+                        .get(&(a, b))
+                        .expect("boundary-face edge must be in the edge table");
+                    dofs.push(self.n_nodes + idx as usize);
+                }
+            }
+        }
+        dofs.sort_unstable();
+        dofs.dedup();
+        dofs
+    }
+}
+
+/// Assembled 3-D **quadratic (P2)** scalar electrostatic system, indexed on
+/// the `n_nodes + n_edges` P2 DOFs of a [`TetMesh`], with the Dirichlet
+/// electrode/ground DOFs eliminated but the **full pre-elimination
+/// stiffness retained** for the energy method.
+///
+/// Second-order sibling of [`ElectrostaticSystem`]; see
+/// [`assemble_electrostatic_p2`].
+#[derive(Debug, Clone)]
+pub struct ElectrostaticP2System {
+    /// Reduced SPD stiffness `K` restricted to the free DOFs.
+    pub k: SparseColMat<usize, f64>,
+    /// Full, unconstrained stiffness `K` on all `n_dof` DOFs (the energy
+    /// method's operator, as in the P1 system).
+    pub k_full: SparseColMat<usize, f64>,
+    /// Reduced RHS on the free DOFs (Dirichlet columns folded in).
+    pub b: Vec<f64>,
+    /// Prescribed Dirichlet value per DOF (`0.0` for free DOFs). Length
+    /// `n_dof`.
+    pub dirichlet_value: Vec<f64>,
+    /// Global → free-DOF renumber (`None` = pinned). Length `n_dof`.
+    pub free_of_global: Vec<Option<usize>>,
+    /// Number of free (unpinned) DOFs = order of `k`.
+    pub n_free: usize,
+    /// Total P2 DOF count (`n_nodes + n_edges`).
+    pub n_dof: usize,
+    /// Node count of the source mesh (edge DOFs start at this offset).
+    pub n_nodes: usize,
+    /// The P2 DOF bookkeeping (edge table + boundary faces), retained so
+    /// [`extract_capacitance_p2`] can re-derive per-conductor pinned DOF
+    /// sets with the same facet rule the assembly used.
+    pub dof_map: P2DofMap,
+}
+
+impl ElectrostaticP2System {
+    /// Solve `K u = b` on the free DOFs and scatter back to a full-length
+    /// `[n_dof]` quadratic potential (vertex values, then edge-midpoint
+    /// values; pinned DOFs carry their Dirichlet value).
+    pub fn solve(&self) -> Result<Vec<f64>, ElectrostaticError> {
+        use faer::linalg::solvers::Solve;
+
+        let lu = self
+            .k
+            .as_ref()
+            .sp_lu()
+            .map_err(|e| ElectrostaticError::Factorization(format!("{e:?}")))?;
+
+        let mut rhs: Mat<f64> = Mat::from_fn(self.n_free, 1, |i, _| self.b[i]);
+        lu.solve_in_place(rhs.as_mut());
+
+        let mut u = self.dirichlet_value.clone();
+        for (g, slot) in self.free_of_global.iter().enumerate() {
+            if let Some(fi) = slot {
+                u[g] = rhs[(*fi, 0)];
+            }
+        }
+        Ok(u)
+    }
+
+    /// Solve with re-folded pinned potentials (the per-excitation solve of
+    /// the capacitance extraction) — P2 twin of
+    /// [`ElectrostaticSystem::solve_with_pinned`]. `pinned_value[g]`
+    /// supplies the Dirichlet potential for pinned DOF `g` (ignored for
+    /// free DOFs); the charge RHS is zero (capacitance runs are
+    /// source-free).
+    fn solve_with_pinned(&self, pinned_value: &[f64]) -> Result<Vec<f64>, ElectrostaticError> {
+        use faer::linalg::solvers::Solve;
+
+        let mut b_free = vec![0.0_f64; self.n_free];
+        let k_ref = self.k_full.as_ref();
+        let cp = k_ref.col_ptr();
+        let row_idx = k_ref.row_idx();
+        let vals = k_ref.val();
+        for j in 0..self.n_dof {
+            if self.free_of_global[j].is_some() {
+                continue;
+            }
+            let vj = pinned_value[j];
+            if vj == 0.0 {
+                continue;
+            }
+            for k in cp[j]..cp[j + 1] {
+                let i = row_idx[k];
+                if let Some(fi) = self.free_of_global[i] {
+                    b_free[fi] -= vals[k] * vj;
+                }
+            }
+        }
+
+        let lu = self
+            .k
+            .as_ref()
+            .sp_lu()
+            .map_err(|e| ElectrostaticError::Factorization(format!("{e:?}")))?;
+        let mut rhs: Mat<f64> = Mat::from_fn(self.n_free, 1, |i, _| b_free[i]);
+        lu.solve_in_place(rhs.as_mut());
+
+        let mut u = vec![0.0_f64; self.n_dof];
+        for (g, slot) in self.free_of_global.iter().enumerate() {
+            match slot {
+                Some(fi) => u[g] = rhs[(*fi, 0)],
+                None => u[g] = pinned_value[g],
+            }
+        }
+        Ok(u)
+    }
+
+    /// Total field energy `W = ½ uᵀ K u` using the **full** stiffness, for
+    /// a full-length `[n_dof]` quadratic potential.
+    pub fn field_energy(&self, u: &[f64]) -> f64 {
+        0.5 * quad_form(&self.k_full, u, u)
+    }
+}
+
+/// Assemble the reduced SPD **quadratic (P2)** electrostatic system for
+/// `−∇·(ε₀ ε_r ∇φ) = ρ` — second-order, opt-in sibling of
+/// [`assemble_electrostatic`] (whose behavior is unchanged).
+///
+/// Arguments are identical to [`assemble_electrostatic`]. Dirichlet
+/// handling differs only in the edge-midpoint DOFs: an electrode pins its
+/// node set's vertex DOFs plus the edge DOFs selected by the
+/// boundary-facet rule ([`P2DofMap::electrode_dofs`]) — **not** every edge
+/// whose two endpoints happen to lie on electrodes.
+///
+/// # Errors
+///
+/// As [`assemble_electrostatic`].
+pub fn assemble_electrostatic_p2(
+    mesh: &TetMesh,
+    eps_r: &[f64],
+    rho: &[f64],
+    electrodes: &[Electrode],
+    ground: &[u32],
+) -> Result<ElectrostaticP2System, ElectrostaticError> {
+    let n_nodes = mesh.n_nodes();
+    let n_tets = mesh.n_tets();
+    if eps_r.len() != n_tets {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "eps_r length {} != tet count {n_tets}",
+            eps_r.len()
+        )));
+    }
+    if rho.len() != n_tets {
+        return Err(ElectrostaticError::ShapeMismatch(format!(
+            "rho length {} != tet count {n_tets}",
+            rho.len()
+        )));
+    }
+    for e in electrodes {
+        if e.nodes.is_empty() {
+            return Err(ElectrostaticError::EmptyElectrode(e.name.clone()));
+        }
+    }
+
+    let dof_map = P2DofMap::new(mesh);
+    let n_dof = dof_map.n_dof();
+    let tet_edges = mesh.tet_edges();
+
+    // Element stiffness/load scatter over the full P2 DOF system.
+    let mut full_trips: Vec<Triplet<usize, usize, f64>> =
+        Vec::with_capacity(n_tets * TET_P2_DOFS * TET_P2_DOFS);
+    let mut b_full = vec![0.0_f64; n_dof];
+
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords = [
+            mesh.nodes[tet[0] as usize],
+            mesh.nodes[tet[1] as usize],
+            mesh.nodes[tet[2] as usize],
+            mesh.nodes[tet[3] as usize],
+        ];
+        let (k_local, load, _vol) = tet_p2_local(&coords);
+        let eps_t = EPS_0 * eps_r[t];
+        let rho_t = rho[t];
+        let te = &tet_edges[t];
+        // Local P2 DOF (0..10) → global DOF. The edge sign is deliberately
+        // discarded: midpoint value DOFs are orientation-independent.
+        let gdof = |l: usize| -> usize {
+            if l < 4 {
+                tet[l] as usize
+            } else {
+                n_nodes + te[l - 4].0 as usize
+            }
+        };
+        for (p, k_row) in k_local.iter().enumerate() {
+            let gp = gdof(p);
+            b_full[gp] += load[p] * rho_t;
+            for (q, &kpq) in k_row.iter().enumerate() {
+                full_trips.push(Triplet::new(gp, gdof(q), eps_t * kpq));
+            }
+        }
+    }
+
+    let k_full = SparseColMat::<usize, f64>::try_new_from_triplets(n_dof, n_dof, &full_trips)
+        .map_err(|e| ElectrostaticError::Assembly(format!("{e:?}")))?;
+
+    // Dirichlet pinning: ground first, then electrodes (later wins),
+    // matching the P1 path's ordering. Edge DOFs come from the facet rule.
+    let mut dirichlet_value = vec![0.0_f64; n_dof];
+    let mut pinned = vec![false; n_dof];
+    for d in dof_map.electrode_dofs(ground) {
+        pinned[d] = true;
+        dirichlet_value[d] = 0.0;
+    }
+    for e in electrodes {
+        for d in dof_map.electrode_dofs(&e.nodes) {
+            pinned[d] = true;
+            dirichlet_value[d] = e.voltage;
+        }
+    }
+
+    let mut free_of_global = vec![None; n_dof];
+    let mut n_free = 0usize;
+    for (g, &p) in pinned.iter().enumerate() {
+        if !p {
+            free_of_global[g] = Some(n_free);
+            n_free += 1;
+        }
+    }
+
+    let mut red_trips: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(full_trips.len());
+    let mut b_free = vec![0.0_f64; n_free];
+    for (i, slot) in free_of_global.iter().enumerate() {
+        if let Some(fi) = slot {
+            b_free[*fi] = b_full[i];
+        }
+    }
+    let k_ref = k_full.as_ref();
+    let cp = k_ref.col_ptr();
+    let row_idx = k_ref.row_idx();
+    let vals = k_ref.val();
+    for j in 0..n_dof {
+        for k in cp[j]..cp[j + 1] {
+            let i = row_idx[k];
+            let v = vals[k];
+            match (free_of_global[i], free_of_global[j]) {
+                (Some(fi), Some(fj)) => red_trips.push(Triplet::new(fi, fj, v)),
+                (Some(fi), None) => {
+                    b_free[fi] -= v * dirichlet_value[j];
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let k = SparseColMat::<usize, f64>::try_new_from_triplets(n_free, n_free, &red_trips)
+        .map_err(|e| ElectrostaticError::Assembly(format!("{e:?}")))?;
+
+    Ok(ElectrostaticP2System {
+        k,
+        k_full,
+        b: b_free,
+        dirichlet_value,
+        free_of_global,
+        n_free,
+        n_dof,
+        n_nodes,
+        dof_map,
+    })
+}
+
+/// Extract the N×N Maxwell capacitance matrix by the **energy method** at
+/// P2 — second-order sibling of [`extract_capacitance`], structurally
+/// identical: `N` unit-voltage solves reusing the assembled system, then
+/// `C_ij = u⁽ⁱ⁾ᵀ K u⁽ʲ⁾` with the full P2 stiffness. Per-conductor pinned
+/// DOF sets are re-derived with the same boundary-facet rule the assembly
+/// used ([`P2DofMap::electrode_dofs`]).
+///
+/// The P1 path's optional surface-flux diagonal cross-check is **not**
+/// offered at P2 (it consumes a piecewise-constant per-tet `E`, a
+/// P1-specific recovery); `c_flux_diag` is all-`None`. The
+/// [`CapacitanceMatrix`] invariants (`max_rel_asymmetry`,
+/// `has_maxwell_sign_structure`) apply unchanged.
+///
+/// # Errors
+///
+/// Propagates [`ElectrostaticError`] from the per-excitation solves.
+pub fn extract_capacitance_p2(
+    sys: &ElectrostaticP2System,
+    conductors: &[Electrode],
+    ground: &[u32],
+) -> Result<CapacitanceMatrix, ElectrostaticError> {
+    let n = conductors.len();
+
+    let ground_dofs = sys.dof_map.electrode_dofs(ground);
+    let cond_dofs: Vec<Vec<usize>> = conductors
+        .iter()
+        .map(|c| sys.dof_map.electrode_dofs(&c.nodes))
+        .collect();
+
+    // One unit-voltage solve per conductor.
+    let mut us: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for i in 0..n {
+        let mut pinned_value = vec![0.0_f64; sys.n_dof];
+        for &d in &ground_dofs {
+            pinned_value[d] = 0.0;
+        }
+        for (k, dofs) in cond_dofs.iter().enumerate() {
+            let v = if k == i { 1.0 } else { 0.0 };
+            for &d in dofs {
+                pinned_value[d] = v;
+            }
+        }
+        us.push(sys.solve_with_pinned(&pinned_value)?);
+    }
+
+    // Energy-method matrix: C_ij = u⁽ⁱ⁾ᵀ K u⁽ʲ⁾ (full K).
+    let mut c = vec![vec![0.0_f64; n]; n];
+    for i in 0..n {
+        for j in i..n {
+            let v = quad_form(&sys.k_full, &us[i], &us[j]);
+            c[i][j] = v;
+            c[j][i] = v;
+        }
+    }
+
+    Ok(CapacitanceMatrix {
+        names: conductors.iter().map(|c| c.name.clone()).collect(),
+        c,
+        c_flux_diag: vec![None; n],
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Host-side P1 tet element geometry (f64), mirroring the closed form of
 // `crate::elements::p1::batched_p1_local_matrices` without the Burn backend.
 // ─────────────────────────────────────────────────────────────────────────
@@ -1298,6 +1730,129 @@ mod tests {
         // And the isotropic anisotropic run recovers ε₀·ε_r·A/d.
         let c_analytic = EPS_0 * eps_scalar;
         assert!((cm_t.c[0][0] - c_analytic).abs() / c_analytic < 1e-6);
+    }
+
+    /// P2 reproduces the parallel-plate ramp `φ = x` **exactly** (linear
+    /// solutions are in the P2 space), so `C = ε₀ A/d` to solver rounding,
+    /// and the edge-midpoint DOFs carry the exact midpoint values.
+    #[test]
+    fn p2_parallel_plate_capacitor_exact() {
+        let n = 4;
+        let mesh = cube_tet_mesh(n, 1.0);
+        let eps_r = vec![1.0; mesh.n_tets()];
+        let rho = vec![0.0; mesh.n_tets()];
+        let tol = 1e-9;
+        let plate_hi: Vec<u32> = mesh
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| (p[0] - 1.0).abs() < tol)
+            .map(|(i, _)| i as u32)
+            .collect();
+        let plate_lo: Vec<u32> = mesh
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p[0].abs() < tol)
+            .map(|(i, _)| i as u32)
+            .collect();
+        let electrodes = vec![Electrode {
+            name: "hi".into(),
+            nodes: plate_hi,
+            voltage: 1.0,
+        }];
+        let sys = assemble_electrostatic_p2(&mesh, &eps_r, &rho, &electrodes, &plate_lo).unwrap();
+        assert_eq!(sys.n_dof, p2_dof_count(&mesh));
+        let u = sys.solve().unwrap();
+        // Vertex DOFs carry φ = x; edge DOFs carry the midpoint x value.
+        for (i, p) in mesh.nodes.iter().enumerate() {
+            assert!((u[i] - p[0]).abs() < 1e-9, "u[{i}] {} != {}", u[i], p[0]);
+        }
+        for (k, e) in sys.dof_map.edges.iter().enumerate() {
+            let xm = 0.5 * (mesh.nodes[e[0] as usize][0] + mesh.nodes[e[1] as usize][0]);
+            let um = u[sys.n_nodes + k];
+            assert!(
+                (um - xm).abs() < 1e-9,
+                "edge DOF {k} value {um} != midpoint x {xm}"
+            );
+        }
+        let c = 2.0 * sys.field_energy(&u); // at V = 1
+        let rel = (c - EPS_0).abs() / EPS_0;
+        assert!(rel < 1e-9, "P2 parallel-plate C {c} vs {EPS_0}, rel {rel}");
+        // extract_capacitance_p2 agrees and the invariants hold.
+        let cm = extract_capacitance_p2(&sys, &electrodes, &plate_lo).unwrap();
+        assert!((cm.c[0][0] - EPS_0).abs() / EPS_0 < 1e-9);
+        assert!(cm.has_maxwell_sign_structure(1e-9));
+        assert_eq!(cm.c_flux_diag[0], None);
+    }
+
+    /// **The issue-#602 pitfall test.** On a 1-cell-thick parallel-plate
+    /// mesh, every mesh node lies on one of the two plates, so a naive
+    /// "both endpoints on an electrode" vertex-AND rule would pin EVERY
+    /// edge-midpoint DOF — including the plate-crossing edges whose
+    /// midpoints must be free unknowns at φ = ½. The boundary-facet rule
+    /// leaves them free, and the exact ramp solution certifies it: the
+    /// crossing midpoints solve to 0.5, and C = ε₀ exactly.
+    #[test]
+    fn p2_pitfall_cross_plate_edges_stay_free() {
+        let mesh = cube_tet_mesh(1, 1.0);
+        let eps_r = vec![1.0; mesh.n_tets()];
+        let rho = vec![0.0; mesh.n_tets()];
+        let tol = 1e-9;
+        let hi: Vec<u32> = mesh
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| (p[0] - 1.0).abs() < tol)
+            .map(|(i, _)| i as u32)
+            .collect();
+        let lo: Vec<u32> = mesh
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p[0].abs() < tol)
+            .map(|(i, _)| i as u32)
+            .collect();
+        // Every node is on a plate…
+        assert_eq!(hi.len() + lo.len(), mesh.n_nodes());
+        let electrodes = vec![Electrode {
+            name: "hi".into(),
+            nodes: hi,
+            voltage: 1.0,
+        }];
+        let sys = assemble_electrostatic_p2(&mesh, &eps_r, &rho, &electrodes, &lo).unwrap();
+        // …yet the plate-crossing edge midpoints remain FREE unknowns: the
+        // vertex-AND rule would give n_free = 0 here.
+        let n_crossing = sys
+            .dof_map
+            .edges
+            .iter()
+            .filter(|e| {
+                let x0 = mesh.nodes[e[0] as usize][0];
+                let x1 = mesh.nodes[e[1] as usize][0];
+                (x0 - x1).abs() > 0.5
+            })
+            .count();
+        assert!(n_crossing > 0, "fixture must contain plate-crossing edges");
+        assert_eq!(
+            sys.n_free, n_crossing,
+            "exactly the crossing-edge midpoint DOFs must be free \
+             (vertex-AND mis-pinning would leave 0 free)"
+        );
+        let u = sys.solve().unwrap();
+        for (k, e) in sys.dof_map.edges.iter().enumerate() {
+            let x0 = mesh.nodes[e[0] as usize][0];
+            let x1 = mesh.nodes[e[1] as usize][0];
+            if (x0 - x1).abs() > 0.5 {
+                let um = u[sys.n_nodes + k];
+                assert!(
+                    (um - 0.5).abs() < 1e-12,
+                    "crossing-edge midpoint DOF {k} = {um}, want 0.5"
+                );
+            }
+        }
+        let c = 2.0 * sys.field_energy(&u);
+        assert!((c - EPS_0).abs() / EPS_0 < 1e-12);
     }
 
     /// An anisotropic tensor with a LARGER through-thickness (x) component

--- a/crates/geode-core/src/elements/mod.rs
+++ b/crates/geode-core/src/elements/mod.rs
@@ -7,6 +7,9 @@
 //!
 //! - [`p1`] — P1 (linear Lagrange) nodal elements: closed-form local
 //!   stiffness and consistent-mass matrices for affine tets.
+//! - [`p2`] — P2 (quadratic Lagrange) nodal elements: 10-DOF (4 vertex +
+//!   6 edge-midpoint) shape functions, gradients, and the exactly-
+//!   integrated local stiffness on affine tets (issue #602).
 //! - [`nedelec`] — first-order Nédélec (Whitney 1-form) curl-conforming
 //!   edge elements: 6 edge DOFs per tet, with the batched curl-curl,
 //!   mass, RHS, and anisotropic/weighted kernels.
@@ -17,4 +20,5 @@
 //! crate top level in [`crate::derham`].
 pub mod nedelec;
 pub mod p1;
+pub mod p2;
 pub(crate) mod whitney;

--- a/crates/geode-core/src/elements/p2.rs
+++ b/crates/geode-core/src/elements/p2.rs
@@ -1,0 +1,324 @@
+//! P2 (quadratic Lagrange) nodal elements on affine tetrahedra
+//! (Epic #475, issue #602).
+//!
+//! The 10-node quadratic Lagrange tet: one DOF per vertex plus one DOF per
+//! edge midpoint. In barycentric coordinates `λ = (λ₀..λ₃)` the shape
+//! functions are
+//!
+//! ```text
+//!   vertex p:      N_p  = λ_p (2λ_p − 1)                (p = 0..3)
+//!   edge (a, b):   N_ab = 4 λ_a λ_b                     (6 edges)
+//! ```
+//!
+//! with gradients (constant `∇λ_p` on an affine tet)
+//!
+//! ```text
+//!   ∇N_p  = (4λ_p − 1) ∇λ_p
+//!   ∇N_ab = 4 (λ_a ∇λ_b + λ_b ∇λ_a)
+//! ```
+//!
+//! # Local DOF ordering
+//!
+//! `[v0, v1, v2, v3, e01, e02, e03, e12, e13, e23]` — the four vertices in
+//! tet order followed by the six edges in the canonical
+//! [`TET_LOCAL_EDGES`] order. Global P2 DOF
+//! numbering (vertex DOFs at their node index, edge-midpoint DOFs offset by
+//! `n_nodes`) is the assembler's concern
+//! ([`crate::assembly::electrostatic::assemble_electrostatic_p2`]); this
+//! module is purely local. Edge-midpoint **value** DOFs are
+//! orientation-independent, so the sign field of
+//! [`TetMesh::tet_edges`](crate::mesh::TetMesh::tet_edges) is irrelevant
+//! here (unlike the signed Nédélec edge DOFs).
+//!
+//! # Quadrature
+//!
+//! The stiffness integrand `∇N_i · ∇N_j` is **quadratic** in the
+//! barycentrics on an affine tet, so the symmetric degree-2 4-point rule
+//! ([`TET_QUAD4_A`]/[`TET_QUAD4_B`], shared with the Nédélec kernels)
+//! integrates it **exactly** — no new rule is needed, and the local
+//! stiffness below is exact up to rounding. The load integrals `∫ N_p dV`
+//! are taken from the closed-form barycentric monomial formula
+//! (`∫ λ^α dV = V α! 3!/(|α|+3)!`): `−V/20` per vertex DOF and `V/5` per
+//! edge DOF (they sum to `V`, the integral of the partition of unity).
+//!
+//! This is the 3-D sibling of the 2-D P2 triangle path
+//! (`crate::assembly::magnetostatic`, issue #472); the element functions
+//! live here in `elements/` rather than inline in the assembler, per the
+//! issue-#602 scoping.
+
+use crate::elements::nedelec::{TET_QUAD4_A, TET_QUAD4_B};
+use crate::mesh::TET_LOCAL_EDGES;
+
+/// Number of local DOFs of the P2 Lagrange tet (4 vertices + 6 edges).
+pub const TET_P2_DOFS: usize = 10;
+
+/// The ten P2 shape-function values at a barycentric point.
+///
+/// Local order `[v0..v3, e01, e02, e03, e12, e13, e23]` (see module docs).
+pub fn tet_p2_shape(lam: &[f64; 4]) -> [f64; TET_P2_DOFS] {
+    let mut n = [0.0_f64; TET_P2_DOFS];
+    for p in 0..4 {
+        n[p] = lam[p] * (2.0 * lam[p] - 1.0);
+    }
+    for (e, &(a, b)) in TET_LOCAL_EDGES.iter().enumerate() {
+        n[4 + e] = 4.0 * lam[a] * lam[b];
+    }
+    n
+}
+
+/// The ten P2 shape-function gradients at a barycentric point, given the
+/// (constant, per-affine-tet) barycentric gradients `∇λ_p`.
+///
+/// Local order `[v0..v3, e01, e02, e03, e12, e13, e23]` (see module docs).
+pub fn tet_p2_grads(lam: &[f64; 4], bary: &[[f64; 3]; 4]) -> [[f64; 3]; TET_P2_DOFS] {
+    let mut g = [[0.0_f64; 3]; TET_P2_DOFS];
+    for p in 0..4 {
+        let c = 4.0 * lam[p] - 1.0;
+        for d in 0..3 {
+            g[p][d] = c * bary[p][d];
+        }
+    }
+    for (e, &(a, b)) in TET_LOCAL_EDGES.iter().enumerate() {
+        for d in 0..3 {
+            g[4 + e][d] = 4.0 * (lam[a] * bary[b][d] + lam[b] * bary[a][d]);
+        }
+    }
+    g
+}
+
+/// Local P2 tet stiffness `K`, load-integral vector `∫ N_p dV`, and
+/// (unsigned) volume for an affine tet.
+///
+/// `K_ij = ∫_T ∇N_i · ∇N_j dV`, evaluated with the degree-2 4-point rule —
+/// **exact** for the quadratic integrand on an affine tet (see module
+/// docs). The load vector carries the exact `∫ N_p dV` (`−V/20` for vertex
+/// DOFs, `V/5` for edge DOFs), which is what a piecewise-constant source
+/// `ρ` needs on the RHS: `b_p = ρ ∫ N_p dV`.
+///
+/// The material weighting (`ε₀ ε_r` etc.) is the caller's concern, matching
+/// [`crate::assembly::electrostatic::tet_p1_local`].
+pub fn tet_p2_local(
+    coords: &[[f64; 3]; 4],
+) -> ([[f64; TET_P2_DOFS]; TET_P2_DOFS], [f64; TET_P2_DOFS], f64) {
+    // Barycentric gradients from the cofactor construction, matching the
+    // host-side P1 kernel: e_i = v_i − v₀, g₁ = e₂×e₃, g₂ = e₃×e₁,
+    // g₃ = e₁×e₂, det = e₁·g₁ = 6V, ∇λ_i = g_i/det, ∇λ₀ = −Σ ∇λ_i.
+    let v0 = coords[0];
+    let e1 = sub(coords[1], v0);
+    let e2 = sub(coords[2], v0);
+    let e3 = sub(coords[3], v0);
+    let g1 = cross(e2, e3);
+    let g2 = cross(e3, e1);
+    let g3 = cross(e1, e2);
+    let det = dot(e1, g1); // = 6V (signed)
+    let vol = det.abs() / 6.0;
+    let inv = 1.0 / det;
+    let gl1 = [g1[0] * inv, g1[1] * inv, g1[2] * inv];
+    let gl2 = [g2[0] * inv, g2[1] * inv, g2[2] * inv];
+    let gl3 = [g3[0] * inv, g3[1] * inv, g3[2] * inv];
+    let gl0 = [
+        -(gl1[0] + gl2[0] + gl3[0]),
+        -(gl1[1] + gl2[1] + gl3[1]),
+        -(gl1[2] + gl2[2] + gl3[2]),
+    ];
+    let bary = [gl0, gl1, gl2, gl3];
+
+    // Degree-2 symmetric 4-point rule: point q has λ_q = A, λ_{p≠q} = B,
+    // weight V/4. Exact for the quadratic ∇N_i·∇N_j integrand.
+    let w = vol / 4.0;
+    let mut k = [[0.0_f64; TET_P2_DOFS]; TET_P2_DOFS];
+    for q in 0..4 {
+        let mut lam = [TET_QUAD4_B; 4];
+        lam[q] = TET_QUAD4_A;
+        let g = tet_p2_grads(&lam, &bary);
+        for i in 0..TET_P2_DOFS {
+            for j in 0..TET_P2_DOFS {
+                k[i][j] += w * dot(g[i], g[j]);
+            }
+        }
+    }
+
+    // Exact load integrals ∫ N_p dV (barycentric monomial formula):
+    //   vertex: ∫ λ(2λ−1) = 2·V/10 − V/4 = −V/20;  edge: 4·∫ λ_a λ_b = V/5.
+    let mut load = [vol / 5.0; TET_P2_DOFS];
+    for l in load.iter_mut().take(4) {
+        *l = -vol / 20.0;
+    }
+
+    (k, load, vol)
+}
+
+#[inline]
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+#[inline]
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+#[inline]
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REF_TET: [[f64; 3]; 4] = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ];
+
+    /// A deliberately skewed, non-degenerate tet for generality.
+    const SKEW_TET: [[f64; 3]; 4] = [
+        [0.1, 0.2, -0.3],
+        [1.3, 0.4, 0.2],
+        [-0.2, 1.1, 0.5],
+        [0.3, -0.1, 1.4],
+    ];
+
+    /// The local coordinates of the ten P2 nodes of a tet (4 vertices, 6
+    /// edge midpoints in `TET_LOCAL_EDGES` order).
+    fn p2_node_coords(coords: &[[f64; 3]; 4]) -> [[f64; 3]; TET_P2_DOFS] {
+        let mut x = [[0.0; 3]; TET_P2_DOFS];
+        x[..4].copy_from_slice(coords);
+        for (e, &(a, b)) in TET_LOCAL_EDGES.iter().enumerate() {
+            for d in 0..3 {
+                x[4 + e][d] = 0.5 * (coords[a][d] + coords[b][d]);
+            }
+        }
+        x
+    }
+
+    #[test]
+    fn partition_of_unity_and_zero_gradient_sum() {
+        // At arbitrary barycentric points: Σ N_i = 1 and Σ ∇N_i = 0.
+        let pts = [
+            [0.25, 0.25, 0.25, 0.25],
+            [
+                0.585_410_196_624_968_5,
+                0.138_196_601_125_010_5,
+                0.138_196_601_125_010_5,
+                0.138_196_601_125_010_5,
+            ],
+            [0.1, 0.2, 0.3, 0.4],
+            [0.7, 0.05, 0.15, 0.1],
+        ];
+        // Barycentric gradients of the skew tet, via the exposed kernel's
+        // internals reproduced (partition of unity is basis-only).
+        for lam in &pts {
+            let n = tet_p2_shape(lam);
+            let s: f64 = n.iter().sum();
+            assert!((s - 1.0).abs() < 1e-14, "Σ N = {s} != 1 at {lam:?}");
+        }
+        // Gradient sum: Σ ∇N_i = 3 Σ_p ∇λ_p (coefficient of each ∇λ_p is
+        // (4λ_p − 1) + 4 Σ_{q≠p} λ_q = 3), which vanishes exactly when the
+        // barycentric gradients satisfy Σ ∇λ_p = 0 — as any valid set does.
+        // This synthetic set sums to zero, so it is a valid algebraic check.
+        let bary = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [-1.0, -1.0, -1.0],
+        ];
+        for lam in &pts {
+            let g = tet_p2_grads(lam, &bary);
+            for d in 0..3 {
+                let s: f64 = g.iter().map(|gi| gi[d]).sum();
+                assert!(s.abs() < 1e-13, "Σ ∇N[{d}] = {s} != 0 at {lam:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn stiffness_rows_sum_to_zero_and_symmetric() {
+        // Constant field ⇒ zero gradient: K · 1 = 0; and K is symmetric.
+        let (k, _, _) = tet_p2_local(&SKEW_TET);
+        for (i, row) in k.iter().enumerate() {
+            let s: f64 = row.iter().sum();
+            assert!(s.abs() < 1e-12, "stiffness row {i} sum {s} != 0");
+            for (j, &kij) in row.iter().enumerate() {
+                assert!(
+                    (kij - k[j][i]).abs() < 1e-13,
+                    "K not symmetric at ({i},{j})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn load_integrals_sum_to_volume() {
+        let (_, load, vol) = tet_p2_local(&SKEW_TET);
+        let s: f64 = load.iter().sum();
+        assert!(
+            (s - vol).abs() < 1e-14 * vol.max(1.0),
+            "Σ ∫N_p = {s} != V = {vol}"
+        );
+        // Exact per-DOF values.
+        for l in load.iter().take(4) {
+            assert!((l + vol / 20.0).abs() < 1e-15);
+        }
+        for l in load.iter().skip(4) {
+            assert!((l - vol / 5.0).abs() < 1e-15);
+        }
+    }
+
+    /// Dirichlet-energy exactness on a **linear** field: the P2 interpolant
+    /// of `f = c·x` is exact, so `uᵀ K u = |∇f|² V`.
+    #[test]
+    fn linear_field_energy_exact() {
+        for coords in [&REF_TET, &SKEW_TET] {
+            let (k, _, vol) = tet_p2_local(coords);
+            let f = |p: &[f64; 3]| 2.0 * p[0] - 0.5 * p[1] + 3.0 * p[2] + 1.0;
+            let grad2 = 2.0_f64.powi(2) + 0.5_f64.powi(2) + 3.0_f64.powi(2);
+            let x = p2_node_coords(coords);
+            let u: Vec<f64> = x.iter().map(f).collect();
+            let mut e = 0.0;
+            for i in 0..TET_P2_DOFS {
+                for j in 0..TET_P2_DOFS {
+                    e += u[i] * k[i][j] * u[j];
+                }
+            }
+            let want = grad2 * vol;
+            assert!(
+                (e - want).abs() < 1e-12 * want,
+                "linear Dirichlet energy {e} != {want}"
+            );
+        }
+    }
+
+    /// Dirichlet-energy exactness on a **quadratic** field — the property
+    /// that separates P2 from P1. On the reference tet, `f = x²` has
+    /// `∫ |∇f|² dV = ∫ 4x² dV = 4·(V/10) = 4/60 = 1/15` (barycentric
+    /// monomial formula with `λ₁ = x`, `V = 1/6`). The P2 interpolant of a
+    /// quadratic is the quadratic itself, and the degree-2 rule integrates
+    /// its gradient-product exactly, so `uᵀ K u` must equal `1/15` to
+    /// rounding. P1 on this single tet would get `1/12` (the interpolant
+    /// `u = x` has `|∇u|² = 1`... times V — a ~11% miss), so this test
+    /// has teeth against a silently-linear basis.
+    #[test]
+    fn quadratic_field_energy_exact() {
+        let (k, _, _) = tet_p2_local(&REF_TET);
+        let x = p2_node_coords(&REF_TET);
+        let u: Vec<f64> = x.iter().map(|p| p[0] * p[0]).collect();
+        let mut e = 0.0;
+        for i in 0..TET_P2_DOFS {
+            for j in 0..TET_P2_DOFS {
+                e += u[i] * k[i][j] * u[j];
+            }
+        }
+        let want = 1.0 / 15.0;
+        assert!(
+            (e - want).abs() < 1e-13,
+            "quadratic Dirichlet energy {e} != {want} (P1 would give {})",
+            1.0 / 12.0
+        );
+    }
+}

--- a/crates/geode-core/tests/electrostatic_capacitance.rs
+++ b/crates/geode-core/tests/electrostatic_capacitance.rs
@@ -21,11 +21,282 @@ use std::path::PathBuf;
 
 use geode_core::assembly::electrostatic::{
     CapacitanceMatrix, ConductorSurface, EPS_0, Electrode, assemble_electrostatic,
-    extract_capacitance,
+    assemble_electrostatic_p2, extract_capacitance, extract_capacitance_p2,
 };
 use geode_core::mesh::electrostatic_fixtures::{
     coax_shell_mesh, sphere_shell_mesh, two_sphere_box_mesh,
 };
+
+/// P2 sibling of [`coax_capacitance_per_length`]: same fixture, quadratic
+/// solve, energy-method extraction (no flux cross-check at P2).
+fn coax_capacitance_per_length_p2(
+    a: f64,
+    b: f64,
+    length: f64,
+    n_theta: usize,
+    n_r: usize,
+    n_z: usize,
+    eps_r_val: f64,
+) -> f64 {
+    let fx = coax_shell_mesh(a, b, length, n_theta, n_r, n_z);
+    let mesh = &fx.mesh;
+    let eps_r = vec![eps_r_val; mesh.n_tets()];
+    let rho = vec![0.0; mesh.n_tets()];
+    let inner = Electrode {
+        name: "inner".into(),
+        nodes: fx.inner.clone(),
+        voltage: 1.0,
+    };
+    let conductors = [inner];
+    let sys = assemble_electrostatic_p2(mesh, &eps_r, &rho, &conductors, &fx.outer).unwrap();
+    let cm = extract_capacitance_p2(&sys, &conductors, &fx.outer).unwrap();
+    cm.c[0][0] / length
+}
+
+/// P2 sibling of [`sphere_capacitance`].
+fn sphere_capacitance_p2(a: f64, b: f64, subdiv: usize, n_r: usize, eps_r_val: f64) -> f64 {
+    let fx = sphere_shell_mesh(a, b, subdiv, n_r);
+    let mesh = &fx.mesh;
+    let eps_r = vec![eps_r_val; mesh.n_tets()];
+    let rho = vec![0.0; mesh.n_tets()];
+    let inner = Electrode {
+        name: "inner".into(),
+        nodes: fx.inner.clone(),
+        voltage: 1.0,
+    };
+    let conductors = [inner];
+    let sys = assemble_electrostatic_p2(mesh, &eps_r, &rho, &conductors, &fx.outer).unwrap();
+    let cm = extract_capacitance_p2(&sys, &conductors, &fx.outer).unwrap();
+    cm.c[0][0]
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// P2 (quadratic) oracles — issue #602. Observed-slope context, measured on
+// this exact code (macOS arm64, 2026-07-17) and reported honestly:
+//
+// The fixtures approximate CURVED conductors with straight-edged tets, so
+// every family's error has two parts: the FIELD discretization error (what
+// the element order controls) and a GEOMETRY error from the polygonal /
+// faceted conductor surfaces (O(h²) in the angular resolution, untouched
+// by element order — that is epic gap #4, curved elements). P2 collapses
+// the field error so fast that on the sphere family it saturates the
+// faceting floor almost immediately; the coax polygon error is far
+// smaller, so the coax family shows the clean uniform-refinement win.
+//
+//   coax uniform family (n_theta, n_r) ∈ (16,1)…(128,8), vs analytic:
+//     P1: 8.296% → 2.309% → 0.601% → 0.152%   (slope ≈ 1.92)
+//     P2: 1.072% → 0.117% → 0.0131% → 0.00154% (slope ≈ 3.15)
+//   sphere, fixed sd=2 geometry, n_r ∈ 1,2,4 vs converged same-geometry
+//   P2 reference (n_r = 16) — isolates the field order:
+//     P1: 17.41% → 5.28% → 1.84%  (slope ≈ 1.62, saturating toward the
+//                                   fixed angular error of sd=2)
+//     P2: 1.45% → 0.274% → 0.0736% (slope ≈ 2.15)
+//   sphere vs ANALYTIC on deeper uniform families: P2 saturates at the
+//   faceting floor (e.g. −0.064% at sd=4) so its analytic-referenced
+//   slope decays even though its absolute error stays 20–50× below P1 —
+//   asserted as the absolute-error criterion, not a slope.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Coax uniform-refinement family (angular and radial resolution refined
+/// together, halving h at each level): the P2 convergence slope must be
+/// strictly better than P1's on the same meshes, and the P2 error must be
+/// well below the P1 error at every level.
+#[test]
+fn p2_oracle_coax_slope_beats_p1_on_uniform_family() {
+    let (a, b, length): (f64, f64, f64) = (1.0, 2.5, 1.0);
+    let c_exact = 2.0 * PI * EPS_0 / (b / a).ln();
+    let family = [(16usize, 1usize), (32, 2), (64, 4), (128, 8)];
+
+    let mut e1 = Vec::new();
+    let mut e2 = Vec::new();
+    for &(nt, nr) in &family {
+        let (c1, _) = coax_capacitance_per_length(a, b, length, nt, nr, 1, 1.0);
+        let c2 = coax_capacitance_per_length_p2(a, b, length, nt, nr, 1, 1.0);
+        e1.push((c1 - c_exact).abs() / c_exact);
+        e2.push((c2 - c_exact).abs() / c_exact);
+        eprintln!(
+            "coax (n_theta={nt}, n_r={nr}): P1 rel {:.5}%, P2 rel {:.5}%",
+            e1.last().unwrap() * 100.0,
+            e2.last().unwrap() * 100.0
+        );
+    }
+
+    // Per-level absolute superiority (measured ratios 7.7×–99×).
+    for i in 0..family.len() {
+        assert!(
+            e2[i] < e1[i] / 5.0,
+            "level {i}: P2 error {} must be ≤ P1 error {} / 5",
+            e2[i],
+            e1[i]
+        );
+    }
+    // Pairwise and overall observed slopes (h halves per level).
+    for i in 0..family.len() - 1 {
+        let s1 = (e1[i] / e1[i + 1]).log2();
+        let s2 = (e2[i] / e2[i + 1]).log2();
+        eprintln!("coax slope level {i}→{}: P1 {s1:.3}, P2 {s2:.3}", i + 1);
+        assert!(
+            s2 > s1 + 0.5,
+            "pairwise P2 slope {s2:.3} must beat P1 {s1:.3} by > 0.5"
+        );
+    }
+    let n = (family.len() - 1) as f64;
+    let s1 = (e1[0] / e1[family.len() - 1]).log2() / n;
+    let s2 = (e2[0] / e2[family.len() - 1]).log2() / n;
+    eprintln!("coax overall slopes: P1 {s1:.3}, P2 {s2:.3} (measured ≈1.92 vs ≈3.15)");
+    assert!(
+        s2 > s1 + 0.8,
+        "overall P2 slope {s2:.3} must beat P1 {s1:.3} by > 0.8"
+    );
+    // Finest-level P2 error is deep below the 1% oracle bar (measured
+    // 0.00154%).
+    assert!(e2[family.len() - 1] < 5e-5);
+}
+
+/// Shared-coarsest-mesh criterion on the P1 sphere oracle family
+/// (subdiv 4, n_r = 3, the coarse member of
+/// `oracle_concentric_spheres_within_one_percent_and_converges`): the P2
+/// absolute capacitance error must be below the P1 error — measured
+/// 0.038% vs 2.083%, a ~55× reduction, already below the 1% bar on the
+/// mesh where P1 sits at 2%.
+#[test]
+fn p2_oracle_spheres_beats_p1_at_shared_coarsest() {
+    let (a, b) = (1.0, 2.0);
+    let c_exact = 4.0 * PI * EPS_0 * a * b / (b - a);
+    let (c1, _, _) = sphere_capacitance(a, b, 4, 3, 1.0);
+    let c2 = sphere_capacitance_p2(a, b, 4, 3, 1.0);
+    let e1 = (c1 - c_exact).abs() / c_exact;
+    let e2 = (c2 - c_exact).abs() / c_exact;
+    eprintln!(
+        "sphere shared coarsest (sd=4, n_r=3): P1 rel {:.4}%, P2 rel {:.4}% ({}× smaller)",
+        e1 * 100.0,
+        e2 * 100.0,
+        (e1 / e2).round()
+    );
+    assert!(
+        e2 < e1 / 10.0,
+        "P2 coarsest-mesh error {e2} must be ≤ P1 error {e1} / 10"
+    );
+    // P2 meets the 1% oracle bar on the mesh where P1 fails it.
+    assert!(e2 < 0.01, "P2 rel err {e2} exceeds the 1% oracle bar");
+    assert!(
+        e1 > 0.01,
+        "P1 coarse error unexpectedly under 1% — fixture drifted"
+    );
+}
+
+/// Sphere-family field-convergence order: fixed faceted geometry (sd=2),
+/// radial refinement n_r ∈ {1, 2, 4}, errors measured against a converged
+/// **same-geometry** P2 reference (n_r = 16). This isolates the element's
+/// field order from the O(h²_angular) faceting error that an
+/// analytic-referenced slope saturates on (P2 reaches the faceting floor
+/// almost immediately — see the module-level measurement notes). The P2
+/// field slope must be strictly better than P1's on the same meshes.
+#[test]
+fn p2_oracle_spheres_field_order_beats_p1_on_same_geometry() {
+    let (a, b) = (1.0, 2.0);
+    let c_exact = 4.0 * PI * EPS_0 * a * b / (b - a);
+    let c_ref = sphere_capacitance_p2(a, b, 2, 16, 1.0);
+    // The reference itself sits at the sd=2 faceting floor vs analytic
+    // (measured −0.987%): the polyhedral conductor is slightly smaller
+    // than the sphere it approximates.
+    let ref_vs_analytic = (c_ref - c_exact) / c_exact;
+    eprintln!(
+        "sd=2 P2 reference vs analytic: {:+.4}%",
+        ref_vs_analytic * 100.0
+    );
+    assert!(ref_vs_analytic.abs() < 0.015);
+
+    let mut e1 = Vec::new();
+    let mut e2 = Vec::new();
+    for n_r in [1usize, 2, 4] {
+        let (c1, _, _) = sphere_capacitance(a, b, 2, n_r, 1.0);
+        let c2 = sphere_capacitance_p2(a, b, 2, n_r, 1.0);
+        e1.push((c1 - c_ref).abs() / c_ref);
+        e2.push((c2 - c_ref).abs() / c_ref);
+        eprintln!(
+            "sphere sd=2 n_r={n_r} vs same-geometry ref: P1 field rel {:.5}%, P2 field rel {:.5}%",
+            e1.last().unwrap() * 100.0,
+            e2.last().unwrap() * 100.0
+        );
+    }
+
+    for i in 0..3 {
+        assert!(
+            e2[i] < e1[i] / 5.0,
+            "level {i}: P2 field error {} must be ≤ P1 field error {} / 5",
+            e2[i],
+            e1[i]
+        );
+    }
+    for i in 0..2 {
+        let s1 = (e1[i] / e1[i + 1]).log2();
+        let s2 = (e2[i] / e2[i + 1]).log2();
+        eprintln!(
+            "sphere field slope level {i}→{}: P1 {s1:.3}, P2 {s2:.3}",
+            i + 1
+        );
+        assert!(
+            s2 > s1,
+            "pairwise P2 field slope {s2:.3} must be strictly better than P1 {s1:.3}"
+        );
+    }
+    let s1 = (e1[0] / e1[2]).log2() / 2.0;
+    let s2 = (e2[0] / e2[2]).log2() / 2.0;
+    eprintln!("sphere overall field slopes: P1 {s1:.3}, P2 {s2:.3} (measured ≈1.62 vs ≈2.15)");
+    assert!(
+        s2 > s1 + 0.4,
+        "overall P2 field slope {s2:.3} must beat P1 {s1:.3} by > 0.4"
+    );
+}
+
+/// Maxwell C-matrix invariants at P2 on a genuine two-conductor system
+/// (two staircase spheres in a grounded box, deliberately small — the
+/// invariants are structural, not accuracy-bound): symmetry to solver
+/// tolerance and the Maxwell sign structure.
+#[test]
+fn p2_maxwell_invariants_two_conductor_box() {
+    let fx = two_sphere_box_mesh(0.5, 1.5, 2.5, 12);
+    let mesh = &fx.mesh;
+    assert!(!fx.sphere_a.is_empty() && !fx.sphere_b.is_empty());
+    let eps_r = vec![1.0; mesh.n_tets()];
+    let rho = vec![0.0; mesh.n_tets()];
+    let conductors = vec![
+        Electrode {
+            name: "A".into(),
+            nodes: fx.sphere_a.clone(),
+            voltage: 1.0,
+        },
+        Electrode {
+            name: "B".into(),
+            nodes: fx.sphere_b.clone(),
+            voltage: 0.0,
+        },
+    ];
+    let sys = assemble_electrostatic_p2(mesh, &eps_r, &rho, &conductors, &fx.ground).unwrap();
+    let cm = extract_capacitance_p2(&sys, &conductors, &fx.ground).unwrap();
+    eprintln!(
+        "P2 two-conductor Maxwell matrix (F):\n [{:.4e}, {:.4e}]\n [{:.4e}, {:.4e}]",
+        cm.c[0][0], cm.c[0][1], cm.c[1][0], cm.c[1][1]
+    );
+    let asym = cm.max_rel_asymmetry();
+    eprintln!("P2 max rel asymmetry = {asym:.2e}");
+    assert!(
+        asym < 1e-9,
+        "P2 Maxwell matrix must be symmetric (rel asym {asym})"
+    );
+    assert!(
+        cm.has_maxwell_sign_structure(1e-6),
+        "P2 Maxwell sign structure violated"
+    );
+    // Mirror-symmetric conductors: the two diagonals agree closely.
+    let d_rel = (cm.c[0][0] - cm.c[1][1]).abs() / cm.c[0][0];
+    assert!(
+        d_rel < 1e-6,
+        "mirror symmetry broken: diagonals differ by {d_rel}"
+    );
+    assert!(cm.c_sigma(0) > 0.0);
+}
 
 /// Coax per-unit-length capacitance from a shell fixture with the given
 /// mesh resolution, uniform `eps_r`.


### PR DESCRIPTION
## Summary

Breaks the p=1 ceiling in 3-D at its cheapest entry point (Epic #475 gap #3, electrostatics-first): 10-node **P2 Lagrange tet elements** with an opt-in quadratic electrostatic pipeline parallel to the untouched P1 path, and — per the Epic #569 framing — the FD-validated **∂C/∂ε adjoint ships with the order lift**, not deferred.

## Changes

- **`crates/geode-core/src/elements/p2.rs` (new)**: P2 shape functions / gradients (local order `[v0..v3, e01..e23]` on `TET_LOCAL_EDGES`), exactly-integrated local stiffness via the existing degree-2 4-point rule (`TET_QUAD4_A/B` — exact for the quadratic `∇Nᵢ·∇Nⱼ` integrand on affine tets), exact load integrals (−V/20 vertex, V/5 edge). Unit tests include a quadratic-Dirichlet-energy exactness check with teeth (P1 would miss by ~11%).
- **`assembly/electrostatic.rs`**: `p2_dof_count`, `P2DofMap`, `ElectrostaticP2System` (full K retained for the energy method), `assemble_electrostatic_p2`, `extract_capacitance_p2` (same `CapacitanceMatrix` type, so `max_rel_asymmetry` / `has_maxwell_sign_structure` apply unchanged; flux cross-check is P1-only and documented as such). Edge-midpoint Dirichlet DOFs are classified by the **boundary-facet rule** (edge pinned iff on a boundary face fully inside the electrode node set), not the vertex-AND shortcut — `p2_pitfall_cross_plate_edges_stay_free` builds the 1-cell mesh where every node is on a plate and proves the plate-crossing edge midpoints stay free unknowns (vertex-AND would pin all of them; n_free would be 0).
- **`adjoint.rs`**: `electrostatic_adjoint_gradient_p2` (general-objective P2 twin — a twin rather than a generalized signature, keeping the merged #570/#571 P1 results bit-for-bit) and `capacitance_adjoint_gradient_p2` (two-terminal `C = 2W/V²` with the energy objective's explicit-∂K term **plus** the adjoint term computed, not assumed away; one factorization for forward + adjoint).
- **`tests/electrostatic_capacitance.rs`**: P2 oracle, slope-comparison, and invariant tests with the measured numbers recorded in comments.
- The geometry/shape adjoint (`shape.rs`) rides the P1 path and is untouched (out of scope per the issue).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| P2 slope strictly better than P1, same mesh family (coax) | ✅ | Uniform family (n_theta,n_r) = (16,1)→(128,8): P2 slope **3.15** vs P1 **1.92**; every pairwise slope better by >1.0; per-level errors 7.7×–99× smaller (`p2_oracle_coax_slope_beats_p1_on_uniform_family`) |
| P2 slope strictly better than P1, same mesh family (spheres) | ⚠️ honest caveat | Vs the **analytic** value the sphere-family P2 slope saturates: P2 reaches the fixed O(h²) faceting-geometry floor of the straight-tet icosphere almost immediately (e.g. −0.064% at subdiv 4), so its analytic-referenced slope decays even though its absolute error stays 20–55× below P1. Measured **field** order on the same mesh family vs a converged same-geometry P2 reference: P2 **2.15** vs P1 **1.62**, every pairwise slope strictly better (`p2_oracle_spheres_field_order_beats_p1_on_same_geometry`). Curved geometry is epic gap #4, explicitly out of scope and dependent on this issue. |
| Shared coarsest mesh: P2 absolute error < P1 | ✅ | Sphere (subdiv 4, n_r=3): P2 **0.038%** vs P1 **2.083%** (55×; P2 meets the 1% bar where P1 fails it). Coax coarsest (16,1): 1.07% vs 8.30% (`p2_oracle_spheres_beats_p1_at_shared_coarsest`, coax test level 0) |
| Maxwell invariants green at P2 | ✅ | Two-conductor box at P2: `max_rel_asymmetry` = 0.0, `has_maxwell_sign_structure` ✓, mirror-symmetric diagonals (`p2_maxwell_invariants_two_conductor_box`); 1×1 invariants also checked in the parallel-plate unit test |
| ∂C/∂ε FD-validated at P2 at the existing bar | ✅ | `p2_capacitance_gradient_matches_central_finite_difference`: central FD h=1e-5, rel < 1e-4 per region, 1 factorization; bonus: P2 layered-capacitor C equals the analytic series capacitance to 1e-9 (slab-aligned mesh, piecewise-linear exact solution). General-objective twin also FD-validated at rel < 1e-4 (`adjoint_gradient_p2_matches_central_finite_difference`) |
| P1 path behavior unchanged; P2 opt-in | ✅ | No P1 code path modified (additive `_p2` entry points only); all pre-existing tests pass unchanged |
| Regression suite green + `cargo fmt` | ✅ | See test plan; `cargo fmt --all` applied (repo has no fmt hook); `cargo clippy` clean; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace` clean |

## Test Plan

- `cargo test --workspace` (debug profile): all 123 test binaries pass with 0 failures. One environment note, reported honestly: the pre-existing heavy `sphere_pec_eigenmode` (dense-QZ debug test with its own dedicated CI arrangements documented in the workspace `Cargo.toml`) was killed twice by this environment's background-task limit at 50+ min CPU before completing in debug; it passes in `--release` (3 passed, 51 s). It shares no code with this PR (eigen/Nédélec path untouched). All other 122 binaries plus all doc-tests pass in the default debug profile.
- New tests: 5 element unit tests, 2 assembly unit tests (incl. the pitfall tripwire), 2 adjoint FD validations, 4 oracle/invariant integration tests — all green; measured slopes and errors printed by the tests match the numbers quoted above.
- Added test wall-time is modest: the heaviest new test (sphere shared-coarsest, subdiv 4 n_r=3 at P2, ~130k DOF LU) runs in ~35 s; the P2 sphere fine mesh (167 s) was deliberately **not** put in the routine suite.

Closes #602