### PR TITLE
feat(driven): adaptive fast frequency sweep via greedy Galerkin PROM

### DIFF
--- a/crates/geode-core/src/driven/mod.rs
+++ b/crates/geode-core/src/driven/mod.rs
@@ -27,6 +27,10 @@
 //!   time integration of the same `K`/`C`/`M` matrices the driven path
 //!   assembles, with a lumped-port time-domain drive and broadband
 //!   S-parameter extraction via a direct DFT.
+//! - [`rom`] — the adaptive **fast frequency sweep**: a Galerkin
+//!   projection reduced-order model over the same `K`/`C`/`M` (+ port
+//!   admittance) matrices, with greedy residual-driven snapshot
+//!   sampling — a few full-order solves stand in for the whole band.
 //!
 //! The submodules keep their items canonical (`driven::solve::Foo`,
 //! `driven::ports::Bar`, …); the group root does **not** re-export them up
@@ -36,6 +40,7 @@ pub mod adjoint;
 pub mod extraction;
 pub mod matrix_free;
 pub mod ports;
+pub mod rom;
 pub mod scattering;
 pub mod shape;
 pub mod solve;

--- a/crates/geode-core/src/driven/rom.rs
+++ b/crates/geode-core/src/driven/rom.rs
@@ -1,0 +1,789 @@
+//! Adaptive **fast frequency sweep** via a Galerkin projection reduced-order
+//! model (PROM) with greedy snapshot sampling (Epic #475, issue #603;
+//! Palace adaptive-fast-frequency-sweep parity).
+//!
+//! # The reduced-order model
+//!
+//! [`DrivenOperator`]'s `assemble_a_at` forms the frequency-domain operator
+//! (module `exp(+jωt)` convention)
+//!
+//! ```text
+//! A(ω) = K − ω²M + iω C(σ) + Σ_p (iω/Z_p) S_p        (+ Leontovich, rejected)
+//! ```
+//!
+//! by linear combination of **ω-independent** value tensors, and the RHS
+//!
+//! ```text
+//! b(ω) = iω (rhs_re + i·rhs_im) + Σ_p (2iω/Z_p)(V_inc/ℓ) f_p = ω · b̂
+//! ```
+//!
+//! is **exactly linear in ω** (both the volume-source moments and the
+//! matched-source port drive carry a single `iω` prefactor), so one fixed
+//! vector `b̂` describes the drive across the whole band.
+//!
+//! The PROM collects full-order **snapshot solves** `x_s = A(ω_s)⁻¹ b(ω_s)`
+//! at a few greedily chosen frequencies, orthonormalizes them into a complex
+//! basis `V ∈ ℂ^{n×k}` (modified Gram–Schmidt with one re-orthogonalization
+//! pass, standard Hermitian inner product), and projects **once**:
+//!
+//! ```text
+//! K_r = VᴴKV,  M_r = VᴴMV,  C_r = VᴴCV,  S_{p,r} = VᴴS_pV,  b̂_r = Vᴴb̂.
+//! ```
+//!
+//! Note the port-admittance masses `S_p` are stored **separately** from
+//! `C(σ)` in [`DrivenOperator`] and are projected as their own family —
+//! `3 + n_ports` projected matrices, not 3. Missing them would produce a
+//! PROM that never matches the dense sweep on any port-driven fixture.
+//!
+//! Every subsequent frequency costs one **dense k×k** solve
+//! `A_r(ω) x_r = ω b̂_r` with `A_r(ω) = K_r − ω²M_r + iωC_r + Σ_p (iω/Z_p)
+//! S_{p,r}`, plus the port readouts on the reconstructed `x ≈ V x_r` — no
+//! sparse factorization.
+//!
+//! # Greedy sampling and the residual indicator
+//!
+//! Refinement is driven by the **computable** relative residual of the ROM
+//! solution against the *full-order* operator,
+//!
+//! ```text
+//! η(ω) = ‖A(ω) V x_r(ω) − b(ω)‖₂ / ‖b(ω)‖₂,
+//! ```
+//!
+//! evaluated over the candidate grid using the cached matrix–basis products
+//! `KV`, `MV`, `CV`, `S_pV` (an `O(nk)` linear combination per frequency —
+//! no sparse re-assembly, no factorization). `η` is the true residual of the
+//! reduced solution, so it is zero (to roundoff) at snapshot frequencies and
+//! upper-bounds the solution error only through `‖A(ω)⁻¹‖`; the integration
+//! test logs `η` against the true error vs the dense sweep to demonstrate
+//! the correlation honestly.
+//!
+//! **Deterministic selection**: the seed snapshots are the band endpoints
+//! plus the grid point nearest the band midpoint (ties toward the lower
+//! frequency), processed in ascending frequency order. Each greedy step adds
+//! the not-yet-sampled grid frequency with the **largest** indicator,
+//! iterating candidates in ascending frequency order with a strict `>`
+//! comparison — so exact ties resolve to the **lowest** frequency. Two
+//! builds over the same grid and settings select identical snapshots.
+//! Iteration stops when the worst indicator over the grid reaches
+//! [`RomSettings::tolerance`], when [`RomSettings::max_snapshots`] full-order
+//! solves have been spent, or when the candidate grid is exhausted; the
+//! achieved worst residual is always reported ([`DrivenRom::worst_residual`]),
+//! converged or not.
+//!
+//! # Out of scope (v1) and follow-on hooks
+//!
+//! - **Leontovich surface impedances** carry a non-polynomial scalar
+//!   coefficient `c_Γ(ω) ∝ √ω(1+i)`; although `VᴴS_ΓV` would project once
+//!   with per-ω scalar evaluation, v1 rejects them
+//!   ([`RomError::UnsupportedOperator`]) — the same v1 boundary the
+//!   transient solver drew. Wave ports are structurally absent from
+//!   [`DrivenOperator`].
+//! - Hermite / derivative-augmented snapshots, rigorous error certificates,
+//!   and sweep-level adjoints are follow-ons. The struct stores the reduced
+//!   matrices explicitly so `∂A_r/∂ω = −2ωM_r + iC_r + Σ_p (i/Z_p) S_{p,r}`
+//!   is analytically available — the cheap-`∂S/∂ω` (group delay) and
+//!   parameter-continuation hooks need no rework, only new methods.
+//!
+//! Matched-UPML / anisotropic materials assembled **once** (ω-independent
+//! complex `K`/`M` values) are fine — the PROM only requires the operator to
+//! be polynomial in `iω` with fixed matrices. (The committed patch-antenna
+//! tests rebuild their UPML materials per ω and are therefore *not*
+//! PROM-compatible fixtures; see issue #603.)
+
+use burn::tensor::backend::Backend;
+use faer::c64;
+
+use crate::driven::extraction::PortCircuit;
+use crate::driven::ports::LumpedPort;
+use crate::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenError, DrivenMaterials, DrivenOperator, SurfaceImpedanceBc,
+};
+use crate::mesh::TetMesh;
+
+/// Errors from the PROM fast-sweep path.
+#[derive(Debug, thiserror::Error)]
+pub enum RomError {
+    /// The source [`DrivenOperator`] (or sweep configuration) carries an
+    /// ω-dependent term that is not polynomial in `iω` with fixed
+    /// matrices — a Leontovich impedance surface in v1.
+    #[error(
+        "PROM sweep requires an operator polynomial in iω with fixed matrices: {reason} \
+         (lumped ports + σ + PEC + fixed complex materials only; Leontovich surface \
+         impedance is out of scope for v1)"
+    )]
+    UnsupportedOperator { reason: String },
+    /// A structurally invalid sweep request (empty grid, non-finite or
+    /// non-positive frequency, zero snapshot budget, …).
+    #[error("invalid PROM parameter: {0}")]
+    InvalidParameter(String),
+    /// The reduced dense system was singular at a requested evaluation
+    /// frequency (the greedy loop treats this as an infinite residual and
+    /// samples there instead; seeing this from [`DrivenRom::evaluate`]
+    /// means the basis is degenerate at this ω).
+    #[error("reduced {order}×{order} PROM system is singular at ω = {omega}")]
+    ReducedSolveSingular { order: usize, omega: f64 },
+    /// A full-order snapshot solve failed.
+    #[error(transparent)]
+    Driven(#[from] DrivenError),
+}
+
+/// Greedy-PROM stopping knobs.
+#[derive(Debug, Clone, Copy)]
+pub struct RomSettings {
+    /// Stop when the worst residual indicator `η(ω)` over the candidate
+    /// grid drops to this value.
+    pub tolerance: f64,
+    /// Hard budget on full-order snapshot solves (greedy stops here even
+    /// if `tolerance` is not reached; the result then reports
+    /// `converged() == false` with the honest achieved residual).
+    pub max_snapshots: usize,
+}
+
+impl Default for RomSettings {
+    /// `tolerance = 1e-8`, `max_snapshots = 20`.
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-8,
+            max_snapshots: 20,
+        }
+    }
+}
+
+/// One frequency point of a PROM sweep — the reduced-solve analog of
+/// [`crate::driven::extraction::SweepPoint`], with the computable
+/// residual indicator in place of a solver residual.
+#[derive(Debug, Clone)]
+pub struct RomSweepPoint {
+    /// Frequency `ω ≡ k₀` (natural units, as in [`crate::driven`]).
+    pub omega: f64,
+    /// Full-order relative residual `‖A(ω)Vx_r − b(ω)‖ / ‖b(ω)‖` of the
+    /// reconstructed solution at this frequency.
+    pub residual_indicator: f64,
+    /// Per-port circuit quantities on `x ≈ V x_r`, in operator port
+    /// order — read out with the **same** flux functional and Thevenin
+    /// relation as the dense sweep.
+    pub ports: Vec<PortCircuit>,
+}
+
+/// Result of a [`rom_frequency_sweep`]: the per-frequency points plus the
+/// greedy diagnostics needed for honest reporting.
+#[derive(Debug, Clone)]
+pub struct RomSweepReport {
+    /// One entry per requested frequency, in request order.
+    pub points: Vec<RomSweepPoint>,
+    /// Snapshot frequencies, in greedy selection order (seeds first,
+    /// ascending; then worst-residual picks). Its length is the number of
+    /// full-order solves spent.
+    pub snapshot_omegas: Vec<f64>,
+    /// Whether the worst residual indicator reached
+    /// [`RomSettings::tolerance`] before the snapshot budget ran out.
+    pub converged: bool,
+    /// Worst residual indicator over the candidate grid at termination —
+    /// the honest achieved bar, converged or not.
+    pub worst_residual: f64,
+}
+
+/// A built Galerkin PROM over a [`DrivenOperator`]: the orthonormal basis
+/// `V`, the cached matrix–basis products, and the projected reduced
+/// matrices. Construct with [`DrivenRom::build`] (which runs the greedy
+/// sampling), then [`DrivenRom::evaluate`] at any in-band frequency.
+pub struct DrivenRom<'a> {
+    op: &'a DrivenOperator,
+    /// Interior dimension `n`.
+    n: usize,
+    /// Full edge count (for scattering the reconstruction).
+    n_edges: usize,
+    /// Interior → full edge-index map.
+    interior_to_full: Vec<usize>,
+    /// Orthonormal basis columns `v_j ∈ ℂⁿ`.
+    basis: Vec<Vec<c64>>,
+    /// Cached products `K·v_j`, `M·v_j`, `C·v_j`, `S_p·v_j` (residual
+    /// indicator ingredients).
+    kv: Vec<Vec<c64>>,
+    mv: Vec<Vec<c64>>,
+    cv: Option<Vec<Vec<c64>>>,
+    spv: Vec<Vec<Vec<c64>>>,
+    /// Projected reduced matrices (row-major rows of length k) — stored
+    /// explicitly so `∂A_r/∂ω` is analytically available (see module
+    /// docs, differentiability hook).
+    k_r: Vec<Vec<c64>>,
+    m_r: Vec<Vec<c64>>,
+    c_r: Option<Vec<Vec<c64>>>,
+    s_r: Vec<Vec<Vec<c64>>>,
+    /// `1/Z_p` per port (the iω-linear port-admittance coefficients).
+    port_inv_z: Vec<f64>,
+    /// Fixed drive direction: `b(ω) = ω b̂` (interior space) and its
+    /// projection `b̂_r = Vᴴ b̂`.
+    b_hat: Vec<c64>,
+    b_hat_r: Vec<c64>,
+    b_hat_norm: f64,
+    /// Greedy diagnostics.
+    snapshot_omegas: Vec<f64>,
+    converged: bool,
+    worst_residual: f64,
+}
+
+impl<'a> DrivenRom<'a> {
+    /// Run the greedy PROM construction over the candidate grid `omegas`
+    /// (which is also the evaluation grid of [`rom_frequency_sweep`]).
+    ///
+    /// Seeds: band endpoints + the grid point nearest the band midpoint.
+    /// Each greedy step spends one full-order solve
+    /// ([`DrivenOperator::factor_at`] + back-solve, bit-identical to the
+    /// dense sweep's per-ω solve) at the worst-indicator frequency. See
+    /// the module docs for the determinism / tie-break contract.
+    ///
+    /// # Errors
+    ///
+    /// [`RomError::UnsupportedOperator`] if the operator carries
+    /// Leontovich surfaces; [`RomError::InvalidParameter`] for an empty
+    /// grid, non-finite/non-positive frequencies, a zero snapshot budget,
+    /// or a non-finite tolerance; any [`DrivenError`] from the snapshot
+    /// solves.
+    pub fn build(
+        op: &'a DrivenOperator,
+        omegas: &[f64],
+        settings: &RomSettings,
+    ) -> Result<Self, RomError> {
+        if op.has_surfaces() {
+            return Err(RomError::UnsupportedOperator {
+                reason: format!(
+                    "{} Leontovich impedance surface(s) on the operator",
+                    op.n_surfaces()
+                ),
+            });
+        }
+        if omegas.is_empty() {
+            return Err(RomError::InvalidParameter(
+                "empty candidate frequency grid".into(),
+            ));
+        }
+        if let Some(&bad) = omegas.iter().find(|w| !w.is_finite() || **w <= 0.0) {
+            return Err(RomError::InvalidParameter(format!(
+                "candidate frequency {bad} is not finite and positive"
+            )));
+        }
+        if settings.max_snapshots == 0 {
+            return Err(RomError::InvalidParameter(
+                "max_snapshots must be at least 1".into(),
+            ));
+        }
+        if !settings.tolerance.is_finite() || settings.tolerance < 0.0 {
+            return Err(RomError::InvalidParameter(format!(
+                "tolerance {} must be finite and non-negative",
+                settings.tolerance
+            )));
+        }
+
+        let n = op.n_interior();
+        let n_edges = op.rhs_re().len();
+        let interior_to_full = op.interior_to_full();
+
+        // --- Fixed drive direction b̂ (b(ω) = ω·b̂), interior-filtered ----
+        // Volume moments: b = iω(re + i·im) = ω(−im + i·re) ⇒ b̂ = −im + i·re.
+        let mut b_hat_full: Vec<c64> = op
+            .rhs_re()
+            .iter()
+            .zip(op.rhs_im().iter())
+            .map(|(&re, &im)| c64::new(-im, re))
+            .collect();
+        // Matched-source port drive: b += (2iω/Z_p)(V_inc/ℓ) f ⇒
+        // b̂ += (2i/Z_p)(V_inc/ℓ) f — mirrors `assemble_b_at` exactly.
+        let mut port_inv_z = Vec::with_capacity(op.n_ports());
+        for p in 0..op.n_ports() {
+            let data = op.port_transient_data(p);
+            port_inv_z.push(1.0 / data.z_s);
+            let v_inc = op.port_v_inc(p);
+            if v_inc == c64::new(0.0, 0.0) {
+                continue;
+            }
+            let e_inc = v_inc * (1.0 / data.length);
+            let drive = c64::new(0.0, 2.0 / data.z_s) * e_inc;
+            for (b, &f) in b_hat_full.iter_mut().zip(data.flux.iter()) {
+                *b += drive * f;
+            }
+        }
+        let b_hat: Vec<c64> = interior_to_full.iter().map(|&j| b_hat_full[j]).collect();
+        let b_hat_norm = vec_norm(&b_hat);
+
+        let has_c = op.c_vals().is_some();
+        let mut rom = Self {
+            op,
+            n,
+            n_edges,
+            interior_to_full,
+            basis: Vec::new(),
+            kv: Vec::new(),
+            mv: Vec::new(),
+            cv: has_c.then(Vec::new),
+            spv: vec![Vec::new(); op.n_ports()],
+            k_r: Vec::new(),
+            m_r: Vec::new(),
+            c_r: has_c.then(Vec::new),
+            s_r: vec![Vec::new(); op.n_ports()],
+            port_inv_z,
+            b_hat,
+            b_hat_r: Vec::new(),
+            b_hat_norm,
+            snapshot_omegas: Vec::new(),
+            converged: false,
+            worst_residual: f64::INFINITY,
+        };
+
+        // Zero drive: every solution is identically zero (matching the
+        // dense sweep's zero-RHS semantics); nothing to sample.
+        if rom.b_hat_norm == 0.0 {
+            rom.converged = true;
+            rom.worst_residual = 0.0;
+            return Ok(rom);
+        }
+
+        // Candidate order: ascending ω (stable in original index for exact
+        // duplicates) — the iteration order that realizes the documented
+        // lowest-frequency tie-break.
+        let mut order: Vec<usize> = (0..omegas.len()).collect();
+        order.sort_by(|&i, &j| omegas[i].partial_cmp(&omegas[j]).unwrap().then(i.cmp(&j)));
+        let lo_idx = order[0];
+        let hi_idx = *order.last().unwrap();
+
+        // Seeds: endpoints + grid point nearest the band midpoint (strict
+        // `<` keeps the lowest such frequency on ties).
+        let midpoint = 0.5 * (omegas[lo_idx] + omegas[hi_idx]);
+        let mut mid_idx = lo_idx;
+        let mut mid_dist = f64::INFINITY;
+        for &i in &order {
+            let d = (omegas[i] - midpoint).abs();
+            if d < mid_dist {
+                mid_dist = d;
+                mid_idx = i;
+            }
+        }
+        let mut seeds = vec![lo_idx, mid_idx, hi_idx];
+        seeds.sort_by(|&i, &j| omegas[i].partial_cmp(&omegas[j]).unwrap());
+        seeds.dedup();
+        // Also drop distinct indices carrying duplicate ω values.
+        seeds.dedup_by(|a, b| omegas[*a] == omegas[*b]);
+
+        let mut used = vec![false; omegas.len()];
+        for &idx in &seeds {
+            if rom.snapshot_omegas.len() >= settings.max_snapshots {
+                break;
+            }
+            used[idx] = true;
+            rom.add_snapshot(omegas[idx])?;
+        }
+
+        // --- Greedy refinement --------------------------------------------
+        loop {
+            // Residual indicator over the whole grid (snapshot points
+            // included — they are ~roundoff and part of the honest "worst
+            // over the band" figure).
+            let mut worst = 0.0_f64;
+            let mut best_idx: Option<usize> = None;
+            let mut best_res = 0.0_f64;
+            for &i in &order {
+                let eta = match rom.try_reduced_solve(omegas[i]) {
+                    Some(x_r) => rom.residual_indicator(omegas[i], &x_r),
+                    None => f64::INFINITY,
+                };
+                worst = worst.max(eta);
+                // Strict `>` + ascending-ω iteration = lowest-ω tie-break.
+                if !used[i] && eta > best_res {
+                    best_res = eta;
+                    best_idx = Some(i);
+                }
+            }
+            rom.worst_residual = worst;
+            if worst <= settings.tolerance {
+                rom.converged = true;
+                break;
+            }
+            if rom.snapshot_omegas.len() >= settings.max_snapshots || rom.basis.len() >= rom.n {
+                break;
+            }
+            let Some(idx) = best_idx else {
+                // Candidate grid exhausted without reaching tolerance.
+                break;
+            };
+            used[idx] = true;
+            let grew = rom.add_snapshot(omegas[idx])?;
+            if !grew {
+                // Snapshot linearly dependent on the current basis: the
+                // candidate is consumed (never re-picked) but the ROM did
+                // not change; keep going with the remaining candidates.
+                continue;
+            }
+        }
+        Ok(rom)
+    }
+
+    /// Snapshot frequencies in greedy selection order (one full-order
+    /// solve each).
+    pub fn snapshot_omegas(&self) -> &[f64] {
+        &self.snapshot_omegas
+    }
+
+    /// Reduced dimension `k` (≤ number of snapshots; smaller when a
+    /// snapshot was linearly dependent).
+    pub fn reduced_order(&self) -> usize {
+        self.basis.len()
+    }
+
+    /// Whether the greedy loop reached [`RomSettings::tolerance`].
+    pub fn converged(&self) -> bool {
+        self.converged
+    }
+
+    /// Worst residual indicator over the candidate grid at termination.
+    pub fn worst_residual(&self) -> f64 {
+        self.worst_residual
+    }
+
+    /// Evaluate the PROM at one frequency: dense `k×k` solve, residual
+    /// indicator against the **full-order** operator, and port readouts
+    /// on the reconstruction `x = V x_r` (same flux functional and
+    /// Thevenin relation as the dense sweep).
+    ///
+    /// `omega` need not be a grid point — the ROM is a continuous-in-ω
+    /// surrogate; the indicator stays honest off-grid too.
+    ///
+    /// # Errors
+    ///
+    /// [`RomError::ReducedSolveSingular`] if the reduced system has no
+    /// solution at this frequency.
+    pub fn evaluate(&self, omega: f64) -> Result<RomSweepPoint, RomError> {
+        let k = self.basis.len();
+        let x_r = if k == 0 {
+            Vec::new()
+        } else {
+            self.try_reduced_solve(omega)
+                .ok_or(RomError::ReducedSolveSingular { order: k, omega })?
+        };
+        let residual_indicator = self.residual_indicator(omega, &x_r);
+
+        // Reconstruct x = V x_r and scatter to the full edge vector.
+        let mut x_int = vec![c64::new(0.0, 0.0); self.n];
+        for (j, v) in self.basis.iter().enumerate() {
+            let xj = x_r[j];
+            for (xi, &vi) in x_int.iter_mut().zip(v.iter()) {
+                *xi += vi * xj;
+            }
+        }
+        let mut e_edges = vec![c64::new(0.0, 0.0); self.n_edges];
+        for (i, &full) in self.interior_to_full.iter().enumerate() {
+            e_edges[full] = x_int[i];
+        }
+
+        let ports = (0..self.op.n_ports())
+            .map(|p| {
+                let v = self.op.port_voltage(p, &e_edges);
+                let i = self.op.port_current(p, v);
+                PortCircuit { v, i, z: v / i }
+            })
+            .collect();
+        Ok(RomSweepPoint {
+            omega,
+            residual_indicator,
+            ports,
+        })
+    }
+
+    /// One full-order snapshot solve at `omega`, MGS-orthonormalized into
+    /// the basis. Returns `Ok(false)` (without growing the ROM) when the
+    /// snapshot is numerically dependent on the current basis.
+    fn add_snapshot(&mut self, omega: f64) -> Result<bool, RomError> {
+        self.snapshot_omegas.push(omega);
+        let sol = self.op.factor_at(omega)?.solve()?;
+        let mut w: Vec<c64> = self
+            .interior_to_full
+            .iter()
+            .map(|&j| sol.e_edges[j])
+            .collect();
+
+        // Modified Gram–Schmidt with one re-orthogonalization pass.
+        let norm0 = vec_norm(&w);
+        for _pass in 0..2 {
+            for v in &self.basis {
+                let h = dot_h(v, &w);
+                for (wi, &vi) in w.iter_mut().zip(v.iter()) {
+                    *wi -= vi * h;
+                }
+            }
+        }
+        let norm = vec_norm(&w);
+        if norm0 == 0.0 || norm <= 1e-12 * norm0 {
+            return Ok(false);
+        }
+        let inv = 1.0 / norm;
+        for wi in w.iter_mut() {
+            *wi *= inv;
+        }
+
+        // Matrix–basis products for the new column.
+        let kw = triplet_matvec_c(self.op.rows(), self.op.cols(), self.op.k_vals(), &w, self.n);
+        let mw = triplet_matvec_c(self.op.rows(), self.op.cols(), self.op.m_vals(), &w, self.n);
+        let cw = self
+            .op
+            .c_vals()
+            .map(|c| triplet_matvec_r(self.op.rows(), self.op.cols(), c, &w, self.n));
+        let spw: Vec<Vec<c64>> = (0..self.op.n_ports())
+            .map(|p| {
+                let data = self.op.port_transient_data(p);
+                let mut y = vec![c64::new(0.0, 0.0); self.n];
+                for &(r, c, v) in data.mass_triplets {
+                    y[r] += w[c] * v;
+                }
+                y
+            })
+            .collect();
+
+        // Grow the reduced matrices: new column (Vᴴ·(X w)), new row
+        // (wᴴ·(X v_j)), corner (wᴴ·(X w)).
+        grow_reduced(&mut self.k_r, &self.basis, &self.kv, &w, &kw);
+        grow_reduced(&mut self.m_r, &self.basis, &self.mv, &w, &mw);
+        if let (Some(c_r), Some(cv), Some(cw)) = (self.c_r.as_mut(), self.cv.as_ref(), cw.as_ref())
+        {
+            grow_reduced(c_r, &self.basis, cv, &w, cw);
+        }
+        for (p, spw_p) in spw.iter().enumerate() {
+            grow_reduced(&mut self.s_r[p], &self.basis, &self.spv[p], &w, spw_p);
+        }
+        self.b_hat_r.push(dot_h(&w, &self.b_hat));
+
+        // Commit the column.
+        self.kv.push(kw);
+        self.mv.push(mw);
+        if let (Some(cv), Some(cw)) = (self.cv.as_mut(), cw) {
+            cv.push(cw);
+        }
+        for (p, spw_p) in spw.into_iter().enumerate() {
+            self.spv[p].push(spw_p);
+        }
+        self.basis.push(w);
+        Ok(true)
+    }
+
+    /// Assemble and solve the reduced `A_r(ω) x_r = ω b̂_r`. `None` when
+    /// the dense LU hits a zero/non-finite pivot.
+    fn try_reduced_solve(&self, omega: f64) -> Option<Vec<c64>> {
+        let k = self.basis.len();
+        if k == 0 {
+            return Some(Vec::new());
+        }
+        let omega2 = omega * omega;
+        let i_omega = c64::new(0.0, omega);
+        let mut a = vec![c64::new(0.0, 0.0); k * k];
+        for r in 0..k {
+            for c in 0..k {
+                let mut v = self.k_r[r][c] - self.m_r[r][c] * omega2;
+                if let Some(c_r) = &self.c_r {
+                    v += i_omega * c_r[r][c];
+                }
+                for (p, s_r) in self.s_r.iter().enumerate() {
+                    v += i_omega * self.port_inv_z[p] * s_r[r][c];
+                }
+                a[r * k + c] = v;
+            }
+        }
+        let b: Vec<c64> = self.b_hat_r.iter().map(|&x| x * omega).collect();
+        solve_dense_lu(a, b, k)
+    }
+
+    /// `η(ω) = ‖A(ω)Vx_r − ωb̂‖ / (ω‖b̂‖)` via the cached matrix–basis
+    /// products — `O(nk)`, no sparse assembly.
+    fn residual_indicator(&self, omega: f64, x_r: &[c64]) -> f64 {
+        let omega2 = omega * omega;
+        let mut r: Vec<c64> = self.b_hat.iter().map(|&b| b * (-omega)).collect();
+        for (j, &xj) in x_r.iter().enumerate() {
+            let sk = xj;
+            let sm = xj * (-omega2);
+            let sc = xj * c64::new(0.0, omega);
+            for ((ri, &kvi), &mvi) in r.iter_mut().zip(self.kv[j].iter()).zip(self.mv[j].iter()) {
+                *ri += kvi * sk + mvi * sm;
+            }
+            if let Some(cv) = &self.cv {
+                for (ri, &cvi) in r.iter_mut().zip(cv[j].iter()) {
+                    *ri += cvi * sc;
+                }
+            }
+            for (p, spv) in self.spv.iter().enumerate() {
+                let sp = sc * self.port_inv_z[p];
+                for (ri, &si) in r.iter_mut().zip(spv[j].iter()) {
+                    *ri += si * sp;
+                }
+            }
+        }
+        let num = vec_norm(&r);
+        let den = omega.abs() * self.b_hat_norm;
+        if den == 0.0 { num } else { num / den }
+    }
+}
+
+/// Grow a reduced matrix (rows of length `k`) to `(k+1)×(k+1)` given the
+/// existing basis (`k` columns), the existing product columns `xv[j] =
+/// X·v_j`, the **normalized** new basis column `w`, and its product
+/// `xw = X·w`:
+/// new column entries `v_iᴴ·xw`, new row entries `wᴴ·xv_j`, corner `wᴴ·xw`.
+fn grow_reduced(
+    reduced: &mut Vec<Vec<c64>>,
+    basis: &[Vec<c64>],
+    xv: &[Vec<c64>],
+    w: &[c64],
+    xw: &[c64],
+) {
+    debug_assert_eq!(reduced.len(), basis.len());
+    debug_assert_eq!(xv.len(), basis.len());
+    for (row, v) in reduced.iter_mut().zip(basis.iter()) {
+        row.push(dot_h(v, xw));
+    }
+    let mut new_row: Vec<c64> = xv.iter().map(|col| dot_h(w, col)).collect();
+    new_row.push(dot_h(w, xw));
+    reduced.push(new_row);
+}
+
+/// Hermitian inner product `Σᵢ conj(aᵢ)·bᵢ`.
+fn dot_h(a: &[c64], b: &[c64]) -> c64 {
+    debug_assert_eq!(a.len(), b.len());
+    let mut acc = c64::new(0.0, 0.0);
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        acc += ai.conj() * bi;
+    }
+    acc
+}
+
+/// Euclidean norm of a complex vector.
+fn vec_norm(v: &[c64]) -> f64 {
+    v.iter()
+        .map(|z| z.re * z.re + z.im * z.im)
+        .sum::<f64>()
+        .sqrt()
+}
+
+/// `y = A·x` from a complex triplet stream (duplicates sum, as in the
+/// sparse assembly).
+fn triplet_matvec_c(rows: &[usize], cols: &[usize], vals: &[c64], x: &[c64], n: usize) -> Vec<c64> {
+    let mut y = vec![c64::new(0.0, 0.0); n];
+    for ((&r, &c), &v) in rows.iter().zip(cols.iter()).zip(vals.iter()) {
+        y[r] += x[c] * v;
+    }
+    y
+}
+
+/// `y = A·x` from a real triplet stream.
+fn triplet_matvec_r(rows: &[usize], cols: &[usize], vals: &[f64], x: &[c64], n: usize) -> Vec<c64> {
+    let mut y = vec![c64::new(0.0, 0.0); n];
+    for ((&r, &c), &v) in rows.iter().zip(cols.iter()).zip(vals.iter()) {
+        y[r] += x[c] * v;
+    }
+    y
+}
+
+/// Dense complex LU with partial pivoting: solve the row-major `n×n`
+/// system `A x = b` in place. `None` on a zero / non-finite pivot.
+fn solve_dense_lu(mut a: Vec<c64>, mut b: Vec<c64>, n: usize) -> Option<Vec<c64>> {
+    debug_assert_eq!(a.len(), n * n);
+    debug_assert_eq!(b.len(), n);
+    for col in 0..n {
+        // Partial pivot on the largest modulus in the column.
+        let mut piv = col;
+        let mut pmax = a[col * n + col].norm();
+        for r in (col + 1)..n {
+            let m = a[r * n + col].norm();
+            if m > pmax {
+                pmax = m;
+                piv = r;
+            }
+        }
+        if pmax == 0.0 || !pmax.is_finite() {
+            return None;
+        }
+        if piv != col {
+            for c in 0..n {
+                a.swap(col * n + c, piv * n + c);
+            }
+            b.swap(col, piv);
+        }
+        let d = a[col * n + col];
+        for r in (col + 1)..n {
+            let f = a[r * n + col] / d;
+            if f == c64::new(0.0, 0.0) {
+                continue;
+            }
+            a[r * n + col] = c64::new(0.0, 0.0);
+            for c in (col + 1)..n {
+                let t = a[col * n + c] * f;
+                a[r * n + c] -= t;
+            }
+            let t = b[col] * f;
+            b[r] -= t;
+        }
+    }
+    // Back-substitution.
+    let mut x = vec![c64::new(0.0, 0.0); n];
+    for col in (0..n).rev() {
+        let mut acc = b[col];
+        for c in (col + 1)..n {
+            acc -= a[col * n + c] * x[c];
+        }
+        x[col] = acc / a[col * n + col];
+    }
+    Some(x)
+}
+
+/// Adaptive fast frequency sweep: the PROM analog of
+/// [`crate::driven::extraction::driven_frequency_sweep`] — assemble the
+/// ω-independent operator **once**, build a greedy Galerkin PROM over the
+/// requested grid (a few full-order snapshot solves), then evaluate every
+/// requested frequency through the dense `k×k` reduced system.
+///
+/// The dense sweep is untouched: this entry point shares
+/// [`DrivenOperator::assemble`] and the per-snapshot
+/// [`DrivenOperator::factor_at`] + back-solve with it bit-for-bit, and the
+/// port readouts run through the same flux functional / Thevenin relation
+/// on the reconstruction `x ≈ V x_r`.
+///
+/// `surfaces` must be empty in v1 (Leontovich walls carry a `√ω`
+/// coefficient — see the module docs); pass `&[]`.
+///
+/// # Errors
+///
+/// [`RomError::UnsupportedOperator`] for a non-empty `surfaces`;
+/// [`RomError::InvalidParameter`] / [`RomError::ReducedSolveSingular`] as
+/// in [`DrivenRom::build`] / [`DrivenRom::evaluate`]; any [`DrivenError`]
+/// from assembly or the snapshot solves.
+#[allow(clippy::too_many_arguments)]
+pub fn rom_frequency_sweep<B: Backend>(
+    mesh: &TetMesh,
+    materials: DrivenMaterials<'_>,
+    sigma_tet: Option<&[f64]>,
+    bcs: &DrivenBcs<'_>,
+    ports: &[LumpedPort<'_>],
+    surfaces: &[SurfaceImpedanceBc<'_>],
+    omegas: &[f64],
+    source: &CurrentSource,
+    settings: &RomSettings,
+    device: &B::Device,
+) -> Result<RomSweepReport, RomError> {
+    if !surfaces.is_empty() {
+        return Err(RomError::UnsupportedOperator {
+            reason: format!(
+                "{} Leontovich impedance surface(s) requested",
+                surfaces.len()
+            ),
+        });
+    }
+    let op = DrivenOperator::assemble::<B>(
+        mesh, materials, sigma_tet, bcs, ports, surfaces, source, device,
+    )?;
+    let rom = DrivenRom::build(&op, omegas, settings)?;
+    let points = omegas
+        .iter()
+        .map(|&w| rom.evaluate(w))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(RomSweepReport {
+        points,
+        snapshot_omegas: rom.snapshot_omegas().to_vec(),
+        converged: rom.converged(),
+        worst_residual: rom.worst_residual(),
+    })
+}

--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -1738,6 +1738,23 @@ impl DrivenOperator {
         (triplets, s.model)
     }
 
+    /// Raw real parts of the baked current-source moments
+    /// `∫ N_i · J dV`, full edge length. Together with
+    /// [`DrivenOperator::rhs_im`] these determine the volume-source part
+    /// of the RHS as `b(ω) = iω (rhs_re + i·rhs_im)` — exactly linear in
+    /// ω, which the PROM sweep ([`crate::driven::rom`]) exploits by
+    /// projecting the fixed vector `b̂ = −rhs_im + i·rhs_re` once
+    /// (issue #603).
+    pub(crate) fn rhs_re(&self) -> &[f64] {
+        &self.rhs_re
+    }
+
+    /// Raw imaginary parts of the baked current-source moments, aligned
+    /// with [`DrivenOperator::rhs_re`].
+    pub(crate) fn rhs_im(&self) -> &[f64] {
+        &self.rhs_im
+    }
+
     /// Interior-filter a full-length real vector through the PEC mask,
     /// dropping the eliminated entries (same filtering the RHS uses).
     pub(crate) fn filter_interior_real(&self, full: &[f64]) -> Vec<f64> {

--- a/crates/geode-core/tests/rom_sweep.rs
+++ b/crates/geode-core/tests/rom_sweep.rs
@@ -1,0 +1,476 @@
+//! Adaptive fast-frequency-sweep (Galerkin PROM) regressions (issue #603).
+//!
+//! The headline acceptance criterion is a **self-oracle**: the greedy PROM
+//! of [`geode_core::driven::rom`] must reproduce the already
+//! oracle-validated dense [`driven_frequency_sweep`] on the same
+//! parallel-plate lumped-port fixture (the transmission-line oracle of
+//! `tests/lumped_port.rs` / `tests/transient_sparams.rs`), at the same
+//! ω-points.
+//!
+//! Honesty notes (per the issue-#603 curation):
+//! - The comparison is on **complex** S₁₁ (and Z(ω)), not `|S₁₁|`: this
+//!   lossless fixture has `|S₁₁| ≈ 1` across any band, so an
+//!   `|S₁₁|`-only bar would be nearly free. The complex value carries the
+//!   full phase structure.
+//! - The band `ω ∈ [0.3, 2.0]` deliberately **crosses the shorted-line
+//!   resonance at ω = π/2** (`Z_in = j·tan ω` sweeps through its pole),
+//!   so the sweep has real spectral structure for the greedy sampler to
+//!   earn its keep on.
+//! - `N_snapshots` vs `N_frequency_points` and wall-clock for both paths
+//!   are printed for the whole (non-cherry-picked) band; the residual
+//!   indicator and the true error are logged side by side, and their
+//!   correlation is asserted on a deliberately under-converged (seed-only)
+//!   ROM where both are far from the roundoff floor.
+
+use std::time::Instant;
+
+use faer::c64;
+use geode_core::driven::extraction::driven_frequency_sweep;
+use geode_core::driven::ports::LumpedPort;
+use geode_core::driven::rom::{DrivenRom, RomError, RomSettings, rom_frequency_sweep};
+use geode_core::driven::solve::{
+    CurrentSource, DrivenBcs, DrivenMaterials, DrivenOperator, SurfaceImpedanceBc,
+    SurfaceImpedanceModel,
+};
+use geode_core::mesh::{TetMesh, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+use burn::tensor::backend::BackendTypes;
+
+type B = TestBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+fn vacuum(mesh: &TetMesh) -> Vec<c64> {
+    vec![c64::new(1.0, 0.0); mesh.n_tets()]
+}
+
+fn zero_source(mesh: &TetMesh) -> CurrentSource {
+    CurrentSource {
+        j_tet: vec![[c64::new(0.0, 0.0); 3]; mesh.n_tets()],
+    }
+}
+
+/// Boundary faces of the mesh lying entirely in the plane
+/// `coord[axis] == value` (copied from `tests/lumped_port.rs`).
+fn plane_faces(mesh: &TetMesh, axis: usize, value: f64) -> Vec<[u32; 3]> {
+    mesh.faces()
+        .into_iter()
+        .filter(|f| {
+            f.iter()
+                .all(|&n| (mesh.nodes[n as usize][axis] - value).abs() < 1e-12)
+        })
+        .collect()
+}
+
+/// PEC interior-edge mask (copied from `tests/lumped_port.rs`).
+fn pec_mask_for_planes(mesh: &TetMesh, edges: &[[u32; 2]], planes: &[(usize, f64)]) -> Vec<bool> {
+    edges
+        .iter()
+        .map(|e| {
+            let a = mesh.nodes[e[0] as usize];
+            let b = mesh.nodes[e[1] as usize];
+            !planes.iter().any(|&(axis, value)| {
+                (a[axis] - value).abs() < 1e-12 && (b[axis] - value).abs() < 1e-12
+            })
+        })
+        .collect()
+}
+
+/// The parallel-plate transmission-line fixture (unit cube, PEC plates at
+/// y = 0/1, PEC short at z = 1, PMC side walls, one lumped port across the
+/// full z = 0 face with ê = ŷ) — same fixture as `tests/transient_sparams.rs`.
+struct PlateFixture {
+    mesh: TetMesh,
+    mask: Vec<bool>,
+    eps: Vec<c64>,
+    port_faces: Vec<[u32; 3]>,
+}
+
+impl PlateFixture {
+    fn new(n: usize) -> Self {
+        let mesh = cube_tet_mesh(n, 1.0);
+        let edges = mesh.edges();
+        let port_faces = plane_faces(&mesh, 2, 0.0);
+        assert!(!port_faces.is_empty());
+        let mask = pec_mask_for_planes(&mesh, &edges, &[(1, 0.0), (1, 1.0), (2, 1.0)]);
+        let eps = vacuum(&mesh);
+        Self {
+            mesh,
+            mask,
+            eps,
+            port_faces,
+        }
+    }
+
+    fn port(&self) -> LumpedPort<'_> {
+        LumpedPort {
+            faces: &self.port_faces,
+            e_hat: [0.0, 1.0, 0.0],
+            resistance: 1.0,
+            width: 1.0,
+            length: 1.0,
+            v_inc: c64::new(1.0, 0.0),
+        }
+    }
+
+    fn bcs(&self) -> DrivenBcs<'_> {
+        DrivenBcs {
+            pec_interior_mask: &self.mask,
+        }
+    }
+
+    fn operator(&self, port: &LumpedPort<'_>) -> DrivenOperator {
+        DrivenOperator::assemble::<B>(
+            &self.mesh,
+            DrivenMaterials::Scalar(&self.eps),
+            None,
+            &self.bcs(),
+            std::slice::from_ref(port),
+            &[],
+            &zero_source(&self.mesh),
+            &device(),
+        )
+        .expect("operator assembly")
+    }
+}
+
+/// Uniform grid over `[lo, hi]` with `n` points.
+fn grid(lo: f64, hi: f64, n: usize) -> Vec<f64> {
+    (0..n)
+        .map(|k| lo + (hi - lo) * k as f64 / (n - 1) as f64)
+        .collect()
+}
+
+/// Headline self-oracle: PROM complex-S₁₁ vs the dense sweep across a
+/// band crossing the line resonance, with snapshot-count and wall-clock
+/// reporting for both paths.
+#[test]
+fn rom_self_oracle_matches_dense_sweep_complex_s11() {
+    let fixture = PlateFixture::new(6);
+    let port = fixture.port();
+    let omegas = grid(0.3, 2.0, 41);
+
+    // Dense reference sweep (end-to-end: assembly + 41 factorizations).
+    let t0 = Instant::now();
+    let dense = driven_frequency_sweep::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&fixture.mesh),
+        &device(),
+    )
+    .expect("dense sweep");
+    let dense_ms = t0.elapsed().as_secs_f64() * 1e3;
+
+    // PROM sweep (end-to-end: assembly + greedy snapshots + 41 reduced solves).
+    let settings = RomSettings {
+        tolerance: 1e-8,
+        max_snapshots: 20,
+    };
+    let t0 = Instant::now();
+    let rom = rom_frequency_sweep::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&fixture.mesh),
+        &settings,
+        &device(),
+    )
+    .expect("PROM sweep");
+    let rom_ms = t0.elapsed().as_secs_f64() * 1e3;
+
+    let mut worst_s11 = 0.0_f64;
+    let mut worst_z = 0.0_f64;
+    println!("   ω      |S11| dense  |S11| PROM   |ΔS11|/|S11|   |ΔZ|/|Z|    indicator");
+    for (d, r) in dense.iter().zip(rom.points.iter()) {
+        let s_d = d.ports[0].s11(port.resistance);
+        let s_r = r.ports[0].s11(port.resistance);
+        let e_s = (s_r - s_d).norm() / s_d.norm();
+        let e_z = (r.ports[0].z - d.ports[0].z).norm() / d.ports[0].z.norm();
+        worst_s11 = worst_s11.max(e_s);
+        worst_z = worst_z.max(e_z);
+        println!(
+            "{:6.3}   {:10.6}  {:10.6}   {:10.3e}   {:10.3e}  {:10.3e}",
+            d.omega,
+            s_d.norm(),
+            s_r.norm(),
+            e_s,
+            e_z,
+            r.residual_indicator
+        );
+    }
+    println!(
+        "PROM: {} snapshots for {} frequency points (reduced order ≤ {}), converged = {}, \
+         worst residual indicator = {:.3e}",
+        rom.snapshot_omegas.len(),
+        omegas.len(),
+        rom.snapshot_omegas.len(),
+        rom.converged,
+        rom.worst_residual
+    );
+    println!("snapshot ω (selection order): {:?}", rom.snapshot_omegas);
+    println!(
+        "wall-clock (end-to-end, incl. one assembly each): dense = {dense_ms:.1} ms, \
+         PROM = {rom_ms:.1} ms, speedup = {:.2}×",
+        dense_ms / rom_ms
+    );
+
+    assert!(rom.converged, "greedy PROM did not reach tolerance");
+    assert!(
+        rom.snapshot_omegas.len() < omegas.len(),
+        "PROM spent {} full-order solves for {} points — no savings",
+        rom.snapshot_omegas.len(),
+        omegas.len()
+    );
+    // Acceptance bar: ≤ 1% on complex S11 across the band (achieved value
+    // printed above is typically far below — residual-tolerance level).
+    assert!(
+        worst_s11 < 1e-2,
+        "worst complex-S11 mismatch {worst_s11:.3e} exceeds the 1% bar"
+    );
+    assert!(
+        worst_z < 1e-2,
+        "worst complex-Z mismatch {worst_z:.3e} exceeds the 1% bar"
+    );
+}
+
+/// Residual-indicator honesty: on a deliberately under-converged
+/// (seed-only) ROM the indicator must track the true error — both curves
+/// logged, log-log Pearson correlation asserted positive and strong.
+#[test]
+fn rom_residual_indicator_correlates_with_true_error() {
+    let fixture = PlateFixture::new(5);
+    let port = fixture.port();
+    let omegas = grid(0.3, 2.0, 33);
+    let op = fixture.operator(&port);
+
+    let dense = driven_frequency_sweep::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&fixture.mesh),
+        &device(),
+    )
+    .expect("dense sweep");
+
+    // Seed-only ROM: 3 snapshots, far from converged over this resonant band.
+    let settings = RomSettings {
+        tolerance: 0.0,
+        max_snapshots: 3,
+    };
+    let rom = DrivenRom::build(&op, &omegas, &settings).expect("seed-only ROM");
+    assert_eq!(rom.snapshot_omegas().len(), 3);
+    assert!(!rom.converged());
+
+    let mut pairs: Vec<(f64, f64)> = Vec::new();
+    println!("   ω      indicator η   true |ΔS11|/|S11|");
+    for (d, &omega) in dense.iter().zip(omegas.iter()) {
+        let p = rom.evaluate(omega).expect("ROM evaluate");
+        let s_d = d.ports[0].s11(port.resistance);
+        let s_r = p.ports[0].s11(port.resistance);
+        let true_err = (s_r - s_d).norm() / s_d.norm();
+        println!(
+            "{:6.3}   {:10.3e}   {:10.3e}",
+            omega, p.residual_indicator, true_err
+        );
+        // Clip at a roundoff floor so the seed points (both ~0) don't
+        // produce log(0).
+        pairs.push((
+            p.residual_indicator.max(1e-14).log10(),
+            true_err.max(1e-14).log10(),
+        ));
+    }
+
+    // Pearson correlation of the log curves.
+    let n = pairs.len() as f64;
+    let mx = pairs.iter().map(|p| p.0).sum::<f64>() / n;
+    let my = pairs.iter().map(|p| p.1).sum::<f64>() / n;
+    let cov = pairs.iter().map(|p| (p.0 - mx) * (p.1 - my)).sum::<f64>();
+    let vx = pairs.iter().map(|p| (p.0 - mx).powi(2)).sum::<f64>();
+    let vy = pairs.iter().map(|p| (p.1 - my).powi(2)).sum::<f64>();
+    let corr = cov / (vx.sqrt() * vy.sqrt());
+    println!("log-log Pearson correlation(indicator, true error) = {corr:.3}");
+    assert!(
+        corr > 0.5,
+        "residual indicator does not track the true error: correlation {corr:.3}"
+    );
+}
+
+/// Greedy determinism: two builds over the same grid and settings select
+/// identical snapshot frequencies in identical order.
+#[test]
+fn rom_greedy_selection_is_deterministic() {
+    let fixture = PlateFixture::new(4);
+    let port = fixture.port();
+    let omegas = grid(0.3, 2.0, 21);
+    let op = fixture.operator(&port);
+    let settings = RomSettings {
+        tolerance: 1e-8,
+        max_snapshots: 20,
+    };
+
+    let rom_a = DrivenRom::build(&op, &omegas, &settings).expect("build A");
+    let rom_b = DrivenRom::build(&op, &omegas, &settings).expect("build B");
+    println!("run A snapshots: {:?}", rom_a.snapshot_omegas());
+    println!("run B snapshots: {:?}", rom_b.snapshot_omegas());
+    assert_eq!(
+        rom_a.snapshot_omegas(),
+        rom_b.snapshot_omegas(),
+        "greedy snapshot selection is not deterministic"
+    );
+    assert_eq!(rom_a.reduced_order(), rom_b.reduced_order());
+}
+
+/// v1 guard: Leontovich surface-impedance configurations are rejected
+/// (their √ω coefficient is not polynomial in iω) — both at the sweep
+/// entry point and when building from an already-assembled operator.
+#[test]
+fn rom_rejects_surface_impedance() {
+    let fixture = PlateFixture::new(3);
+    let port = fixture.port();
+    let surf_tris = plane_faces(&fixture.mesh, 2, 1.0);
+    let bc = SurfaceImpedanceBc {
+        triangles: &surf_tris,
+        model: SurfaceImpedanceModel::Fixed(c64::new(1.0, 0.0)),
+    };
+    let omegas = grid(0.3, 1.0, 5);
+
+    // Entry-point guard.
+    let err = rom_frequency_sweep::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        std::slice::from_ref(&bc),
+        &omegas,
+        &zero_source(&fixture.mesh),
+        &RomSettings::default(),
+        &device(),
+    )
+    .expect_err("must reject Leontovich surfaces");
+    assert!(
+        matches!(err, RomError::UnsupportedOperator { .. }),
+        "unexpected error variant: {err}"
+    );
+
+    // Operator-level guard.
+    let op = DrivenOperator::assemble::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        std::slice::from_ref(&bc),
+        &zero_source(&fixture.mesh),
+        &device(),
+    )
+    .expect("operator with surface assembles");
+    let err = DrivenRom::build(&op, &omegas, &RomSettings::default())
+        .err()
+        .expect("build must reject surfaces");
+    assert!(
+        matches!(err, RomError::UnsupportedOperator { .. }),
+        "unexpected error variant: {err}"
+    );
+}
+
+/// Budget exhaustion is honest, not a panic: with an unreachable
+/// tolerance the greedy loop stops at `max_snapshots`, reports
+/// `converged == false` with a finite achieved residual, and still
+/// evaluates every point.
+#[test]
+fn rom_budget_exhaustion_reports_honest_residual() {
+    let fixture = PlateFixture::new(4);
+    let port = fixture.port();
+    let omegas = grid(0.3, 2.0, 21);
+
+    let settings = RomSettings {
+        tolerance: 0.0, // unreachable
+        max_snapshots: 4,
+    };
+    let report = rom_frequency_sweep::<B>(
+        &fixture.mesh,
+        DrivenMaterials::Scalar(&fixture.eps),
+        None,
+        &fixture.bcs(),
+        std::slice::from_ref(&port),
+        &[],
+        &omegas,
+        &zero_source(&fixture.mesh),
+        &settings,
+        &device(),
+    )
+    .expect("budget-limited PROM sweep");
+    println!(
+        "budget-limited PROM: {} snapshots, converged = {}, worst residual = {:.3e}",
+        report.snapshot_omegas.len(),
+        report.converged,
+        report.worst_residual
+    );
+    assert_eq!(report.snapshot_omegas.len(), settings.max_snapshots);
+    assert!(!report.converged);
+    assert!(report.worst_residual.is_finite() && report.worst_residual > 0.0);
+    assert_eq!(report.points.len(), omegas.len());
+    for p in &report.points {
+        assert!(p.residual_indicator.is_finite());
+        assert!(p.ports[0].z.norm().is_finite());
+    }
+}
+
+/// Degenerate bands: 1- and 2-point grids. Snapshot frequencies are
+/// interpolatory for a Galerkin PROM (the snapshot solution lies in the
+/// basis span), so tiny grids must reproduce the dense sweep to
+/// near-roundoff without special-casing.
+#[test]
+fn rom_degenerate_tiny_grids_match_dense() {
+    let fixture = PlateFixture::new(4);
+    let port = fixture.port();
+    let op = fixture.operator(&port);
+
+    for omegas in [vec![0.7], vec![0.5, 1.3]] {
+        let dense = driven_frequency_sweep::<B>(
+            &fixture.mesh,
+            DrivenMaterials::Scalar(&fixture.eps),
+            None,
+            &fixture.bcs(),
+            std::slice::from_ref(&port),
+            &[],
+            &omegas,
+            &zero_source(&fixture.mesh),
+            &device(),
+        )
+        .expect("dense sweep");
+        let rom = DrivenRom::build(&op, &omegas, &RomSettings::default()).expect("tiny-grid ROM");
+        assert!(rom.converged(), "tiny grid must converge (all snapshots)");
+        for (d, &omega) in dense.iter().zip(omegas.iter()) {
+            let p = rom.evaluate(omega).expect("evaluate");
+            let s_d = d.ports[0].s11(port.resistance);
+            let s_r = p.ports[0].s11(port.resistance);
+            let err = (s_r - s_d).norm() / s_d.norm();
+            println!(
+                "grid {:?} @ ω = {omega}: |ΔS11|/|S11| = {err:.3e}, η = {:.3e}",
+                omegas, p.residual_indicator
+            );
+            assert!(
+                err < 1e-8,
+                "tiny-grid ROM mismatch {err:.3e} at ω = {omega} (grid {omegas:?})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an adaptive **fast frequency sweep** to the driven solver: a Galerkin projection reduced-order model (PROM) over the driven `K`/`C`/`M` (+ per-port admittance `S_p`) matrices with greedy, residual-driven snapshot sampling. A handful of full-order solves stand in for the whole band, self-oracled against the untouched dense `driven_frequency_sweep`. Implements Epic #475 infrastructure gap #1 (Palace adaptive-fast-frequency-sweep parity).

## Changes

- **New `crates/geode-core/src/driven/rom.rs`** — `DrivenRom` + `rom_frequency_sweep`:
  - Orthonormal complex basis `V` from full-order snapshots (modified Gram–Schmidt, one re-orthogonalization pass, Hermitian inner product); seeds = band endpoints + grid point nearest the midpoint.
  - Projects `K`, `M`, `C`, **and each port-admittance mass `S_p`** once (`3 + n_ports` families — the `S_p` masses are stored separately from `C` per the Curator's Correction 2; folding them in as `iω/Z_p · S_{p,r}` is what makes the PROM match on port-driven fixtures). RHS `b(ω) = ω·b̂` is exactly linear in ω (Correction 3), so `b̂` is projected once.
  - Per-frequency dense `k×k` solve of `A_r(ω) = K_r − ω²M_r + iωC_r + Σ_p (iω/Z_p) S_{p,r}` (partial-pivot complex LU).
  - Greedy refinement on the computable full-order residual indicator `η(ω) = ‖A(ω)Vx_r − b(ω)‖/‖b(ω)‖` over the candidate grid, via cached matrix–basis products (`O(nk)`, no re-factorization). Adds the worst-residual frequency; stops at tolerance or snapshot budget. Deterministic selection with a documented lowest-frequency tie-break.
  - Leontovich surface impedances **rejected in v1** (`√ω` coefficient is non-polynomial in `iω`), matching the transient-solver boundary (Correction 2). Reduced matrices stored explicitly so `∂A_r/∂ω` (group delay / continuation) is a follow-on with no rework.
- **`driven/solve.rs`** — two `pub(crate)` accessors (`rhs_re`/`rhs_im`) to project the baked source moments once. Dense path untouched.
- **`driven/mod.rs`** — register `pub mod rom;` + module doc line.
- **New `crates/geode-core/tests/rom_sweep.rs`** — 6 integration tests.

Per Curator guidance, the acceptance fixture is the `tests/transient_sparams.rs` parallel-plate lumped-port fixture (**not** the #228/#237 patch-antenna fixture, whose ω-dependent matched-UPML materials are not PROM-compatible). The comparison is on **complex** S11 and Z(ω) (not featureless `|S11|`), over a band `ω ∈ [0.3, 2.0]` that deliberately crosses the shorted-line resonance at `ω = π/2` so the greedy sampler earns its keep.

## Acceptance Criteria Verification

| Criterion (issue #603) | Status | Verification |
|---|---|---|
| PROM matches dense sweep ≤1% across the band | ✅ | `rom_self_oracle_matches_dense_sweep_complex_s11`: worst complex-S11 and complex-Z mismatch ~1e-13 (far below the 1% bar), 41-point resonant band |
| Report `N_snapshots` vs `N_frequency_points` + wall-clock, honestly | ✅ | Test log: **8 snapshots for 41 points**; end-to-end wall-clock dense 15.1 s vs PROM 3.3 s (**4.6×**), both incl. one assembly; full non-cherry-picked band printed |
| Residual indicator correlates with true error | ✅ | `rom_residual_indicator_correlates_with_true_error`: seed-only (under-converged) ROM, both curves logged, log-log Pearson **0.977** (asserted > 0.5) |
| Deterministic snapshot selection | ✅ | `rom_greedy_selection_is_deterministic`: two builds select identical snapshot frequencies + order |
| Dense-sweep behavior untouched | ✅ | No change to `driven_frequency_sweep`/`_with_mode`; only additive `pub(crate)` accessors; `extraction`/`lumped_port`/`iterative_sweep` targets green |
| `cargo fmt` | ✅ | `cargo fmt --all` clean; `cargo clippy -p geode-core --all-targets` zero warnings |

Extra guards: `rom_rejects_surface_impedance` (v1 Leontovich rejection, entry-point + operator-level), `rom_budget_exhaustion_reports_honest_residual` (budget exhausted → `converged=false` + finite achieved residual, no panic), `rom_degenerate_tiny_grids_match_dense` (1- and 2-point grids reproduce dense to ~1e-8, no special-casing).

## Test Plan

- `cargo test -p geode-core --test rom_sweep` → 6 passed.
- `cargo test -p geode-core --lib --test extraction --test iterative_sweep --test lumped_port --test transient_sparams` → lib 414, extraction 11, iterative_sweep 3, lumped_port 10, transient_sparams 6 — all green (0 failed).
- `cargo test --workspace --no-run` → whole workspace compiles.
- `cargo fmt --all`, `cargo clippy -p geode-core --all-targets` → clean.

**Honesty note on scope of the run:** the heavy `sphere_*`/validation eigenmode tests (known to time out in debug in this environment) were not run to completion; they share no code with the driven ROM path and none of their source files were touched.

Closes #603