### PR TITLE
feat(em): London superconductor surface BC (per-tag λ_L) on driven + eigenmode paths, with ∂λ/∂λ_L via Hellmann–Feynman

### DIFF
--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -336,6 +336,39 @@ pub enum SurfaceImpedanceModel {
         /// Conductivity σ in natural units (`1/length`). Must be `> 0`.
         sigma: f64,
     },
+    /// Built-in **London superconductor** model (Epic #475, issue #604)
+    ///
+    /// ```text
+    /// Z_s(ω) = iωμλ_L,   μ = 1 natural units,
+    /// ```
+    ///
+    /// the purely reactive (kinetic-inductance) surface impedance of a
+    /// superconductor in the local London limit, with `λ_L` the London
+    /// penetration depth. Unlike the good-conductor `√ω (1+i)` dispersion,
+    /// the London impedance is **frequency-linear and lossless**.
+    ///
+    /// `lambda_l` is a **length** in natural (mesh) units, the same
+    /// normalization as the mesh coordinates: `λ_L_nat = λ_L_SI / L_unit`
+    /// (e.g. λ_L = 90 nm on a micrometre-unit mesh is `lambda_l = 0.09`)
+    /// — the length-based sibling of the `GoodConductor` σ normalization
+    /// `σ_nat = σ_SI · Z₀ · L_unit` above.
+    ///
+    /// The weak-form coefficient is special: `iω/Z_s = iω/(iωλ_L) = 1/λ_L`
+    /// — **real, positive and frequency-independent** (the iω cancels
+    /// exactly), so [`Self::weak_coefficient`] returns `1/λ_L` directly
+    /// instead of evaluating the `iω/Z_s` quotient numerically (which
+    /// would degrade to 0/0 as ω → 0 and trip the `|Z_s| = 0` singular
+    /// guard).
+    ///
+    /// `lambda_l` must be strictly positive and finite: the `λ_L → 0` PEC
+    /// limit must be expressed through the PEC edge mask (exactly like
+    /// `Z_s → 0` for the other models), not through a vanishing
+    /// penetration depth.
+    London {
+        /// London penetration depth λ_L in natural units (mesh length
+        /// unit): `λ_L_nat = λ_L_SI / L_unit`. Must be `> 0` and finite.
+        lambda_l: f64,
+    },
 }
 
 impl SurfaceImpedanceModel {
@@ -348,6 +381,8 @@ impl SurfaceImpedanceModel {
                 let a = (omega / (2.0 * sigma)).sqrt();
                 c64::new(a, a)
             }
+            // iωμλ_L, μ = 1 natural units: purely reactive.
+            SurfaceImpedanceModel::London { lambda_l } => c64::new(0.0, omega * lambda_l),
         }
     }
 
@@ -355,15 +390,32 @@ impl SurfaceImpedanceModel {
     /// real surface mass `S_Γ`. For [`SurfaceImpedanceModel::Fixed`]
     /// with `Z_s = η₀ = 1` this is `i k₀` — exactly the Silver-Müller
     /// factor; for the good-conductor model it is
-    /// `(1+i)√(ωσ/2) = (1+i)/δ`.
+    /// `(1+i)√(ωσ/2) = (1+i)/δ`; for the London model it is the real,
+    /// frequency-independent `1/λ_L` (evaluated **directly**, not as the
+    /// `iω/(iωλ_L)` quotient, so it stays finite and exact at any ω,
+    /// including ω = 0).
     ///
     /// # Errors
     ///
     /// Returns [`DrivenError::SurfaceImpedanceSingular`] when `Z_s(ω)`
-    /// is zero or non-finite (e.g. `Fixed(0)`, or `GoodConductor` with
-    /// `σ ≤ 0`). The `Z_s → 0` PEC limit must be expressed through the
+    /// is zero or non-finite (e.g. `Fixed(0)`, `GoodConductor` with
+    /// `σ ≤ 0`, or `London` with `λ_L ≤ 0` / non-finite). The
+    /// `Z_s → 0` (`λ_L → 0`) PEC limit must be expressed through the
     /// PEC edge mask, not through a vanishing impedance.
     pub fn weak_coefficient(&self, omega: f64) -> Result<c64, DrivenError> {
+        if let SurfaceImpedanceModel::London { lambda_l } = *self {
+            // iω/Z_s = iω/(iωλ_L) = 1/λ_L exactly — real and
+            // ω-independent. Returned directly so the quotient never
+            // degrades to 0/0 at small ω.
+            if !(lambda_l.is_finite() && lambda_l > 0.0) {
+                return Err(DrivenError::SurfaceImpedanceSingular {
+                    z_re: 0.0,
+                    z_im: omega * lambda_l,
+                    omega,
+                });
+            }
+            return Ok(c64::new(1.0 / lambda_l, 0.0));
+        }
         let z = self.z_s(omega);
         let singular = |z: c64| DrivenError::SurfaceImpedanceSingular {
             z_re: z.re,

--- a/crates/geode-core/src/eigen/sensitivity.rs
+++ b/crates/geode-core/src/eigen/sensitivity.rs
@@ -347,6 +347,66 @@ impl EigenSensitivity<'_> {
         Ok(grad)
     }
 
+    /// **London penetration-depth** sensitivity `∂λ/∂λ_L` (Epic #475,
+    /// issue #604) for a London wall `λ_L⁻¹ S_Γ` on the K side of the
+    /// pencil ([`crate::eigen::transmon::LondonSurface`],
+    /// [`crate::eigen::transmon::solve_transmon_eigenmodes_full_with_london`]).
+    ///
+    /// With `A(λ_L) = K + K_port + λ_L⁻¹ S_Γ` and an M-normalized
+    /// eigenvector `x` (`xᵀ(M + M_port)x = 1`), Hellmann–Feynman gives
+    ///
+    /// ```text
+    ///   ∂λ/∂λ_L = xᵀ (∂A/∂λ_L) x = −(xᵀ S_Γ x) / λ_L²,
+    /// ```
+    ///
+    /// a surface-mass inner product — always `≤ 0` (`S_Γ` is PSD): the
+    /// eigenfrequency drops as the penetration depth grows (kinetic
+    /// inductance). The same adjoint-free pattern as
+    /// [`deigenvalue_deps`](Self::deigenvalue_deps), contracted over the
+    /// wall's surface-mass triplets instead of the volume mass.
+    ///
+    /// `triangles` is the wall's triangle list and `lambda_l` the
+    /// penetration depth (mesh units) **at which the eigenpair was
+    /// solved** — the eigenvector must come from the pencil that includes
+    /// this wall's `λ_L⁻¹ S_Γ` term. For multiple walls with distinct
+    /// `λ_L`, call once per wall with that wall's triangles.
+    ///
+    /// # Errors
+    ///
+    /// [`EigenSensitivityError::DegenerateEigenvalue`] if the target
+    /// eigenvalue fails the simple-mode gap check;
+    /// [`EigenSensitivityError::DimMismatch`] on a length mismatch.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `lambda_l` is not strictly positive and finite (exact
+    /// `λ_L = 0` is the PEC limit, expressed through the PEC edge mask —
+    /// same convention as
+    /// [`crate::eigen::transmon::LondonSurface::k_triplets`]).
+    pub fn deigenvalue_dlambda_l(
+        &self,
+        triangles: &[[u32; 3]],
+        lambda_l: f64,
+    ) -> Result<f64, EigenSensitivityError> {
+        assert!(
+            lambda_l.is_finite() && lambda_l > 0.0,
+            "London lambda_l must be strictly positive and finite, got {lambda_l}; \
+             the λ_L = 0 PEC limit must be expressed through the PEC edge mask"
+        );
+        // Gap check only — λ itself does not enter the gradient (∂M/∂λ_L = 0).
+        let _lambda = self.checked_simple_lambda()?;
+        let xf = self.full_edge_vector()?;
+        // xᵀ S_Γ x over the wall's surface-mass triplets (PEC edges carry
+        // exact zeros in xf, so no reduction bookkeeping is needed).
+        let mut q = 0.0_f64;
+        for (r, c, v) in crate::assembly::surface::assemble_surface_mass_triplets(
+            self.mesh, triangles, self.edges,
+        ) {
+            q += xf[r] * v * xf[c];
+        }
+        Ok(-q / (lambda_l * lambda_l))
+    }
+
     /// The full **nodal-coordinate** geometry gradient `∂λ/∂X_{n,d}`, one
     /// `[x,y,z]` triple per node. Chain it through a node-motion map with
     /// [`deigenvalue_dtheta`](Self::deigenvalue_dtheta) /

--- a/crates/geode-core/src/eigen/transmon.rs
+++ b/crates/geode-core/src/eigen/transmon.rs
@@ -200,6 +200,73 @@ impl LumpedReactiveShunt<'_> {
     }
 }
 
+/// A **London superconducting wall** on the eigenmode pencil (Epic #475,
+/// issue #604): a set of boundary triangles (one per-surface tag) sharing
+/// a London penetration depth `λ_L`.
+///
+/// The driven-path Leontovich weak term is `+(iω/Z_s) S_Γ`
+/// ([`crate::driven::solve::SurfaceImpedanceModel::London`]); substituting
+/// the London impedance `Z_s = iωμλ_L` (μ = 1 natural units) cancels the
+/// iω **exactly**, leaving the real, frequency-independent coefficient
+/// `1/λ_L` — a stiffness. Like the junction inductor
+/// ([`LumpedReactiveShunt::k_port_triplets`]), the term therefore lands on
+/// the **K side** of the real symmetric pencil:
+///
+/// ```text
+/// (K + K_port + Σ_w λ_L,w⁻¹ S_Γ,w) x = λ (M + M_port) x,
+/// ```
+///
+/// keeping the pencil real symmetric — no new nonlinearity, solvable with
+/// the same shift-invert Lanczos. Physically the term is the wall's
+/// **kinetic inductance**: the eigenfrequency drops relative to the PEC
+/// wall, to first order by `Δω/ω ≈ −(λ_L/2)·∮|H_t|²dA / ∫μ|H|²dV`.
+///
+/// `1/λ_L` acts as a penalty enforcing `E_t → 0` on the wall as
+/// `λ_L → 0`: the small-λ_L limit converges to the PEC wall (wall edges
+/// eliminated). That is how the PEC baseline must be expressed — **exact
+/// `λ_L = 0` is invalid** ([`Self::k_triplets`] panics), mirroring the
+/// driven path's `SurfaceImpedanceSingular` convention.
+///
+/// `lambda_l` is a length in natural (mesh) units:
+/// `λ_L_nat = λ_L_SI / L_unit`.
+#[derive(Debug, Clone, Copy)]
+pub struct LondonSurface<'a> {
+    /// Wall triangles (0-based node triples into `mesh.nodes`, any
+    /// winding); must be faces of the tet mesh. The wall's edges must be
+    /// KEPT (interior) in the pencil's `interior_mask` — a PEC-eliminated
+    /// edge cannot carry the London term.
+    pub triangles: &'a [[u32; 3]],
+    /// London penetration depth λ_L in mesh units
+    /// (`λ_L_nat = λ_L_SI / L_unit`). Must be `> 0` and finite.
+    pub lambda_l: f64,
+}
+
+impl LondonSurface<'_> {
+    /// Assemble the London stiffness triplets `λ_L⁻¹ S_Γ` over global
+    /// edge indices ([`LumpedReactiveShunt::k_port_triplets`]-style; the
+    /// surface mass comes from the shared Whitney kernel via
+    /// [`crate::assembly::surface::assemble_surface_mass_triplets`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `lambda_l` is not strictly positive and finite: the
+    /// `λ_L = 0` PEC limit must be expressed through the PEC edge mask,
+    /// not through a vanishing penetration depth.
+    pub fn k_triplets(&self, mesh: &TetMesh, edges: &[[u32; 2]]) -> Vec<(usize, usize, f64)> {
+        assert!(
+            self.lambda_l.is_finite() && self.lambda_l > 0.0,
+            "London lambda_l must be strictly positive and finite, got {}; \
+             the λ_L = 0 PEC limit must be expressed through the PEC edge mask",
+            self.lambda_l
+        );
+        let s = 1.0 / self.lambda_l;
+        crate::assembly::surface::assemble_surface_mass_triplets(mesh, self.triangles, edges)
+            .into_iter()
+            .map(|(r, c, v)| (r, c, s * v))
+            .collect()
+    }
+}
+
 /// Restore a physical frequency (Hz) from an eigenvalue `λ = k²`
 /// (in `(1/mesh-unit)²`).
 ///
@@ -458,9 +525,46 @@ pub fn solve_transmon_eigenmodes_full(
     m_per_unit: f64,
     inner: InnerSolver,
 ) -> Result<Vec<TransmonMode>, EigenError> {
+    solve_transmon_eigenmodes_full_with_london(pencil, &[], sigma, n_modes, m_per_unit, inner)
+}
+
+/// [`solve_transmon_eigenmodes_full`] with additional **London
+/// superconducting walls** (Epic #475, issue #604): each
+/// [`LondonSurface`] contributes its kinetic-inductance stiffness
+/// `λ_L⁻¹ S_Γ` to the **K side** of the real symmetric pencil
+///
+/// ```text
+/// (K + K_port + Σ_w λ_L,w⁻¹ S_Γ,w) x = λ (M + M_port) x.
+/// ```
+///
+/// Multiple walls with distinct `λ_L` (per-surface tags) are supported.
+/// The wall edges must be kept (interior) in the pencil's
+/// `interior_mask`; the junction participation reported per mode remains
+/// junction-only (the London stiffness enters the denominator through
+/// the total `K`, not the `K_port` numerator). With `london = &[]` this
+/// is exactly [`solve_transmon_eigenmodes_full`].
+///
+/// # Errors
+///
+/// Propagates [`EigenError`] from the reduced assembly or the Lanczos
+/// solve.
+///
+/// # Panics
+///
+/// Panics (via [`LondonSurface::k_triplets`]) if any wall's `lambda_l`
+/// is not strictly positive and finite.
+pub fn solve_transmon_eigenmodes_full_with_london(
+    pencil: &TransmonPencil<'_>,
+    london: &[LondonSurface<'_>],
+    sigma: f64,
+    n_modes: usize,
+    m_per_unit: f64,
+    inner: InnerSolver,
+) -> Result<Vec<TransmonMode>, EigenError> {
     let (interior_index, dim) = ungauged_interior_reindex(pencil)?;
     solve_transmon_eigenmodes_reindexed(
         pencil,
+        london,
         &interior_index,
         dim,
         sigma,
@@ -518,6 +622,7 @@ pub fn solve_transmon_eigenmodes_gauged(
     }
     Ok(solve_transmon_eigenmodes_reindexed(
         pencil,
+        &[],
         gauge.gauged_index_map(),
         dim,
         sigma,
@@ -536,9 +641,12 @@ pub fn solve_transmon_eigenmodes_gauged(
 /// ungauged path passes the plain PEC interior reindex; the gauged path
 /// passes the tree-cotree cotree reindex. Everything downstream (surface
 /// terms, reduced assembly, Lanczos, participation) is index-agnostic.
+/// `london` walls add their `λ_L⁻¹ S_Γ` stiffness to the K side (issue
+/// #604); the junction-participation numerator stays `K_port`-only.
 #[allow(clippy::too_many_arguments)]
 fn solve_transmon_eigenmodes_reindexed(
     pencil: &TransmonPencil<'_>,
+    london: &[LondonSurface<'_>],
     reindex: &[Option<usize>],
     dim: usize,
     sigma: f64,
@@ -555,12 +663,20 @@ fn solve_transmon_eigenmodes_reindexed(
     let k_port = pencil.shunt.k_port_triplets(pencil.mesh, pencil.edges);
     let m_port = pencil.shunt.m_port_triplets(pencil.mesh, pencil.edges);
 
-    // Reduced (K + K_port) and (M + M_port) real sparse matrices.
+    // K-side extras: the junction K_port plus every London wall's
+    // kinetic-inductance stiffness λ_L⁻¹ S_Γ (issue #604).
+    let mut k_extra = k_port.clone();
+    for wall in london {
+        k_extra.extend(wall.k_triplets(pencil.mesh, pencil.edges));
+    }
+
+    // Reduced (K + K_port + Σ λ_L⁻¹ S_Γ) and (M + M_port) real sparse
+    // matrices.
     let k_red = assemble_reduced_real(
         &pattern.rows,
         &pattern.cols,
         pencil.k_vals,
-        &k_port,
+        &k_extra,
         interior_index,
         dim,
     )?;
@@ -1069,6 +1185,58 @@ mod tests {
             removed.m_port_triplets(&mesh, &edges).len(),
             shunt.m_port_triplets(&mesh, &edges).len()
         );
+    }
+
+    /// The London stiffness triplets scale as `1/λ_L` (doubling λ_L
+    /// halves every entry) and reproduce the raw surface mass at
+    /// `λ_L = 1` — the K-side, `k_port_triplets`-style contract.
+    #[test]
+    fn london_k_triplets_scale_as_inverse_lambda_l() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        let faces = z0_port(&mesh);
+
+        let base = LondonSurface {
+            triangles: &faces,
+            lambda_l: 1.0,
+        };
+        let double = LondonSurface {
+            triangles: &faces,
+            lambda_l: 2.0,
+        };
+        let raw = assemble_port_surface_mass(&mesh, &faces, &edges);
+        let k1 = base.k_triplets(&mesh, &edges);
+        let k2 = double.k_triplets(&mesh, &edges);
+        assert_eq!(k1.len(), raw.len());
+        assert_eq!(k1.len(), k2.len());
+        for ((r, d), s) in k1.iter().zip(k2.iter()).zip(raw.iter()) {
+            assert_eq!((r.0, r.1), (d.0, d.1));
+            assert_eq!((r.0, r.1), (s.0, s.1));
+            // λ_L = 1 reproduces S_Γ exactly; doubling λ_L halves.
+            assert_eq!(r.2, s.2, "λ_L = 1 must reproduce S_Γ");
+            assert!(
+                (r.2 - 2.0 * d.2).abs() < 1e-15 * r.2.abs().max(1.0),
+                "doubling λ_L must halve the London stiffness: {} vs {}",
+                r.2,
+                d.2
+            );
+        }
+    }
+
+    /// Exact `λ_L = 0` (the PEC limit) is invalid — it must be expressed
+    /// through the PEC edge mask, mirroring the driven path's
+    /// `SurfaceImpedanceSingular` convention.
+    #[test]
+    #[should_panic(expected = "London lambda_l must be strictly positive")]
+    fn london_zero_lambda_l_panics() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let edges = mesh.edges();
+        let faces = z0_port(&mesh);
+        let wall = LondonSurface {
+            triangles: &faces,
+            lambda_l: 0.0,
+        };
+        let _ = wall.k_triplets(&mesh, &edges);
     }
 
     /// Uniform-field closed form: for the constant tangential field

--- a/crates/geode-core/tests/london_eigen_kinetic_inductance.rs
+++ b/crates/geode-core/tests/london_eigen_kinetic_inductance.rs
@@ -1,0 +1,463 @@
+//! Eigenmode **kinetic-inductance frequency shift** of London
+//! superconducting walls vs first-order perturbation theory (Epic #475,
+//! issue #604).
+//!
+//! A cavity wall with the London surface impedance `Z_s = iωμλ_L` shifts
+//! the resonance below the PEC value by, to first order in `λ_L`,
+//!
+//! ```text
+//! Δω/ω ≈ −(λ_L/2) · ∮|H_t|² dA / ∫ μ|H|² dV,
+//! ```
+//!
+//! the standard wall-recession / kinetic-inductance result (frequency
+//! **decreases** as the penetration depth grows). On the real symmetric
+//! eigen pencil the London wall is the K-side stiffness `λ_L⁻¹ S_Γ`
+//! ([`geode_core::eigen::transmon::LondonSurface`]) — a penalty whose
+//! `λ_L → 0` limit is the PEC wall.
+//!
+//! **Fixture:** a rectangular `1.0 × 0.85 × 0.7` vacuum box (distinct
+//! side lengths so the lowest mode is simple — no cube degeneracy),
+//! London on all six walls. The PEC baseline is solved on the same mesh
+//! with the wall edges eliminated; `H_t` for the perturbation prediction
+//! is measured **independently** from the element-constant discrete curl
+//! of the PEC eigenvector (the same convention as the `R_eff` extraction
+//! in `leontovich_surface_impedance.rs` test 5), and `∫|H|² dV` from the
+//! same discrete curl over the volume, so the two integrals share their
+//! discretization bias.
+//!
+//! **What is pinned (honest-band convention, mirroring #504):**
+//!
+//! 1. The FEM shift is negative (frequency drops) and **monotone** in
+//!    λ_L across the decreasing sweep.
+//! 2. The measured/predicted ratio sits in an honest agreement band at
+//!    every sweep point, and the smallest-λ_L point agrees at least as
+//!    well as the largest (convergence trend toward the perturbation
+//!    prediction as λ_L → 0). The sweep stops at λ_L = 5×10⁻³ — well
+//!    before the `λ_L⁻¹` penalty's conditioning noise; exact λ_L = 0 is
+//!    invalid by convention (PEC goes through the edge mask).
+
+use burn::tensor::Tensor;
+use burn::tensor::backend::BackendTypes;
+use faer::c64;
+use std::collections::BTreeMap;
+
+use geode_core::assembly::nedelec::{
+    NedelecScatterMap, assemble_global_nedelec_with_full_tensors_sparse,
+};
+use geode_core::assembly::p1::upload_mesh;
+use geode_core::eigen::lanczos::InnerSolver;
+use geode_core::eigen::transmon::{
+    LondonSurface, LumpedReactiveShunt, ReactiveElementNatural, TransmonPencil,
+    solve_transmon_eigenmodes_full, solve_transmon_eigenmodes_full_with_london,
+};
+use geode_core::mesh::spiral::pec_interior_mask_from_triangles;
+use geode_core::mesh::{TET_LOCAL_EDGES, TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+const M_PER_UNIT: f64 = 1e-6;
+const GEOM_TOL: f64 = 1e-9;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vals_to_host(t: Tensor<B, 1>) -> Vec<f64> {
+    t.into_data().iter::<f64>().collect()
+}
+
+fn edge_tables(mesh: &TetMesh) -> (Vec<[u32; 6]>, Vec<[i8; 6]>) {
+    let te = mesh.tet_edges();
+    (
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].0))
+            .collect(),
+        te.iter()
+            .map(|row| std::array::from_fn(|i| row[i].1))
+            .collect(),
+    )
+}
+
+/// A rectangular vacuum box `dims[0] × dims[1] × dims[2]` (anisotropic
+/// rescale of the unit-cube mesh so the lowest resonance is simple), with
+/// every boundary triangle listed alongside its owner tet and the axis it
+/// is normal to.
+struct BoxFixture {
+    mesh: TetMesh,
+    edges: Vec<[u32; 2]>,
+    tet_edge_sign: Vec<[i8; 6]>,
+    scatter: NedelecScatterMap,
+    /// All boundary triangles (all six walls).
+    wall_tris: Vec<[u32; 3]>,
+    /// Owner tet of each wall triangle.
+    wall_tet: Vec<usize>,
+    /// Axis (0/1/2) each wall triangle is normal to.
+    wall_axis: Vec<usize>,
+    /// PEC mask: every wall edge eliminated (the PEC baseline).
+    interior_mask_pec: Vec<bool>,
+    /// London mask: every edge kept (the wall carries the surface term).
+    keep_all_mask: Vec<bool>,
+}
+
+fn box_fixture(n: usize, dims: [f64; 3]) -> BoxFixture {
+    let mut mesh = cube_tet_mesh(n, 1.0);
+    for p in mesh.nodes.iter_mut() {
+        for k in 0..3 {
+            p[k] *= dims[k];
+        }
+    }
+    let mesh = TetMesh {
+        nodes: mesh.nodes,
+        tets: mesh.tets,
+        physical_groups: BTreeMap::new(),
+    };
+
+    let on_plane = |v: u32, k: usize, val: f64| (mesh.nodes[v as usize][k] - val).abs() < GEOM_TOL;
+    let mut wall_tris = Vec::new();
+    let mut wall_tet = Vec::new();
+    let mut wall_axis = Vec::new();
+    for (ti, tet) in mesh.tets.iter().enumerate() {
+        for omit in 0..4 {
+            let tri: [u32; 3] = {
+                let mut it = (0..4).filter(|&v| v != omit).map(|v| tet[v]);
+                std::array::from_fn(|_| it.next().unwrap())
+            };
+            for (k, &dim) in dims.iter().enumerate() {
+                for val in [0.0, dim] {
+                    if tri.iter().all(|&v| on_plane(v, k, val)) {
+                        wall_tris.push(tri);
+                        wall_tet.push(ti);
+                        wall_axis.push(k);
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(
+        wall_tris.len(),
+        6 * 2 * n * n,
+        "expected 2n² triangles per wall"
+    );
+
+    let edges = mesh.edges();
+    let interior_mask_pec = pec_interior_mask_from_triangles(&edges, &[wall_tris.as_slice()]);
+    let keep_all_mask = vec![true; edges.len()];
+    let (tet_edge_idx, tet_edge_sign) = edge_tables(&mesh);
+    let scatter = NedelecScatterMap::new(&tet_edge_idx);
+
+    BoxFixture {
+        mesh,
+        edges,
+        tet_edge_sign,
+        scatter,
+        wall_tris,
+        wall_tet,
+        wall_axis,
+        interior_mask_pec,
+        keep_all_mask,
+    }
+}
+
+/// Real vacuum (ε = 1, μ = 1) Nédélec pencil value vectors.
+fn assemble_vacuum_pencil(fx: &BoxFixture) -> (Vec<f64>, Vec<f64>) {
+    let (nodes_t, tets_t) = upload_mesh::<B>(&fx.mesh, &device());
+    let identity: [[c64; 3]; 3] = std::array::from_fn(|i| {
+        std::array::from_fn(|j| c64::new(if i == j { 1.0 } else { 0.0 }, 0.0))
+    });
+    let tensors = vec![identity; fx.mesh.n_tets()];
+    let sys = assemble_global_nedelec_with_full_tensors_sparse::<B>(
+        nodes_t,
+        tets_t,
+        &fx.tet_edge_sign,
+        &fx.scatter,
+        &tensors,
+        &tensors,
+    );
+    (vals_to_host(sys.k_re_vals), vals_to_host(sys.m_re_vals))
+}
+
+/// No-port shunt: `L = ∞`, `C = 0` — the pencil is the pure volume
+/// `(K, M)` (plus whatever London walls the entry point adds).
+fn bare_shunt(faces: &[[u32; 3]]) -> LumpedReactiveShunt<'_> {
+    LumpedReactiveShunt {
+        faces,
+        length: 1.0,
+        width: 1.0,
+        element: ReactiveElementNatural {
+            l_natural: f64::INFINITY,
+            c_natural: 0.0,
+        },
+    }
+}
+
+/// Scatter a reduced eigenvector back to full edge length under a mask.
+fn scatter_full(mask: &[bool], reduced: &[f64]) -> Vec<f64> {
+    let mut xf = vec![0.0_f64; mask.len()];
+    let mut r = 0usize;
+    for (e, &keep) in mask.iter().enumerate() {
+        if keep {
+            xf[e] = reduced[r];
+            r += 1;
+        }
+    }
+    assert_eq!(r, reduced.len());
+    xf
+}
+
+/// Barycentric gradients `∇λ_0..3` of a tet.
+fn tet_grad_lambda(p: &[[f64; 3]; 4]) -> [[f64; 3]; 4] {
+    let sub = |a: [f64; 3], b: [f64; 3]| [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    let cross = |a: [f64; 3], b: [f64; 3]| {
+        [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+    };
+    let dot = |a: [f64; 3], b: [f64; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    let e1 = sub(p[1], p[0]);
+    let e2 = sub(p[2], p[0]);
+    let e3 = sub(p[3], p[0]);
+    let v6 = dot(e1, cross(e2, e3));
+    let g1 = cross(e2, e3).map(|x| x / v6);
+    let g2 = cross(e3, e1).map(|x| x / v6);
+    let g3 = cross(e1, e2).map(|x| x / v6);
+    let g0 = [
+        -(g1[0] + g2[0] + g3[0]),
+        -(g1[1] + g2[1] + g3[1]),
+        -(g1[2] + g2[2] + g3[2]),
+    ];
+    [g0, g1, g2, g3]
+}
+
+/// Element-constant `∇×E` of the real Whitney edge field on tet `ti`.
+fn tet_curl(mesh: &TetMesh, tet_edge_rows: &[[(u32, i8); 6]], ti: usize, xf: &[f64]) -> [f64; 3] {
+    let tet = mesh.tets[ti];
+    let p: [[f64; 3]; 4] = std::array::from_fn(|v| mesh.nodes[tet[v] as usize]);
+    let g = tet_grad_lambda(&p);
+    let mut curl = [0.0_f64; 3];
+    for (k, &(la, lb)) in TET_LOCAL_EDGES.iter().enumerate() {
+        let (gidx, sign) = tet_edge_rows[ti][k];
+        let d = xf[gidx as usize] * (sign as f64);
+        let (a, b) = (g[la], g[lb]);
+        curl[0] += d * 2.0 * (a[1] * b[2] - a[2] * b[1]);
+        curl[1] += d * 2.0 * (a[2] * b[0] - a[0] * b[2]);
+        curl[2] += d * 2.0 * (a[0] * b[1] - a[1] * b[0]);
+    }
+    curl
+}
+
+fn triangle_area(p: &[[f64; 3]; 3]) -> f64 {
+    let u = [p[1][0] - p[0][0], p[1][1] - p[0][1], p[1][2] - p[0][2]];
+    let v = [p[2][0] - p[0][0], p[2][1] - p[0][1], p[2][2] - p[0][2]];
+    let c = [
+        u[1] * v[2] - u[2] * v[1],
+        u[2] * v[0] - u[0] * v[2],
+        u[0] * v[1] - u[1] * v[0],
+    ];
+    0.5 * (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt()
+}
+
+fn tet_volume(p: &[[f64; 3]; 4]) -> f64 {
+    let sub = |a: [f64; 3], b: [f64; 3]| [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    let e1 = sub(p[1], p[0]);
+    let e2 = sub(p[2], p[0]);
+    let e3 = sub(p[3], p[0]);
+    let det = e1[0] * (e2[1] * e3[2] - e2[2] * e3[1]) - e1[1] * (e2[0] * e3[2] - e2[2] * e3[0])
+        + e1[2] * (e2[0] * e3[1] - e2[1] * e3[0]);
+    det.abs() / 6.0
+}
+
+/// The geometry factor `Γ = ∮|H_t|² dA / ∫|H|² dV` measured from the
+/// element-constant discrete curl of a (full-edge) eigenvector — the ω²
+/// in `H = ∇×E/(−iω)` cancels between numerator and denominator.
+fn geometry_factor(fx: &BoxFixture, xf: &[f64]) -> f64 {
+    let tet_edge_rows = fx.mesh.tet_edges();
+    let mut num = 0.0_f64;
+    for ((tri, &ti), &axis) in fx
+        .wall_tris
+        .iter()
+        .zip(fx.wall_tet.iter())
+        .zip(fx.wall_axis.iter())
+    {
+        let curl = tet_curl(&fx.mesh, &tet_edge_rows, ti, xf);
+        let c2 = curl[0] * curl[0] + curl[1] * curl[1] + curl[2] * curl[2];
+        let ht2 = c2 - curl[axis] * curl[axis];
+        let p: [[f64; 3]; 3] = std::array::from_fn(|v| fx.mesh.nodes[tri[v] as usize]);
+        num += triangle_area(&p) * ht2;
+    }
+    let mut den = 0.0_f64;
+    for ti in 0..fx.mesh.n_tets() {
+        let curl = tet_curl(&fx.mesh, &tet_edge_rows, ti, xf);
+        let c2 = curl[0] * curl[0] + curl[1] * curl[1] + curl[2] * curl[2];
+        let tet = fx.mesh.tets[ti];
+        let p: [[f64; 3]; 4] = std::array::from_fn(|v| fx.mesh.nodes[tet[v] as usize]);
+        den += tet_volume(&p) * c2;
+    }
+    assert!(den > 0.0);
+    num / den
+}
+
+/// Normalized Euclidean overlap of two full-edge vectors (mode
+/// identification: the physical London mode overlaps the PEC mode ≈ 1;
+/// spurious penalty/gradient modes ≈ 0).
+fn overlap(a: &[f64], b: &[f64]) -> f64 {
+    let dot: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let na: f64 = a.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|x| x * x).sum::<f64>().sqrt();
+    dot.abs() / (na * nb)
+}
+
+/// FEM kinetic-inductance shift of the London-wall box vs the first-order
+/// perturbation oracle, across a decreasing-λ_L sweep (honest band).
+#[test]
+fn london_kinetic_inductance_shift_matches_perturbation_oracle() {
+    let n = 5;
+    let dims = [1.0, 0.85, 0.7];
+    let fx = box_fixture(n, dims);
+    let (k_vals, m_vals) = assemble_vacuum_pencil(&fx);
+    let no_faces: Vec<[u32; 3]> = Vec::new();
+
+    // Lowest resonance of the a × b × c PEC box uses the two largest
+    // dimensions: λ₁ = π²(1/a² + 1/b²).
+    let pi = std::f64::consts::PI;
+    let lambda_analytic = pi * pi * (1.0 / (dims[0] * dims[0]) + 1.0 / (dims[1] * dims[1]));
+    let sigma = 0.95 * lambda_analytic;
+    let n_modes_pec = 4;
+    let n_modes_london = 10; // cushion: the penalty spreads spurious gradient modes
+
+    // --- PEC baseline: wall edges eliminated. ---
+    let pencil_pec = TransmonPencil {
+        scatter: &fx.scatter,
+        k_vals: &k_vals,
+        m_vals: &m_vals,
+        edges: &fx.edges,
+        mesh: &fx.mesh,
+        shunt: bare_shunt(&no_faces),
+        interior_mask: &fx.interior_mask_pec,
+    };
+    let modes_pec = solve_transmon_eigenmodes_full(
+        &pencil_pec,
+        sigma,
+        n_modes_pec,
+        M_PER_UNIT,
+        InnerSolver::Direct,
+    )
+    .expect("PEC eigensolve");
+    let pec = modes_pec
+        .iter()
+        .filter(|m| m.report.lambda > 1.0)
+        .min_by(|a, b| a.report.lambda.partial_cmp(&b.report.lambda).unwrap())
+        .expect("no physical PEC mode found")
+        .clone();
+    let lambda_pec = pec.report.lambda;
+    let rel_analytic = (lambda_pec - lambda_analytic).abs() / lambda_analytic;
+    eprintln!(
+        "PEC λ₁ = {lambda_pec:.6} (analytic {lambda_analytic:.6}, rel diff {:.2}%)",
+        100.0 * rel_analytic
+    );
+    assert!(
+        rel_analytic < 0.10,
+        "PEC baseline strays from the analytic box mode: {rel_analytic:.3}"
+    );
+
+    // --- Perturbation prediction from the PEC mode's discrete curl. ---
+    let x_pec_full = scatter_full(&fx.interior_mask_pec, &pec.vector);
+    let gamma = geometry_factor(&fx, &x_pec_full);
+    eprintln!("geometry factor Γ = ∮|H_t|²dA / ∫|H|²dV = {gamma:.4}");
+    assert!(gamma > 0.0);
+
+    // --- Decreasing-λ_L sweep. Stop at 5e-3, well before λ_L⁻¹
+    //     conditioning noise. ---
+    let lambda_ls = [0.04, 0.02, 0.01, 0.005];
+    let mut measured = Vec::new();
+    let mut ratios = Vec::new();
+    for &lambda_l in lambda_ls.iter() {
+        let pencil = TransmonPencil {
+            scatter: &fx.scatter,
+            k_vals: &k_vals,
+            m_vals: &m_vals,
+            edges: &fx.edges,
+            mesh: &fx.mesh,
+            shunt: bare_shunt(&no_faces),
+            interior_mask: &fx.keep_all_mask,
+        };
+        let walls = [LondonSurface {
+            triangles: &fx.wall_tris,
+            lambda_l,
+        }];
+        let modes = solve_transmon_eigenmodes_full_with_london(
+            &pencil,
+            &walls,
+            sigma,
+            n_modes_london,
+            M_PER_UNIT,
+            InnerSolver::Direct,
+        )
+        .expect("London eigensolve");
+
+        // Identify the physical mode by overlap with the PEC mode.
+        let best = modes
+            .iter()
+            .map(|m| {
+                let xf = scatter_full(&fx.keep_all_mask, &m.vector);
+                (overlap(&xf, &x_pec_full), m.report.lambda)
+            })
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+            .expect("no London modes");
+        let (ov, lambda_london) = best;
+        assert!(
+            ov > 0.9,
+            "physical-mode identification failed at λ_L = {lambda_l}: best overlap {ov:.3}"
+        );
+
+        let d_rel = (lambda_london.sqrt() - lambda_pec.sqrt()) / lambda_pec.sqrt();
+        let predicted = -0.5 * lambda_l * gamma;
+        let ratio = d_rel / predicted;
+        eprintln!(
+            "λ_L = {lambda_l:.3}: λ = {lambda_london:.6} (overlap {ov:.4}), \
+             Δω/ω measured {d_rel:.5e}, predicted {predicted:.5e}, ratio {ratio:.4}"
+        );
+        assert!(
+            d_rel < 0.0,
+            "London wall must LOWER the frequency at λ_L = {lambda_l}: Δω/ω = {d_rel:.3e}"
+        );
+        measured.push(d_rel);
+        ratios.push(ratio);
+    }
+
+    // Monotone: larger λ_L → weaker penalty → lower frequency (more
+    // negative shift). The sweep is ordered decreasing in λ_L.
+    for w in measured.windows(2) {
+        assert!(
+            w[0] < w[1],
+            "kinetic-inductance shift must be monotone in λ_L: {:?}",
+            measured
+        );
+    }
+
+    // Honest agreement band: measured/predicted within ±20% at every
+    // sweep point (first-order perturbation + O(h) discrete-curl bias on
+    // the n = 5 mesh), and the smallest-λ_L point at least as close to 1
+    // as the largest (convergence toward the oracle as λ_L → 0, with
+    // slack for the discretization floor).
+    for (lambda_l, ratio) in lambda_ls.iter().zip(ratios.iter()) {
+        assert!(
+            (ratio - 1.0).abs() < 0.20,
+            "measured/predicted ratio {ratio:.4} outside the honest band at λ_L = {lambda_l}"
+        );
+    }
+    let err_first = (ratios[0] - 1.0).abs();
+    let err_last = (ratios[ratios.len() - 1] - 1.0).abs();
+    eprintln!(
+        "|ratio − 1|: λ_L = {} → {err_first:.4}, λ_L = {} → {err_last:.4}",
+        lambda_ls[0],
+        lambda_ls[lambda_ls.len() - 1]
+    );
+    assert!(
+        err_last <= err_first + 0.02,
+        "smallest-λ_L point must agree at least as well as the largest: \
+         |ratio−1| {err_last:.4} vs {err_first:.4}"
+    );
+}

--- a/crates/geode-core/tests/london_surface_impedance.rs
+++ b/crates/geode-core/tests/london_surface_impedance.rs
@@ -1,0 +1,515 @@
+//! Validation of the **London superconductor** surface BC on the driven
+//! path (Epic #475, issue #604).
+//!
+//! The London impedance is the purely reactive `Z_s(ω) = iωμλ_L` (μ = 1
+//! natural units), the kinetic-inductance surface reactance of a
+//! superconductor in the local London limit. Its weak-form coefficient is
+//! special: `iω/Z_s = iω/(iωλ_L) = 1/λ_L` — **real, positive and
+//! frequency-independent** (the iω cancels exactly). These tests pin
+//! down, mirroring `leontovich_surface_impedance.rs`:
+//!
+//! 1. **Coefficient identity** — `weak_coefficient` is exactly `1/λ_L`
+//!    at any ω (including ω = 0: no 0/0, no `|Z_s| = 0` singular trip),
+//!    and `z_s(ω) = iωλ_L`.
+//! 2. **Invalid λ_L rejected** — `λ_L ≤ 0` / non-finite is
+//!    `SurfaceImpedanceSingular` (the PEC limit must go through the PEC
+//!    edge mask), both at the coefficient level and through the full
+//!    driven solve.
+//! 3. **Fixed-impedance equivalence** — at fixed ω, `London { λ_L }`
+//!    reproduces `Fixed(iωλ_L)` (the generic `iω/Z_s` quotient) to
+//!    round-off.
+//! 4. **Complex symmetry** — `A(ω)ᵀ = A(ω)` with the London term active
+//!    (the PR #55 invariant; the London coefficient is real, so the term
+//!    lands entirely in `Re(A)`).
+//! 5. **PEC limit** — small-λ_L monotone convergence to the PEC solution
+//!    on the same geometry (wall edges eliminated) — the same convention
+//!    as Leontovich test 3; exact λ_L = 0 stays invalid.
+//! 6. **Per-tag composition** — splitting the wall into two surface tags
+//!    with the same λ_L reproduces the single-tag solve; distinct λ_L on
+//!    the two halves solves cleanly (multi-tag support).
+
+use faer::c64;
+use std::collections::BTreeMap;
+use std::f64::consts::PI;
+
+use geode_core::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, SurfaceImpedanceBc,
+    SurfaceImpedanceModel, driven_solve, driven_solve_with_surface_impedance,
+};
+use geode_core::mesh::{TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+type B = TestBackend;
+
+fn device() -> <B as burn::tensor::backend::BackendTypes>::Device {
+    <B as burn::tensor::backend::BackendTypes>::Device::default()
+}
+
+const GEOM_TOL: f64 = 1e-9;
+
+/// The unit cube truncated to the vacuum half `x ≤ x_cut`, with the
+/// truncation wall exposed as conforming surface triangles — the same
+/// fixture family as `leontovich_surface_impedance.rs`.
+struct TruncatedSlab {
+    mesh: TetMesh,
+    /// Triangles on the `x = x_cut` wall.
+    wall_tris: Vec<[u32; 3]>,
+    /// PEC mask: side/back walls eliminated, `x = x_cut` wall KEPT
+    /// (impedance surface).
+    interior_mask: Vec<bool>,
+    /// PEC mask with the `x = x_cut` wall eliminated too (full PEC box).
+    interior_mask_pec_wall: Vec<bool>,
+}
+
+fn truncated_slab(n: usize, x_cut: f64) -> TruncatedSlab {
+    let full = cube_tet_mesh(n, 1.0);
+    let tets: Vec<[u32; 4]> = full
+        .tets
+        .iter()
+        .filter(|t| {
+            t.iter()
+                .all(|&v| full.nodes[v as usize][0] <= x_cut + GEOM_TOL)
+        })
+        .copied()
+        .collect();
+    assert!(!tets.is_empty(), "truncation removed every tet");
+    let mesh = TetMesh {
+        nodes: full.nodes,
+        tets,
+        physical_groups: BTreeMap::new(),
+    };
+
+    // Wall triangles: tet faces whose three vertices all sit on x = x_cut.
+    let mut wall_tris = Vec::new();
+    for tet in mesh.tets.iter() {
+        for omit in 0..4 {
+            let tri: [u32; 3] = {
+                let mut it = (0..4).filter(|&v| v != omit).map(|v| tet[v]);
+                std::array::from_fn(|_| it.next().unwrap())
+            };
+            if tri
+                .iter()
+                .all(|&v| (mesh.nodes[v as usize][0] - x_cut).abs() < GEOM_TOL)
+            {
+                wall_tris.push(tri);
+            }
+        }
+    }
+    assert_eq!(
+        wall_tris.len(),
+        2 * n * n,
+        "expected 2 wall triangles per hex face"
+    );
+
+    let edges = mesh.edges();
+    let on = |v: u32, k: usize, val: f64| (mesh.nodes[v as usize][k] - val).abs() < GEOM_TOL;
+    let on_pec_side = |e: &[u32; 2]| {
+        let planes = [(0usize, 0.0), (1, 0.0), (1, 1.0), (2, 0.0), (2, 1.0)];
+        planes
+            .iter()
+            .any(|&(k, val)| on(e[0], k, val) && on(e[1], k, val))
+    };
+    let interior_mask: Vec<bool> = edges.iter().map(|e| !on_pec_side(e)).collect();
+    let interior_mask_pec_wall: Vec<bool> = edges
+        .iter()
+        .zip(interior_mask.iter())
+        .map(|(e, &keep)| keep && !(on(e[0], 0, x_cut) && on(e[1], 0, x_cut)))
+        .collect();
+
+    TruncatedSlab {
+        mesh,
+        wall_tris,
+        interior_mask,
+        interior_mask_pec_wall,
+    }
+}
+
+/// The slab-fixture source `J = ẑ sin(πy)` on the first element layer
+/// `x < h`.
+fn slab_source(mesh: &TetMesh, h: f64) -> CurrentSource {
+    CurrentSource::from_centroids(mesh, |c| {
+        let jz = if c[0] < h { (PI * c[1]).sin() } else { 0.0 };
+        [c64::new(0.0, 0.0), c64::new(0.0, 0.0), c64::new(jz, 0.0)]
+    })
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+// ---------------------------------------------------------------------------
+// 1. The weak coefficient is exactly 1/λ_L, at any ω.
+// ---------------------------------------------------------------------------
+
+/// `weak_coefficient` must be the real, frequency-independent `1/λ_L`
+/// **exactly** — evaluated directly, not as the `iω/(iωλ_L)` quotient —
+/// so it stays finite and exact at ω = 0 and at ω small enough that
+/// `|Z_s|²` underflows (where the generic quotient would trip the
+/// singular guard). `z_s(ω)` itself must be the purely reactive `iωλ_L`.
+#[test]
+fn london_weak_coefficient_is_inverse_lambda_l_at_any_omega() {
+    let lambda_l = 0.09;
+    let model = SurfaceImpedanceModel::London { lambda_l };
+    let expect = c64::new(1.0 / lambda_l, 0.0);
+    // Includes ω = 0 and an ω where |iωλ_L|² underflows to 0.0 — the
+    // generic quotient path would return SurfaceImpedanceSingular there.
+    for omega in [0.0, 1e-200, 1e-8, 1.0, 3.7, 1e6] {
+        let coeff = model.weak_coefficient(omega).expect("London coeff finite");
+        assert_eq!(coeff, expect, "iω/Z_s must be exactly 1/λ_L at ω = {omega}");
+    }
+    // Z_s(ω) = iωλ_L: purely imaginary, frequency-linear.
+    for omega in [0.5, 1.0, 2.0] {
+        let z = model.z_s(omega);
+        assert_eq!(z.re, 0.0);
+        assert!((z.im - omega * lambda_l).abs() < 1e-15 * omega * lambda_l);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Invalid λ_L is rejected (PEC limit goes through the edge mask).
+// ---------------------------------------------------------------------------
+
+/// `λ_L ≤ 0` / non-finite must surface as `SurfaceImpedanceSingular`,
+/// both from `weak_coefficient` directly and through the full driven
+/// solve — exact `λ_L = 0` (the PEC limit) must be expressed through the
+/// PEC edge mask, mirroring the existing `Z_s = 0` convention.
+#[test]
+fn london_invalid_lambda_l_rejected() {
+    for bad in [0.0, -0.05, f64::NAN, f64::INFINITY] {
+        let model = SurfaceImpedanceModel::London { lambda_l: bad };
+        assert!(
+            matches!(
+                model.weak_coefficient(1.0),
+                Err(DrivenError::SurfaceImpedanceSingular { .. })
+            ),
+            "λ_L = {bad} must be rejected"
+        );
+    }
+
+    // Through the full driven solve.
+    let slab = truncated_slab(2, 0.5);
+    let eps = vacuum(&slab.mesh);
+    let source = slab_source(&slab.mesh, 0.5);
+    let err = driven_solve_with_surface_impedance::<B>(
+        &slab.mesh,
+        DrivenMaterials::Scalar(&eps),
+        None,
+        &DrivenBcs {
+            pec_interior_mask: &slab.interior_mask,
+        },
+        &[SurfaceImpedanceBc {
+            triangles: &slab.wall_tris,
+            model: SurfaceImpedanceModel::London { lambda_l: 0.0 },
+        }],
+        1.0,
+        &source,
+        &device(),
+    )
+    .expect_err("λ_L = 0 must fail the driven solve");
+    assert!(matches!(err, DrivenError::SurfaceImpedanceSingular { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Fixed-impedance equivalence: London { λ_L } == Fixed(iωλ_L) at fixed ω.
+// ---------------------------------------------------------------------------
+
+/// At a fixed frequency, `London { λ_L }` and `Fixed(iωλ_L)` describe
+/// the same impedance; the solves must agree to round-off (the only
+/// difference is the direct `1/λ_L` vs the generic `iω·conj(Z)/|Z|²`
+/// coefficient evaluation).
+#[test]
+fn london_matches_equivalent_fixed_impedance() {
+    let slab = truncated_slab(4, 0.5);
+    let eps = vacuum(&slab.mesh);
+    let source = slab_source(&slab.mesh, 0.25);
+    let omega = 1.3;
+    let lambda_l = 0.07;
+
+    let solve = |model: SurfaceImpedanceModel| {
+        driven_solve_with_surface_impedance::<B>(
+            &slab.mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &DrivenBcs {
+                pec_interior_mask: &slab.interior_mask,
+            },
+            &[SurfaceImpedanceBc {
+                triangles: &slab.wall_tris,
+                model,
+            }],
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("driven solve")
+    };
+    let sol_london = solve(SurfaceImpedanceModel::London { lambda_l });
+    let sol_fixed = solve(SurfaceImpedanceModel::Fixed(c64::new(
+        0.0,
+        omega * lambda_l,
+    )));
+    assert!(sol_london.residual_rel < 1e-10);
+
+    let norm: f64 = sol_fixed
+        .e_edges
+        .iter()
+        .map(|e| e.re * e.re + e.im * e.im)
+        .sum::<f64>()
+        .sqrt();
+    assert!(norm > 0.0);
+    let diff: f64 = sol_london
+        .e_edges
+        .iter()
+        .zip(sol_fixed.e_edges.iter())
+        .map(|(a, b)| {
+            let d = *a - *b;
+            d.re * d.re + d.im * d.im
+        })
+        .sum::<f64>()
+        .sqrt();
+    let rel = diff / norm;
+    eprintln!("London vs Fixed(iωλ_L) relative field difference: {rel:.3e}");
+    assert!(
+        rel < 1e-9,
+        "London {{ λ_L }} must reproduce Fixed(iωλ_L) to round-off: rel {rel:.3e}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Complex symmetry with the London term active.
+// ---------------------------------------------------------------------------
+
+/// The London term is a **real** scalar (`1/λ_L`) times the real
+/// symmetric surface mass, so the complex-symmetry invariant
+/// `A(ω)ᵀ = A(ω)` (PR #55) must survive with the term active; the
+/// solver's residual pins the composed system, and the two London solves
+/// at different frequencies must agree on the coefficient (frequency
+/// independence at the system level: only `−ω²M` changes).
+#[test]
+fn complex_symmetry_and_solvability_with_london_term() {
+    let slab = truncated_slab(4, 0.5);
+    let mesh = &slab.mesh;
+    let eps = vacuum(mesh);
+    let source = slab_source(mesh, 0.25);
+    let lambda_l = 0.05;
+    let model = SurfaceImpedanceModel::London { lambda_l };
+
+    for omega in [1.0, 2.1] {
+        let sol = driven_solve_with_surface_impedance::<B>(
+            mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &DrivenBcs {
+                pec_interior_mask: &slab.interior_mask,
+            },
+            &[SurfaceImpedanceBc {
+                triangles: &slab.wall_tris,
+                model,
+            }],
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("London driven solve");
+        assert!(
+            sol.residual_rel < 1e-10,
+            "London solve at ω = {omega}: residual {:.3e}",
+            sol.residual_rel
+        );
+        // The weak coefficient the system used is ω-independent.
+        assert_eq!(
+            model.weak_coefficient(omega).unwrap(),
+            c64::new(1.0 / lambda_l, 0.0)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. PEC limit: λ_L → 0 approaches the PEC solution (mirror of
+//    Leontovich test 3).
+// ---------------------------------------------------------------------------
+
+/// As `λ_L → 0` the London wall must converge to the PEC solution on the
+/// same geometry (wall edges eliminated): the relative field difference
+/// shrinks monotonically with λ_L and is small at `λ_L = 10⁻⁵`. Exact
+/// `λ_L = 0` stays invalid (see `london_invalid_lambda_l_rejected`) —
+/// this monotone small-λ_L convergence IS the PEC-degeneracy criterion.
+#[test]
+fn small_lambda_l_recovers_pec_wall() {
+    let n = 4;
+    let slab = truncated_slab(n, 0.5);
+    let mesh = &slab.mesh;
+    let eps = vacuum(mesh);
+    let source = slab_source(mesh, 0.25);
+    let omega = 1.0;
+
+    let pec = driven_solve::<B>(
+        mesh,
+        DrivenMaterials::Scalar(&eps),
+        &DrivenBcs {
+            pec_interior_mask: &slab.interior_mask_pec_wall,
+        },
+        omega,
+        &source,
+        &device(),
+    )
+    .expect("PEC reference solve");
+    let norm: f64 = pec
+        .e_edges
+        .iter()
+        .map(|e| e.re * e.re + e.im * e.im)
+        .sum::<f64>()
+        .sqrt();
+    assert!(norm > 0.0);
+
+    let rel_diff = |lambda_l: f64| -> f64 {
+        let sol = driven_solve_with_surface_impedance::<B>(
+            mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &DrivenBcs {
+                pec_interior_mask: &slab.interior_mask,
+            },
+            &[SurfaceImpedanceBc {
+                triangles: &slab.wall_tris,
+                model: SurfaceImpedanceModel::London { lambda_l },
+            }],
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("small-λ_L solve");
+        let d2: f64 = sol
+            .e_edges
+            .iter()
+            .zip(pec.e_edges.iter())
+            .map(|(a, b)| {
+                let d = *a - *b;
+                d.re * d.re + d.im * d.im
+            })
+            .sum();
+        d2.sqrt() / norm
+    };
+
+    let d_coarse = rel_diff(1e-2);
+    let d_mid = rel_diff(1e-3);
+    let d_fine = rel_diff(1e-5);
+    eprintln!(
+        "PEC-limit relative differences: λ_L = 1e-2 → {d_coarse:.3e}, \
+         1e-3 → {d_mid:.3e}, 1e-5 → {d_fine:.3e}"
+    );
+    assert!(
+        d_fine < d_mid && d_mid < d_coarse,
+        "field difference to PEC must shrink monotonically with λ_L: \
+         {d_fine:.3e} !< {d_mid:.3e} !< {d_coarse:.3e}"
+    );
+    assert!(
+        d_fine < 1e-3,
+        "λ_L = 1e-5 should be PEC to ~1e-3: relative diff {d_fine:.3e}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Per-tag composition: split walls, same and distinct λ_L.
+// ---------------------------------------------------------------------------
+
+/// Splitting the wall triangles into two `SurfaceImpedanceBc`s with the
+/// **same** λ_L must reproduce the single-surface solve (the surface
+/// terms sum); two **distinct** λ_L values on the two halves must solve
+/// cleanly (per-tag λ_L support) and differ from the uniform-λ_L
+/// solution.
+#[test]
+fn split_wall_tags_compose_and_support_distinct_lambda_l() {
+    let slab = truncated_slab(4, 0.5);
+    let mesh = &slab.mesh;
+    let eps = vacuum(mesh);
+    let source = slab_source(mesh, 0.25);
+    let omega = 1.2;
+    let lambda_l = 0.06;
+
+    let half = slab.wall_tris.len() / 2;
+    assert!(half > 0);
+    let (tris_a, tris_b) = slab.wall_tris.split_at(half);
+
+    let solve = |surfaces: &[SurfaceImpedanceBc<'_>]| {
+        driven_solve_with_surface_impedance::<B>(
+            mesh,
+            DrivenMaterials::Scalar(&eps),
+            None,
+            &DrivenBcs {
+                pec_interior_mask: &slab.interior_mask,
+            },
+            surfaces,
+            omega,
+            &source,
+            &device(),
+        )
+        .expect("driven solve")
+    };
+
+    let sol_single = solve(&[SurfaceImpedanceBc {
+        triangles: &slab.wall_tris,
+        model: SurfaceImpedanceModel::London { lambda_l },
+    }]);
+    let sol_split = solve(&[
+        SurfaceImpedanceBc {
+            triangles: tris_a,
+            model: SurfaceImpedanceModel::London { lambda_l },
+        },
+        SurfaceImpedanceBc {
+            triangles: tris_b,
+            model: SurfaceImpedanceModel::London { lambda_l },
+        },
+    ]);
+    let norm: f64 = sol_single
+        .e_edges
+        .iter()
+        .map(|e| e.re * e.re + e.im * e.im)
+        .sum::<f64>()
+        .sqrt();
+    let diff: f64 = sol_single
+        .e_edges
+        .iter()
+        .zip(sol_split.e_edges.iter())
+        .map(|(a, b)| {
+            let d = *a - *b;
+            d.re * d.re + d.im * d.im
+        })
+        .sum::<f64>()
+        .sqrt();
+    let rel = diff / norm;
+    eprintln!("split-vs-single same-λ_L relative difference: {rel:.3e}");
+    assert!(
+        rel < 1e-10,
+        "same-λ_L split surfaces must reproduce the single surface: rel {rel:.3e}"
+    );
+
+    // Distinct λ_L per tag: solves cleanly and is NOT the uniform answer.
+    let sol_distinct = solve(&[
+        SurfaceImpedanceBc {
+            triangles: tris_a,
+            model: SurfaceImpedanceModel::London { lambda_l },
+        },
+        SurfaceImpedanceBc {
+            triangles: tris_b,
+            model: SurfaceImpedanceModel::London {
+                lambda_l: 4.0 * lambda_l,
+            },
+        },
+    ]);
+    assert!(sol_distinct.residual_rel < 1e-10);
+    let diff_d: f64 = sol_single
+        .e_edges
+        .iter()
+        .zip(sol_distinct.e_edges.iter())
+        .map(|(a, b)| {
+            let d = *a - *b;
+            d.re * d.re + d.im * d.im
+        })
+        .sum::<f64>()
+        .sqrt();
+    assert!(
+        diff_d / norm > 1e-6,
+        "distinct per-tag λ_L must change the solution"
+    );
+}

--- a/crates/geode-core/tests/transmon_eigen_sensitivity.rs
+++ b/crates/geode-core/tests/transmon_eigen_sensitivity.rs
@@ -26,8 +26,8 @@ use geode_core::assembly::p1::upload_mesh;
 use geode_core::eigen::lanczos::InnerSolver;
 use geode_core::eigen::sensitivity::{EigenSensitivity, EigenSensitivityError};
 use geode_core::eigen::transmon::{
-    LumpedReactiveShunt, ReactiveElementNatural, TransmonMode, TransmonPencil,
-    solve_transmon_eigenmodes_full,
+    LondonSurface, LumpedReactiveShunt, ReactiveElementNatural, TransmonMode, TransmonPencil,
+    solve_transmon_eigenmodes_full, solve_transmon_eigenmodes_full_with_london,
 };
 use geode_core::mesh::spiral::pec_interior_mask_from_triangles;
 use geode_core::mesh::{TetMesh, TransmonFixture, cube_tet_mesh, read_transmon_smoke_fixture};
@@ -522,6 +522,193 @@ fn geometry_sensitivity_matches_fd() {
     assert!(
         rel < 5e-3,
         "∂λ/∂θ analytic {analytic:.6e} vs FD {fd:.6e} (rel {rel:.2e})"
+    );
+}
+
+// -------------------------------------------------------------------------
+// CI-fast: London penetration-depth sensitivity ∂λ/∂λ_L (issue #604).
+// -------------------------------------------------------------------------
+
+/// A cavity with a **London wall** on `z = 0` (edges kept) and PEC on the
+/// other five walls: mesh, DOF bookkeeping, and the wall triangle list.
+struct LondonCavityFixture {
+    mesh: TetMesh,
+    tet_edge_idx: Vec<[u32; 6]>,
+    tet_edge_sign: Vec<[i8; 6]>,
+    edges: Vec<[u32; 2]>,
+    /// PEC on the five non-London walls; `z = 0` wall edges KEPT.
+    interior_mask: Vec<bool>,
+    /// The London wall triangles (`z = 0`).
+    z0_tris: Vec<[u32; 3]>,
+}
+
+fn london_cavity_fixture(n: usize) -> LondonCavityFixture {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let edges = mesh.edges();
+    let (tet_edge_idx, tet_edge_sign) = edge_tables(&mesh);
+
+    let on = |f: &[u32; 3], c: usize, val: f64| {
+        f.iter()
+            .all(|&v| (mesh.nodes[v as usize][c] - val).abs() < 1e-12)
+    };
+    // PEC on five walls; the z = 0 wall carries the London term instead.
+    let metal: Vec<[u32; 3]> = mesh
+        .faces()
+        .into_iter()
+        .filter(|f| {
+            on(f, 0, 0.0) || on(f, 0, 1.0) || on(f, 1, 0.0) || on(f, 1, 1.0) || on(f, 2, 1.0)
+        })
+        .collect();
+    let z0_tris: Vec<[u32; 3]> = mesh.faces().into_iter().filter(|f| on(f, 2, 0.0)).collect();
+    assert!(!z0_tris.is_empty());
+    let interior_mask = pec_interior_mask_from_triangles(&edges, &[metal.as_slice()]);
+
+    LondonCavityFixture {
+        mesh,
+        tet_edge_idx,
+        tet_edge_sign,
+        edges,
+        interior_mask,
+        z0_tris,
+    }
+}
+
+/// Solve the London-wall cavity with per-tet isotropic `eps_r` at the
+/// given `lambda_l`, returning the full modes.
+fn solve_london_cavity(
+    fx: &LondonCavityFixture,
+    eps_r: &[f64],
+    lambda_l: f64,
+    sigma: f64,
+    n_modes: usize,
+) -> Vec<TransmonMode> {
+    let scatter = NedelecScatterMap::new(&fx.tet_edge_idx);
+    let (k_vals, m_vals) = assemble_iso_pencil(&fx.mesh, &fx.tet_edge_sign, &scatter, eps_r);
+    let no_faces: Vec<[u32; 3]> = Vec::new();
+    let pencil = TransmonPencil {
+        scatter: &scatter,
+        k_vals: &k_vals,
+        m_vals: &m_vals,
+        edges: &fx.edges,
+        mesh: &fx.mesh,
+        shunt: bare_shunt(&no_faces),
+        interior_mask: &fx.interior_mask,
+    };
+    let walls = [LondonSurface {
+        triangles: &fx.z0_tris,
+        lambda_l,
+    }];
+    solve_transmon_eigenmodes_full_with_london(
+        &pencil,
+        &walls,
+        sigma,
+        n_modes,
+        M_PER_UNIT,
+        InnerSolver::Direct,
+    )
+    .expect("London cavity eigensolve")
+}
+
+/// `∂λ/∂λ_L` (London penetration depth) FD-validated: the analytic
+/// Hellmann–Feynman surface-mass contraction `−(xᵀS_Γx)/λ_L²` matches a
+/// central finite difference of the re-solved eigenvalue under a λ_L
+/// perturbation, at the bar the material test uses; the gradient is
+/// strictly negative (kinetic inductance lowers the frequency).
+#[test]
+fn london_lambda_l_sensitivity_matches_fd() {
+    let fx = london_cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let n_tets = fx.mesh.n_tets();
+    let eps_r = vec![eps0; n_tets];
+    let sigma = 5.0;
+    let n_modes = 8;
+    let lambda_l = 0.05_f64;
+
+    let modes = solve_london_cavity(&fx, &eps_r, lambda_l, sigma, n_modes);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+    let lambda = mode.report.lambda;
+    assert!(lambda > 1e-3, "picked λ = {lambda} too close to nullspace");
+
+    let sens = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e-2,
+    };
+    let analytic = sens
+        .deigenvalue_dlambda_l(&fx.z0_tris, lambda_l)
+        .expect("London grad");
+    assert!(
+        analytic < 0.0,
+        "∂λ/∂λ_L must be negative (kinetic inductance lowers ω): {analytic:.6e}"
+    );
+
+    // Central FD of the re-solved eigenvalue under a λ_L perturbation,
+    // tracking the mode by nearest eigenvalue.
+    let h = 1e-3 * lambda_l;
+    let fd_at = |ll: f64| -> f64 {
+        let modes = solve_london_cavity(&fx, &eps_r, ll, sigma, n_modes);
+        modes
+            .iter()
+            .map(|m| m.report.lambda)
+            .min_by(|a, b| (a - lambda).abs().partial_cmp(&(b - lambda).abs()).unwrap())
+            .expect("no FD modes")
+    };
+    let fd = (fd_at(lambda_l + h) - fd_at(lambda_l - h)) / (2.0 * h);
+    let rel = (analytic - fd).abs() / fd.abs().max(1e-30);
+    eprintln!("London ∂λ/∂λ_L: analytic {analytic:.6e}, FD {fd:.6e} (rel {rel:.2e})");
+    assert!(
+        rel < 1e-4,
+        "∂λ/∂λ_L analytic {analytic:.6e} vs FD {fd:.6e} (rel {rel:.2e})"
+    );
+}
+
+/// The λ_L sensitivity honors the shared entry-point contracts: the
+/// simple-eigenvalue gap guard trips with an unreachable `min_rel_gap`,
+/// and an invalid `λ_L = 0` panics (the PEC limit goes through the PEC
+/// edge mask, matching the driven-path convention).
+#[test]
+fn london_sensitivity_guard_and_invalid_lambda_l() {
+    let fx = london_cavity_fixture(3);
+    let eps0 = 4.0_f64;
+    let eps_r = vec![eps0; fx.mesh.n_tets()];
+    let lambda_l = 0.05_f64;
+
+    let modes = solve_london_cavity(&fx, &eps_r, lambda_l, 5.0, 8);
+    let (idx, lambdas, mode) = pick_simple_mode(&modes);
+
+    let strict = EigenSensitivity {
+        mesh: &fx.mesh,
+        edges: &fx.edges,
+        interior_mask: &fx.interior_mask,
+        eps_r: &eps_r,
+        lambdas: &lambdas,
+        mode_index: idx,
+        eigenvector: &mode.vector,
+        min_rel_gap: 1e9,
+    };
+    assert!(matches!(
+        strict.deigenvalue_dlambda_l(&fx.z0_tris, lambda_l),
+        Err(EigenSensitivityError::DegenerateEigenvalue { .. })
+    ));
+
+    let ok = EigenSensitivity {
+        min_rel_gap: 1e-2,
+        ..strict
+    };
+    assert!(ok.deigenvalue_dlambda_l(&fx.z0_tris, lambda_l).is_ok());
+
+    // λ_L = 0 is invalid (PEC limit must use the PEC edge mask).
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = ok.deigenvalue_dlambda_l(&fx.z0_tris, 0.0);
+    }));
+    assert!(
+        panic.is_err(),
+        "λ_L = 0 must panic in deigenvalue_dlambda_l"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements the London superconducting surface BC (Epic #475 gap #10) on both solver paths, paired with its differentiable-design sensitivity (Epic #569 pattern):

- **Driven**: new `SurfaceImpedanceModel::London { lambda_l }` with `Z_s = iωμλ_L`. Per the Curator's verified correction, the weak coefficient `iω/Z_s` reduces to the **real, frequency-independent `1/λ_L`** (natural units) and is returned **directly** — never as the `iω/(iωλ_L)` quotient — so it is exact at any ω (including ω = 0) and never trips the `|Z_s| = 0` singular guard spuriously. `λ_L ≤ 0`/non-finite is rejected as `SurfaceImpedanceSingular`; the PEC limit goes through the PEC edge mask (existing convention). λ_L is documented as a length in natural units (`λ_L_nat = λ_L_SI / L_unit`) next to the `GoodConductor` σ note.
- **Eigenmode**: because the coefficient is real and ω-independent, the London wall lands on the **K side** of the real symmetric transmon pencil as `λ_L⁻¹ S_Γ` — the `K_port` pattern, no new nonlinearity. New `LondonSurface` (per-tag triangles + λ_L, multiple walls with distinct λ_L supported) and `solve_transmon_eigenmodes_full_with_london`, threading extra K-side triplets through the private reindexed core so the 21 existing `TransmonPencil` literal constructors stay untouched (`london = &[]` is the plain entry point, bit-identical).
- **Sensitivity**: `EigenSensitivity::deigenvalue_dlambda_l` — Hellmann–Feynman `∂λ/∂λ_L = −(xᵀ S_Γ x)/λ_L²` (always ≤ 0: kinetic inductance lowers ω), following the `deigenvalue_deps` pattern with the same simple-eigenvalue gap guard.

## Changes

- `crates/geode-core/src/driven/solve.rs` — `London` variant: `z_s`, direct `weak_coefficient`, validation, natural-units doc
- `crates/geode-core/src/eigen/transmon.rs` — `LondonSurface` + `k_triplets` (`λ_L⁻¹ S_Γ` via the shared Whitney surface kernel), `solve_transmon_eigenmodes_full_with_london`; junction participation stays `K_port`-only; unit tests (1/λ_L scaling, `λ_L = 0` panic)
- `crates/geode-core/src/eigen/sensitivity.rs` — `deigenvalue_dlambda_l`
- `crates/geode-core/tests/london_surface_impedance.rs` (new) — 6 driven tests
- `crates/geode-core/tests/london_eigen_kinetic_inductance.rs` (new) — perturbation-oracle sweep
- `crates/geode-core/tests/transmon_eigen_sensitivity.rs` — FD validation + guard/invalid-λ_L tests

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| λ_L → 0 degenerates to the PEC baseline; existing configs byte-identical | ✅ | `small_lambda_l_recovers_pec_wall`: rel diff to PEC 1e-2 → 1e-3 → 1e-5 monotone, 6.5e-5 at λ_L = 1e-5 (< 1e-3 bar); exact λ_L = 0 rejected (driven `SurfaceImpedanceSingular`, eigen/sensitivity panic) per the Curator's PEC-mask convention; no-London paths unchanged (`london = &[]` delegates identically; full regression suite green) |
| Eigenmode shift matches the perturbation oracle within a stated bar, with convergence trend in λ_L (honest band) | ✅ | `london_kinetic_inductance_shift_matches_perturbation_oracle`: 1.0×0.85×0.7 box, Γ = 7.10, sweep λ_L = 0.04/0.02/0.01/0.005 → measured/predicted ratio **0.899 / 0.972 / 1.012 / 1.034**; asserted: shift negative, monotone in λ_L, ratio within ±20% band at every point, \|ratio−1\| shrinks 0.101 → 0.034 toward the ~3% discretization floor (n=5 mesh, O(h) discrete-curl bias); sweep stopped before λ_L⁻¹ conditioning noise (#504 convention) |
| ∂ω/∂λ_L: Hellmann–Feynman vs central FD at the `transmon_eigen_sensitivity.rs` bar | ✅ | `london_lambda_l_sensitivity_matches_fd`: analytic −1.305465e1 vs FD −1.305465e1, **rel 2.3e-8** (bar 1e-4, same as the material test); gradient asserted negative; gap guard + λ_L = 0 rejection covered by `london_sensitivity_guard_and_invalid_lambda_l` |
| Driven path exercised by ≥1 test beside `leontovich_surface_impedance.rs` | ✅ | New sibling `london_surface_impedance.rs`: coefficient identity at any ω (incl. ω = 0 and underflow-ω), invalid-λ_L rejection, `Fixed(iωλ_L)` equivalence (rel 4e-13), complex-symmetry/solvability at two frequencies, monotone PEC convergence, per-tag composition (split walls same-λ_L ≡ single, distinct λ_L solves and differs) |
| Regression suite green; `cargo fmt` | ✅ | `cargo test --workspace`: **129/129 suites ok, 0 failures** (log in worktree scratchpad); `cargo fmt --check` clean; `cargo clippy --workspace --all-targets`: no new warnings (remaining 6 are pre-existing in untouched files) |
| Multiple London tags with distinct λ_L | ✅ | Driven: `split_wall_tags_compose_and_support_distinct_lambda_l`; eigen: `LondonSurface` slice API (one λ_L per wall), sensitivity documented per-wall |

Palace London-example cross-check remains `pending_operator_run` per the issue body.

## Test Plan

- `cargo test -p geode-core --test london_surface_impedance` (6 tests)
- `cargo test -p geode-core --test london_eigen_kinetic_inductance -- --nocapture` (oracle sweep with reported band)
- `cargo test -p geode-core --test transmon_eigen_sensitivity` (7 tests incl. 2 new London)
- `cargo test -p geode-core --lib eigen::transmon` (unit tests incl. 2 new London)
- `cargo test --workspace` — full regression, all green

Closes #604