### PR TITLE
feat(adjoint): inductance-matrix reluctivity sensitivity ∂L/∂ν via the self-adjoint energy form

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 602
-# Branch: feature/issue-602
+# Issue: 612
+# Branch: feature/issue-612
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/crates/geode-core/src/adjoint.rs
+++ b/crates/geode-core/src/adjoint.rs
@@ -71,12 +71,17 @@
 
 use faer::Mat;
 use faer::linalg::solvers::Solve;
-use faer::sparse::SparseColMat;
+use faer::sparse::{SparseColMat, Triplet};
 
 use crate::assembly::electrostatic::{
     EPS_0, Electrode, ElectrostaticError, assemble_electrostatic, assemble_electrostatic_p2,
     tet_p1_local,
 };
+use crate::assembly::magnetostatic3d::{
+    CurrentTerminal, Magnetostatic3dError, NU_0, assemble_current_rhs, assemble_magnetostatic3d,
+    check_solenoidal, tet_nedelec_stiffness,
+};
+use crate::eigen::gauge::TreeCotreeGauge;
 use crate::elements::p2::{TET_P2_DOFS, tet_p2_local};
 use crate::mesh::TetMesh;
 
@@ -601,6 +606,290 @@ pub fn build_region_eps(region_of_tet: &[usize], eps_region: &[f64]) -> Vec<f64>
                 eps_region.len()
             );
             eps_region[r]
+        })
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Magnetostatic inductance-matrix reluctivity sensitivity ∂L/∂ν (Epic #569
+// differentiable row, #475 Magnetostatic parity), built on the shipped
+// `magnetostatic3d` forward path.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Result of a magnetostatic **inductance-matrix reluctivity sensitivity**:
+/// the N×N Maxwell inductance matrix and its exact discrete gradient
+/// `∂L_ij/∂ν_k` with respect to each per-region relative reluctivity
+/// `ν_r = 1/μ_r`.
+///
+/// This is the magnetostatic dual of [`CapacitanceGradient`] — the `∂C/∂ε`
+/// electrostatic sensitivity — completing the #569 sensitivity matrix with
+/// the inductance row.
+#[derive(Debug, Clone)]
+pub struct InductanceSensitivity {
+    /// Terminal names in matrix row/column order.
+    pub names: Vec<String>,
+    /// The N×N Maxwell inductance matrix (H): `L_ij = A⁽ⁱ⁾ᵀ K A⁽ʲ⁾/(I_i I_j)`,
+    /// on the **full** pre-gauge curl-curl `K` (mirrors
+    /// [`crate::assembly::magnetostatic3d::extract_inductance`]).
+    pub l: Vec<Vec<f64>>,
+    /// The sensitivity tensor: `dl_dnu[k]` is the N×N matrix `∂L/∂ν_k` of the
+    /// inductance matrix to the region-`k` relative reluctivity, so
+    /// `dl_dnu[k][i][j] = ∂L_ij/∂ν_k`. Symmetric in `(i, j)` by construction
+    /// (the self-adjoint energy form).
+    pub dl_dnu: Vec<Vec<Vec<f64>>>,
+    /// Number of sparse LU **factorizations** performed. Always `1`: a single
+    /// gauged cotree factorization serves all `N` unit-current forward solves,
+    /// and the **self-adjoint** gradient needs no additional factorization and
+    /// no adjoint solve (see below). Asserted by the FD-validation tests.
+    pub n_factorizations: usize,
+}
+
+/// Compute the Maxwell inductance matrix `L` and its exact per-region
+/// reluctivity gradient `∂L_ij/∂ν_k` via the **self-adjoint** energy form,
+/// on the already-shipped [`crate::assembly::magnetostatic3d`] forward solve.
+///
+/// # The self-adjoint collapse (no separate adjoint solve)
+///
+/// Unlike the electrostatic capacitance adjoint, the magnetostatic excitation
+/// is a **ν-independent current RHS** `b⁽ⁱ⁾ = ∫N·J` (see
+/// [`crate::assembly::magnetostatic3d::assemble_current_rhs`] — it carries no
+/// ν). With the gauged system `K A⁽ⁱ⁾ = b⁽ⁱ⁾` and `A` zero on the
+/// eliminated (tree / PEC) DOFs, the energy-method entry is
+///
+/// ```text
+///   L_ij (I_i I_j) = A⁽ⁱ⁾ᵀ K A⁽ʲ⁾ = b⁽ⁱ⁾ᵀ K⁻¹ b⁽ʲ⁾ ,
+/// ```
+///
+/// whose derivative — since only `K⁻¹` depends on ν — is the **purely local**
+/// contraction
+///
+/// ```text
+///   ∂L_ij/∂ν_k = −A⁽ⁱ⁾ᵀ (∂K/∂ν_k) A⁽ʲ⁾ / (I_i I_j) ,
+///   ∂K/∂ν_k = ν₀ · Σ_{t ∈ region k} K_tⁿᵉᵈ   (linear in per-tet ν_r).
+/// ```
+///
+/// The "adjoint vector" `λ` **is** the forward solution `A⁽ⁱ⁾`; there is no
+/// distinct adjoint RHS and no transpose solve. The whole L-matrix gradient
+/// falls out of the `N` forward solves plus one element loop — cheaper than
+/// the general electrostatic adjoint. The contraction is done in the **full**
+/// `k_full` edge-DOF space (exactly mirroring `extract_inductance`), so the
+/// gauge nullspace never re-enters the arithmetic (`A` is zero on the
+/// eliminated DOFs, so the full-K and cotree contractions coincide).
+///
+/// # Arguments
+///
+/// * `mesh` — tetrahedral mesh.
+/// * `nu_r` — per-tet **relative reluctivity** `ν_r = 1/μ_r` (length
+///   `mesh.n_tets()`), the *evaluated* material at which the gradient is
+///   taken. Build it from per-region values with [`build_region_nu`] so
+///   `nu_r[t]` and the region parameter `ν_{region_of_tet[t]}` agree. (The
+///   forward assembler is parameterized by `μ_r`; this function maps
+///   `μ_r = 1/ν_r` internally so `K` is exactly linear in `ν_r`.)
+/// * `interior_mask` — per-edge PEC mask exactly as
+///   [`assemble_magnetostatic3d`] takes it.
+/// * `terminals` — the current terminals (their `j`, `current`, and
+///   `exempt_nodes`), exactly as
+///   [`crate::assembly::magnetostatic3d::extract_inductance`].
+/// * `region_of_tet` — per-tet region label in `0..n_regions`;
+///   `∂L/∂ν_k` sums the contribution of every tet with `region_of_tet[t]==k`.
+/// * `n_regions` — number of design regions.
+/// * `tol_solenoidal` — discrete-solenoidality tolerance for each terminal's
+///   `J` (passed straight to [`check_solenoidal`]).
+///
+/// # Errors
+///
+/// Propagates [`Magnetostatic3dError`] from assembly / factorization / the
+/// compatibility check, and [`Magnetostatic3dError::ShapeMismatch`] on any
+/// length mismatch or out-of-range region label.
+#[allow(clippy::too_many_arguments)]
+pub fn inductance_adjoint_sensitivity(
+    mesh: &TetMesh,
+    nu_r: &[f64],
+    interior_mask: &[bool],
+    terminals: &[CurrentTerminal],
+    region_of_tet: &[usize],
+    n_regions: usize,
+    tol_solenoidal: f64,
+) -> Result<InductanceSensitivity, Magnetostatic3dError> {
+    let n_tets = mesh.n_tets();
+    if nu_r.len() != n_tets {
+        return Err(Magnetostatic3dError::ShapeMismatch(format!(
+            "nu_r length {} != tet count {n_tets}",
+            nu_r.len()
+        )));
+    }
+    if region_of_tet.len() != n_tets {
+        return Err(Magnetostatic3dError::ShapeMismatch(format!(
+            "region_of_tet length {} != tet count {n_tets}",
+            region_of_tet.len()
+        )));
+    }
+    if let Some(&bad) = region_of_tet.iter().find(|&&r| r >= n_regions) {
+        return Err(Magnetostatic3dError::ShapeMismatch(format!(
+            "region label {bad} out of range for n_regions {n_regions}"
+        )));
+    }
+
+    // Map per-tet reluctivity ν_r → μ_r for the shipped assembler, which
+    // weights each element curl-curl by ν_t = ν₀/μ_r = ν₀·ν_r. K is then
+    // exactly linear in the design parameter ν_r.
+    let mu_r: Vec<f64> = nu_r.iter().map(|&nu| 1.0 / nu).collect();
+    let sys = assemble_magnetostatic3d(mesh, &mu_r, interior_mask)?;
+
+    // Build the tree-cotree gauge ONCE and factor the gauged cotree block
+    // ONCE; every unit-current forward solve reuses this single
+    // factorization (this hoists the per-solve factorization that
+    // `solve_with_gauge` would otherwise repeat, so `n_factorizations == 1`).
+    let gauge = TreeCotreeGauge::build(&sys.edges, &sys.interior_mask, sys.n_nodes);
+    let gdim = gauge.gauged_dim();
+    let gidx = gauge.gauged_index_map();
+
+    let mut red_trips: Vec<Triplet<usize, usize, f64>> = Vec::new();
+    {
+        let k_ref = sys.k_full.as_ref();
+        let cp = k_ref.col_ptr();
+        let row_idx = k_ref.row_idx();
+        let vals = k_ref.val();
+        for j in 0..sys.n_edges {
+            let Some(gj) = gidx[j] else { continue };
+            for k in cp[j]..cp[j + 1] {
+                let i = row_idx[k];
+                if let Some(gi) = gidx[i] {
+                    red_trips.push(Triplet::new(gi, gj, vals[k]));
+                }
+            }
+        }
+    }
+    let k_cc = SparseColMat::<usize, f64>::try_new_from_triplets(gdim, gdim, &red_trips)
+        .map_err(|e| Magnetostatic3dError::Assembly(format!("{e:?}")))?;
+    let lu = k_cc
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| Magnetostatic3dError::Factorization(format!("{e:?}")))?;
+    let n_factorizations = 1;
+
+    // Forward unit-current solves, all reusing the single factorization.
+    let n = terminals.len();
+    let mut a_sols: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for term in terminals {
+        if term.j.len() != n_tets {
+            return Err(Magnetostatic3dError::ShapeMismatch(format!(
+                "terminal {} j length {} != tet count {n_tets}",
+                term.name,
+                term.j.len()
+            )));
+        }
+        let b = assemble_current_rhs(&sys, mesh, &term.j)?;
+        check_solenoidal(&sys, &b, &term.exempt_nodes, tol_solenoidal)?;
+        // Fold b onto the cotree DOFs, solve, scatter A back to full length.
+        let mut rhs: Mat<f64> = Mat::zeros(gdim, 1);
+        for (e, slot) in gidx.iter().enumerate() {
+            if let Some(g) = slot {
+                rhs[(*g, 0)] = b[e];
+            }
+        }
+        lu.solve_in_place(rhs.as_mut());
+        let mut a_full = vec![0.0_f64; sys.n_edges];
+        for (e, slot) in gidx.iter().enumerate() {
+            if let Some(g) = slot {
+                a_full[e] = rhs[(*g, 0)];
+            }
+        }
+        a_sols.push(a_full);
+    }
+
+    // Inductance matrix L_ij = A⁽ⁱ⁾ᵀ K A⁽ʲ⁾ / (I_i I_j) on the full K.
+    let ka: Vec<Vec<f64>> = a_sols
+        .iter()
+        .map(|a| sparse_matvec(&sys.k_full, a))
+        .collect();
+    let mut l = vec![vec![0.0_f64; n]; n];
+    for i in 0..n {
+        for j in i..n {
+            let e: f64 = a_sols[i].iter().zip(ka[j].iter()).map(|(a, b)| a * b).sum();
+            let v = e / (terminals[i].current * terminals[j].current);
+            l[i][j] = v;
+            l[j][i] = v;
+        }
+    }
+
+    // Self-adjoint gradient: ∂L_ij/∂ν_k = −ν₀ A⁽ⁱ⁾ᵀ(Σ_{t∈k} K_tⁿᵉᵈ)A⁽ʲ⁾/(I_i I_j).
+    // A pure local element contraction — no adjoint solve, no extra
+    // factorization. Uses the same element curl-curl kernel and orientation
+    // signs the assembler uses, so ∂K/∂ν_k is an exact analytic JVP.
+    let mut dl_dnu = vec![vec![vec![0.0_f64; n]; n]; n_regions];
+    // Per-terminal local signed edge value on the current tet (reused buffer).
+    let mut loc = vec![[0.0_f64; 6]; n];
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords = [
+            mesh.nodes[tet[0] as usize],
+            mesh.nodes[tet[1] as usize],
+            mesh.nodes[tet[2] as usize],
+            mesh.nodes[tet[3] as usize],
+        ];
+        let k_local = tet_nedelec_stiffness(&coords);
+        let te = &sys.tet_edges[t];
+        for m in 0..n {
+            for p in 0..6 {
+                let (g, s) = te[p];
+                loc[m][p] = (s as f64) * a_sols[m][g as usize];
+            }
+        }
+        let r = region_of_tet[t];
+        for i in 0..n {
+            // K_local · loc[i] (depends only on i, reused across j ≥ i).
+            let mut kloci = [0.0_f64; 6];
+            for p in 0..6 {
+                let mut acc = 0.0_f64;
+                for q in 0..6 {
+                    acc += k_local[p][q] * loc[i][q];
+                }
+                kloci[p] = acc;
+            }
+            for j in i..n {
+                let mut c = 0.0_f64;
+                for p in 0..6 {
+                    c += loc[j][p] * kloci[p];
+                }
+                let contrib = -NU_0 * c / (terminals[i].current * terminals[j].current);
+                dl_dnu[r][i][j] += contrib;
+                if i != j {
+                    dl_dnu[r][j][i] += contrib;
+                }
+            }
+        }
+    }
+
+    Ok(InductanceSensitivity {
+        names: terminals.iter().map(|t| t.name.clone()).collect(),
+        l,
+        dl_dnu,
+        n_factorizations,
+    })
+}
+
+/// Expand a per-region **relative-reluctivity** table into the per-tet `ν_r`
+/// vector that [`inductance_adjoint_sensitivity`] consumes — the reluctivity
+/// twin of [`build_region_eps`].
+///
+/// `nu_region[region_of_tet[t]]` becomes `nu_r[t]`, keeping the design
+/// parameter (`nu_region[k]`) and the assembled material in exact
+/// correspondence so a finite-difference perturbation of `nu_region[k]`
+/// perturbs precisely the tets region `k` owns.
+///
+/// # Panics
+///
+/// Panics if any region label indexes past `nu_region`.
+pub fn build_region_nu(region_of_tet: &[usize], nu_region: &[f64]) -> Vec<f64> {
+    region_of_tet
+        .iter()
+        .map(|&r| {
+            assert!(
+                r < nu_region.len(),
+                "build_region_nu: region {r} out of range for nu_region of length {}",
+                nu_region.len()
+            );
+            nu_region[r]
         })
         .collect()
 }

--- a/crates/geode-core/tests/magnetostatic_inductance.rs
+++ b/crates/geode-core/tests/magnetostatic_inductance.rs
@@ -36,6 +36,7 @@
 use std::f64::consts::PI;
 use std::path::PathBuf;
 
+use geode_core::adjoint::{build_region_nu, inductance_adjoint_sensitivity};
 use geode_core::assembly::magnetostatic3d::{
     CurrentTerminal, MU_0, Magnetostatic3dError, assemble_current_rhs, assemble_magnetostatic3d,
     axial_current_density, check_solenoidal, extract_inductance, loop_current_density,
@@ -516,5 +517,245 @@ fn committed_benchmark_records_oracle_bars() {
     assert!(
         get("loop_pair", "max_rel_asymmetry") < 1e-9,
         "committed L asymmetry too large"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 6. Inductance-matrix reluctivity sensitivity ∂L/∂ν (Epic #569 / #475).
+//    The differentiable row on top of the shipped forward path — validated
+//    against a central finite difference of the SAME discrete pipeline (so
+//    mesh coarseness only bounds runtime, not the gradient-correctness bar),
+//    at the electrostatic adjoint bar (h = 1e-5, rel < 1e-4).
+// ─────────────────────────────────────────────────────────────────────
+
+/// Per-tet region tag for the solid coax: inner conductor core (centroid
+/// r < a) is region 0, the vacuum annulus (r ≥ a) is region 1.
+fn coax_region_of_tet(mesh: &geode_core::mesh::TetMesh, a: f64) -> Vec<usize> {
+    mesh.tets
+        .iter()
+        .map(|tet| {
+            let mut c = [0.0_f64; 3];
+            for &v in tet {
+                for d in 0..3 {
+                    c[d] += mesh.nodes[v as usize][d] * 0.25;
+                }
+            }
+            let r = (c[0] * c[0] + c[1] * c[1]).sqrt();
+            if r < a { 0 } else { 1 }
+        })
+        .collect()
+}
+
+#[test]
+fn inductance_sensitivity_coax_matches_central_fd() {
+    // Single-terminal coax: validate ∂L_00/∂ν_k for the two regions (current
+    // core + vacuum annulus) against a full central FD of the shipped
+    // `extract_inductance`. Coarse mesh — the gradient check is mesh-agnostic.
+    let (a, b, length) = (1.0_f64, 3.0_f64, 1.0_f64);
+    let fx = solid_coax_mesh(a, b, length, 24, 8, 2);
+    let (_edges, mask) = cylinder_pec_interior_mask(&fx.mesh, b, length);
+    let region_of_tet = coax_region_of_tet(&fx.mesh, a);
+    let n_regions = 2;
+    // Heterogeneous base point (μ_core = 1/0.75, μ_annulus = 1).
+    let nu_region = [0.75_f64, 1.0];
+    let nu_r = build_region_nu(&region_of_tet, &nu_region);
+
+    let j = axial_current_density(&fx.mesh, a, 1.0);
+    let i_meas = measure_axial_current(&fx.mesh, &j, length);
+    let term = CurrentTerminal {
+        name: "coax".into(),
+        j,
+        current: i_meas,
+        exempt_nodes: cylinder_cap_nodes(&fx.mesh, length),
+    };
+
+    let sens = inductance_adjoint_sensitivity(
+        &fx.mesh,
+        &nu_r,
+        &mask,
+        std::slice::from_ref(&term),
+        &region_of_tet,
+        n_regions,
+        1e-6,
+    )
+    .unwrap();
+
+    // Single gauged factorization for the forward solves; the self-adjoint
+    // gradient adds none.
+    assert_eq!(
+        sens.n_factorizations, 1,
+        "inductance sensitivity must use exactly one factorization"
+    );
+
+    // The self-adjoint L must reproduce the shipped extractor's L bit-for-bit
+    // (up to solver round-off) — forward physics is byte-identical.
+    let mu_r: Vec<f64> = nu_r.iter().map(|&nu| 1.0 / nu).collect();
+    let sys = assemble_magnetostatic3d(&fx.mesh, &mu_r, &mask).unwrap();
+    let lm = extract_inductance(&sys, &fx.mesh, std::slice::from_ref(&term), 1e-6).unwrap();
+    assert!(
+        (sens.l[0][0] - lm.l[0][0]).abs() / lm.l[0][0].abs() < 1e-10,
+        "self-adjoint L {} disagrees with extract_inductance L {}",
+        sens.l[0][0],
+        lm.l[0][0]
+    );
+
+    // Central FD of the full re-assemble → re-solve → L pipeline per region.
+    let l_of = |nur: &[f64]| -> f64 {
+        let mu: Vec<f64> = nur.iter().map(|&nu| 1.0 / nu).collect();
+        let s = assemble_magnetostatic3d(&fx.mesh, &mu, &mask).unwrap();
+        extract_inductance(&s, &fx.mesh, std::slice::from_ref(&term), 1e-6)
+            .unwrap()
+            .l[0][0]
+    };
+
+    let h = 1e-5;
+    for k in 0..n_regions {
+        let mut nup = nu_region;
+        let mut num = nu_region;
+        nup[k] += h;
+        num[k] -= h;
+        let fd = (l_of(&build_region_nu(&region_of_tet, &nup))
+            - l_of(&build_region_nu(&region_of_tet, &num)))
+            / (2.0 * h);
+        let g = sens.dl_dnu[k][0][0];
+        let rel = (g - fd).abs() / fd.abs().max(f64::MIN_POSITIVE);
+        assert!(
+            fd.abs() > 1e-20,
+            "coax region {k} FD ∂L/∂ν {fd} unexpectedly ~0 (fixture degenerate?)"
+        );
+        assert!(
+            rel < 1e-4,
+            "coax region {k}: adjoint ∂L/∂ν {g} vs central-FD {fd}, rel-err {rel:.3e} exceeds 1e-4"
+        );
+    }
+}
+
+#[test]
+fn inductance_sensitivity_loop_pair_offdiag_symmetry_and_fd() {
+    // Two-terminal loop pair: validate the FULL ∂L_ij/∂ν_k tensor (both
+    // self- and mutual-inductance rows), its symmetry ∂L_ij/∂ν_k =
+    // ∂L_ji/∂ν_k, and one factorization. Regions split by z-half so both
+    // regions carry a nontrivial gradient.
+    let (r1, z1, r2, z2) = (1.0_f64, 2.0_f64, 1.0_f64, 3.0_f64);
+    let (rbox, length, rtube) = (5.0_f64, 5.0_f64, 0.25_f64);
+    // Coarse mesh: the gradient-correctness bar is mesh-agnostic (FD of the
+    // same discrete pipeline), and n_r/n_z = 10 put a radial ring at r_loop=1
+    // and z-stations at the loop heights so the current tube is still meshed.
+    let fx = loop_pair_mesh(r1, z1, r2, z2, rbox, length, 16, 10, 10);
+    let tolb = 1e-6 * rbox;
+    let tolz = 1e-6 * length;
+    let on_bdry: Vec<bool> = fx
+        .mesh
+        .nodes
+        .iter()
+        .map(|p| {
+            let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+            (r - rbox).abs() < tolb || p[2].abs() < tolz || (p[2] - length).abs() < tolz
+        })
+        .collect();
+    let edges = fx.mesh.edges();
+    let mask = pec_interior_edge_mask(&edges, &on_bdry);
+
+    // Regions by tet-centroid z-half.
+    let zmid = 0.5 * length;
+    let region_of_tet: Vec<usize> = fx
+        .mesh
+        .tets
+        .iter()
+        .map(|tet| {
+            let zc = tet
+                .iter()
+                .map(|&v| fx.mesh.nodes[v as usize][2])
+                .sum::<f64>()
+                / 4.0;
+            if zc < zmid { 0 } else { 1 }
+        })
+        .collect();
+    let n_regions = 2;
+    let nu_region = [1.0_f64, 1.0];
+    let nu_r = build_region_nu(&region_of_tet, &nu_region);
+
+    let j1 = loop_current_density(&fx.mesh, r1, z1, rtube, 1.0);
+    let j2 = loop_current_density(&fx.mesh, r2, z2, rtube, 1.0);
+    let i1 = measure_loop_current(&fx.mesh, &j1);
+    let i2 = measure_loop_current(&fx.mesh, &j2);
+    let terms = vec![
+        CurrentTerminal {
+            name: "loop1".into(),
+            j: j1,
+            current: i1,
+            exempt_nodes: vec![],
+        },
+        CurrentTerminal {
+            name: "loop2".into(),
+            j: j2,
+            current: i2,
+            exempt_nodes: vec![],
+        },
+    ];
+
+    let sens = inductance_adjoint_sensitivity(
+        &fx.mesh,
+        &nu_r,
+        &mask,
+        &terms,
+        &region_of_tet,
+        n_regions,
+        5e-2,
+    )
+    .unwrap();
+    assert_eq!(sens.n_factorizations, 1);
+
+    // Symmetry of the sensitivity tensor (falls out of the self-adjoint form).
+    for k in 0..n_regions {
+        for i in 0..2 {
+            for j in 0..2 {
+                let a = sens.dl_dnu[k][i][j];
+                let b = sens.dl_dnu[k][j][i];
+                let denom = a.abs().max(b.abs()).max(f64::MIN_POSITIVE);
+                assert!(
+                    (a - b).abs() / denom < 1e-12,
+                    "∂L/∂ν not symmetric at region {k}, ({i},{j}): {a} vs {b}"
+                );
+            }
+        }
+    }
+
+    // Central FD of every L_ij entry per region.
+    let l_of = |nur: &[f64], i: usize, j: usize| -> f64 {
+        let mu: Vec<f64> = nur.iter().map(|&nu| 1.0 / nu).collect();
+        let s = assemble_magnetostatic3d(&fx.mesh, &mu, &mask).unwrap();
+        extract_inductance(&s, &fx.mesh, &terms, 5e-2).unwrap().l[i][j]
+    };
+
+    let h = 1e-5;
+    let mut worst = 0.0_f64;
+    for k in 0..n_regions {
+        let mut nup = nu_region;
+        let mut num = nu_region;
+        nup[k] += h;
+        num[k] -= h;
+        let nurp = build_region_nu(&region_of_tet, &nup);
+        let nurm = build_region_nu(&region_of_tet, &num);
+        for i in 0..2 {
+            for j in 0..2 {
+                let fd = (l_of(&nurp, i, j) - l_of(&nurm, i, j)) / (2.0 * h);
+                let g = sens.dl_dnu[k][i][j];
+                let rel = (g - fd).abs() / fd.abs().max(f64::MIN_POSITIVE);
+                worst = worst.max(rel);
+                assert!(
+                    fd.abs() > 1e-20,
+                    "loop-pair region {k} L[{i}][{j}] FD {fd} unexpectedly ~0"
+                );
+                assert!(
+                    rel < 1e-4,
+                    "loop-pair region {k} L[{i}][{j}]: adjoint {g} vs central-FD {fd}, rel-err {rel:.3e} exceeds 1e-4"
+                );
+            }
+        }
+    }
+    assert!(
+        worst < 1e-4,
+        "worst ∂L/∂ν-vs-FD rel-err {worst:.3e} exceeds 1e-4"
     );
 }


### PR DESCRIPTION
## Summary

Adds the **inductance-matrix reluctivity sensitivity `∂L_ij/∂ν_k`** as a new differentiable layer on top of the already-shipped `magnetostatic3d` forward solve (PR #512) — the magnetostatic dual of the shipped electrostatic `∂C/∂ε` adjoint. This completes the Epic #569 sensitivity matrix with the inductance row and is the one genuinely net-new increment identified during re-scoping (the 3D vector forward path + `extract_inductance` + tree-cotree gauge already shipped). No forward physics is reimplemented.

## Key result: the sensitivity is fully self-adjoint

Because the magnetostatic excitation is a **ν-independent current RHS** `b⁽ⁱ⁾ = ∫N·J`, with `K A⁽ⁱ⁾ = b⁽ⁱ⁾` and `A` zero on the eliminated (tree/PEC) DOFs:

```
L_ij (I_i I_j) = A⁽ⁱ⁾ᵀ K A⁽ʲ⁾ = b⁽ⁱ⁾ᵀ K⁻¹ b⁽ʲ⁾
  ⇒  ∂L_ij/∂ν_k = −A⁽ⁱ⁾ᵀ (∂K/∂ν_k) A⁽ʲ⁾ / (I_i I_j),   ∂K/∂ν_k = ν₀ Σ_{t∈region k} K_tⁿᵉᵈ
```

The adjoint vector **is** the forward solution `A⁽ⁱ⁾` — no distinct adjoint RHS, no transpose solve. The whole L-matrix gradient falls out of the N forward solves plus one local element loop, cheaper than the general electrostatic adjoint.

## Changes

- `crates/geode-core/src/adjoint.rs`: new `inductance_adjoint_sensitivity`, `InductanceSensitivity` struct, and `build_region_nu` (reluctivity twin of `build_region_eps`). A single tree-cotree-gauged cotree factorization serves all N unit-current forward solves (`n_factorizations == 1`); the self-adjoint gradient adds none. The `−A⁽ⁱ⁾ᵀ(∂K/∂ν_k)A⁽ʲ⁾` contraction runs in the full `k_full` edge-DOF space (mirrors `extract_inductance`) so the gauge nullspace never re-enters the arithmetic. Per-region ν_r = 1/μ_r parameterization mirrors the electrostatic side; the forward assembler's μ_r input is mapped internally so K is exactly linear in ν_r.
- `crates/geode-core/tests/magnetostatic_inductance.rs`: two FD-validation tests reusing the coax / loop-pair fixtures.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| ∂L/∂ν central-FD-validated at the electrostatic bar (h=1e-5, rel < 1e-4) | ✅ | `inductance_sensitivity_coax_matches_central_fd` (2 regions, single terminal) + `inductance_sensitivity_loop_pair_offdiag_symmetry_and_fd` (full 2×2 tensor × 2 regions) both assert rel < 1e-4 |
| Single gauged factorization; no extra factorization for the gradient | ✅ | `n_factorizations == 1` asserted in both tests; gradient is a pure local element loop |
| Reuse coax / loop-pair fixtures, no new forward physics | ✅ | Uses `solid_coax_mesh` / `loop_pair_mesh`; forward via the shipped `assemble_magnetostatic3d` + `extract_inductance` |
| Forward `magnetostatic3d` byte-identical | ✅ | `magnetostatic3d.rs` untouched; self-adjoint L cross-checked to `extract_inductance` at rel < 1e-10 |
| Symmetry ∂L_ij/∂ν_k == ∂L_ji/∂ν_k | ✅ | Asserted < 1e-12 in the loop-pair test |
| Regression suite green; `cargo fmt` | ✅ | See Test Plan |

## Test Plan

- `cargo test -p geode-core --test magnetostatic_inductance` — 12 passed (10 pre-existing oracles/tripwires + 2 new), 108s.
- `cargo test -p geode-core --lib adjoint` — 11 passed (electrostatic + driven adjoints unaffected).
- `cargo test -p geode-core --test magnetostatic_wire --test magnetostatic_heterogeneous` — green.
- `cargo clippy -p geode-core --lib --tests` — clean; `cargo fmt` applied.

Heavy `sphere_*` eigenmode tests were not run — they time out in debug in this environment and share no code with this path.

Closes #612