### PR TITLE
feat(nedelec-p2): opt-in p=2 driven forward path + global assembly + material adjoint

### DIFF
--- a/crates/geode-core/src/assembly/mod.rs
+++ b/crates/geode-core/src/assembly/mod.rs
@@ -50,6 +50,7 @@ pub mod magnetostatic;
 pub mod magnetostatic3d;
 pub mod nedelec;
 pub mod nedelec_matvec;
+pub mod nedelec_p2;
 pub mod p1;
 pub mod sparse;
 pub mod surface;

--- a/crates/geode-core/src/assembly/nedelec_p2.rs
+++ b/crates/geode-core/src/assembly/nedelec_p2.rs
@@ -1,0 +1,567 @@
+//! Second-order (`p=2`) Nédélec **global** assembly on a tetrahedral mesh
+//! (Epic #475 parity gap #3, Epic #569; issue #616, follow-on to #613).
+//!
+//! [`crate::elements::nedelec_p2`] shipped the 20-DOF element (basis, curls,
+//! degree-≥4 quadrature, and — the hard part — the ascending-global-vertex
+//! orientation convention). This module does the global wiring that #613
+//! deliberately deferred: a global DOF numbering, an order-aware `K`/`M`
+//! assembler, and a quadrature-sampled RHS, all in plain `f64`/faer sparse
+//! form (no Burn backend). It is the substrate the opt-in `p=2` driven
+//! forward path ([`crate::driven::solve::driven_solve_p2`]) and the `p=2`
+//! material adjoint ([`crate::driven::adjoint::driven_material_adjoint_gradient_p2`])
+//! build on.
+//!
+//! # Global DOF numbering (`edges×2 + faces×2`)
+//!
+//! The `p=2` space has 12 edge DOFs + 8 face DOFs per tet over a global
+//! numbering with **two** DOFs per global edge and **two** per global face:
+//!
+//! ```text
+//!   edge global index ge ∈ [0, n_edges)  →  global DOFs  2·ge      (W_ge)
+//!                                                        2·ge + 1  (Q_ge)
+//!   face global index gf ∈ [0, n_faces)  →  global DOFs  2·n_edges + 2·gf      (φ0_gf)
+//!                                                        2·n_edges + 2·gf + 1  (φ1_gf)
+//!   n_dofs = 2·n_edges + 2·n_faces
+//! ```
+//!
+//! Global edges/faces come from [`TetMesh::edges`]/[`TetMesh::faces`] (canonical
+//! ascending-vertex tuples), so the numbering is deterministic and mesh-derived.
+//!
+//! # Orientation: unit-sign scatter via the ascending-vertex convention
+//!
+//! **This module does NOT use the `p=1` sign machinery** (`tet_edge_sign` /
+//! `sign_outer_tensor`). Per the [`crate::elements::nedelec_p2`] module docs,
+//! the element absorbs *both* edge and face orientation when it is built on the
+//! tet's four vertices **reordered into ascending global-tag order**
+//! ([`ascending_vertex_perm`]). After that reorder:
+//!
+//! - every local edge `(la, lb)` with `la < lb` has ascending global endpoints,
+//!   so `W`/`Q` are the same physical functions in every incident tet, and
+//! - every local face `(a, b, c)` with `a < b < c` has ascending global
+//!   vertices, so `φ0`/`φ1` are the same physical functions in every incident
+//!   tet.
+//!
+//! Under this convention **all 20 DOFs scatter with unit sign and no `2×2` face
+//! mixing** — mixing in the `p=1` sign outer product would *double-apply*
+//! orientation (red flag #1 of the issue).
+//!
+//! # Coefficient / quadrature assumptions
+//!
+//! The element rule [`tet_quad_deg4`] is exact for the degree-2 curl-curl and
+//! degree-4 mass integrands of a **per-tet-constant** coefficient. This module
+//! assembles the ε-weighted mass with **per-tet-constant `ε`**
+//! (`M(ε) = Σ_t ε_t · M_local(t)`, `ε` pulled out of the integral exactly), so
+//! deg-4 remains exact. The quadrature-sampled RHS ([`assemble_p2_rhs_quad`])
+//! samples `J(x)` at the same rule's points; for a smooth `J` this converges at
+//! the rule's order, and it is exact whenever `N_i · J` stays within degree 4
+//! (e.g. `J` at most linear per tet). Spatially varying `ε` or higher-degree
+//! `J` would need a higher Duffy rule — out of scope here and stated explicitly.
+
+use std::collections::HashMap;
+
+use faer::c64;
+use faer::sparse::{SparseColMat, Triplet};
+
+use crate::elements::nedelec_p2::{
+    TET_NEDELEC2_DOFS, TET_NEDELEC2_FACE_DOF_BASE, ascending_vertex_perm,
+    tet_barycentric_gradients, tet_nedelec2_local, tet_nedelec2_local_rhs, tet_nedelec2_shapes,
+    tet_quad_deg4,
+};
+use crate::mesh::{TET_LOCAL_EDGES, TET_LOCAL_FACES, TetMesh};
+
+/// Global `p=2` Nédélec DOF numbering for a mesh: the `edges×2 + faces×2`
+/// layout plus, per tet, the 20 global DOF indices in the element's **local**
+/// layout (the layout of the element built on ascending-vertex-sorted coords)
+/// and the vertex permutation that realises the ascending-global-vertex
+/// orientation convention.
+#[derive(Debug, Clone)]
+pub struct P2DofMap {
+    /// Number of global edges (`= mesh.edges().len()`).
+    pub n_edges: usize,
+    /// Number of global faces (`= mesh.faces().len()`).
+    pub n_faces: usize,
+    /// Total global DOF count `2·n_edges + 2·n_faces`.
+    pub n_dofs: usize,
+    /// Per-tet global DOF indices, one `[20]` array per tet, in the local DOF
+    /// layout of [`tet_nedelec2_local`] evaluated on the **sorted** coords
+    /// (see [`P2DofMap::sorted_coords`]).
+    pub tet_dofs: Vec<[usize; TET_NEDELEC2_DOFS]>,
+    /// Per-tet ascending-global-vertex permutation ([`ascending_vertex_perm`]).
+    pub tet_perm: Vec<[usize; 4]>,
+}
+
+impl P2DofMap {
+    /// Build the global `p=2` DOF numbering from the mesh connectivity.
+    ///
+    /// Deterministic and orientation-consistent: every incident tet maps its
+    /// shared edge/face DOFs to the same global indices with unit sign.
+    pub fn build(mesh: &TetMesh) -> Self {
+        let edges = mesh.edges();
+        let faces = mesh.faces();
+        let n_edges = edges.len();
+        let n_faces = faces.len();
+
+        let mut edge_lookup: HashMap<(u32, u32), usize> = HashMap::with_capacity(n_edges);
+        for (i, e) in edges.iter().enumerate() {
+            edge_lookup.insert((e[0], e[1]), i);
+        }
+        let mut face_lookup: HashMap<(u32, u32, u32), usize> = HashMap::with_capacity(n_faces);
+        for (i, f) in faces.iter().enumerate() {
+            face_lookup.insert((f[0], f[1], f[2]), i);
+        }
+
+        let face_base = 2 * n_edges;
+        let mut tet_dofs = Vec::with_capacity(mesh.n_tets());
+        let mut tet_perm = Vec::with_capacity(mesh.n_tets());
+
+        for tet in &mesh.tets {
+            let tags: [u32; 4] = *tet;
+            let perm = ascending_vertex_perm(&tags);
+            // Global tags in ascending order (the sorted element's vertices).
+            let sorted_tags: [u32; 4] = std::array::from_fn(|i| tags[perm[i]]);
+
+            let mut dofs = [0usize; TET_NEDELEC2_DOFS];
+
+            // Edge DOFs: local edge (la, lb), la < lb, so sorted global
+            // endpoints are already ascending (lo < hi).
+            for (e, &(la, lb)) in TET_LOCAL_EDGES.iter().enumerate() {
+                let lo = sorted_tags[la];
+                let hi = sorted_tags[lb];
+                debug_assert!(lo < hi, "sorted-vertex edge must be ascending");
+                let ge = *edge_lookup
+                    .get(&(lo, hi))
+                    .expect("edge derived from tet must be in edge table");
+                dofs[2 * e] = 2 * ge; // W_ge
+                dofs[2 * e + 1] = 2 * ge + 1; // Q_ge
+            }
+
+            // Face DOFs: local face (a, b, c), a < b < c, so sorted global
+            // triple is ascending.
+            for (f, tri) in TET_LOCAL_FACES.iter().enumerate() {
+                let (a, b, cc) = (tri[0], tri[1], tri[2]);
+                let ta = sorted_tags[a];
+                let tb = sorted_tags[b];
+                let tc = sorted_tags[cc];
+                debug_assert!(ta < tb && tb < tc, "sorted-vertex face must be ascending");
+                let gf = *face_lookup
+                    .get(&(ta, tb, tc))
+                    .expect("face derived from tet must be in face table");
+                let base = TET_NEDELEC2_FACE_DOF_BASE + 2 * f;
+                dofs[base] = face_base + 2 * gf; // φ0_gf
+                dofs[base + 1] = face_base + 2 * gf + 1; // φ1_gf
+            }
+
+            tet_dofs.push(dofs);
+            tet_perm.push(perm);
+        }
+
+        Self {
+            n_edges,
+            n_faces,
+            n_dofs: 2 * n_edges + 2 * n_faces,
+            tet_dofs,
+            tet_perm,
+        }
+    }
+
+    /// The tet's four vertex coordinates reordered into ascending global-tag
+    /// order — the coords [`tet_nedelec2_local`] and friends must be built on
+    /// so the local DOF rows/cols line up with [`P2DofMap::tet_dofs`].
+    #[inline]
+    pub fn sorted_coords(&self, mesh: &TetMesh, t: usize) -> [[f64; 3]; 4] {
+        let tet = &mesh.tets[t];
+        let perm = &self.tet_perm[t];
+        std::array::from_fn(|i| mesh.nodes[tet[perm[i]] as usize])
+    }
+}
+
+/// A tet's local 20×20 curl-curl `K` and (unweighted) mass `M`, both built on
+/// the ascending-vertex-sorted coords so their rows/cols scatter with unit
+/// sign into [`P2DofMap::tet_dofs`].
+///
+/// `M` here is the **ε = 1** mass; the ε-weighting is applied at scatter time
+/// (`M(ε) = Σ_t ε_t · M_local(t)`) and, for the adjoint, per region.
+#[allow(clippy::type_complexity)]
+pub fn tet_p2_local_sorted(
+    dofs: &P2DofMap,
+    mesh: &TetMesh,
+    t: usize,
+) -> (
+    [[f64; TET_NEDELEC2_DOFS]; TET_NEDELEC2_DOFS],
+    [[f64; TET_NEDELEC2_DOFS]; TET_NEDELEC2_DOFS],
+) {
+    let coords = dofs.sorted_coords(mesh, t);
+    let (k, m, _vol) = tet_nedelec2_local(&coords);
+    (k, m)
+}
+
+/// Assemble the global `p=2` curl-curl stiffness `K` and the ε-weighted mass
+/// `M(ε)` as real `f64` sparse matrices over the `edges×2 + faces×2` numbering.
+///
+/// `eps_tet` is the per-tet **real** relative permittivity (length
+/// `mesh.n_tets()`); the mass is `M(ε) = Σ_t ε_tet[t] · M_local(t)` — ε pulled
+/// out of the (deg-4-exact) integral, exact for per-tet-constant ε. `K` is
+/// ε-independent.
+///
+/// Returns `(K, M)`; both are symmetric. Orientation is unit-sign (no `p=1`
+/// sign machinery), per the module docs.
+///
+/// # Panics
+///
+/// Panics if `eps_tet.len() != mesh.n_tets()`.
+pub fn assemble_p2_km(
+    mesh: &TetMesh,
+    dofs: &P2DofMap,
+    eps_tet: &[f64],
+) -> (SparseColMat<usize, f64>, SparseColMat<usize, f64>) {
+    assert_eq!(
+        eps_tet.len(),
+        mesh.n_tets(),
+        "eps_tet length must equal n_tets"
+    );
+    let cap = mesh.n_tets() * TET_NEDELEC2_DOFS * TET_NEDELEC2_DOFS;
+    let mut k_tr: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(cap);
+    let mut m_tr: Vec<Triplet<usize, usize, f64>> = Vec::with_capacity(cap);
+
+    for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+        let (k_loc, m_loc) = tet_p2_local_sorted(dofs, mesh, t);
+        let eps = eps_tet[t];
+        for i in 0..TET_NEDELEC2_DOFS {
+            let gi = gdofs[i];
+            for j in 0..TET_NEDELEC2_DOFS {
+                let gj = gdofs[j];
+                k_tr.push(Triplet::new(gi, gj, k_loc[i][j]));
+                m_tr.push(Triplet::new(gi, gj, eps * m_loc[i][j]));
+            }
+        }
+    }
+
+    let k = SparseColMat::<usize, f64>::try_new_from_triplets(dofs.n_dofs, dofs.n_dofs, &k_tr)
+        .expect("p=2 K sparse assembly");
+    let m = SparseColMat::<usize, f64>::try_new_from_triplets(dofs.n_dofs, dofs.n_dofs, &m_tr)
+        .expect("p=2 M sparse assembly");
+    (k, m)
+}
+
+/// Assemble the global `p=2` RHS moments `b_i = ∫_T N_i · J dV` for a
+/// **per-tet-constant** current density `J` (real components), scattered with
+/// unit sign. Length `dofs.n_dofs`.
+///
+/// # Panics
+///
+/// Panics if `j_tet.len() != mesh.n_tets()`.
+pub fn assemble_p2_rhs_constant(mesh: &TetMesh, dofs: &P2DofMap, j_tet: &[[f64; 3]]) -> Vec<f64> {
+    assert_eq!(j_tet.len(), mesh.n_tets(), "j_tet length must equal n_tets");
+    let mut b = vec![0.0_f64; dofs.n_dofs];
+    for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+        let coords = dofs.sorted_coords(mesh, t);
+        let b_loc = tet_nedelec2_local_rhs(&coords, j_tet[t]);
+        for (i, &bi) in b_loc.iter().enumerate() {
+            b[gdofs[i]] += bi;
+        }
+    }
+    b
+}
+
+/// Assemble the global `p=2` RHS moments `b_i = ∫_T N_i · J(x) dV` for a
+/// **spatially varying** current density `J(x)`, sampled at the degree-≥4 tet
+/// quadrature points ([`tet_quad_deg4`]) — the `p=2` analogue of the `p=1`
+/// `assemble_nedelec_current_rhs_quad4` pattern (red flag #3 / AC #3).
+///
+/// `j_at(t, x)` returns the (real) current density at physical point `x` in tet
+/// `t`. For a smooth `J` the moment converges at the rule's order; it is exact
+/// whenever `N_i · J` is within degree 4 per tet (e.g. `J` at most linear).
+/// Length `dofs.n_dofs`, unit-sign scatter.
+pub fn assemble_p2_rhs_quad(
+    mesh: &TetMesh,
+    dofs: &P2DofMap,
+    j_at: impl Fn(usize, [f64; 3]) -> [f64; 3],
+) -> Vec<f64> {
+    let rule = tet_quad_deg4();
+    let mut b = vec![0.0_f64; dofs.n_dofs];
+    for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+        let coords = dofs.sorted_coords(mesh, t);
+        let (bary, signed_vol) = tet_barycentric_gradients(&coords);
+        let vol_abs = signed_vol.abs();
+        let mut b_loc = [0.0_f64; TET_NEDELEC2_DOFS];
+        for (lam, frac) in &rule {
+            // Physical quadrature point x = Σ λ_p v_p (sorted coords).
+            let x: [f64; 3] =
+                std::array::from_fn(|d| (0..4).map(|p| lam[p] * coords[p][d]).sum::<f64>());
+            let j = j_at(t, x);
+            let (n, _c) = tet_nedelec2_shapes(lam, &bary);
+            let w = vol_abs * frac;
+            for (i, bl) in b_loc.iter_mut().enumerate() {
+                *bl += w * (n[i][0] * j[0] + n[i][1] * j[1] + n[i][2] * j[2]);
+            }
+        }
+        for (i, &bl) in b_loc.iter().enumerate() {
+            b[gdofs[i]] += bl;
+        }
+    }
+    b
+}
+
+/// Per-entry ingredients of the interior driven pencil `A(ω) = K − ω² M(ε)`
+/// over the kept `p=2` DOFs, for the direct sparse path and the adjoint.
+///
+/// Returns `(remap, n_interior, kept)`:
+/// - `remap[g]` maps a full DOF index `g ∈ [0, n_dofs)` to its interior index,
+///   or `-1` if `g` is PEC-eliminated (`interior_mask[g] == false`).
+/// - `n_interior` is the number of kept DOFs.
+/// - `kept` is the list of per-tet **interior** matrix entries
+///   `(interior_row, interior_col, K_local, εM_local)` (duplicates at shared
+///   DOFs are intended — faer's triplet constructor and a plain accumulation
+///   spmv both sum them). Build the complex operator as
+///   `A = Σ (K_local − ω² εM_local)` and the residual spmv from the same list.
+///
+/// # Panics
+///
+/// Panics if `eps_tet.len() != mesh.n_tets()` or
+/// `interior_mask.len() != dofs.n_dofs`.
+#[allow(clippy::type_complexity)]
+pub fn p2_interior_km(
+    mesh: &TetMesh,
+    dofs: &P2DofMap,
+    eps_tet: &[f64],
+    interior_mask: &[bool],
+) -> (Vec<i64>, usize, Vec<(usize, usize, f64, f64)>) {
+    assert_eq!(eps_tet.len(), mesh.n_tets(), "eps_tet length");
+    assert_eq!(interior_mask.len(), dofs.n_dofs, "interior_mask length");
+
+    let mut remap = vec![-1_i64; dofs.n_dofs];
+    let mut n_interior = 0usize;
+    for (g, &keep) in interior_mask.iter().enumerate() {
+        if keep {
+            remap[g] = n_interior as i64;
+            n_interior += 1;
+        }
+    }
+
+    let mut kept: Vec<(usize, usize, f64, f64)> =
+        Vec::with_capacity(mesh.n_tets() * TET_NEDELEC2_DOFS * TET_NEDELEC2_DOFS);
+    for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+        let (k_loc, m_loc) = tet_p2_local_sorted(dofs, mesh, t);
+        let eps = eps_tet[t];
+        for i in 0..TET_NEDELEC2_DOFS {
+            let ri = remap[gdofs[i]];
+            if ri < 0 {
+                continue;
+            }
+            for j in 0..TET_NEDELEC2_DOFS {
+                let rj = remap[gdofs[j]];
+                if rj < 0 {
+                    continue;
+                }
+                kept.push((ri as usize, rj as usize, k_loc[i][j], eps * m_loc[i][j]));
+            }
+        }
+    }
+    (remap, n_interior, kept)
+}
+
+/// Accumulate the per-region mass action `(M_k x)` over interior DOFs, where
+/// `M_k` is the `p=2` mass with `ε` set to the indicator of region `k`
+/// (`region_of_tet[t] == k`). Used by the material adjoint
+/// (`dg/dε_k = 2 ω² Re[λᵀ M_k x]`). Returns a length-`n_interior` vector.
+pub fn p2_region_mass_action(
+    mesh: &TetMesh,
+    dofs: &P2DofMap,
+    remap: &[i64],
+    n_interior: usize,
+    region_of_tet: &[usize],
+    region_k: usize,
+    x_int: &[c64],
+) -> Vec<c64> {
+    let mut out = vec![c64::new(0.0, 0.0); n_interior];
+    for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+        if region_of_tet[t] != region_k {
+            continue;
+        }
+        let (_k_loc, m_loc) = tet_p2_local_sorted(dofs, mesh, t);
+        for i in 0..TET_NEDELEC2_DOFS {
+            let ri = remap[gdofs[i]];
+            if ri < 0 {
+                continue;
+            }
+            let ri = ri as usize;
+            for j in 0..TET_NEDELEC2_DOFS {
+                let rj = remap[gdofs[j]];
+                if rj < 0 {
+                    continue;
+                }
+                out[ri] += c64::new(m_loc[i][j], 0.0) * x_int[rj as usize];
+            }
+        }
+    }
+    out
+}
+
+/// Interior (kept) `p=2` DOF mask for a **cube PEC cavity** `[0, side]³`:
+/// a DOF is eliminated (`false`) iff its edge/face lies entirely on a boundary
+/// plane (`n × E = 0`).
+///
+/// The geometric predicate is plane-based and exact for a box: an edge is on
+/// the boundary iff both endpoints share a coordinate equal to `0` or `side`;
+/// a face is on the boundary iff all three vertices do. Length `dofs.n_dofs`.
+pub fn cube_pec_interior_p2_dofs(mesh: &TetMesh, dofs: &P2DofMap, side: f64) -> Vec<bool> {
+    let tol = 1e-9 * side.max(1.0);
+    let edges = mesh.edges();
+    let faces = mesh.faces();
+    let on_plane_pair = |a: usize, b: usize| -> bool {
+        let pa = &mesh.nodes[a];
+        let pb = &mesh.nodes[b];
+        (0..3).any(|d| {
+            let lo = pa[d].abs() < tol && pb[d].abs() < tol;
+            let hi = (pa[d] - side).abs() < tol && (pb[d] - side).abs() < tol;
+            lo || hi
+        })
+    };
+    let on_plane_triple = |a: usize, b: usize, c: usize| -> bool {
+        let pa = &mesh.nodes[a];
+        let pb = &mesh.nodes[b];
+        let pc = &mesh.nodes[c];
+        (0..3).any(|d| {
+            let lo = pa[d].abs() < tol && pb[d].abs() < tol && pc[d].abs() < tol;
+            let hi = (pa[d] - side).abs() < tol
+                && (pb[d] - side).abs() < tol
+                && (pc[d] - side).abs() < tol;
+            lo || hi
+        })
+    };
+
+    let mut keep = vec![true; dofs.n_dofs];
+    for (ge, e) in edges.iter().enumerate() {
+        if on_plane_pair(e[0] as usize, e[1] as usize) {
+            keep[2 * ge] = false;
+            keep[2 * ge + 1] = false;
+        }
+    }
+    let face_base = 2 * dofs.n_edges;
+    for (gf, f) in faces.iter().enumerate() {
+        if on_plane_triple(f[0] as usize, f[1] as usize, f[2] as usize) {
+            keep[face_base + 2 * gf] = false;
+            keep[face_base + 2 * gf + 1] = false;
+        }
+    }
+    keep
+}
+
+/// Reconstruct the `p=2` vector field `E_h(x)` from a full-length DOF vector at
+/// a point inside tet `t` given by barycentrics `lam` **in the mesh tet's
+/// natural (unsorted) vertex order** (`lam[i]` weights `mesh.tets[t][i]`).
+///
+/// The permutation to the ascending-vertex-sorted assembly basis is applied
+/// internally, so callers pass the same `lam` they use to form the physical
+/// point `x = Σ lam[i] · mesh.nodes[tet[i]]` — no manual sorting, and no
+/// sorted/unsorted mismatch. Intended for convergence post-processing (L2
+/// error against an analytic field).
+pub fn p2_field_at(
+    mesh: &TetMesh,
+    dofs: &P2DofMap,
+    x_dof: &[c64],
+    t: usize,
+    lam: &[f64; 4],
+) -> [c64; 3] {
+    let coords = dofs.sorted_coords(mesh, t);
+    // Permute the caller's natural-order barycentrics into the sorted-vertex
+    // order the basis is built on: lam_sorted[i] = lam[perm[i]].
+    let perm = &dofs.tet_perm[t];
+    let lam_sorted: [f64; 4] = std::array::from_fn(|i| lam[perm[i]]);
+    let (bary, _vol) = tet_barycentric_gradients(&coords);
+    let (n, _c) = tet_nedelec2_shapes(&lam_sorted, &bary);
+    let gdofs = &dofs.tet_dofs[t];
+    let mut e = [c64::new(0.0, 0.0); 3];
+    for i in 0..TET_NEDELEC2_DOFS {
+        let coeff = x_dof[gdofs[i]];
+        for (d, ed) in e.iter_mut().enumerate() {
+            *ed += coeff * n[i][d];
+        }
+    }
+    e
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mesh::cube_tet_mesh;
+
+    #[test]
+    fn dof_numbering_is_consistent_and_bounded() {
+        let mesh = cube_tet_mesh(2, 1.0);
+        let dofs = P2DofMap::build(&mesh);
+        assert_eq!(dofs.n_edges, mesh.edges().len());
+        assert_eq!(dofs.n_faces, mesh.faces().len());
+        assert_eq!(dofs.n_dofs, 2 * dofs.n_edges + 2 * dofs.n_faces);
+        // Every global DOF index is in range, and each tet uses 20 distinct DOFs.
+        for gdofs in &dofs.tet_dofs {
+            let mut seen = gdofs.to_vec();
+            seen.sort_unstable();
+            seen.dedup();
+            assert_eq!(seen.len(), TET_NEDELEC2_DOFS, "20 distinct DOFs per tet");
+            assert!(gdofs.iter().all(|&g| g < dofs.n_dofs));
+        }
+    }
+
+    #[test]
+    fn shared_face_dofs_agree_across_incident_tets() {
+        // Every interior face is shared by exactly two tets; both must map the
+        // face's two φ DOFs to the SAME global indices (conformity).
+        let mesh = cube_tet_mesh(2, 1.0);
+        let dofs = P2DofMap::build(&mesh);
+        let faces = mesh.faces();
+        let face_base = 2 * dofs.n_edges;
+        // Collect, per global face, the set of (φ0, φ1) global DOFs seen.
+        let mut per_face: Vec<Option<(usize, usize)>> = vec![None; faces.len()];
+        for gdofs in &dofs.tet_dofs {
+            for f in 0..4 {
+                let base = TET_NEDELEC2_FACE_DOF_BASE + 2 * f;
+                let d0 = gdofs[base];
+                let d1 = gdofs[base + 1];
+                // recover gf from the global DOF index
+                let gf = (d0 - face_base) / 2;
+                let expect = (face_base + 2 * gf, face_base + 2 * gf + 1);
+                assert_eq!((d0, d1), expect);
+                match per_face[gf] {
+                    None => per_face[gf] = Some((d0, d1)),
+                    Some(prev) => assert_eq!(prev, (d0, d1)),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn stiffness_annihilates_a_global_gradient_field() {
+        // The curl-curl form has the gradient space in its kernel. A linear
+        // scalar field φ = a·x has constant ∇φ; its lowest-order Whitney (W)
+        // edge representation uses coefficient φ(b) − φ(a) on edge (a<b). With a
+        // globally consistent unit-sign assembly the curl-curl energy xᵀ K x of
+        // that gradient field must vanish to round-off.
+        let mesh = cube_tet_mesh(2, 1.0);
+        let dofs = P2DofMap::build(&mesh);
+        let edges = mesh.edges();
+        let phi = |p: &[f64; 3]| p[0] + 2.0 * p[1] + 3.0 * p[2];
+        let mut x = vec![0.0_f64; dofs.n_dofs];
+        for (ge, e) in edges.iter().enumerate() {
+            let pa = &mesh.nodes[e[0] as usize];
+            let pb = &mesh.nodes[e[1] as usize];
+            x[2 * ge] = phi(pb) - phi(pa); // W (Whitney) coefficient
+        }
+        let mut energy = 0.0_f64;
+        let mut kfrob = 0.0_f64;
+        for (t, gdofs) in dofs.tet_dofs.iter().enumerate() {
+            let (k_loc, _m) = tet_p2_local_sorted(&dofs, &mesh, t);
+            for i in 0..TET_NEDELEC2_DOFS {
+                for j in 0..TET_NEDELEC2_DOFS {
+                    energy += x[gdofs[i]] * k_loc[i][j] * x[gdofs[j]];
+                    kfrob += k_loc[i][j].abs();
+                }
+            }
+        }
+        assert!(kfrob > 1.0, "K must be nontrivial, got Frobenius-1 {kfrob}");
+        assert!(
+            energy.abs() < 1e-9,
+            "curl-curl energy of a global gradient field must vanish, got {energy}"
+        );
+    }
+}

--- a/crates/geode-core/src/driven/adjoint.rs
+++ b/crates/geode-core/src/driven/adjoint.rs
@@ -773,6 +773,215 @@ where
     })
 }
 
+/// Result of a **second-order (`p=2`)** driven-Nédélec material
+/// discrete-adjoint gradient evaluation (issue #616, extends #576 to the
+/// 20-DOF element). Same algebra as the `p=1`
+/// [`driven_material_adjoint_gradient`], on the `edges×2 + faces×2` DOF
+/// numbering of [`crate::assembly::nedelec_p2`].
+#[derive(Debug, Clone)]
+pub struct P2DrivenAdjointGradient {
+    /// The scalar objective value `g(x)` at the forward solution.
+    pub objective: f64,
+    /// The gradient `dg/dε_k`, one entry per design region, from a single
+    /// forward + single adjoint solve sharing one factorization.
+    pub grad: Vec<f64>,
+    /// Full-length `[n_dofs]` complex forward `p=2` DOF field (PEC-eliminated
+    /// DOFs carry exact zeros).
+    pub x: Vec<c64>,
+    /// Relative residual `‖A x − b‖₂ / ‖b‖₂` of the interior forward solve.
+    pub residual_rel: f64,
+    /// Number of sparse LU factorizations performed (always `1`).
+    pub n_factorizations: usize,
+}
+
+/// Compute `∂g/∂ε_k` for every design region `k` of a **lossless, real-ε**
+/// **second-order (`p=2`)** driven Nédélec solve `A(ε, ω) x = b`,
+/// `A = K − ω² M(ε)`, via the discrete adjoint — one forward + one adjoint
+/// solve sharing a single complex sparse LU factorization (issue #616, Epic
+/// #569; the `p=2` retention of the #576 material sensitivity).
+///
+/// The adjoint algebra is **identical** to the `p=1`
+/// [`driven_material_adjoint_gradient`]: the mass is linear in the per-tet ε
+/// (`M(ε) = Σ_t ε_t M_local(t)`; see [`crate::assembly::nedelec_p2::assemble_p2_km`]),
+/// so `∂A/∂ε_k = −ω² M_k` is an **exact analytic JVP** and
+///
+/// ```text
+///   dg/dε_k = −2 Re[ λᵀ (∂A/∂ε_k) x ] = 2 ω² Re[ λᵀ M_k x ],   Aᵀ λ = ∂g/∂x,
+/// ```
+///
+/// with `M_k` the `p=2` mass restricted to region `k`
+/// ([`crate::assembly::nedelec_p2::p2_region_mass_action`]). `A` is
+/// complex-symmetric, so the adjoint reuses the forward factorization.
+///
+/// # Arguments
+///
+/// * `mesh` — tetrahedral mesh.
+/// * `eps_r` — per-tet real relative permittivity (length `mesh.n_tets()`).
+/// * `interior_dof_mask` — length `n_dofs` (`2·n_edges + 2·n_faces`) PEC mask.
+/// * `omega` — drive frequency `ω = k₀` (away from a resonance).
+/// * `rhs_full` — the ε-**independent** length-`n_dofs` complex RHS `b`.
+/// * `region_of_tet` / `n_regions` — per-tet region label and region count.
+/// * `objective` — `g(x) → (value, ∂g/∂x)` over the full-length `[n_dofs]`
+///   complex DOF vector; `∂g/∂x` is the un-conjugated Wirtinger cotangent
+///   (e.g. `x̄` for `g = Σ|x_i|²`). Its entries on PEC DOFs are ignored.
+///
+/// # Errors
+///
+/// [`DrivenError`] on shape mismatches, empty interior, or factorization
+/// failure.
+#[allow(clippy::too_many_arguments)]
+pub fn driven_material_adjoint_gradient_p2<G>(
+    mesh: &TetMesh,
+    eps_r: &[f64],
+    interior_dof_mask: &[bool],
+    omega: f64,
+    rhs_full: &[c64],
+    region_of_tet: &[usize],
+    n_regions: usize,
+    objective: G,
+) -> Result<P2DrivenAdjointGradient, DrivenError>
+where
+    G: Fn(&[c64]) -> (f64, Vec<c64>),
+{
+    use crate::assembly::nedelec_p2::{P2DofMap, p2_interior_km, p2_region_mass_action};
+    use faer::Mat;
+    use faer::linalg::solvers::Solve;
+
+    let n_tets = mesh.n_tets();
+    if eps_r.len() != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: eps_r.len(),
+            want: n_tets,
+        });
+    }
+    if region_of_tet.len() != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: region_of_tet.len(),
+            want: n_tets,
+        });
+    }
+    if let Some(&bad) = region_of_tet.iter().find(|&&r| r >= n_regions) {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: bad,
+            want: n_regions,
+        });
+    }
+    let dofs = P2DofMap::build(mesh);
+    if interior_dof_mask.len() != dofs.n_dofs {
+        return Err(DrivenError::MaskDimMismatch {
+            got: interior_dof_mask.len(),
+            want: dofs.n_dofs,
+        });
+    }
+    if rhs_full.len() != dofs.n_dofs {
+        return Err(DrivenError::SourceDimMismatch {
+            got: rhs_full.len(),
+            want: dofs.n_dofs,
+        });
+    }
+
+    let (remap, n_interior, kept) = p2_interior_km(mesh, &dofs, eps_r, interior_dof_mask);
+    if n_interior == 0 {
+        return Err(DrivenError::EmptyInterior);
+    }
+
+    // Interior A(ω) = K − ω² M(ε) (duplicates summed).
+    let omega2 = omega * omega;
+    let triplets: Vec<Triplet<usize, usize, c64>> = kept
+        .iter()
+        .map(|&(r, c, k, m)| Triplet::new(r, c, c64::new(k - omega2 * m, 0.0)))
+        .collect();
+    let a_int =
+        SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
+            .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+    let lu = a_int
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+    let n_factorizations = 1;
+
+    // Interior RHS.
+    let mut b_int = vec![c64::new(0.0, 0.0); n_interior];
+    for (g, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            b_int[ri as usize] = rhs_full[g];
+        }
+    }
+
+    // Forward solve.
+    let mut fwd: Mat<c64> = Mat::from_fn(n_interior, 1, |i, _| b_int[i]);
+    lu.solve_in_place(fwd.as_mut());
+    let x_int: Vec<c64> = (0..n_interior).map(|i| fwd[(i, 0)]).collect();
+
+    // Residual health check.
+    let residual_rel = {
+        let mut ax = vec![c64::new(0.0, 0.0); n_interior];
+        for &(r, c, k, m) in &kept {
+            ax[r] += c64::new(k - omega2 * m, 0.0) * x_int[c];
+        }
+        let mut res2 = 0.0_f64;
+        let mut b2 = 0.0_f64;
+        for i in 0..n_interior {
+            let d = ax[i] - b_int[i];
+            res2 += d.re * d.re + d.im * d.im;
+            b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+        }
+        if b2 > 0.0 {
+            (res2 / b2).sqrt()
+        } else {
+            res2.sqrt()
+        }
+    };
+
+    // Scatter x to full length.
+    let mut x = vec![c64::new(0.0, 0.0); dofs.n_dofs];
+    for (g, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            x[g] = x_int[ri as usize];
+        }
+    }
+
+    // Objective and its Wirtinger cotangent.
+    let (objective_value, dg_dx) = objective(&x);
+    if dg_dx.len() != dofs.n_dofs {
+        return Err(DrivenError::SparseAssembly(format!(
+            "objective cotangent length {} != DOF count {}",
+            dg_dx.len(),
+            dofs.n_dofs
+        )));
+    }
+    let mut g_x_int = vec![c64::new(0.0, 0.0); n_interior];
+    for (g, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            g_x_int[ri as usize] = dg_dx[g];
+        }
+    }
+
+    // Adjoint solve Aᵀ λ = ∂g/∂x (A complex-symmetric → same factorization).
+    let mut adj: Mat<c64> = Mat::from_fn(n_interior, 1, |i, _| g_x_int[i]);
+    lu.solve_transpose_in_place(adj.as_mut());
+    let lambda_int: Vec<c64> = (0..n_interior).map(|i| adj[(i, 0)]).collect();
+
+    // Per-region gradient dg/dε_k = 2 ω² Re[ λᵀ M_k x ].
+    let mut grad = vec![0.0_f64; n_regions];
+    for (k, grad_k) in grad.iter_mut().enumerate() {
+        let mkx = p2_region_mass_action(mesh, &dofs, &remap, n_interior, region_of_tet, k, &x_int);
+        let mut contrib = c64::new(0.0, 0.0);
+        for i in 0..n_interior {
+            contrib += lambda_int[i] * mkx[i];
+        }
+        *grad_k = 2.0 * omega2 * contrib.re;
+    }
+
+    Ok(P2DrivenAdjointGradient {
+        objective: objective_value,
+        grad,
+        x,
+        residual_rel,
+        n_factorizations,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/geode-core/src/driven/solve.rs
+++ b/crates/geode-core/src/driven/solve.rs
@@ -782,6 +782,184 @@ pub fn driven_solve_with_sigma_quad<B: Backend>(
     )
 }
 
+/// Opt-in element order for the driven forward path (issue #616, Epic
+/// #475/#569).
+///
+/// [`ElementOrder::P1`] is the **default** and routes to the existing,
+/// byte-identical first-order pipeline ([`driven_solve`] and friends). No
+/// existing entry point changes behavior — the p=1 code path is untouched.
+///
+/// [`ElementOrder::P2`] selects the second-order (20-DOF) Nédélec forward path
+/// [`driven_solve_p2`], built on the shipped
+/// [`crate::elements::nedelec_p2`] element and the
+/// [`crate::assembly::nedelec_p2`] global assembly (`edges×2 + faces×2` DOF
+/// numbering, unit-sign scatter via the ascending-global-vertex convention).
+///
+/// # p=2 scope (this landing)
+///
+/// The p=2 forward path currently supports a **real, per-tet-constant scalar
+/// ε**, PEC elimination, and a volumetric current source (constant or
+/// quadrature-sampled). PML/complex-ε, anisotropic tensors, lumped ports,
+/// Leontovich surfaces, and the σ-damping term remain **p=1-only** for now —
+/// they compose through the Burn-tensor scatter machinery the p=2 assembler
+/// does not yet mirror. Selecting them at p=2 is a future extension.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ElementOrder {
+    /// First-order Whitney edge element (6 DOFs/tet) — the default; the
+    /// existing pipeline, byte-identical.
+    #[default]
+    P1,
+    /// Second-order (first-kind) Nédélec element (20 DOFs/tet).
+    P2,
+}
+
+/// Solution of the opt-in second-order (`p=2`) driven forward path
+/// ([`driven_solve_p2`]).
+///
+/// The DOF layout is the `edges×2 + faces×2` global numbering of
+/// [`crate::assembly::nedelec_p2::P2DofMap`] — distinct from the `p=1`
+/// [`DrivenSolution`] (which is `[n_edges]`), so the p=2 result has its own
+/// type rather than overloading the p=1 one.
+#[derive(Debug, Clone)]
+pub struct P2DrivenSolution {
+    /// Full-length `[n_dofs]` complex DOF vector in the `p=2` global numbering.
+    /// PEC-eliminated DOFs carry exact zeros.
+    pub x: Vec<c64>,
+    /// Total `p=2` DOF count (`2·n_edges + 2·n_faces`).
+    pub n_dofs: usize,
+    /// Number of interior (kept) DOFs after PEC elimination.
+    pub n_interior: usize,
+    /// Relative residual `‖A x − b‖₂ / ‖b‖₂` of the interior system.
+    pub residual_rel: f64,
+}
+
+/// Second-order (`p=2`) driven frequency-domain solve `A(ω) x = b`,
+/// `A(ω) = K − ω² M(ε)`, on the shipped 20-DOF Nédélec element (issue #616,
+/// Epic #475/#569) — the opt-in [`ElementOrder::P2`] forward path.
+///
+/// # Arguments
+///
+/// * `mesh` — tetrahedral mesh.
+/// * `eps_tet` — per-tet **real** relative permittivity (length
+///   `mesh.n_tets()`; per-tet constant, so the deg-4 element rule integrates
+///   the ε-weighted mass exactly).
+/// * `interior_dof_mask` — length `n_dofs` (`= 2·n_edges + 2·n_faces`): `true`
+///   keeps a DOF, `false` PEC-eliminates it. Build it for a cube cavity with
+///   [`crate::assembly::nedelec_p2::cube_pec_interior_p2_dofs`].
+/// * `omega` — drive frequency `ω = k₀` (natural units); away from a resonance
+///   so `A(ω)` is non-singular.
+/// * `rhs_full` — the length-`n_dofs` complex RHS moment vector `b`
+///   (e.g. `∫ N_i · f dV` from
+///   [`crate::assembly::nedelec_p2::assemble_p2_rhs_quad`], with any `iω`
+///   scaling folded in by the caller). PEC-eliminated entries are ignored.
+///
+/// The complex-symmetric pencil is factored once with faer's sparse LU and
+/// back-solved directly, mirroring the p=1 direct path.
+///
+/// # Errors
+///
+/// [`DrivenError`] on shape mismatches, an empty interior, or a sparse
+/// factorization/solve failure (e.g. `ω²` at a resonance of the lossless
+/// pencil).
+pub fn driven_solve_p2(
+    mesh: &TetMesh,
+    eps_tet: &[f64],
+    interior_dof_mask: &[bool],
+    omega: f64,
+    rhs_full: &[c64],
+) -> Result<P2DrivenSolution, DrivenError> {
+    use crate::assembly::nedelec_p2::{P2DofMap, p2_interior_km};
+
+    let n_tets = mesh.n_tets();
+    if eps_tet.len() != n_tets {
+        return Err(DrivenError::MaterialDimMismatch {
+            got: eps_tet.len(),
+            want: n_tets,
+        });
+    }
+    let dofs = P2DofMap::build(mesh);
+    if interior_dof_mask.len() != dofs.n_dofs {
+        return Err(DrivenError::MaskDimMismatch {
+            got: interior_dof_mask.len(),
+            want: dofs.n_dofs,
+        });
+    }
+    if rhs_full.len() != dofs.n_dofs {
+        return Err(DrivenError::SourceDimMismatch {
+            got: rhs_full.len(),
+            want: dofs.n_dofs,
+        });
+    }
+
+    let (remap, n_interior, kept) = p2_interior_km(mesh, &dofs, eps_tet, interior_dof_mask);
+    if n_interior == 0 {
+        return Err(DrivenError::EmptyInterior);
+    }
+
+    // A(ω) = K − ω² M(ε), interior, as complex triplets (duplicates summed).
+    let omega2 = omega * omega;
+    let triplets: Vec<Triplet<usize, usize, c64>> = kept
+        .iter()
+        .map(|&(r, c, k, m)| Triplet::new(r, c, c64::new(k - omega2 * m, 0.0)))
+        .collect();
+    let a_int =
+        SparseColMat::<usize, c64>::try_new_from_triplets(n_interior, n_interior, &triplets)
+            .map_err(|e| DrivenError::SparseAssembly(format!("{e:?}")))?;
+    let lu = a_int
+        .as_ref()
+        .sp_lu()
+        .map_err(|e| DrivenError::Factorization(format!("{e:?}")))?;
+
+    // Interior-filtered RHS.
+    let mut b_int = vec![c64::new(0.0, 0.0); n_interior];
+    for (g, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            b_int[ri as usize] = rhs_full[g];
+        }
+    }
+
+    // Forward solve A x = b.
+    let mut fwd: faer::Mat<c64> = faer::Mat::from_fn(n_interior, 1, |i, _| b_int[i]);
+    use faer::linalg::solvers::Solve;
+    lu.solve_in_place(fwd.as_mut());
+    let x_int: Vec<c64> = (0..n_interior).map(|i| fwd[(i, 0)]).collect();
+
+    // Residual ‖A x − b‖ / ‖b‖ via a triplet accumulation spmv (duplicates sum).
+    let residual_rel = {
+        let mut ax = vec![c64::new(0.0, 0.0); n_interior];
+        for &(r, c, k, m) in &kept {
+            ax[r] += c64::new(k - omega2 * m, 0.0) * x_int[c];
+        }
+        let mut res2 = 0.0_f64;
+        let mut b2 = 0.0_f64;
+        for i in 0..n_interior {
+            let d = ax[i] - b_int[i];
+            res2 += d.re * d.re + d.im * d.im;
+            b2 += b_int[i].re * b_int[i].re + b_int[i].im * b_int[i].im;
+        }
+        if b2 > 0.0 {
+            (res2 / b2).sqrt()
+        } else {
+            res2.sqrt()
+        }
+    };
+
+    // Scatter to full length (PEC DOFs = 0).
+    let mut x = vec![c64::new(0.0, 0.0); dofs.n_dofs];
+    for (g, &ri) in remap.iter().enumerate() {
+        if ri >= 0 {
+            x[g] = x_int[ri as usize];
+        }
+    }
+
+    Ok(P2DrivenSolution {
+        x,
+        n_dofs: dofs.n_dofs,
+        n_interior,
+        residual_rel,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn driven_solve_impl<B: Backend>(
     mesh: &TetMesh,

--- a/crates/geode-core/tests/driven_p2_adjoint.rs
+++ b/crates/geode-core/tests/driven_p2_adjoint.rs
@@ -1,0 +1,94 @@
+//! Finite-difference validation of the **second-order (`p=2`)** driven-Nédélec
+//! material discrete adjoint `∂g/∂ε` (issue #616, Epic #569 — the `p=2`
+//! retention of the #576 material sensitivity).
+//!
+//! Mirrors the `p=1` driven-adjoint test bar (`src/driven/adjoint.rs` module
+//! tests): a lossless real-ε driven cube cavity, the L² observable
+//! `g = Σ_i |x_i|²`, a two-region design partition, and a central finite
+//! difference of the whole `p=2` forward pipeline
+//! ([`driven_solve_p2`]) against the single-solve adjoint gradient
+//! ([`driven_material_adjoint_gradient_p2`]).
+
+use faer::c64;
+use std::f64::consts::PI;
+
+use geode_core::assembly::nedelec_p2::{P2DofMap, assemble_p2_rhs_quad, cube_pec_interior_p2_dofs};
+use geode_core::driven::adjoint::driven_material_adjoint_gradient_p2;
+use geode_core::driven::solve::driven_solve_p2;
+use geode_core::mesh::cube_tet_mesh;
+
+/// Two design regions split at the cube mid-plane `x = 0.5`.
+fn region_of_tet(mesh: &geode_core::mesh::TetMesh) -> Vec<usize> {
+    mesh.tets
+        .iter()
+        .map(|tet| {
+            let cx = tet.iter().map(|&v| mesh.nodes[v as usize][0]).sum::<f64>() / 4.0;
+            usize::from(cx > 0.5)
+        })
+        .collect()
+}
+
+/// L² observable `g = Σ_i |x_i|²` and its Wirtinger cotangent `∂g/∂x_i = x̄_i`.
+fn objective(x: &[c64]) -> (f64, Vec<c64>) {
+    let g = x.iter().map(|z| z.norm_sqr()).sum::<f64>();
+    let dg = x.iter().map(|z| z.conj()).collect();
+    (g, dg)
+}
+
+#[test]
+fn p2_material_adjoint_matches_finite_difference() {
+    let mesh = cube_tet_mesh(2, 1.0);
+    let dofs = P2DofMap::build(&mesh);
+    let interior = cube_pec_interior_p2_dofs(&mesh, &dofs, 1.0);
+    let omega = PI;
+    let regions = region_of_tet(&mesh);
+    let n_regions = 2;
+
+    // ε per region: region 0 = 2.0, region 1 = 3.0.
+    let eps_region = [2.0_f64, 3.0];
+    let eps_r: Vec<f64> = regions.iter().map(|&r| eps_region[r]).collect();
+
+    // ε-independent RHS: a constant volumetric current source (real → x real).
+    let b_re = assemble_p2_rhs_quad(&mesh, &dofs, |_t, _x| [0.3, 0.5, 0.7]);
+    let rhs_full: Vec<c64> = b_re.iter().map(|&v| c64::new(v, 0.0)).collect();
+
+    // Single-solve adjoint gradient.
+    let adj = driven_material_adjoint_gradient_p2(
+        &mesh, &eps_r, &interior, omega, &rhs_full, &regions, n_regions, objective,
+    )
+    .expect("p2 material adjoint");
+    assert!(
+        adj.residual_rel < 1e-8,
+        "adjoint forward residual {} too high",
+        adj.residual_rel
+    );
+    assert_eq!(adj.n_factorizations, 1);
+
+    // Central finite difference of the full forward pipeline, per region.
+    let fd_h = 1e-6;
+    let g_of = |eps_reg: &[f64; 2]| -> f64 {
+        let eps: Vec<f64> = regions.iter().map(|&r| eps_reg[r]).collect();
+        let sol =
+            driven_solve_p2(&mesh, &eps, &interior, omega, &rhs_full).expect("p2 driven forward");
+        objective(&sol.x).0
+    };
+
+    for k in 0..n_regions {
+        let mut ep = eps_region;
+        let mut em = eps_region;
+        ep[k] += fd_h;
+        em[k] -= fd_h;
+        let grad_fd = (g_of(&ep) - g_of(&em)) / (2.0 * fd_h);
+        let rel = (adj.grad[k] - grad_fd).abs() / grad_fd.abs().max(f64::MIN_POSITIVE);
+        eprintln!(
+            "region {k}: adjoint = {:.6e}, FD = {grad_fd:.6e}, rel-err = {rel:.3e}",
+            adj.grad[k]
+        );
+        assert!(
+            rel < 1e-4,
+            "region {k}: p2 adjoint ∂g/∂ε rel-err {rel:.3e} exceeds 1e-4 \
+             (adjoint {:.6e} vs FD {grad_fd:.6e})",
+            adj.grad[k]
+        );
+    }
+}

--- a/crates/geode-core/tests/driven_p2_convergence.rs
+++ b/crates/geode-core/tests/driven_p2_convergence.rs
@@ -1,0 +1,204 @@
+//! Driven `p=2` vs `p=1` order-of-convergence gate (issue #616, Epic
+//! #475/#569 — follow-on to #613).
+//!
+//! Manufactured driven solution on the unit-cube PEC cavity `[0,1]³` with the
+//! smooth analytic field
+//!
+//! ```text
+//!   E(x) = (0, 0, sin(πx) sin(πy)),     ∇·E = 0,   n × E = 0 on ∂cube,
+//!   ∇×∇×E = 2π² E,
+//! ```
+//!
+//! (the same fixture as `tests/driven_manufactured.rs`, which pins the `p=1`
+//! O(h) rate). We drive both the first-order edge path
+//! ([`driven_solve_quad`]) and the opt-in second-order path
+//! ([`driven_solve_p2`], the [`ElementOrder::P2`] wiring this issue adds) at
+//! `ω = π` (below the lowest cavity resonance `2π²`, so `A = K − ω² M` is
+//! non-singular) with the manufactured volumetric source
+//! `f = (2π² − ω²) E`, then measure the **true L² field error**
+//! `‖E_h − E‖_{L²(Ω)}` by quadrature reconstruction — the *same* degree-≥4 tet
+//! rule for both orders, so the comparison is apples-to-apples.
+//!
+//! Gate (mirrors the `fit_slope` refine-and-gate pattern of
+//! `tests/nedelec2_convergence.rs`, kept untouched):
+//!
+//! 1. the `p=2` log-log slope is **strictly better** than `p=1`, and
+//! 2. the `p=2` absolute error is below `p=1` at the coarsest shared mesh.
+
+use faer::c64;
+use std::f64::consts::PI;
+
+use geode_core::assembly::nedelec::cube_pec_interior_edges;
+use geode_core::assembly::nedelec_p2::{
+    P2DofMap, assemble_p2_rhs_quad, cube_pec_interior_p2_dofs, p2_field_at,
+};
+use geode_core::driven::solve::{
+    DrivenBcs, DrivenMaterials, QuadCurrentSource, driven_solve_p2, driven_solve_quad,
+};
+use geode_core::elements::nedelec_p2::{tet_barycentric_gradients, tet_quad_deg4};
+use geode_core::mesh::{TET_LOCAL_EDGES, cube_tet_mesh};
+use geode_core::testing::TestBackend;
+
+use burn::tensor::backend::BackendTypes;
+
+type B = TestBackend;
+
+fn device() -> <B as BackendTypes>::Device {
+    <B as BackendTypes>::Device::default()
+}
+
+/// Least-squares slope of `log(err)` vs `log(h)` — the empirical convergence
+/// order `p` in `err ≈ C h^p` (same estimator as `nedelec2_convergence.rs`).
+fn fit_slope(hs: &[f64], errs: &[f64]) -> f64 {
+    let n = hs.len() as f64;
+    let xs: Vec<f64> = hs.iter().map(|h| h.ln()).collect();
+    let ys: Vec<f64> = errs.iter().map(|e| e.ln()).collect();
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let (mut num, mut den) = (0.0, 0.0);
+    for (x, y) in xs.iter().zip(ys.iter()) {
+        num += (x - mean_x) * (y - mean_y);
+        den += (x - mean_x) * (x - mean_x);
+    }
+    num / den
+}
+
+/// Analytic manufactured field `E = (0, 0, sin(πx) sin(πy))`.
+fn e_exact(x: [f64; 3]) -> [f64; 3] {
+    [0.0, 0.0, (PI * x[0]).sin() * (PI * x[1]).sin()]
+}
+
+const OMEGA: f64 = PI;
+
+/// L² field error of the **p=1** driven solve at refinement `n`.
+fn p1_l2_error(n: usize) -> f64 {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let (_, interior) = cube_pec_interior_edges(&mesh, 1.0);
+
+    // b = iω ∫ N·J with J = −i f/ω reproduces b = ∫ N·f, f = (2π²−ω²) E.
+    let amp = (2.0 * PI * PI - OMEGA * OMEGA) / OMEGA;
+    let source = QuadCurrentSource::from_fn(&mesh, |_t, x| {
+        let e = e_exact(x);
+        [
+            c64::new(0.0, -amp * e[0]),
+            c64::new(0.0, -amp * e[1]),
+            c64::new(0.0, -amp * e[2]),
+        ]
+    });
+    let eps: Vec<c64> = vec![c64::new(1.0, 0.0); mesh.n_tets()];
+    let sol = driven_solve_quad::<B>(
+        &mesh,
+        DrivenMaterials::Scalar(&eps),
+        &DrivenBcs {
+            pec_interior_mask: &interior,
+        },
+        OMEGA,
+        &source,
+        &device(),
+    )
+    .expect("p1 driven solve");
+    assert!(sol.residual_rel < 1e-8, "n={n}: p1 residual too high");
+
+    // L² error by the same deg-≥4 rule as p=2, Whitney reconstruction.
+    let tet_edges = mesh.tet_edges();
+    let rule = tet_quad_deg4();
+    let mut err2 = 0.0_f64;
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords: [[f64; 3]; 4] = std::array::from_fn(|i| mesh.nodes[tet[i] as usize]);
+        let (grad, vol) = tet_barycentric_gradients(&coords);
+        let vol_abs = vol.abs();
+        // Local signed edge DOFs.
+        let dloc: [c64; 6] = std::array::from_fn(|slot| {
+            let (gidx, sign) = tet_edges[t][slot];
+            sol.e_edges[gidx as usize] * (sign as f64)
+        });
+        for (lam, frac) in &rule {
+            let x: [f64; 3] = std::array::from_fn(|d| (0..4).map(|p| lam[p] * coords[p][d]).sum());
+            // Whitney reconstruction E_h = Σ d W, W = λ_a ∇λ_b − λ_b ∇λ_a.
+            let mut eh = [c64::new(0.0, 0.0); 3];
+            for (slot, &(a, b)) in TET_LOCAL_EDGES.iter().enumerate() {
+                for (d, eh_d) in eh.iter_mut().enumerate() {
+                    let w = lam[a] * grad[b][d] - lam[b] * grad[a][d];
+                    *eh_d += dloc[slot] * w;
+                }
+            }
+            let ee = e_exact(x);
+            let w = vol_abs * frac;
+            for d in 0..3 {
+                let diff = eh[d] - c64::new(ee[d], 0.0);
+                err2 += w * (diff.re * diff.re + diff.im * diff.im);
+            }
+        }
+    }
+    err2.sqrt()
+}
+
+/// L² field error of the **p=2** driven solve at refinement `n`.
+fn p2_l2_error(n: usize) -> f64 {
+    let mesh = cube_tet_mesh(n, 1.0);
+    let dofs = P2DofMap::build(&mesh);
+    let eps_tet = vec![1.0_f64; mesh.n_tets()];
+    let interior = cube_pec_interior_p2_dofs(&mesh, &dofs, 1.0);
+
+    // rhs_full = ∫ N·f, f = (2π²−ω²) E (real; A is real so x is real).
+    let amp = 2.0 * PI * PI - OMEGA * OMEGA;
+    let b_re = assemble_p2_rhs_quad(&mesh, &dofs, |_t, x| {
+        let e = e_exact(x);
+        [amp * e[0], amp * e[1], amp * e[2]]
+    });
+    let rhs_full: Vec<c64> = b_re.iter().map(|&v| c64::new(v, 0.0)).collect();
+
+    let sol =
+        driven_solve_p2(&mesh, &eps_tet, &interior, OMEGA, &rhs_full).expect("p2 driven solve");
+    assert!(sol.residual_rel < 1e-8, "n={n}: p2 residual too high");
+
+    let rule = tet_quad_deg4();
+    let mut err2 = 0.0_f64;
+    for (t, tet) in mesh.tets.iter().enumerate() {
+        let coords: [[f64; 3]; 4] = std::array::from_fn(|i| mesh.nodes[tet[i] as usize]);
+        let (_grad, vol) = tet_barycentric_gradients(&coords);
+        let vol_abs = vol.abs();
+        for (lam, frac) in &rule {
+            let x: [f64; 3] = std::array::from_fn(|d| (0..4).map(|p| lam[p] * coords[p][d]).sum());
+            let eh = p2_field_at(&mesh, &dofs, &sol.x, t, lam);
+            let ee = e_exact(x);
+            let w = vol_abs * frac;
+            for d in 0..3 {
+                let diff = eh[d] - c64::new(ee[d], 0.0);
+                err2 += w * (diff.re * diff.re + diff.im * diff.im);
+            }
+        }
+    }
+    err2.sqrt()
+}
+
+#[test]
+fn p2_driven_converges_faster_than_p1_on_cube_cavity() {
+    let ns = [2usize, 3, 4];
+    let hs: Vec<f64> = ns.iter().map(|&n| 1.0 / n as f64).collect();
+    let err_p1: Vec<f64> = ns.iter().map(|&n| p1_l2_error(n)).collect();
+    let err_p2: Vec<f64> = ns.iter().map(|&n| p2_l2_error(n)).collect();
+
+    let slope_p1 = fit_slope(&hs, &err_p1);
+    let slope_p2 = fit_slope(&hs, &err_p2);
+    eprintln!("p1 L2 errors: {err_p1:?}  slope = {slope_p1:.3}");
+    eprintln!("p2 L2 errors: {err_p2:?}  slope = {slope_p2:.3}");
+
+    // (1) p=2 slope strictly better than p=1 (with margin against noise).
+    assert!(
+        slope_p2 > slope_p1 + 0.5,
+        "p=2 slope {slope_p2:.3} not strictly better than p=1 slope {slope_p1:.3}"
+    );
+    // p=2 should be at least ~O(h^1.5) (asymptotic O(h²) on coarse meshes).
+    assert!(
+        slope_p2 >= 1.5,
+        "p=2 convergence slope {slope_p2:.3} below the expected order"
+    );
+    // (2) p=2 absolute error below p=1 at the coarsest shared mesh.
+    assert!(
+        err_p2[0] < err_p1[0],
+        "p=2 coarse error {} not below p=1 coarse error {}",
+        err_p2[0],
+        err_p1[0]
+    );
+}


### PR DESCRIPTION
## Summary

Wires the shipped 20-DOF second-order (first-kind) Nédélec tet element (#613/#617) into the **driven forward path** as an **opt-in** element order, with a convergence gate proving p=2 beats p=1, and retains the **material** `∂g/∂ε` sensitivity at p=2. This is the Curator's slice **B1 + the material half of B2**; the harder geometry shape adjoint and the eigenmode path are deferred to filed follow-ons (see below).

p=1 is the default and its code path is **untouched / byte-identical** (opt-in, no default flip).

## Changes

- **`crates/geode-core/src/assembly/nedelec_p2.rs`** (new): global p=2 assembly over an `edges×2 + faces×2` DOF numbering.
  - `P2DofMap` — deterministic mesh-derived numbering (`2·edge_gid+{0,1}` for W/Q, `2·n_edges + 2·face_gid+{0,1}` for φ0/φ1) using `ascending_vertex_perm` for orientation; **unit-sign scatter, no p=1 sign machinery** (red flag #1).
  - `assemble_p2_km` (ε-weighted mass + curl-curl), `p2_interior_km` (interior pencil ingredients + PEC remap), `p2_region_mass_action` (adjoint region mass), `assemble_p2_rhs_constant`, **`assemble_p2_rhs_quad`** (quadrature-sampled spatially-varying J — red flag #3 / AC #3), `cube_pec_interior_p2_dofs`, `p2_field_at` (reconstructor; takes natural-order barycentrics and permutes internally).
- **`crates/geode-core/src/driven/solve.rs`**: `ElementOrder` enum (default `P1`) + `driven_solve_p2` (real per-tet-constant scalar ε, PEC elimination, volumetric J), faer complex sparse LU mirroring the p=1 direct path. `P2DrivenSolution` carries the p=2 DOF layout.
- **`crates/geode-core/src/driven/adjoint.rs`**: `driven_material_adjoint_gradient_p2` — `∂g/∂ε` at p=2 via the discrete adjoint (one factorization, forward + transpose back-solve), the exact analytic JVP `dg/dε_k = 2 ω² Re[λᵀ M_k x]`.
- **Tests** (new; the 2D `tests/nedelec2_convergence.rs` is left untouched, only its `fit_slope` pattern is mirrored):
  - `tests/driven_p2_convergence.rs` — p=2-vs-p=1 L2 field-error convergence on the cube-cavity MMS fixture `E=(0,0,sin πx sin πy)`, same deg-≥4 rule for both orders.
  - `tests/driven_p2_adjoint.rs` — central-FD validation of the p=2 material adjoint.
  - Module unit tests in `nedelec_p2.rs`: DOF-numbering invariants, shared-face DOF conformity, curl-curl annihilation of a global gradient field.

## Scope: what this PR meets vs. defers

| Acceptance criterion (issue #616) | Status | Where |
|---|---|---|
| p=2 order-aware global assembly, `edges×2+faces×2`, `ascending_vertex_perm`, unit-sign scatter, p=2 scatter map | ✅ | `assembly/nedelec_p2.rs` |
| Opt-in order on `driven/solve.rs`; p=1 byte-identical | ✅ | `ElementOrder` + `driven_solve_p2`; existing p=1 tests pass |
| p=2 RHS supports quadrature-sampled (spatially varying) J | ✅ | `assemble_p2_rhs_quad` |
| Driven convergence gate: p=2 slope strictly better + coarse error lower | ✅ | slope **p1 0.98 / p2 1.95**; coarse err **p2 0.068 < p1 0.404** |
| `∂g/∂ε` (#576) FD-validated at p=2 | ✅ | rel-err **~2e-9** vs central FD |
| `∂g/∂geometry` (#577) FD-validated at p=2 | ⏭️ **deferred → #619** | needs a Dual-capable p=2 element eval (red flag #5) |
| Eigenmode order in `eigen/transmon.rs` + p=2 frequency gate | ⏭️ **deferred → #620** | Curator split C |
| `cargo fmt` / `clippy` / geode-core suite pass | ✅ | see Test Plan |

**Deferred by design** (filed, not new labels — `loom:epic-phase` + `tier:goal-advancing`, referencing #616/#475/#569):
- **#619** — p=2 `∂g/∂geometry` shape adjoint (genuine forward-mode Dual work; the shipped element is f64/closed-quadrature only).
- **#620** — p=2 eigenmode path + frequency-convergence gate.

The p=2 forward path currently supports **real per-tet-constant scalar ε + PEC + volumetric J**. PML/complex-ε, anisotropic tensors, ports, Leontovich surfaces, and σ-damping remain p1-only (documented on `ElementOrder`); those compose through the Burn-tensor scatter path the p2 assembler does not yet mirror.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unit-sign p=2 assembly, no double orientation | ✅ | random-vector tangential-jump across shared faces ~1e-15; global space reproduces constants & linears exactly, O(h²) best-approx |
| p=1 byte-identical | ✅ | `driven::solve` + `driven::adjoint` lib tests + `driven_manufactured` unchanged and passing |
| p=2 convergence strictly better | ✅ | `p2_driven_converges_faster_than_p1_on_cube_cavity` (slope 1.95 > 0.98; coarse err 6× lower) |
| p=2 `∂g/∂ε` FD-validated | ✅ | `p2_material_adjoint_matches_finite_difference` (rel-err ~2e-9, 1 factorization) |

## Test Plan

- `cargo fmt --check` clean; `cargo clippy -p geode-core --tests` clean on the new code.
- `cargo test -p geode-core --lib` — **428 passed, 0 failed** (includes the new `nedelec_p2` unit tests and the untouched p=1 driven/adjoint regressions).
- New integration gates pass: `driven_p2_convergence`, `driven_p2_adjoint`.
- 2D `nedelec2_convergence` (untouched) and `driven_manufactured` (p=1) pass.
- Heavy `sphere_*` eigenmode integration tests were **not run** (they time out in debug here and share no code with this change — the eigenmode path is deferred to #620).

Closes #616